### PR TITLE
datetime: fix parse and use of %s (epoch)

### DIFF
--- a/changelogs/unreleased/gh-12143-datetime-parse-epoch-ignored.md
+++ b/changelogs/unreleased/gh-12143-datetime-parse-epoch-ignored.md
@@ -1,0 +1,5 @@
+## bugfix/datetime
+
+* The epoch seconds value parsed with `'%s'`
+  by `datetime.parse()` isn't ignored and is used
+  now as a timestamp value by `datetime.new()` (gh-12143).

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -155,10 +155,22 @@ tm_to_datetime(struct tnt_tm *tm, struct datetime *date)
 		if (dt_from_ymd_checked(year + 1900, mon + 1, mday, &dt) == false)
 			return false;
 	}
-	int64_t local_secs =
-		(int64_t)dt * SECS_PER_DAY - SECS_EPOCH_1970_OFFSET;
-	local_secs += tm->tm_hour * 3600 + tm->tm_min * 60 + tm->tm_sec;
-	date->epoch = local_secs - tm->tm_gmtoff;
+
+	int64_t local_secs;
+	bool use_timestamp = (dt == 0) &&
+			     (tm->tm_hour | tm->tm_min | tm->tm_sec) == 0;
+	if (use_timestamp) {
+		local_secs = tm->tm_epoch;
+	} else {
+		local_secs = (int64_t)dt * SECS_PER_DAY -
+			SECS_EPOCH_1970_OFFSET;
+		local_secs += tm->tm_hour * 3600 + tm->tm_min * 60 + tm->tm_sec;
+	}
+	int64_t epoch = local_secs - tm->tm_gmtoff;
+	if (epoch > MAX_EPOCH_SECS_VALUE || epoch < MIN_EPOCH_SECS_VALUE)
+		return false;
+
+	date->epoch = epoch;
 	date->nsec = tm->tm_nsec;
 	date->tzindex = tm->tm_tzindex;
 	date->tzoffset = tm->tm_gmtoff / 60;

--- a/src/lib/tzcode/strptime.c
+++ b/src/lib/tzcode/strptime.c
@@ -518,7 +518,7 @@ tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
 			long n;
 
 			n = strtol(buf, &cp, 10);
-			if (n == 0) {
+			if (buf == cp && n == 0) {
 				return NULL;
 			}
 			buf = cp;
@@ -701,6 +701,40 @@ tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
 			tm->tm_wday = wday_offset;
 			flags |= FLAG_WDAY;
 		}
+	}
+
+	const int ymd_flags = FLAG_YEAR | FLAG_MONTH | FLAG_MDAY;
+	if ((flags & FLAG_EPOCH) == 0)
+		/*
+		 * All branches below run then tm->tm_epoch is defined:
+		 * !((flags & FLAG_EPOCH) == 0) && ...
+		*/
+		;
+	else if ((flags & ymd_flags) != 0) {
+		/*
+		 * Forbid mix of epoch with year/mon/mday as
+		 * in datetime.new().
+		 */
+		return NULL;
+	} else if (tm->tm_hour != 0 || tm->tm_min != 0 || tm->tm_sec != 0) {
+		/*
+		 * Forbid mix of epoch with hour/min/sec as
+		 * in datetime.new().
+		 */
+		return NULL;
+	} else {
+		/*
+		 * Reset predefined nonzero values of Unix epoch
+		 * to note caller to use tm->tm_epoch.
+		 * Another way is to refactor this fn
+		 * to return set of known fields
+		 * & it's callers to use this info.
+		 */
+		tm->tm_year = 0;
+		tm->tm_mon = 0;
+		tm->tm_mday = 0;
+		tm->tm_yday = 0;
+		tm->tm_wday = 0;
 	}
 
 	return (char *)buf;

--- a/test/unit/datetime.c
+++ b/test/unit/datetime.c
@@ -22,6 +22,41 @@ static const char sample[] = "2012-12-24T15:30Z";
 void
 cord_on_yield(void) {}
 
+static char *
+fmt_va(char *fmt, va_list args)
+{
+	static char buf[4096];
+	static size_t buf_used = 0;
+	va_list args_copy;
+	va_copy(args_copy, args);
+
+	int32_t res = vsnprintf(NULL, 0, fmt, args);
+	assert(res >= 0);
+	size_t size = (size_t)res + 1;
+
+	assert(buf_used + size <= sizeof(buf));
+	char *str = buf + buf_used;
+	buf_used += size;
+
+	res = vsnprintf(str, size, fmt, args_copy);
+	assert((res >= 0) && (size_t)res == size - 1);
+	va_end(args_copy);
+	return str;
+}
+
+static char *
+fmt(char *fmt, ...) CFORMAT(printf, 1, 2);
+static char *
+fmt(char *fmt, ...)
+{
+	va_list args;
+	char *ret;
+	va_start(args, fmt);
+	ret = fmt_va(fmt, args);
+	va_end(args);
+	return ret;
+}
+
 #define S(s) {s, sizeof(s) - 1}
 struct {
 	const char *str;
@@ -360,7 +395,19 @@ parse_date_strptime_valid_test(void)
 		{ "%r",                      "03:00:00 AM" },
 		{ "%I:%M:%S %p",             "03:00:00 AM" },
 		{ "%S",                      "00" },
+		{ "%s",                      "0" },
 		{ "%s",                      "10800" },
+		{ "%s %3f",                  "10800 123" },
+		{ "%s %z",                   "10800 +0300" },
+		{ "%s %Z",                   "10800 MSK" },
+		{
+			"%s",
+			fmt("%ld", MIN_EPOCH_SECS_VALUE),
+		},
+		{
+			"%s",
+			fmt("%ld", MAX_EPOCH_SECS_VALUE),
+		},
 		{ "%f",                      "125" },
 		{ "%T",                      "03:00:00" },
 		{ "%H:%M:%S",                "03:00:00" },
@@ -402,7 +449,7 @@ parse_date_strptime_valid_test(void)
 		struct tnt_tm date = { .tm_epoch = 0};
 		char *ptr = tnt_strptime(text, fmt, &date);
 		static char buff[DT_TO_STRING_BUFSIZE];
-		tnt_strftime(buff, sizeof(buff), "%FT%T%z", &date);
+		tnt_strftime(buff, sizeof(buff), "%FT%T.%f%z", &date);
 		isnt(ptr, NULL, "parse string '%s' using '%s' (result '%s')",
 		     text, fmt, buff);
 	}
@@ -413,45 +460,92 @@ parse_date_strptime_valid_test(void)
 static void
 parse_date_strptime_invalid_test(void)
 {
-	/* Check strptime invalid formats. */
+	/* Check tnt_strptime & datetime_strptime invalid formats. */
+	enum {
+		TNT = 1,
+		DATETIME = 2,
+		BOTH = 1 | 2,
+	};
 	const struct {
+		uint fn;
 		const char *fmt;
 		const char *text;
 		const char *fail_case;
 	} format_fail_tests[] = {
 		/* 0000-001 is 0000-01-01. */
 		{
+			BOTH,
 			"%m%g%j",
 			"07001",
 			"%j %m both are used and their months are different"
 		},
 		/* 2025-321 is 2025-11-17. */
 		{
+			BOTH,
 			"%G-%j %m",
 			"2025-321 12",
 			"%j %m both are used and their months are different"
 		},
+		{
+			BOTH,
+			"%s %g-%m-%d",
+			"123 2000-01-02",
+			"mix of timestamp with y/m/d",
+		},
+		{
+			BOTH,
+			"%s %H:%M:%S",
+			"123 12:12:12",
+			"mix of timestamp with h/m/s",
+		},
+		{
+			DATETIME,
+			"%s",
+			fmt("%ld", MIN_EPOCH_SECS_VALUE - 1),
+			"timestamp < MIN_EPOCH_SECS_VALUE",
+		},
+		{
+			DATETIME,
+			"%s",
+			fmt("%ld", MAX_EPOCH_SECS_VALUE + 1),
+			"timestamp > MAX_EPOCH_SECS_VALUE",
+		},
 	};
 
-	const unsigned tap_tests_per_iter = 2;
-	plan(tap_tests_per_iter * lengthof(format_fail_tests));
-	for (size_t index = 0; index < lengthof(format_fail_tests); index++) {
+	size_t index;
+	const uint tnt_tap_tests_per_iter = 1;
+	const uint datetime_tap_tests_per_iter = 1;
+	uint p = 0;
+	for (index = 0; index < lengthof(format_fail_tests); index++) {
+		uint fn = format_fail_tests[index].fn;
+		p += tnt_tap_tests_per_iter * ((TNT & fn) != 0) +
+		     datetime_tap_tests_per_iter * ((DATETIME & fn) != 0);
+	}
+	plan(p);
+
+	for (index = 0; index < lengthof(format_fail_tests); index++) {
 		TAP_TEST_LOCATION();
+		uint fn = format_fail_tests[index].fn;
 		const char *fmt = format_fail_tests[index].fmt;
 		const char *text = format_fail_tests[index].text;
 		const char *fail_case = format_fail_tests[index].fail_case;
 
+		if ((TNT & fn) == 0)
+			goto skip_tnt;
 		struct tnt_tm tm = { 0 };
 		char *ptr = tnt_strptime(text, fmt, &tm);
 		is(ptr, NULL, "tnt_strptime parse string '%s' "
 		   "using '%s' must fail on: %s",
 		   text, fmt, fail_case);
+skip_tnt:
 
+		if ((DATETIME & fn) == 0)
+			continue;
 		struct datetime date = { 0 };
 		size_t res = datetime_strptime(&date, text, fmt);
-		is(res, 0, "datetime_strptime fail to"
-		   " parse string '%s' using '%s'",
-		   text, fmt);
+		is(res, 0, "datetime_strptime parse string '%s' "
+		   "using '%s' must fail on: %s",
+		   text, fmt, fail_case);
 	}
 
 	check_plan();


### PR DESCRIPTION
- The epoch seconds value parsed with `'%s'` by `datetime.parse()` isn't ignored and used now as a timestamp value by `datetime.new()`.
- The zero value doesn't produce an error.

Closes #12143

NO_DOC=bugfix