### PR TITLE
test: refactor hooks usage for luatest API change

### DIFF
--- a/test/box-luatest/gh_2867_raise_on_raw_box_cfg_modifications_test.lua
+++ b/test/box-luatest/gh_2867_raise_on_raw_box_cfg_modifications_test.lua
@@ -3,16 +3,16 @@ local g = t.group()
 local server = require("luatest.server")
 
 -- Create test instance.
-g.before_all = function()
+g.before_all(function()
     g.server = server:new({alias = 'test-gh-2867'})
     g.server:start()
-end
+end)
 
 -- Stop test instance.
-g.after_all = function()
+g.after_all(function()
     g.server:stop()
     g.server:drop()
-end
+end)
 
 g.test_box_cfg_set_known_option = function()
     t.assert_equals(g.server:eval("return box.cfg.read_only"), false)

--- a/test/box-luatest/schema_sys_space_test.lua
+++ b/test/box-luatest/schema_sys_space_test.lua
@@ -2,14 +2,14 @@ local server = require('luatest.server')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function(lg)
+g.before_all(function(lg)
     lg.server = server:new({alias = 'master'})
     lg.server:start()
-end
+end)
 
-g.after_all = function(lg)
+g.after_all(function(lg)
     lg.server:drop()
-end
+end)
 
 g.test_replicaset_uuid_update_ban = function(lg)
     lg.server:exec(function()

--- a/test/replication-luatest/anon_test.lua
+++ b/test/replication-luatest/anon_test.lua
@@ -5,14 +5,14 @@ local g1 = t.group('group1')
 
 local wait_timeout = 60
 
-g1.before_all = function(lg)
+g1.before_all(function(lg)
     lg.master = server:new({alias = 'master'})
     lg.master:start()
-end
+end)
 
-g1.after_all = function(lg)
+g1.after_all(function(lg)
     lg.master:drop()
-end
+end)
 
 --
 -- When an instance failed to apply cfg{replication_anon = false}, it used to


### PR DESCRIPTION
Luatest now forbids direct hook assignment, so tests using `g.before_all = fn`, `g.after_all = fn`, etc. must be rewritten to the call-style API. This patch updates affected tests accordingly.

Follow-up #8187

NO_CHANGELOG=refactoring
NO_DOC=refactoring
NO_TEST=refactoring