### PR TITLE
config: failover HTTP and metrics configuration

### DIFF
--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -992,6 +992,93 @@ I['failover.log.to'] = format_text([[
     - `file`: write logs to a file defined in `failover.log.file`
 ]])
 
+I['failover.http'] = format_text([[
+    The `failover.http` subsection configures HTTP listeners for the
+    failover coordinator API. This functionality is available only in
+    Tarantool Enterprise. It allows the failover coordinator to expose
+    HTTP endpoints that provide monitoring metrics and health checks.
+]])
+
+I['failover.http.listen'] = format_text([[
+    A list of HTTP endpoints that should be started for the failover
+    coordinator. Each entry must describe a listener bound to a
+    `localhost:<port>` URI. These endpoints are used to expose metrics
+    and other health check information about the failover coordinator.
+]])
+
+I['failover.http.listen.*'] = format_text([[
+    This entry configures an individual HTTP listener for the failover
+    coordinator. You can specify the URI and parameters for the listener.
+]])
+
+I['failover.http.listen.*.uri'] = format_text([[
+    A URI in the `<host>:<port>` format that defines where the
+    failover coordinator listens for HTTP requests.
+]])
+
+I['failover.http.listen.*.params'] = I['<uri>.params']
+
+I['failover.http.listen.*.params.transport'] =
+    I['<uri>.params.transport']
+
+I['failover.http.listen.*.params.ssl_key_file'] =
+    I['<uri>.params.ssl_key_file']
+
+I['failover.http.listen.*.params.ssl_cert_file'] =
+    I['<uri>.params.ssl_cert_file']
+
+I['failover.http.listen.*.params.ssl_ca_file'] =
+    I['<uri>.params.ssl_ca_file']
+
+I['failover.http.listen.*.params.ssl_ciphers'] =
+    I['<uri>.params.ssl_ciphers']
+
+I['failover.http.listen.*.params.ssl_password'] =
+    I['<uri>.params.ssl_password']
+
+I['failover.http.listen.*.params.ssl_password_file'] =
+    I['<uri>.params.ssl_password_file']
+
+I['failover.http.listen.*.params.ssl_verify_client'] = format_text([[
+    Controls whether the failover coordinator verifies client SSL certificates.
+
+    The option accepts the following values:
+
+    - `off` (default): client certificates are not verified.
+    - `on`: the server requires and verifies client certificates.
+    - `optional`: the server verifies client certificates only if they are
+      provided by the client.
+]])
+
+I['failover.metrics'] = format_text([[
+    The `failover.metrics` subsection configures metrics exporters for the
+    failover coordinator. This functionality is available only in
+    Tarantool Enterprise. It allows the failover coordinator to expose
+    monitoring metrics through various formats like Prometheus, JSON, etc.
+]])
+
+I['failover.metrics.exporters'] = format_text([[
+    A list of endpoints that expose the failover coordinator metrics. Each
+    exporter corresponds to an HTTP endpoint and a specific format for the
+    exported metrics.
+]])
+
+I['failover.metrics.exporters.*'] = format_text([[
+    This entry configures an individual exporter. You can specify the
+    URI path and the format for the metrics.
+]])
+
+I['failover.metrics.exporters.*.path'] = format_text([[
+    A URI path that should be used to serve metrics. For example,
+    `/metrics/prometheus`, `/metrics/json`, etc.
+]])
+
+I['failover.metrics.exporters.*.format'] = format_text([[
+    A format of the exported metrics. Supported values are `prometheus`,
+    `zabbix`, `telegraf`, and `json`. Each exporter will serve metrics in
+    the specified format.
+]])
+
 I['failover.probe_interval'] = format_text([[
     A time interval (in seconds) that specifies how often a monitoring service
     of the failover coordinator polls an instance for its status.

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2033,6 +2033,70 @@ return schema.new('instance_config', schema.record({
         }, {
             validate = validators['failover.log'],
         }),
+        http = enterprise_edition(schema.record({
+            listen = schema.array({
+                items = schema.record({
+                    uri = schema.scalar({
+                        type = 'string',
+                        validate = validators['failover.http.listen.*.uri'],
+                    }),
+                    params = schema.record({
+                        transport = schema.enum({
+                            'plain',
+                            'ssl',
+                        }),
+                        ssl_key_file = enterprise_edition(schema.scalar({
+                            type = 'string',
+                        })),
+                        ssl_cert_file = enterprise_edition(schema.scalar({
+                            type = 'string',
+                        })),
+                        ssl_ca_file = enterprise_edition(schema.scalar({
+                            type = 'string',
+                        })),
+                        ssl_ciphers = enterprise_edition(schema.scalar({
+                            type = 'string',
+                        })),
+                        ssl_password = enterprise_edition(schema.scalar({
+                            type = 'string',
+                        })),
+                        ssl_password_file = enterprise_edition(schema.scalar({
+                            type = 'string',
+                        })),
+                        ssl_verify_client = schema.enum({
+                            'off',
+                            'on',
+                            'optional',
+                        }, {
+                            default = 'off',
+                        }),
+                    }),
+                }),
+            }),
+        }, {
+            validate = validators['failover.http'],
+        })),
+        metrics = enterprise_edition(schema.record({
+            exporters = schema.array({
+                items = schema.record({
+                    path = schema.scalar({
+                        type = 'string',
+                        validate =
+                            validators['failover.metrics.exporters.*.path'],
+                    }),
+                    format = schema.enum({
+                        'prometheus',
+                        'zabbix',
+                        'telegraf',
+                        'json',
+                    }, {
+                        default = 'prometheus',
+                    }),
+                }),
+            }),
+        }, {
+            validate = validators['failover.metrics'],
+        })),
     }, {
         validate = validators['failover'],
     }),

--- a/src/box/lua/config/validators.lua
+++ b/src/box/lua/config/validators.lua
@@ -181,6 +181,41 @@ M['failover'] = function(_data, w)
     validate_scope(w, {'global'})
 end
 
+M['failover.http'] = function(data, w)
+    if data == nil or next(data) == nil then
+        return
+    end
+    local listen = data.listen or {}
+    if next(listen) == nil then
+        w.error('failover.http.listen must define at least one listener')
+    end
+
+    if #listen > 1 then
+        w.error('failover.http.listen must define only one URI')
+    end
+end
+
+M['failover.http.listen.*.uri'] = function(value, w)
+    validate_uri_field(false, false)(value, w)
+    local parsed = urilib.parse(value)
+    if parsed.service == nil then
+        w.error('failover.http.listen.uri must include a port: %q', value)
+    end
+end
+
+M['failover.metrics'] = function(data, w)
+    if data == nil then
+        w.error("failover.metrics must define at least one exporter")
+    end
+end
+
+M['failover.metrics.exporters.*.path'] = function(value, w)
+    if not value:startswith('/') then
+        w.error('failover.metrics.exporters.path must start with "/": %q',
+                value)
+    end
+end
+
 M['failover.log'] = function(data, w)
     if data.to == 'file' and data.file == nil then
         w.error('log.file must be specified when log.to is "file"')

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1853,6 +1853,32 @@ g.test_failover = function()
         }
     }
 
+    if is_enterprise then
+        iconfig.failover.http = {
+            listen = {{
+                uri = '127.0.0.1:8080',
+                params = {
+                    transport = 'ssl',
+                    ssl_key_file = 'five',
+                    ssl_cert_file = 'six',
+                    ssl_ca_file = 'seven',
+                    ssl_ciphers = 'eight',
+                    ssl_password = 'nine',
+                    ssl_password_file = 'ten',
+                    ssl_verify_client = 'on',
+                },
+            }},
+        }
+        iconfig.failover.metrics = {
+            exporters = {
+                {
+                    path = '/metrics',
+                    format = 'prometheus',
+                },
+            },
+        }
+    end
+
     instance_config:validate(iconfig)
     validate_fields(iconfig.failover, instance_config.schema.fields.failover)
 


### PR DESCRIPTION
This patch adds the `failover.http` and `failover.metrics` sections to the configuration schema for failover coordinator monitoring. It introduces support for configuring HTTP listeners (`failover.http.listen`) with SSL options, and adds the `failover.metrics.exporters` section for metrics exporters (Prometheus, JSON, Telegraf, Zabbix).

Part of tarantool/tarantool-ee#1530

NO_DOC=will be done in EE
NO_CHANGELOG=will be done in EE