### PR TITLE
config: validate permissions in credentials privileges

### DIFF
--- a/src/box/lua/config/applier/credentials.lua
+++ b/src/box/lua/config/applier/credentials.lua
@@ -207,6 +207,7 @@ local function privileges_from_config(config_data)
     }
 
     for _, priv in ipairs(privileges) do
+        assert(type(priv.permissions) == 'table')
         for _, perm in ipairs(priv.permissions) do
             if priv.universe then
                 privileges_add_perm('universe', 'all', perm, intermediate)

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1453,6 +1453,9 @@ return schema.new('instance_config', schema.record({
                                 allowed_values = {'all'},
                             }),
                         }),
+                    }, {
+                        validate =
+                            validators['credentials.roles.*.privileges.*'],
                     }),
                 }),
                 -- The given role has all the privileges from
@@ -1518,6 +1521,9 @@ return schema.new('instance_config', schema.record({
                                 allowed_values = {'all'},
                             }),
                         }),
+                    }, {
+                        validate =
+                            validators['credentials.users.*.privileges.*'],
                     }),
                 }),
                 -- The given user has all the privileges from

--- a/src/box/lua/config/validators.lua
+++ b/src/box/lua/config/validators.lua
@@ -9,6 +9,12 @@ local network = require('internal.config.utils.network')
 -- function that validates the data for that field.
 local M = {}
 
+local function validate_privilege_definition(data, w)
+    if data.permissions == nil then
+        w.error('The permissions field must be defined for a privilege')
+    end
+end
+
 local function validate_uuid_str(data, w)
     if uuid.fromstr(data) == nil then
         w.error('Unable to parse the value as a UUID: %q', data)
@@ -166,6 +172,14 @@ M['config.storage.prefix'] = function(data, w)
 end
 
 -- }}} config
+
+-- {{{ credentials
+
+M['credentials.roles.*.privileges.*'] = validate_privilege_definition
+
+M['credentials.users.*.privileges.*'] = validate_privilege_definition
+
+-- }}} credentials
 
 -- {{{ database
 

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1380,6 +1380,26 @@ g.test_credentials = function()
     t.assert_error_msg_equals(err, function()
         instance_config:validate(iconfig)
     end)
+
+    iconfig = {
+        credentials = {
+            users = {
+                peer = {
+                    privileges = {
+                        {
+                            lua_call = { 'all' },
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    err = '[instance_config] credentials.users.peer.privileges[1]: ' ..
+          'The permissions field must be defined for a privilege'
+    t.assert_error_msg_equals(err, function()
+        instance_config:validate(iconfig)
+    end)
 end
 
 g.test_app = function()


### PR DESCRIPTION
This patch fixes a bug where config:reload() crashes if a credentials.users.<username>.privileges entry misses the `permissions` field, leading to:

```
credentials.lua:207: bad argument #1 to 'ipairs' (table expected, got nil)
```

This patch adds validation that requires `permissions` in each privileges entry and reports a configuration error instead of crashing.

Closes #11441

NO_DOC=bugfix
NO_CHANGELOG=bugfix