### PR TITLE
box: export aggregates option to index object

### DIFF
--- a/test/box-luatest/index_aggregates_test.lua
+++ b/test/box-luatest/index_aggregates_test.lua
@@ -111,3 +111,13 @@ g.test_unsupported = function(cg)
         }, s.create_index, s, 'pk', {aggregates = {{field = 1}}})
     end)
 end
+
+-- Aggregates attribute is optional and mustn't appear in index object
+-- if it doesn't have it.
+g.test_index_object_aggregates = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test', {engine = 'memtx'})
+        local pk = s:create_index('pk')
+        t.assert_equals(pk.aggregates, nil)
+    end)
+end


### PR DESCRIPTION
Let's export index aggregates option to associated Lua index object just as we do with all other options. Note that all CE indexes don't support this option, so it will be covered with test in EE.

Part of tarantool/tarantool-ee#1429

EE part: https://github.com/tarantool/tarantool-ee/pull/1557