### PR TITLE
[backport 3.3] memtx: failing index count limit assertion with MVCC enabled

### DIFF
--- a/changelogs/unreleased/gh-11929-memtx-mvcc-failing-index-count-limit-assertion.md
+++ b/changelogs/unreleased/gh-11929-memtx-mvcc-failing-index-count-limit-assertion.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed a crash when using the maximum allowed number of indexes with Memtx-MVCC
+  enabled (gh-11929).

--- a/test/box-luatest/gh_11929_memtx_mvcc_failing_index_count_limit_assertion_test.lua
+++ b/test/box-luatest/gh_11929_memtx_mvcc_failing_index_count_limit_assertion_test.lua
@@ -1,0 +1,38 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('gh-11929-memtx-mvcc-failing-index-count-limit-assertion')
+--
+-- gh-11929: memtx mvcc failing index count limit assertion
+--
+
+g.before_all(function()
+    g.server = server:new{box_cfg = {memtx_use_mvcc_engine = true}}
+    g.server:start()
+
+    g.server:exec(function()
+        box.schema.space.create("test")
+    end)
+end)
+
+g.after_each(function()
+    g.server:exec(function() box.space.test:truncate() end)
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+g.test_index_id = function()
+    g.server:exec(function()
+        for i = 1, box.schema.INDEX_MAX do
+            box.space.test:create_index(
+                ('idx_%d'):format(i),
+                {parts={{i, is_nullable=(i > 1)}}, unique=true}
+            )
+        end
+
+        box.space.test:replace{1}
+        t.assert_equals(box.space.test:get(1), {1})
+    end)
+end


### PR DESCRIPTION
*(This PR is a backport of #11930 to `release/3.3` to a future `3.3.4` release.)*

----

Fixed a crash when using the maximum allowed number of indexes with Memtx-MVCC enabled.

Closes #11929

NO_DOC=bugfix