### PR TITLE
box: fix yielding DDL ordering on WAL failure

### DIFF
--- a/changelogs/unreleased/gh-11833-yielding-ddl-dd-order-on-wal-failure.md
+++ b/changelogs/unreleased/gh-11833-yielding-ddl-dd-order-on-wal-failure.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed a crash that could happen if two DDL operations (index build or space
+  format change) were executed on the same space and a WAL write error occurred
+  (gh-11833).

--- a/src/box/alter.h
+++ b/src/box/alter.h
@@ -34,7 +34,9 @@
 
 extern struct trigger before_replace_schema;
 
+extern struct trigger alter_space_before_replace_space;
 extern struct trigger alter_space_on_replace_space;
+extern struct trigger alter_space_before_replace_index;
 extern struct trigger alter_space_on_replace_index;
 extern struct trigger on_replace_truncate;
 extern struct trigger on_replace_schema;

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -371,6 +371,9 @@ schema_init(void)
 	/* _space - home for all spaces. */
 	sc_space_new(BOX_SPACE_ID, "_space", key_parts, 1,
 		     &alter_space_on_replace_space);
+	struct space *space = space_by_id(BOX_SPACE_ID);
+	assert(space != NULL);
+	trigger_add(&space->before_replace, &alter_space_before_replace_space);
 
 	/* _truncate - auxiliary space for triggering space truncation. */
 	sc_space_new(BOX_TRUNCATE_ID, "_truncate", key_parts, 1,
@@ -418,6 +421,9 @@ schema_init(void)
 	key_parts[1].type = FIELD_TYPE_UNSIGNED;
 	sc_space_new(BOX_INDEX_ID, "_index", key_parts, 2,
 		     &alter_space_on_replace_index);
+	struct space *index = space_by_id(BOX_INDEX_ID);
+	assert(index != NULL);
+	trigger_add(&index->before_replace, &alter_space_before_replace_index);
 
 	/* _fk_сonstraint - foreign keys constraints. */
 	key_parts[0].fieldno = 0; /* constraint name */

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -570,6 +570,15 @@ space_has_before_replace_triggers(struct space *space)
 }
 
 /**
+ * Check if the space has registered user-defined before_replace triggers.
+ */
+static inline bool
+space_has_before_replace_event_triggers(struct space *space)
+{
+	return space_event_has_triggers(&space->before_replace_event);
+}
+
+/**
  * Run on_replace triggers registered for a space.
  */
 int

--- a/test/box-luatest/gh_11833_two_ddl_of_the_same_space_in_a_row_rollback_test.lua
+++ b/test/box-luatest/gh_11833_two_ddl_of_the_same_space_in_a_row_rollback_test.lua
@@ -1,0 +1,124 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('gh-11833-two-ddl-of-the-same-space-in-a-row-rollback')
+--
+-- gh-11833: two ddl of the same space in a row rollback
+--
+
+g.before_all(function()
+    t.tarantool.skip_if_not_debug()
+
+    g.server = server:new{}
+    g.server:start()
+
+    g.server:exec(function()
+        box.schema.create_space('test')
+        box.space.test:create_index('pk')
+    end)
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+g.after_each(function()
+    g.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end)
+end)
+
+g.test_two_ddl_of_the_same_space_in_a_row_rollback = function()
+    g.server:exec(function()
+        local fiber = require('fiber')
+
+        local format_default = {
+            {'a', 'unsigned'},
+            {'b', 'unsigned'},
+        }
+
+        local format_nullable = {
+            {'a', 'unsigned'},
+            {'b', 'unsigned', is_nullable = true},
+        }
+
+        box.space.test:format(format_default)
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+
+        -- Change format in _space and wait for it to go to WAL.
+        fiber.create(function()
+            box.space.test:format(format_nullable)
+        end)
+
+        -- Change format in _space and wait for the first fiber to complete.
+        local f = fiber.create(function()
+            box.space.test:format(format_default)
+        end)
+        f:set_joinable(true)
+
+        -- WAL write failed so rollback in _space is done for the format
+        -- change from the first fiber which breaks change order.
+        box.error.injection.set('ERRINJ_WAL_WRITE', true)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+
+        local ok, err = f:join()
+        t.assert_not(ok)
+        t.assert_covers(err:unpack(), {
+            type = 'ClientError',
+            code = box.error.ALTER_SPACE,
+            message = string.format("Can't modify space '%d': " ..
+                "the space was concurrently modified", box.space.test.id)
+        })
+    end)
+end
+
+g.test_third_ddl_while_second_waits_in_alter_yield_guard = function()
+    g.server:exec(function()
+        local fiber = require('fiber')
+
+        local format_default = {
+            {'a', 'unsigned'},
+            {'b', 'unsigned'},
+        }
+
+        local format_nullable = {
+            {'a', 'unsigned'},
+            {'b', 'unsigned', is_nullable = true},
+        }
+
+        box.space.test:format(format_default)
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+
+        local f1 = fiber.create(function()
+            box.space.test:format(format_nullable)
+        end)
+        f1:set_joinable(true)
+
+        local f2 = fiber.create(function()
+            box.space.test:format(format_default)
+        end)
+        f2:set_joinable(true)
+
+        local f3 = fiber.new(function()
+            box.space.test:format(format_default)
+        end)
+        f3:set_joinable(true)
+
+        local ok, err = f3:join()
+        t.assert_not(ok)
+        t.assert_covers(err:unpack(), {
+            type = 'ClientError',
+            code = box.error.ALTER_SPACE,
+            message = string.format("Can't modify space 'test': " ..
+                "the space is already being modified")
+        })
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+
+        t.assert(f1:join())
+        t.assert(f2:join())
+    end)
+end


### PR DESCRIPTION
Serialize yielding DDL operations on the same space to avoid reordering of data dictionary updates when the first DDL updated _space/_index in-memory and then failed to write to WAL.

To do so, add internal before_replace triggers for _space and _index that wait for completion of previous yielding alters on the same space before applying the next change.

Closes https://github.com/tarantool/tarantool/issues/11833

NO_DOC=bugfix
