### PR TITLE
config: add deprecation mechanism

### DIFF
--- a/changelogs/unreleased/gh-12033-deprecation-mechanism.md
+++ b/changelogs/unreleased/gh-12033-deprecation-mechanism.md
@@ -1,0 +1,5 @@
+## feature/config
+
+* Print warnings at startup when the configuration uses deprecated
+  sections, including the version since deprecation and a hint about
+  what to use instead (gh-12033).

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -44,6 +44,7 @@ lua_source(lua_sources lua/config/applier/sharding.lua     config_applier_shardi
 lua_source(lua_sources lua/config/applier/box_status.lua   config_applier_box_status_lua)
 lua_source(lua_sources lua/config/cluster_config.lua       config_cluster_config_lua)
 lua_source(lua_sources lua/config/configdata.lua           config_configdata_lua)
+lua_source(lua_sources lua/config/deprecations.lua         config_deprecations_lua)
 lua_source(lua_sources lua/config/descriptions.lua         config_descriptions_lua)
 lua_source(lua_sources lua/config/init.lua                 config_init_lua)
 lua_source(lua_sources lua/config/instance_config.lua      config_instance_config_lua)

--- a/src/box/lua/config/cluster_config.lua
+++ b/src/box/lua/config/cluster_config.lua
@@ -2,6 +2,7 @@ local schema = require('experimental.config.utils.schema')
 local instance_config = require('internal.config.instance_config')
 local expression = require('internal.config.utils.expression')
 local descriptions = require('internal.config.descriptions')
+local deprecations = require('internal.config.deprecations')
 
 -- Extract a field from a table.
 --
@@ -330,6 +331,7 @@ return schema.new('cluster_config', record_from_fields({
     methods = methods,
     _extra_annotations = {
         descriptions = descriptions.cluster_descriptions,
+        deprecations = deprecations.cluster_deprecations,
     }
 })
 

--- a/src/box/lua/config/deprecations.lua
+++ b/src/box/lua/config/deprecations.lua
@@ -1,0 +1,36 @@
+local textutils = require('internal.config.utils.textutils')
+
+local format_text = textutils.format_text
+
+local I = {}
+local C = {}
+
+-- {{{ Instance deprecations
+
+local iproto_ssl_params_deprecation = {
+    since = {'3.3.4', '3.4.2', '3.5.1'},
+    see = 'iproto.ssl',
+    msg = format_text([[
+        These SSL options are used both for the server and for all of the
+        clients which makes them unsuitable to configure different keys and
+        certificates for the peers to use for connecting.
+    ]])
+}
+
+I['iproto.listen.*.params.ssl_ca_file'] = iproto_ssl_params_deprecation
+I['iproto.listen.*.params.ssl_key_file'] = iproto_ssl_params_deprecation
+I['iproto.listen.*.params.ssl_cert_file'] = iproto_ssl_params_deprecation
+I['iproto.listen.*.params.ssl_ciphers'] = iproto_ssl_params_deprecation
+I['iproto.listen.*.params.ssl_password'] = iproto_ssl_params_deprecation
+I['iproto.listen.*.params.ssl_password_file'] = iproto_ssl_params_deprecation
+
+-- }}} Instance deprecations
+
+-- {{{ Cluster deprecations
+
+-- }}} Cluster deprecations
+
+return {
+    instance_deprecations = I,
+    cluster_deprecations = C,
+}

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -1,28 +1,6 @@
-local fun = require('fun')
 local textutils = require('internal.config.utils.textutils')
 
-local function for_each_list_item(s, f)
-    return table.concat(fun.iter(s:split('\n- ')):map(f):totable(), '\n- ')
-end
-
-local function for_each_paragraph(s, f)
-    return table.concat(fun.iter(s:split('\n\n')):map(f):totable(), '\n\n')
-end
-
-local function format_text(s)
-    return for_each_paragraph(textutils.dedent(s), function(paragraph)
-        -- Strip line breaks if the paragraph is not a list.
-        if paragraph:startswith('- ') then
-            -- Strip newlines in each list item.
-            return '- ' .. for_each_list_item(paragraph:sub(3),
-                                              function(list_item)
-                return textutils.toline(list_item)
-            end)
-        else
-            return textutils.toline(paragraph)
-        end
-    end)
-end
+local format_text = textutils.format_text
 
 -- {{{ Instance descriptions
 

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -353,6 +353,12 @@ function methods._store(self, iconfig, cconfig, source_info)
         ]]):format(action, self._instance_name, source_info_str), 0)
     end
 
+    -- Emit deprecation warnings to notify users about outdated
+    -- configuration options.
+    for _, deprecation in pairs(instance_config:_deprecations(iconfig)) do
+        log.warn(deprecation.message)
+    end
+
     self._configdata = configdata.new(iconfig, cconfig, self._instance_name)
 end
 

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1,5 +1,6 @@
 local schema = require('experimental.config.utils.schema')
 local descriptions = require('internal.config.descriptions')
+local deprecations = require('internal.config.deprecations')
 local tarantool = require('tarantool')
 local urilib = require('uri')
 local file = require('internal.config.utils.file')
@@ -2383,5 +2384,6 @@ return schema.new('instance_config', schema.record({
     },
     _extra_annotations = {
         descriptions = descriptions.instance_descriptions,
+        deprecations = deprecations.instance_deprecations,
     }
 })

--- a/src/box/lua/config/utils/schema.lua
+++ b/src/box/lua/config/utils/schema.lua
@@ -9,6 +9,7 @@
 -- * default
 -- * apply_default_if
 -- * description
+-- * deprecated
 --
 -- Others are just stored.
 
@@ -1507,6 +1508,95 @@ end
 
 -- }}} <schema object>:map()
 
+-- {{{ <schema object>:_deprecations()
+
+local function normalize_deprecated_since(since)
+    if since == nil then
+        return nil
+    end
+    if type(since) == 'string' then
+        return since
+    end
+    return table.concat(since, ', ')
+end
+
+-- Represent a data path in a deprecation message.
+--
+-- All array indexes are replaced with '*' to avoid duplicate messages for
+-- different items under the same deprecated schema node.
+local function format_deprecated_path(path)
+    local res = {}
+    for i, part in ipairs(path) do
+        if type(part) == 'number' then
+            res[i] = '*'
+        else
+            res[i] = tostring(part)
+        end
+    end
+    return table.concat(res, '.')
+end
+
+local function ensure_period(text)
+    if text:sub(-1) == '.' then
+        return text
+    end
+    return text .. '.'
+end
+
+local function deprecations_f(data, w, ctx)
+    if data == nil then
+        return data
+    end
+
+    if w.schema == nil then
+        return data
+    end
+
+    local deprecated = w.schema.deprecated
+    if deprecated == nil then
+        return data
+    end
+
+    local path = format_deprecated_path(w.path)
+    local since = normalize_deprecated_since(deprecated.since)
+
+    local message_parts = {('`%s` is deprecated'):format(path)}
+    if since ~= nil then
+        table.insert(message_parts, ('since %s'):format(since))
+    end
+
+    local message = table.concat(message_parts, ' ')
+    message = ensure_period(message)
+    if deprecated.msg ~= nil then
+        message = message .. ' ' .. deprecated.msg
+        message = ensure_period(message)
+    end
+    if deprecated.see ~= nil then
+        message = ensure_period(message)
+        message = message ..
+            (' Consider using `%s` instead.'):format(deprecated.see)
+    end
+
+    local key = ('deprecated_%s'):format(path)
+    if not ctx.seen[key] then
+        ctx.seen[key] = true
+        table.insert(ctx.res, { message = message })
+    end
+
+    return data
+end
+
+-- Collect deprecation warnings for the given data.
+--
+-- The method takes the `deprecated` annotation into account.
+function methods._deprecations(self, data)
+    local ctx = {res = {}, seen = {}}
+    self:map(data, deprecations_f, ctx)
+    return ctx.res
+end
+
+-- }}} <schema object>:_deprecations()
+
 -- {{{ <schema object>:apply_default()
 
 local function apply_default_f(data, w)
@@ -1830,6 +1920,9 @@ local function set_common_jsonschema_fields(res, schema)
     res.description = schema.description
     res.default = schema.default
     res.enum = schema.allowed_values
+    if schema.deprecated ~= nil then
+        res.deprecated = true
+    end
     return setmetatable(res, {
         __serialize = 'map',
     })
@@ -1937,6 +2030,7 @@ local function preprocess_enter(ctx, schema)
         validate = true,
         default = true,
         apply_default_if = true,
+        deprecated = true,
     }
 
     local frame = table.copy(ctx.annotation_stack[#ctx.annotation_stack] or {})
@@ -2078,6 +2172,40 @@ end
 local function validate_schema_impl(schema, ctx)
     validate_schema_node_unique_items(schema, ctx)
 
+    if schema.deprecated ~= nil then
+        walkthrough_assert(ctx, type(schema.deprecated) == 'table',
+            'Deprecated annotation must be a table, got %s',
+            type(schema.deprecated))
+
+        if schema.deprecated.since ~= nil then
+            walkthrough_assert(ctx, type(schema.deprecated.since) == 'string' or
+                type(schema.deprecated.since) == 'table',
+                'Deprecated.since must be a string or an array ' ..
+                'of strings, got %s',
+                type(schema.deprecated.since))
+            if type(schema.deprecated.since) == 'table' then
+                for i, v in ipairs(schema.deprecated.since) do
+                    walkthrough_assert(ctx, type(v) == 'string',
+                        'Deprecated.since[%d] must be a string, got %s',
+                        i, type(v))
+                end
+            end
+        end
+
+        if schema.deprecated.see ~= nil then
+            walkthrough_assert(ctx, type(schema.deprecated.see) == 'string',
+                'Deprecated.see must be a string, got %s',
+                type(schema.deprecated.see))
+        end
+
+        if schema.deprecated.msg ~= nil then
+            walkthrough_assert(ctx, type(schema.deprecated.msg) == 'string',
+                'Deprecated.msg must be a string, got %s',
+                type(schema.deprecated.msg))
+        end
+
+    end
+
     -- luacheck: ignore 542 empty if branch
     if is_scalar(schema) then
         -- Nothing to do.
@@ -2131,6 +2259,7 @@ end
 
 local function set_schema_annotations(schema, annotations)
     local descriptions = annotations.descriptions
+    local deprecations = annotations.deprecations
 
     -- Set the descriptions for the given schema node based on the field
     -- path accumulated in ctx.path.
@@ -2145,11 +2274,28 @@ local function set_schema_annotations(schema, annotations)
             schema.description = description or schema.description
     end
 
+    -- Set deprecated annotations for the given schema node based on the
+    -- field path accumulated in ctx.path.
+    local function set_deprecated(schema, ctx)
+        local field_path = table.concat(ctx.path, '.')
+        local deprecated = deprecations[field_path]
+
+        if deprecated ~= nil then
+            assert(schema.deprecated == nil,
+                string.format('Duplicate deprecated annotation for field %q',
+                field_path))
+            schema.deprecated = deprecated
+        end
+    end
+
     -- Set annotations for the given schema node based
     -- on the field path accumulated in ctx.path.
     local function set_annotations(schema, ctx)
         if descriptions ~= nil then
             set_description(schema, ctx)
+        end
+        if deprecations ~= nil then
+            set_deprecated(schema, ctx)
         end
     end
 

--- a/src/box/lua/config/utils/textutils.lua
+++ b/src/box/lua/config/utils/textutils.lua
@@ -1,3 +1,5 @@
+local fun = require('fun')
+
 -- Remove indent from a text.
 --
 -- Similar to Python's textwrap.dedent().
@@ -27,7 +29,31 @@ local function toline(s)
     return s:gsub('\n', ' '):gsub(' +', ' '):strip()
 end
 
+local function for_each_list_item(s, f)
+    return table.concat(fun.iter(s:split('\n- ')):map(f):totable(), '\n- ')
+end
+
+local function for_each_paragraph(s, f)
+    return table.concat(fun.iter(s:split('\n\n')):map(f):totable(), '\n\n')
+end
+
+local function format_text(s)
+    return for_each_paragraph(dedent(s), function(paragraph)
+        -- Strip line breaks if the paragraph is not a list.
+        if paragraph:startswith('- ') then
+            -- Strip newlines in each list item.
+            return '- ' .. for_each_list_item(paragraph:sub(3),
+                                              function(list_item)
+                return toline(list_item)
+            end)
+        else
+            return toline(paragraph)
+        end
+    end)
+end
+
 return {
     dedent = dedent,
     toline = toline,
+    format_text = format_text,
 }

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -173,6 +173,7 @@ extern char session_lua[],
 	config_applier_sharding_lua[],
 	config_applier_box_status_lua[],
 	config_cluster_config_lua[],
+	config_deprecations_lua[],
 	config_descriptions_lua[],
 	config_validators_lua[],
 	config_configdata_lua[],
@@ -398,6 +399,10 @@ static const char * const lua_sources_main[] = {
 	"config/utils/network",
 	"internal.config.utils.network",
 	config_utils_network_lua,
+
+	"config/deprecations",
+	"internal.config.deprecations",
+	config_deprecations_lua,
 
 	"config/descriptions",
 	"internal.config.descriptions",

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1,6 +1,7 @@
 local fun = require('fun')
 local log = require('log')
 local t = require('luatest')
+local schema_utils = require('experimental.config.utils.schema')
 local instance_config = require('internal.config.instance_config')
 
 local g = t.group()
@@ -2052,4 +2053,65 @@ g.test_threads = function()
         '[instance_config] threads.groups: ' ..
         'Thread group "test3" has invalid size: must be > 0',
         instance_config.validate, instance_config, iconfig)
+end
+
+g.test_schema_deprecations = function()
+    local schema = schema_utils.new('test', schema_utils.record({
+        root = schema_utils.array({
+            items = schema_utils.record({
+                opt = schema_utils.scalar({
+                    type = 'string',
+                    deprecated = {
+                        since = {'1.0.0', '1.1.0'},
+                        msg = 'Use another option',
+                        see = 'root.new_opt',
+                    },
+                }),
+            }),
+        }),
+    }))
+
+    local warnings =
+        schema:_deprecations({root = {{opt = 'foo'}, {opt = 'bar'}}})
+    t.assert_equals(warnings, {{
+        message = '`root.*.opt` is deprecated since 1.0.0, 1.1.0. Use ' ..
+                  'another option. Consider using `root.new_opt` instead.',
+    }})
+end
+
+g.test_iproto_ssl_deprecations = function()
+    if not is_enterprise then
+        t.skip('Enterprise-only options')
+    end
+
+    local iconfig = {
+        iproto = {
+            listen = {
+                {
+                    uri = 'unix/:./{{ instance_name }}.iproto',
+                    params = {
+                        transport = 'ssl',
+                        ssl_key_file = 'key.pem',
+                        ssl_cert_file = 'cert.pem',
+                    },
+                },
+            },
+        },
+    }
+
+    local warnings = instance_config:_deprecations(iconfig)
+    local warning
+    for _, v in ipairs(warnings) do
+        if v.key == 'deprecated_iproto.listen.*.params.ssl_key_file' then
+            warning = v
+            break
+        end
+    end
+
+    t.assert_not_equals(warning, nil)
+    t.assert_str_contains(warning.message,
+        '`iproto.listen.*.params.ssl_key_file` is ' ..
+        'deprecated since 3.3.4, 3.4.2, 3.5.1')
+    t.assert_str_contains(warning.message,
+                          'Consider using `iproto.ssl` instead.')
 end

--- a/test/config-luatest/jsonschema_schema_test.lua
+++ b/test/config-luatest/jsonschema_schema_test.lua
@@ -32,6 +32,14 @@ g.test_json_schema = function()
         naz = schema.scalar({
             type = 'integer',
             allowed_values = {0, 1},
+        }),
+        deprecated = schema.scalar({
+            type = 'string',
+            deprecated = {
+                since = '3.5.0',
+                msg = 'Use another option',
+                see = 'foo.baz',
+            },
         })
     }))
 
@@ -61,6 +69,7 @@ g.test_json_schema = function()
             fuz = {items = {type = 'string'}, type = 'array'},
             laz = {type = 'boolean'},
             naz = {enum = {0, 1}, type = 'integer'},
+            deprecated = {deprecated = true, type = 'string'},
         },
         type = 'object',
     }


### PR DESCRIPTION
This patch adds a deprecation mechanism that allows schema nodes to be annotated as deprecated, specifying the version since which they are deprecated and a message indicating what should be used instead. If a configuration contains deprecated sections, a warning is allerted at Tarantool startup.

Closes #12033