### PR TITLE
lib/bit: introduce bit_copy_range_reverse()

### DIFF
--- a/src/lib/bit/bit.h
+++ b/src/lib/bit/bit.h
@@ -313,6 +313,20 @@ bit_copy_range(uint8_t *restrict dst, size_t dst_i, const uint8_t *restrict src,
 	       size_t src_i, size_t count);
 
 /**
+ * @brief Copy \a count bits from memory chunk \a src starting from bit \a src_i
+ *  in backward order into \a dst starting from bit \a dst_i in forward order.
+ * @param dst - the memory chunk to copy bits into.
+ * @param dst_i - the position to copy bits into.
+ * @param count - the amount of bits to copy.
+ * @param src - the memory chunk to copy bits from.
+ * @param src_i - the position to copy bits from.
+ * @pre the bit buffers do not overlap.
+ */
+void
+bit_copy_range_reverse(uint8_t *restrict dst, size_t dst_i,
+		       const uint8_t *restrict src, size_t src_i, size_t count);
+
+/**
  * @cond false
  * @brief Naive implementation of ctz.
  */
@@ -592,6 +606,20 @@ bswap_u64(uint64_t x)
 		( (x >> 40) & UINT64_C(0x000000000000ff00)) |
 		( (x >> 56) & UINT64_C(0x00000000000000ff));
 #endif
+}
+
+/**
+ * @brief Reverse bits in \a x.
+ * @param x value
+ * @return value with bits reversed
+ */
+static inline uint8_t
+bit_reverse_u8(uint8_t x)
+{
+	x = ((x & 0x55) << 1) | ((x >> 1) & 0x55);
+	x = ((x & 0x33) << 2) | ((x >> 2) & 0x33);
+	x = (x << 4) | (x >> 4);
+	return x;
 }
 
 /**

--- a/test/unit/bit.result
+++ b/test/unit/bit.result
@@ -718,10 +718,16 @@ Clear: 0, 1, 2, 4, 5, 6, 7, 8, 10, 12, 13, 14, 15, 19, 20, 21, 23, 26, 28, 30, 3
 	*** test_bit_set_range ***
 	*** test_bit_set_range: done ***
 	*** test_bit_copy_range ***
-Source value: true
+Reverse: false, source value: true
 	*** test_bit_copy_range: done ***
 	*** test_bit_copy_range ***
-Source value: false
+Reverse: false, source value: false
+	*** test_bit_copy_range: done ***
+	*** test_bit_copy_range ***
+Reverse: true, source value: true
+	*** test_bit_copy_range: done ***
+	*** test_bit_copy_range ***
+Reverse: true, source value: false
 	*** test_bit_copy_range: done ***
 	*** test_bit_count ***
 	*** test_bit_count: done ***


### PR DESCRIPTION
This routine will allow us to scan faster in reverse order in MemCS.

While at it we also relax assertion a bit in `bit_copy_range()` (there is off by one there). Also we don't need `DIV_ROUND_UP` there, plain `/` does the job.

Part of tarantool/tarantool-ee#1479