### PR TITLE
box: fix crash with transactional trigger on system space

### DIFF
--- a/changelogs/unreleased/gh-11766-system-space-txn-trigger.md
+++ b/changelogs/unreleased/gh-11766-system-space-txn-trigger.md
@@ -1,0 +1,3 @@
+## bugfix/box
+
+* Fixed a crash with transactional trigger on the `_space` space (gh-11766).

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -828,6 +828,12 @@ txn_complete_success(struct txn *txn)
 		if (txn->engines[i] != NULL)
 			engine_commit(txn->engines[i], txn);
 	}
+	/*
+	 * Run before internal triggers which destroy old space if this is
+	 * DDL changing space.
+	 */
+	if (txn_event_on_commit_run_triggers(txn) != 0)
+		diag_log();
 	if (txn_has_flag(txn, TXN_HAS_TRIGGERS)) {
 		/*
 		 * Commit triggers must be run in the same order they were added
@@ -844,8 +850,6 @@ txn_complete_success(struct txn *txn)
 		/* Rollback won't happen after commit. */
 		trigger_destroy(&txn->on_rollback);
 	}
-	if (txn_event_on_commit_run_triggers(txn) != 0)
-		diag_log();
 	txn_free_or_wakeup(txn);
 	rmean_collect(rmean_box, IPROTO_COMMIT, 1);
 }

--- a/test/box-luatest/gh_11766_system_space_txn_trigger_test.lua
+++ b/test/box-luatest/gh_11766_system_space_txn_trigger_test.lua
@@ -1,0 +1,49 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g_recovery = t.group('recovery')
+
+g_recovery.after_all(function(cg)
+    if cg.server ~= nil then
+        cg.server:drop()
+        cg.server = nil
+    end
+end)
+
+g_recovery.test_recovery = function(cg)
+    local add_triggers = [[
+        local trigger = require('trigger')
+        trigger.set('box.on_commit.space._space', 'check', function() end)
+    ]]
+    cg.server = server:new({
+        env = {TARANTOOL_RUN_BEFORE_BOX_CFG = add_triggers}
+    })
+    cg.server:start()
+end
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    if cg.server ~= nil then
+        cg.server:drop()
+        cg.server = nil
+    end
+end)
+
+g.test_on_commit = function(cg)
+    cg.server:exec(function()
+        local trigger = require('trigger')
+
+        trigger.set('box.on_commit.space._space', 'check', function() end)
+
+        local s = box.space._space:get(box.space._space.id):totable()
+        -- Change field_count field (currently is 0 for _space).
+        s[5] = #box.space._space:format()
+        box.space._space:replace(s)
+    end)
+end


### PR DESCRIPTION
Currently transactional trigger on space `_space` causes crash on DDL which changes record for `_space` itself in `_space`. In particular this happens on recovery. Similarly there is a crash on trigger on space `_index` and changing record for `_index` itself in `_index`.

The issue is we first commit the DDL which destroys the old space and then run transactional trigger which refers to the old space. Let's do the opposite, first run transactional trigger.

Closes #11766