### PR TITLE
lib: extend bloom API

### DIFF
--- a/src/box/tuple_bloom.h
+++ b/src/box/tuple_bloom.h
@@ -55,6 +55,14 @@ enum tuple_bloom_version {
 	TUPLE_BLOOM_VERSION_V3,
 };
 
+/** Holder for bloom filter definition along with its data. */
+struct tuple_bloom_part {
+	/* Definition of the bloom filter. */
+	struct bloom bloom;
+	/* Data of the bloom filter. */
+	char *data;
+};
+
 /**
  * Tuple bloom filter.
  *
@@ -69,7 +77,7 @@ struct tuple_bloom {
 	/** Number of key parts. */
 	uint32_t part_count;
 	/** Array of bloom filters, one per each partial key. */
-	struct bloom parts[0];
+	struct tuple_bloom_part parts[0];
 };
 
 /**
@@ -162,7 +170,7 @@ tuple_bloom_builder_add_key(struct tuple_bloom_builder *builder,
  * Create a new tuple bloom filter.
  * @param builder - bloom filter builder
  * @param fpr - desired false positive rate
- * @return bloom filter on success or NULL on OOM
+ * @return bloom filter, never fails (never returns NULL)
  */
 struct tuple_bloom *
 tuple_bloom_new(struct tuple_bloom_builder *builder, double fpr);
@@ -223,7 +231,7 @@ tuple_bloom_encode(const struct tuple_bloom *bloom, char *buf);
  * @param data - pointer to buffer storing encoded bloom filter;
  *  on success it is advanced by the number of decoded bytes
  * @param version - how to interpret the data.
- * @return the decoded bloom on success or NULL on OOM
+ * @return the decoded bloom, never fails (never returns NULL)
  */
 struct tuple_bloom *
 tuple_bloom_decode(const char **data, enum tuple_bloom_version version);

--- a/src/box/vy_run.c
+++ b/src/box/vy_run.c
@@ -700,8 +700,6 @@ vy_run_info_decode(struct vy_run_info *run_info,
 		case VY_RUN_INFO_BLOOM_FILTER:
 			run_info->bloom = tuple_bloom_decode(
 				&pos, iproto_to_tuple_bloom_version(key));
-			if (run_info->bloom == NULL)
-				return -1;
 			break;
 		case VY_RUN_INFO_STMT_STAT:
 			vy_stmt_stat_decode(&run_info->stmt_stat, &pos);
@@ -2416,12 +2414,9 @@ vy_run_writer_commit(struct vy_run_writer *writer)
 		goto out;
 	}
 
-	if (writer->bloom != NULL) {
+	if (writer->bloom != NULL)
 		run->info.bloom = tuple_bloom_new(writer->bloom,
 						  writer->bloom_fpr);
-		if (run->info.bloom == NULL)
-			goto out;
-	}
 	if (vy_run_write_index(run, writer->dirpath,
 			       writer->space_id, writer->iid) != 0)
 		goto out;
@@ -2555,8 +2550,6 @@ vy_run_rebuild_index(struct vy_run *run, const char *dir,
 	if (bloom_builder != NULL) {
 		run->info.bloom = tuple_bloom_new(bloom_builder,
 						  opts->bloom_fpr);
-		if (run->info.bloom == NULL)
-			goto close_err;
 		tuple_bloom_builder_delete(bloom_builder);
 		bloom_builder = NULL;
 	}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -276,7 +276,7 @@ create_unit_test(PREFIX light_view
 )
 create_unit_test(PREFIX bloom
                  SOURCES bloom.cc
-                 LIBRARIES salad
+                 LIBRARIES salad unit
 )
 create_unit_test(PREFIX vclock
                  SOURCES vclock.cc core_test_utils.c

--- a/test/unit/bloom.result
+++ b/test/unit/bloom.result
@@ -1,6 +1,0 @@
-*** simple_test ***
-error_count = 0
-fp_rate_too_big = 0
-*** store_load_test ***
-error_count = 0
-fp_rate_too_big = 0


### PR DESCRIPTION
Currently, bloom filter doesn't allow to restore it from saved table without copy and create it with manually allocated table. This logic is required for MemCS skip index, so the commit adds this zero-copy API to bloom filter.

Also, we need a method merging two bloom filters into one, so this commit adds it as well.

Part of tarantool/tarantool-ee#1431

**EE part**: https://github.com/tarantool/tarantool-ee/pull/1554