### PR TITLE
[backport 3.3] config: introduce an `iproto.ssl` section

### DIFF
--- a/changelogs/unreleased/gh-12030-poor-ssl-option-usage.md
+++ b/changelogs/unreleased/gh-12030-poor-ssl-option-usage.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* IPROTO SSL options can now be properly configured by specifying the
+  `iproto.ssl` section.

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -49,7 +49,8 @@ local function peer_uris(configdata)
         local isolated = instance_config:get(iconfig_def, 'isolated')
         if not is_anon and not isolated then
             local uri = instance_config:instance_uri(iconfig_def, 'peer',
-                {log_prefix = "replicaset dataflow configuration: "})
+                {log_prefix = "replicaset dataflow configuration: ",
+                 self_iconfig = configdata._iconfig_def})
             if uri == nil then
                 log.info('%s: instance %q has no iproto.advertise.peer or ' ..
                     'iproto.listen URI suitable to create a client socket',
@@ -67,6 +68,25 @@ local function peer_uris(configdata)
     end
 
     return uris
+end
+
+local function set_listen(configdata, box_cfg)
+    -- Construct box_cfg.listen.
+    if box_cfg.listen == nil then
+        local configured_listen =
+            configdata:get('iproto.listen', {use_default = true})
+        local listen = box.NULL
+
+        if configured_listen ~= nil then
+            listen = {}
+
+            for _, uri in ipairs(configured_listen) do
+                table.insert(listen, configdata:_enhance_uri_ssl_params(uri))
+            end
+        end
+
+        box_cfg.listen = listen
+    end
 end
 
 -- Modify box-level configuration values and perform other actions
@@ -565,6 +585,8 @@ local function apply(config)
     -- TODO: drop this when default for array value will be supported.
     if configdata:get('iproto.listen') == nil then
         box_cfg.listen = box.NULL
+    else
+        set_listen(configdata, box_cfg)
     end
 
     -- Construct box_cfg.replication.

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -72,8 +72,14 @@ end
 
 function methods._instance_uri(self, uri_type, opts, log_opts)
     assert(uri_type == 'peer' or uri_type == 'sharding')
+    local instance_uri_opts = table.copy(log_opts or {})
+    instance_uri_opts.self_iconfig = self._iconfig_def
     return instance_config:instance_uri(choose_iconfig(self, opts), uri_type,
-                                        log_opts)
+                                        instance_uri_opts)
+end
+
+function methods._enhance_uri_ssl_params(self, uri)
+    return instance_config:enhance_uri_ssl_params(self._iconfig_def, uri)
 end
 
 -- Generate a part of a vshard configuration that relates to

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -1372,6 +1372,74 @@ I['iproto.readahead'] = format_text([[
     leave this setting at its default.
 ]])
 
+I['iproto.ssl'] = format_text([[
+    SSL parameters required for encrypted connections. These parameters would be
+    used to set up SSL IProto sockets and to connect to other instances which
+    require certificate authority (CA).
+]])
+
+I['iproto.ssl.ca_file'] = format_text([[
+    (Optional) A path to a trusted certificate authorities (CA) file. If not
+    set, the peer won't be checked for authenticity.
+
+    Both a server and a client can use the ca_file parameter:
+
+    - If it's on the server side, the server verifies the client.
+    - If it's on the client side, the client verifies the server.
+    - If both sides have the CA files, the server and the client verify each
+      other.
+]])
+
+I['iproto.ssl.ssl_cert'] = format_text([[
+    A path to an SSL certificate file:
+
+    - For a server, it's mandatory.
+    - For a client, it's mandatory if the ca_file parameter is set for a
+      server; otherwise, optional.
+]])
+
+I['iproto.ssl.ssl_ciphers'] = format_text([[
+    (Optional) A colon-separated (:) list of SSL cipher suites the connection
+    can use. Note that the list is not validated: if a cipher suite is unknown,
+    Tarantool ignores it, doesn't establish the connection, and writes to the
+    log that no shared cipher was found.
+]])
+
+I['iproto.ssl.ssl_key'] = format_text([[
+    A path to a private SSL key file:
+
+    - For a server, it's mandatory.
+    - For a client, it's mandatory if the `ca_file` parameter is set for a
+      server; otherwise, optional.
+
+    If the private key is encrypted, provide a password for it in the
+    `ssl_password` or `ssl_password_file` parameter
+]])
+
+I['iproto.ssl.ssl_password'] = format_text([[
+    (Optional) A password for an encrypted private SSL key provided using
+    `ssl_key`. Alternatively, the password can be provided in
+    `ssl_password_file`.
+
+    Tarantool applies the `ssl_password` and `ssl_password_file` parameters in
+    the following order:
+
+    - If `ssl_password` is provided, Tarantool tries to decrypt the
+      private key with it.
+    - If `ssl_password` is incorrect or isn't provided, Tarantool
+      tries all passwords from `ssl_password_file` one by one in the
+      order they are written.
+    - If `ssl_password` and all passwords from `ssl_password_file`
+      are incorrect, or none of them is provided, Tarantool treats
+      the private key as unencrypted.
+]])
+
+I['iproto.ssl.ssl_password_file'] = format_text([[
+    (Optional) A text file with one or more passwords for encrypted private
+    SSL keys provided using `ssl_key` (each on a separate line). Alternatively,
+    the password can be provided in `ssl_password`.
+]])
+
 I['iproto.threads'] = format_text([[
     The number of network threads. There can be unusual workloads where the
     network thread is 100% loaded and the transaction processor thread is not,

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -274,8 +274,36 @@ local function find_password(self, iconfig, username)
     return nil
 end
 
+local function enhance_uri_ssl_params(self, iconfig, uri)
+    if uri.params == nil or uri.params.transport ~= 'ssl' then
+        return uri
+    end
+
+    local uri = table.copy(uri)
+    uri.params = table.copy(uri.params)
+
+    local ssl = self:get(iconfig, 'iproto.ssl') or {}
+    local ssl_params = {
+        ssl_ca_file = ssl.ca_file,
+        ssl_key_file = ssl.ssl_key,
+        ssl_cert_file = ssl.ssl_cert,
+        ssl_ciphers = ssl.ssl_ciphers,
+        ssl_password = ssl.ssl_password,
+        ssl_password_file = ssl.ssl_password_file,
+    }
+
+    for k, v in pairs(ssl_params) do
+        if uri.params[k] == nil then
+            uri.params[k] = v
+        end
+    end
+
+    return uri
+end
+
 local function instance_uri(self, iconfig, advertise_type, opts)
-    assert(advertise_type == 'peer' or advertise_type == 'sharding')
+    assert(advertise_type == 'peer' or advertise_type == 'sharding' or
+           advertise_type == 'listen')
 
     -- An effective value of iproto.advertise.sharding defaults to
     -- iproto.advertise.peer.
@@ -311,6 +339,11 @@ local function instance_uri(self, iconfig, advertise_type, opts)
         uri = table.copy(uri)
         uri.password = find_password(self, iconfig, uri.login)
     end
+
+    if opts and opts.self_iconfig then
+        uri = enhance_uri_ssl_params(self, opts.self_iconfig, uri)
+    end
+
     return uri
 end
 
@@ -954,7 +987,6 @@ return schema.new('instance_config', schema.record({
                     end
                 end,
             }),
-            box_cfg = 'listen',
         }),
         -- URIs for clients to let them know where to connect.
         --
@@ -1137,6 +1169,26 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'readahead',
             default = 16320,
         }),
+        ssl = enterprise_edition(schema.record({
+            ca_file = schema.scalar({
+                type = 'string',
+            }),
+            ssl_cert = schema.scalar({
+                type = 'string',
+            }),
+            ssl_ciphers = schema.scalar({
+                type = 'string',
+            }),
+            ssl_key = schema.scalar({
+                type = 'string',
+            }),
+            ssl_password = schema.scalar({
+                type = 'string',
+            }),
+            ssl_password_file = schema.scalar({
+                type = 'string',
+            }),
+        })),
     }),
     database = schema.record({
         instance_uuid = schema.scalar({
@@ -2654,6 +2706,7 @@ return schema.new('instance_config', schema.record({
         apply_vars = apply_vars,
         base_dir = base_dir,
         prepare_file_path = prepare_file_path,
+        enhance_uri_ssl_params = enhance_uri_ssl_params,
     },
     _extra_annotations = {
         descriptions = descriptions.instance_descriptions,

--- a/src/box/lua/config/source/env.lua
+++ b/src/box/lua/config/source/env.lua
@@ -142,8 +142,18 @@ function methods.sync(self, _config_module, _iconfig)
     -- They can be handled separately if there is a demand.
     if self.name == 'env (default)' then
         for _, w in instance_config:pairs() do
+            -- Listen is really special since it is also handled
+            -- separately in the box.cfg and do not have the
+            -- box_cfg annotation.
+            local is_listen = #w.path == 2 and w.path[1] == 'iproto' and
+                              w.path[2] == 'listen'
             if w.schema.box_cfg ~= nil then
                 local value = box_cfg_env_var(w.schema.box_cfg)
+                if value ~= nil then
+                    instance_config:set(values, w.path, value)
+                end
+            elseif is_listen then
+                local value = box_cfg_env_var('listen')
                 if value ~= nil then
                     instance_config:set(values, w.path, value)
                 end

--- a/src/box/lua/net_replicaset.lua
+++ b/src/box/lua/net_replicaset.lua
@@ -326,7 +326,6 @@ local function connect_by_rs_name(replicaset_name, cfg)
     cfg = cfg or {}
     check_options(cfg, connect_by_name_cfg_template, 'connect cfg')
     local config = require('config')
-    local instance_config = require('internal.config.instance_config')
 
     local connect_cfg = {
         name = replicaset_name,
@@ -336,8 +335,8 @@ local function connect_by_rs_name(replicaset_name, cfg)
     for _, instance_info in pairs(config:instances()) do
         if instance_info.replicaset_name == replicaset_name then
             local instance_name = instance_info.instance_name
-            local iconfig = config:get('', {instance = instance_name})
-            local endpoint = instance_config:instance_uri(iconfig, 'sharding')
+            local endpoint = config:instance_uri('sharding',
+                                                 {instance = instance_name})
             connect_cfg.instances[instance_name] = {endpoint = endpoint}
         end
     end

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -495,6 +495,14 @@ g.test_iproto_enterprise = function()
             threads = 1,
             net_msg_max = 1,
             readahead = 1,
+            ssl = {
+                ssl_key = 'one',
+                ssl_cert = 'two',
+                ca_file = 'three',
+                ssl_ciphers = 'four',
+                ssl_password = 'five',
+                ssl_password_file = 'six',
+            },
         },
     }
     instance_config:validate(iconfig)
@@ -1399,6 +1407,7 @@ g.test_box_cfg_coverage = function()
         metrics = true,
         audit_log = true,
         audit_filter = true,
+        listen = true,
 
         -- Controlled by the leader and database.mode options,
         -- handled by the box_cfg applier.

--- a/test/config-luatest/iproto_ssl_test.lua
+++ b/test/config-luatest/iproto_ssl_test.lua
@@ -1,0 +1,188 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local treegen = require('luatest.treegen')
+local cbuilder = require('luatest.cbuilder')
+local fio = require('fio')
+local yaml = require('yaml')
+
+local g = t.group()
+
+local passwd = '123qwe'
+local cert_dir = fio.pathjoin(fio.abspath(os.getenv('SOURCEDIR') or '.'),
+                              'test/enterprise-luatest/ssl_cert')
+local ca_file = fio.pathjoin(cert_dir, 'ca.crt')
+local cert_file = fio.pathjoin(cert_dir, 'client.crt')
+local key_file = fio.pathjoin(cert_dir, 'client.enc.key')
+local ciphers = 'ECDHE-RSA-AES256-GCM-SHA384'
+
+g.before_all(function()
+    t.tarantool.skip_if_not_enterprise(
+        'The iproto.ssl option is supported only by Tarantool ' ..
+        'Enterprise Edition')
+end)
+
+local function base_config(g)
+    return cbuilder:new()
+        :set_global_option('credentials.users.guest', {roles = {'super'}})
+        :set_global_option('replication.bootstrap_strategy', 'config')
+        :set_global_option('iproto.listen', {
+            {
+                uri = 'unix/:./{{ instance_name }}.iproto',
+                params = {
+                    transport = 'ssl',
+                },
+            },
+        })
+        :set_global_option('iproto.ssl', g.ssl_opts)
+        :add_instance('i-001', {database={mode='rw'}})
+        :add_instance('i-002', {})
+        :set_replicaset_option('bootstrap_leader', 'i-001')
+        :config()
+end
+
+g.before_each(function(g)
+    g.dir = treegen.prepare_directory({}, {})
+    g.passwd_file = fio.pathjoin(g.dir, 'passwd.txt')
+    local file = fio.open(g.passwd_file, {'O_WRONLY', 'O_CREAT'},
+                          tonumber('666', 8))
+    t.assert(file ~= nil)
+    file:write(passwd)
+    file:close()
+
+    -- ssl configuration section.
+    g.ssl_opts = {
+        ca_file = ca_file,
+        ssl_cert = cert_file,
+        ssl_key = key_file,
+        ssl_password = passwd,
+        ssl_password_file = g.passwd_file,
+        ssl_ciphers = ciphers,
+    }
+    -- ssl net.box connection parameters
+    g.ssl_params = {
+        transport = 'ssl',
+        ssl_ca_file = ca_file,
+        ssl_cert_file = cert_file,
+        ssl_key_file = key_file,
+        ssl_password = passwd,
+        ssl_password_file = g.passwd_file,
+        ssl_ciphers = ciphers,
+    }
+end)
+
+g.test_basic = function(g)
+    local dir = g.dir
+    local config = base_config(g)
+
+    local config_file = treegen.write_file(dir, 'config.yaml',
+                                           yaml.encode(config))
+    g.server_1 = server:new({
+        config_file = config_file,
+        chdir = dir,
+        alias = 'i-001',
+    })
+    g.server_2 = server:new({
+        config_file = config_file,
+        chdir = dir,
+        alias = 'i-002',
+    })
+
+    g.server_1:start({wait_until_ready = false})
+    g.server_2:start({wait_until_ready = false})
+
+    g.server_1.net_box_uri = {
+        uri = ('unix/:%s/i-001.iproto'):format(dir),
+        params = g.ssl_params,
+    }
+
+    g.server_1:wait_until_ready()
+
+    g.server_1:exec(function(exp)
+        local config = require('config')
+
+        t.assert_equals(#box.cfg.listen, 1)
+        t.assert_equals(box.cfg.listen[1].params, exp)
+
+        t.assert_equals(#box.cfg.replication, 2)
+        t.assert_equals(box.cfg.replication[2].params, exp)
+
+        local uri = config:instance_uri('peer', {instance = 'i-002'})
+        t.assert_equals(uri.params, exp)
+    end, {g.ssl_params})
+end
+
+g.test_not_affects_non_ssl = function(g)
+    local dir = g.dir
+
+    local listen_no_ssl_uri = {uri = 'unix/:./{{ instance_name }}.iproto'}
+    local config = cbuilder:new(base_config(g))
+        :set_instance_option('i-002', 'iproto.listen', {listen_no_ssl_uri})
+        :config()
+
+    local config_file = treegen.write_file(dir, 'config.yaml',
+                                           yaml.encode(config))
+    g.server_1 = server:new({
+        config_file = config_file,
+        chdir = dir,
+        alias = 'i-001',
+    })
+
+    g.server_1:start({wait_until_ready = false})
+
+    g.server_1.net_box_uri = {
+        uri = ('unix/:%s/i-001.iproto'):format(dir),
+        params = g.ssl_params,
+    }
+
+    g.server_1:wait_until_ready()
+
+    g.server_1:exec(function()
+        local config = require('config')
+
+        t.assert_equals(#box.cfg.replication, 2)
+        t.assert_equals(box.cfg.replication[2].params, box.NULL)
+
+        local uri = config:instance_uri('peer', {instance = 'i-002'})
+        t.assert_equals(uri.params, box.NULL)
+    end)
+end
+
+g.test_affects_advertise = function(g)
+    local dir = g.dir
+    local advertised_uri = 'funny-tarantool-instance.ru:3301'
+    local config = cbuilder:new(base_config(g))
+        :set_instance_option('i-002', 'iproto.advertise.peer', {
+            uri = advertised_uri,
+            params = {transport = 'ssl'},
+        })
+        :config()
+
+    local config_file = treegen.write_file(dir, 'config.yaml',
+                                           yaml.encode(config))
+    g.server_1 = server:new({
+        config_file = config_file,
+        chdir = dir,
+        alias = 'i-001',
+    })
+
+    g.server_1:start({wait_until_ready = false})
+
+    g.server_1.net_box_uri = {
+        uri = ('unix/:%s/i-001.iproto'):format(dir),
+        params = g.ssl_params,
+    }
+
+    g.server_1:wait_until_ready()
+
+    g.server_1:exec(function(exp_uri, exp_params)
+        local config = require('config')
+
+        t.assert_equals(#box.cfg.replication, 2)
+        t.assert_equals(box.cfg.replication[2].uri, exp_uri)
+        t.assert_equals(box.cfg.replication[2].params, exp_params)
+
+        local uri = config:instance_uri('peer', {instance = 'i-002'})
+        t.assert_equals(uri.uri, exp_uri)
+        t.assert_equals(uri.params, exp_params)
+    end, {advertised_uri, g.ssl_params})
+end


### PR DESCRIPTION
*(This PR is a backport of #12031 to `release/3.3` to a future `3.3.4` release.)*

---

This patch introduces a new `iproto.ssl` configuration section that can
be used to configure SSL. Previously, SSL might be configured by
providing `params` section in URIs as mentioned in the documentation
[^1]. The problem is that these URIs have been straightforwardly taken
from the configuration and instances tried to use other instances SSL
private keys to connect to them for replication and when using some of
the builtin modules such as `experimental.connpool`. The details are
available within #12030.

This fix aims to fix this problem. It introduces a new section `ssl`
that basically contains all the information the instance will use to
auth to other instances when using SSL. It uses the schema that
resembles existing `config.etcd.ssl`. Using this SSL works as intended.
Example of the new config.

```yaml
storage-1:
  iproto:
    listen:
      - uri: localhost:3301
        params:
          transport: 'ssl'
    ssl:
      ca_file: './certs/rootCA.pem'
      ssl_cert: './certs/storage-1-crt.pem'
      ssl_key: './certs/storage-1-key.pem'
storage-2:
  iproto:
    listen:
      - uri: localhost:3302
        params:
          transport: 'ssl'
    ssl:
      ca_file: './certs/rootCA.pem'
      ssl_cert: './certs/storage-2-crt.pem'
      ssl_key: './certs/storage-2-key.pem'
```

This configuration makes `storage-1` use the `storage-1` key/cert to set
the IProto socket up and to connect to `storage-2`. And `storage-2` uses
the `storage-2` key/cert to set its socket and to connect to `storage-1`
as it is expected.

Note that the old `param` section is still available. It will overwrite
less explicit behavior of the `ssl` section in favor of the backward
compatibility. Also, the parameters are not supplied to the connections
not using `ssl` as transport.

Unfortunately, using old `param` section is not alerted yet since using
configuration alert system will be introduced later since it requires
some non-trivial decisions like possible integrations with compat module
or suppressing warnings. The related issue about deprecated
configuration option is #12033.

Closes #12030
Closes tarantool/tarantool-ee#1504

NOWRAP
[^1] https://www.tarantool.io/en/doc/latest/reference/configuration/configuration_reference/#uri-params
NOWRAP

@TarantoolBot document
Title: config: new `iproto.ssl` section

A new `iproto.ssl` section has been introduced. It has the following
options.

* `iproto.ssl`

SSL parameters required for encrypted connections. These parameters
would be used to set up SSL IProto sockets and to connect to other
instances which require certificate authority (CA).

* `iproto.ssl.ca_file`

(Optional) A path to a trusted certificate authorities (CA) file. If not
set, the peer won't be checked for authenticity.

Both a server and a client can use the ca_file parameter:

- If it's on the server side, the server verifies the client.
- If it's on the client side, the client verifies the server.
- If both sides have the CA files, the server and the client verify each
  other.

* `iproto.ssl.ssl_cert`

A path to an SSL certificate file:

- For a server, it's mandatory.
- For a client, it's mandatory if the ca_file parameter is set for a
  server; otherwise, optional.

* `iproto.ssl.ssl_ciphers` (Optional) A colon-separated (:) list of SSL
  cipher suites the connection can use. Note that the list is not
  validated: if a cipher suite is unknown, Tarantool ignores it, doesn't
  establish the connection, and writes to the log that no shared cipher
  was found.

* `iproto.ssl.ssl_key` A path to a private SSL key file:

- For a server, it's mandatory.
- For a client, it's mandatory if the `ca_file` parameter is set for a
  server; otherwise, optional.

If the private key is encrypted, provide a password for it in the
`ssl_password` or `ssl_password_file` parameter

* `iproto.ssl.ssl_password`

(Optional) A password for an encrypted private SSL key provided using
`ssl_key`. Alternatively, the password can be provided in
`ssl_password_file`.

Tarantool applies the `ssl_password` and `ssl_password_file` parameters
in the following order:

- If `ssl_password` is provided, Tarantool tries to decrypt the private
  key with it.
- If `ssl_password` is incorrect or isn't provided, Tarantool tries all
  passwords from `ssl_password_file` one by one in the order they are
  written.
- If `ssl_password` and all passwords from `ssl_password_file` are
  incorrect, or none of them is provided, Tarantool treats the private
  key as unencrypted.

* `iproto.ssl.ssl_password_file` (Optional) A text file with one or more
  passwords for encrypted private SSL keys provided using `ssl_key`
  (each on a separate line). Alternatively, the password can be provided
  in `ssl_password`.

This section is a replacement for the parameters
`iproto.listen.*.params.ssl_*` and `iproto.advertise.*.params.ssl_*`.

The hints that redirect `iproto.listen.*.params.ssl_*` and
`iproto.advertise.*.params.ssl_*` to `<uri>.params.ssl_*` should be
marked as ones overwriting `iproto.ssl` options and marked for advanced
use only with a hint that the user is likely want to use `iproto.ssl`.
Also, SSL Tarantool examples should be changed w.r.t. new section
`iproto.ssl` instead.

(cherry picked from commit a54a406dd26a2ccd3072c37dca0547214c819894)
