### PR TITLE
config: fail startup on credential errors

### DIFF
--- a/test/config-luatest/credentials_applier_test.lua
+++ b/test/config-luatest/credentials_applier_test.lua
@@ -1138,6 +1138,24 @@ g.test_delayed_grant_alert = function(g)
     })
 end
 
+g.test_unsupported_privilege_fails_blocking_sync = function()
+    helpers.failure_case({
+        options = {
+            ['credentials.users.someone'] = {
+                privileges = {
+                    {
+                        permissions = {'execute'},
+                        spaces = {'first'},
+                    },
+                },
+            },
+        },
+        exp_err = 'credentials.apply: box.schema.user.grant("someone", ' ..
+            '"execute", "space", "first") failed: Unsupported space ' ..
+            'privilege \'execute\'',
+    })
+end
+
 -- Verify that an alert regarding a delayed privilege granting
 -- (due to lack of a space/function/sequence) is dropped, when the
 -- privilege is finally granted.


### PR DESCRIPTION
This patch fixes the issue where configuration-driven credential errors did not stop startup. Now the first alert from the credential applier is returned to the blocking sync caller, so an invalid grant aborts startup as expected.

Closes #9689

NO_DOC=bugfix
NO_CHANGELOG=bugfix