### PR TITLE
raft: fix election deadlock when nodes have election_mode off

### DIFF
--- a/changelogs/unreleased/gh-12018-fix-election-deadlock.md
+++ b/changelogs/unreleased/gh-12018-fix-election-deadlock.md
@@ -1,0 +1,5 @@
+## bugfix/replication
+
+* Fixed a bug where a node configured with `election_mode = 'off'` would prevent
+  nodes with `election_mode = 'candidate'` from starting new elections after the
+  leader death (gh-12018).

--- a/test/unit/raft.c
+++ b/test/unit/raft.c
@@ -1297,7 +1297,7 @@ raft_test_death_timeout(void)
 static void
 raft_test_enable_disable(void)
 {
-	raft_start_test(11);
+	raft_start_test(13);
 	struct raft_node node;
 	raft_node_create(&node);
 
@@ -1317,6 +1317,14 @@ raft_test_enable_disable(void)
 		0 /* Volatile vote. */,
 		"{0: 1}" /* Vclock. */
 	), "leader is seen");
+
+	/* Disabled node should not report is_leader_seen during checkpoint. */
+
+	struct raft_msg msg;
+	raft_checkpoint_remote(&node.raft, &msg);
+	ok(!msg.is_leader_seen, "disabled node reports is_leader_seen=false "
+	   "in checkpoint");
+	ok(node.raft.leader == 2, "leader is still tracked");
 
 	/* When re-enabled, the leader death timer is started. */
 


### PR DESCRIPTION
Closes #12018

When instances with `election_mode=off` exist in a replicaset, they continue to broadcast `is_leader_seen=true` even after the leader dies. (Their death detection timers never start since RAFT is disabled for them). This causes the `leader_witness_map` bits for these hosts to remain set indefinitely on candidate nodes, blocking elections since the pre-vote protection check requires `leader_witness_map==0`.

The root cause is that `election_mode=off` nodes cannot be distinguished from active voters in RAFT messages. Both report state `follower` with `is_leader_seen` based on local state, but `election_mode=off` nodes never update their view since heartbeat [processing exits early when raft is disabled](https://github.com/tarantool/tarantool/blob/0628d91cd76be45cfe0623d955237ca4c7125e0c/src/lib/raft/raft.c#L665-L666).

This fix forces nodes with `election_mode=off` to always broadcast `is_leader_seen=false`. This allows candidate nodes to immediately clear witness map bits for non-participating nodes, enabling elections to proceed with only active participants.

Is this the right approach or have I missed anything?