### PR TITLE
asan: delineate asan/ubsan.supp and asan/asan.supp

### DIFF
--- a/asan/asan.supp
+++ b/asan/asan.supp
@@ -1,6 +1,6 @@
-# All exceptions are under control of the issue:
-# https://github.com/tarantool/tarantool/issues/4360
-#
 # File format:
 #fun:*
 #src:*
+
+# This file is for address suppressions only.
+[address]

--- a/asan/ubsan.supp
+++ b/asan/ubsan.supp
@@ -2,5 +2,8 @@
 #fun:*
 #src:*
 
+# This file is for undefined suppressions only.
+[undefined]
+
 # to be removed in scope of gh-12086
 fun:PMurHash32_Process


### PR DESCRIPTION
Currently both files suppress both address sanitizer issues and undefined sanitizer issues. Fortunately we can use sections to make them work as one would expect.

Closes #12109