### PR TITLE
config: accept super for sharding check

### DIFF
--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -141,7 +141,7 @@ function methods._instance_sharding(self, opts)
                 return false
             end
             for _, role_name in pairs(roles) do
-                if role_name == 'sharding' then
+                if role_name == 'sharding' or role_name == 'super' then
                     return true
                 end
             end

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -504,6 +504,16 @@ g.test_no_sharding_credentials_role_success = function(g)
         },
         verify = function() end,
     })
+
+    helpers.success_case(g, {
+        options = {
+            ['credentials.users.storage.roles'] = {'super'},
+            ['credentials.users.storage.password'] = 'storage',
+            ['sharding.roles'] = {'storage', 'router'},
+            ['iproto.advertise.sharding'] = {login = 'storage'},
+        },
+        verify = function() end,
+    })
 end
 
 g.test_no_sharding_credentials_role_error = function()
@@ -515,7 +525,7 @@ g.test_no_sharding_credentials_role_error = function()
         guest:
           roles: [super]
         storage:
-          roles: [super]
+          roles: []
           password: "storage"
 
     iproto:


### PR DESCRIPTION
This patch fixes an issue where a user with the `super` role did not satisfy the `sharding` requirement during validation, causing the cluster to fail during startup. The presence of `super` is now sufficient to pass the check, while explicitly granting `sharding` is still supported.

Closes #10540
Closes https://github.com/tarantool/tarantool-ee/issues/902

NO_DOC=bugfix
NO_CHANGELOG=bugfix