### PR TITLE
vinyl: fix deferred delete reader not aborted on WAL error

### DIFF
--- a/changelogs/unreleased/gh-11969-vy-deferred-delete-reader-abort-on-wal-error-fix.md
+++ b/changelogs/unreleased/gh-11969-vy-deferred-delete-reader-abort-on-wal-error-fix.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed a bug when a WAL write error could lead to the violation of a unique
+  constraint in a space with the enabled `defer_deletes` option (gh-11969).

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -1413,6 +1413,17 @@ vy_get_by_secondary_tuple(struct vy_lsm *lsm, struct vy_tx *tx,
 	}
 	if (!match) {
 		/*
+		 * If the primary index statement deleting the target
+		 * key from the secondary index hasn't been confirmed,
+		 * we must track it in the transaction read set because
+		 * it may still be rolled back due to a WAL error, in which
+		 * case the overwritten tuple matching the secondary index
+		 * key can be reinstantiated.
+		 */
+		if (tx != NULL && pk_entry.stmt != NULL &&
+		    vy_stmt_is_prepared(pk_entry.stmt))
+			vy_tx_track_point(tx, lsm->pk, pk_entry);
+		/*
 		 * If a tuple read from a secondary index doesn't
 		 * match the tuple corresponding to it in the
 		 * primary index, it must have been overwritten or

--- a/test/vinyl-luatest/gh_11969_deferred_delete_reader_abort_on_wal_error_test.lua
+++ b/test/vinyl-luatest/gh_11969_deferred_delete_reader_abort_on_wal_error_test.lua
@@ -1,0 +1,153 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new({
+        box_cfg = {vinyl_cache = 0},
+    })
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+g.test_deferred_delete_generated_on_commit = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local function join(f)
+            local ok, err = f:join(5)
+            if not ok then
+                error(err)
+            end
+        end
+
+        local s = box.schema.space.create('test', {
+            engine = 'vinyl',
+            defer_deletes = true,
+        })
+        s:create_index('primary')
+        s:create_index('secondary', {parts = {2, 'unsigned'}})
+        s:insert({1, 1})
+        s:insert({2, 2})
+
+        local ch1 = fiber.channel(1)
+        local ch2 = fiber.channel(1)
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+
+        -- Since INSERT{2, 2} is stored in the memory layer, DELETE{2} must be
+        -- generated for the secondary index when the transaction is prepared.
+        local f1 = fiber.new(box.atomic, function()
+            s:delete({2})
+            ch1:put(true)
+        end)
+        f1:set_joinable(true)
+        t.assert(ch1:get(5))
+
+        local f2 = fiber.new(box.atomic, function()
+            -- This statement must not fail because the transaction operates in
+            -- the read-committed isolation level and DELETE{2} was prepared
+            -- for commit.
+            s:replace{1, 2}
+            ch1:put(true)
+            ch2:get(5)
+        end)
+        f2:set_joinable(true)
+        t.assert(ch1:get(5))
+
+        box.error.injection.set('ERRINJ_WAL_WRITE', true)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+
+        t.assert_error_covers({name = 'WAL_IO'}, join, f1)
+
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+
+        -- The transaction must be aborted because DELETE{2} overwriting
+        -- INSERT{2, 2} was rolled back.
+        ch2:put(true)
+        t.assert_error_covers({name = 'TRANSACTION_CONFLICT'}, join, f2)
+
+        local expected = {{1, 1}, {2, 2}}
+        t.assert_equals(s.index.primary:select(), expected)
+        t.assert_equals(s.index.secondary:select(), expected)
+    end)
+end
+
+g.test_deferred_delete_postponed_to_compaction = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local function join(f)
+            local ok, err = f:join(5)
+            if not ok then
+                error(err)
+            end
+        end
+
+        local s = box.schema.space.create('test', {
+            engine = 'vinyl',
+            defer_deletes = true,
+        })
+        s:create_index('primary')
+        s:create_index('secondary', {parts = {2, 'unsigned'}})
+        s:insert({1, 1})
+        s:insert({2, 2})
+        box.snapshot()
+
+        local ch1 = fiber.channel(1)
+        local ch2 = fiber.channel(1)
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+
+        -- Since INSERT{2, 2} is stored on disk, DELETE{2} will not be
+        -- generated for the secondary index when the transaction is prepared.
+        local f1 = fiber.new(box.atomic, function()
+            s:delete({2})
+            ch1:put(true)
+        end)
+        f1:set_joinable(true)
+        t.assert(ch1:get(5))
+
+        local f2 = fiber.new(box.atomic, function()
+            -- This statement must not fail because the transaction operates in
+            -- the read-committed isolation level and DELETE{2} was prepared
+            -- for commit.
+            s:replace({1, 2})
+            ch1:put(true)
+            ch2:get(5)
+        end)
+        f2:set_joinable(true)
+        t.assert(ch1:get(5))
+
+        box.error.injection.set('ERRINJ_WAL_WRITE', true)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+
+        t.assert_error_covers({name = 'WAL_IO'}, join, f1)
+
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+
+        -- The transaction must be aborted because DELETE{2} overwriting
+        -- INSERT{2, 2} was rolled back.
+        ch2:put(true)
+        t.assert_error_covers({name = 'TRANSACTION_CONFLICT'}, join, f2)
+
+        local expected = {{1, 1}, {2, 2}}
+        t.assert_equals(s.index.primary:select(), expected)
+        t.assert_equals(s.index.secondary:select(), expected)
+    end)
+end


### PR DESCRIPTION
With deferred DELETEs enabled, `space.delete()` writes the DELETE statement to the primary index write set only while statements for secondary indexes are generated either when the transaction is prepared (if the deleted tuple is found in the memory layer or cache) or on compaction.

Now imagine the following scenario:

1. There are tuples `{1,1}` and `{2,2}` in the memory layer of a space with enabled deferred DELETEs, the primary index over field 1, and a unique secondary index over field 2.
2. A transaction deletes `{2,2}` by the primary key and blocks on WAL. When the statement is executed, the DELETE statement is written only to the primary index write set because of enabled deferred DELETEs, but when the transaction is prepared (`vy_tx_prepare()`), the corresponding statement for the secondary index is generated because the deleted tuple is found in the in-memory layer, see `vy_tx_handle_deferred_delete()`.
3. In the meantime, another transaction replaces `{1,1}` with `{1,2}` and yields execution. It doesn't violate the unique constraint of the secondary index because `{2,2}` was deleted although not yet confirmed.
4. Imagine a transient WAL error happens and the first transaction is rolled back. The second transaction must be aborted too in this case because it implicitly read the DELETE statement prepared but not confirmed by the first transaction, but it is successfully committed, resulting in the unique constraint violation!

When a transaction is rolled back due to a WAL write error, we do abort all transactions that read statements prepared by it, see `vy_tx_rollback_after_prepare()`, but to do that, we iterate over statements that were inserted into the transaction write set. The problem is, we don't insert deferred DELETE statements generated when a transaction is prepared in `vy_tx_handle_deferred_delete()` into the write set because we don't need them for lookups at that point. As a result, we don't abort transactions that read deferred DELETE statements from secondary indexes.

Let's fix this issue by aborting all dependent transactions for each statement inserted/deleted from the LSM tree. We already loop over all transaction statements in `vy_tx_rollback_after_prepare()` and `vy_tx_prepare` so there's no need to iterate over the write set entries separately.

There's another related issue that may result in the same anomaly. The problem is that we don't track the non-matching primary index statement in the transaction write set when we look up the full tuple by a key found in a secondary index, see `vy_get_by_secondary_tuple()`. Normally, this is fine because we don't care if the primary index statement is overwritten - we never returned it to the user. However, if the statement hasn't been confirmed, it may still be rolled back due to a WAL error reinstantiating the tuple matching the secondary index key and making the lookup invalid. Note that this may happen only if generation of the deferred DELETE is postponed to compaction. Let's fix this issue by tracking unconfirmed primary index statements in `vy_get_by_secondary_tuple()` even if they don't match the secondary index key.

Closes #11969