### PR TITLE
read view closing performance improvement

### DIFF
--- a/changelogs/unreleased/gh-12115-space-format-update-perf.md
+++ b/changelogs/unreleased/gh-12115-space-format-update-perf.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed performance degradation when updating space format or dropping a
+  space due to inefficient tuple dictionary cleanup (gh-12115).

--- a/perf/lua/CMakeLists.txt
+++ b/perf/lua/CMakeLists.txt
@@ -91,6 +91,10 @@ create_perf_lua_test(NAME column_insert
                      DEPENDS column_insert_module
 )
 
+if(ENABLE_READ_VIEW)
+  create_perf_lua_test(NAME read_view_open_close)
+endif()
+
 add_custom_target(test-lua-perf
                   COMMAND ${CMAKE_CTEST_COMMAND}
                           ${TARANTOOL_PERF_CTEST_FLAGS}

--- a/perf/lua/read_view_open_close.lua
+++ b/perf/lua/read_view_open_close.lua
@@ -1,0 +1,60 @@
+local fio = require('fio')
+local benchmark = require('benchmark')
+local clock = require('clock')
+
+local USAGE = [[
+   field_count <number, 10000>  - the number of fields in the space format
+   minimum_run_time <number, 5> - minimal time to run in seconds
+]]
+
+local params = benchmark.argparse(arg, {
+    {'field_count', 'number'},
+    {'minimum_run_time', 'number'},
+}, USAGE)
+local bench = benchmark.new(params)
+
+params.field_count = params.field_count or 10000
+params.minimum_run_time = params.minimum_run_time or 5
+
+local test_dir = fio.tempdir()
+
+box.cfg{
+    log = 'tarantool.log',
+    work_dir = test_dir,
+}
+
+local format = {}
+for i = 1, params.field_count do
+    table.insert(format, {name = 'field'..i, type = 'uint64'})
+end
+
+box.schema.space.create('test', {
+    engine = 'memtx',
+    format = format,
+    field_count = params.field_count,
+})
+
+local start_time = {
+    time = clock.time(),
+    proc = clock.proc(),
+}
+
+local delta_real
+local count = 0
+repeat
+    local rv = box.read_view.open()
+    rv:close()
+    delta_real = clock.time() - start_time.time
+    count = count + 1
+until delta_real > params.minimum_run_time
+
+bench:add_result('open_close', {
+    items = count,
+    real_time = clock.time() - start_time.time,
+    cpu_time = clock.proc() - start_time.proc,
+})
+
+bench:dump_results()
+
+fio.rmtree(test_dir)
+os.exit(0)

--- a/src/box/tuple_dictionary.c
+++ b/src/box/tuple_dictionary.c
@@ -41,10 +41,6 @@ field_name_hash_f field_name_hash;
 static inline void
 tuple_dictionary_delete_hash(struct mh_strnu32_t *hash)
 {
-	while (mh_size(hash)) {
-		mh_int_t i = mh_first(hash);
-		mh_strnu32_del(hash, i, NULL);
-	}
 	mh_strnu32_delete(hash);
 }
 


### PR DESCRIPTION
Inside `tuple_dictionary_delete_hash`, there was a loop that, on each iteration, searched for the first non-deleted element using `mh_first`, which has a complexity of `O(n)`, and deleted it using `mh_strnu32_del`. After the loop finished executing, `tuple_dictionary_delete_hash` immediately called `mh_strnu32_delete`.
All elements are stored in the hashmap inplace, so `del` doesn't invoke any memory deallocation functions. `del` also doesn't call destructors for the elements; it merely sets a specific bit in the bitmap to 0. Immediately after the loop, `mh_strnu32_delete(hash)` will delete the hashmap `hash` along with the array `hash->p` containing all elements inplace.

This PR simply removes this useless loop, which was causing significant performance issues when closing a read view.

Closes tarantool/tarantool-ee#1043, #12115

NO_DOC=performance improvement
NO_TEST=performance improvement
