### PR TITLE
build: fix use --builddir with absolute path

### DIFF
--- a/.test.mk
+++ b/.test.mk
@@ -20,7 +20,7 @@ N_TRIALS ?= 128
 COMMIT_RANGE ?= master..HEAD
 
 VARDIR ?= /tmp/t
-TEST_RUN_PARAMS = --builddir ${PWD}/${BUILD_DIR}
+TEST_RUN_PARAMS = --builddir $(realpath ${BUILD_DIR})
 
 CMAKE = ${CMAKE_ENV} cmake -S ${SRC_DIR} -B ${BUILD_DIR}
 CMAKE_BUILD = ${CMAKE_BUILD_ENV} cmake --build ${BUILD_DIR} --parallel ${NPROC}


### PR DESCRIPTION
Before the patch, `test-run.py` used for `--buildir` option the path provided by the user. If the path was relative and `.test.mk` was executed from another directory, `test-run.py` couldn't find Tarantool executable binary. The patch converts the relative path to an absolute one, and this scenario now works.

Split from #12060 (https://github.com/tarantool/tarantool/pull/12060#discussion_r2557546168)

NO_TEST=internal
NO_CHANGELOG=internal
NO_DOC=internal

Problem: test-run.py script fails to locate the tarantool binary (`/xxx/src/tarantool`) from build dir `/xxx` because it got invalid builddir path `/src//xxx`:

```
	cd /src && BUILD_DIR=/xxx make -f .test.mk test-debug-flaky
```

```
cd test && \
TESTS=$(git diff --relative=test --name-only master..HEAD -- "./*/*test.lua" "./unit/*.c*" | sed 's/\.\(c\|cpp\|cc\)$//' | grep . | sort -u) && \
(([ -n "${TESTS}" ] &&  \
  ./test-run.py --force \
                --vardir /tmp/t \
                --retries=0 \
                --repeat=128 \
                --builddir /src//xxx  \
                ${TESTS}) || \
 [ ! -n "${TESTS}" ])
Traceback (most recent call last):
  File "./test-run.py", line 56, in <module>
    from lib import Options
  File "/src/test-run/lib/__init__.py", line 92, in <module>
    module_init()
  File "/src/test-run/lib/__init__.py", line 80, in module_init
    TarantoolServer.find_exe(args.builddir, executable=args.executable)
  File "/src/test-run/lib/tarantool_server.py", line 743, in find_exe
    raise RuntimeError("Can't find server executable in " + path)
RuntimeError: Can't find server executable in /src/xxx/src:/src/test-run/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```