### PR TITLE
datetime: fixed unit test checks for parse

### DIFF
--- a/test/unit/datetime.c
+++ b/test/unit/datetime.c
@@ -116,8 +116,8 @@ datetime_test(void)
 
 	for (index = 0; index < lengthof(tests); index++) {
 		struct datetime date;
-		size_t len = datetime_parse_full(&date, tests[index].str,
-						 tests[index].len);
+		ssize_t len = datetime_parse_full(&date, tests[index].str,
+						  tests[index].len);
 		is(len > 0, true, "correct parse_datetime return value "
 		   "for '%s'", tests[index].str);
 		is(date.epoch, date_expected.epoch,


### PR DESCRIPTION
The tests producing negative result looks as "good" in an unsigned var.

The actual result type `ssize_t` of `datetime_parse_full` is used to fix the error detecion.

Needed #12103
Part of #12095

NO_DOC=tests
NO_CHANGELOG=tests