### PR TITLE
index: encapsulate virtual functions responsible for updates in memtx

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -188,6 +188,7 @@ set(box_sources
     index_def.c
     index_weak_ref.c
     iterator_type.c
+    memtx_index.c
     memtx_hash.cc
     memtx_tree.cc
     memtx_rtree.cc

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -1180,20 +1180,6 @@ generic_index_get(struct index *index, const char *key,
 	return -1;
 }
 
-int
-generic_index_replace(struct index *index, struct tuple *old_tuple,
-		      struct tuple *new_tuple, enum dup_replace_mode mode,
-		      struct tuple **result, struct tuple **successor)
-{
-	(void)old_tuple;
-	(void)new_tuple;
-	(void)mode;
-	(void)result;
-	(void)successor;
-	diag_set(UnsupportedIndexFeature, index->def, "replace()");
-	return -1;
-}
-
 struct iterator *
 generic_index_create_iterator(struct index *base, enum iterator_type type,
 			      const char *key, uint32_t part_count,
@@ -1323,55 +1309,6 @@ void
 generic_index_reset_stat(struct index *index)
 {
 	(void)index;
-}
-
-void
-generic_index_begin_build(struct index *)
-{
-}
-
-int
-generic_index_reserve(struct index *, uint32_t)
-{
-	return 0;
-}
-
-int
-generic_index_build_next(struct index *index, struct tuple *tuple)
-{
-	struct tuple *unused;
-	/*
-	 * Note this is not no-op call in case of rtee index:
-	 * reserving 0 bytes is required during rtree recovery.
-	 * For details see memtx_rtree_index_reserve().
-	 */
-	if (index_reserve(index, 0) != 0)
-		return -1;
-	return index_replace(index, NULL, tuple, DUP_INSERT, &unused, &unused);
-}
-
-void
-generic_index_end_build(struct index *)
-{
-}
-
-int
-disabled_index_build_next(struct index *index, struct tuple *tuple)
-{
-	(void) index; (void) tuple;
-	return 0;
-}
-
-int
-disabled_index_replace(struct index *index, struct tuple *old_tuple,
-		       struct tuple *new_tuple, enum dup_replace_mode mode,
-		       struct tuple **result, struct tuple **successor)
-{
-	(void) old_tuple; (void) new_tuple; (void) mode;
-	(void) index;
-	*result = NULL;
-	*successor = NULL;
-	return 0;
 }
 
 int

--- a/src/box/memtx_index.c
+++ b/src/box/memtx_index.c
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2025, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "memtx_index.h"
+
+void
+generic_memtx_index_begin_build(struct index *index)
+{
+	(void)index;
+}
+
+int
+generic_memtx_index_reserve(struct index *index, uint32_t size_hint)
+{
+	(void)index;
+	(void)size_hint;
+	return 0;
+}
+
+int
+generic_memtx_index_build_next(struct index *index, struct tuple *tuple)
+{
+	struct tuple *unused;
+	/*
+	 * Note this is not no-op call in case of rtee index:
+	 * reserving 0 bytes is required during rtree recovery.
+	 * For details see memtx_rtree_index_reserve().
+	 */
+	if (memtx_index_reserve(index, 0) != 0)
+		return -1;
+	return memtx_index_replace(index, NULL, tuple, DUP_INSERT, &unused,
+				   &unused);
+}
+
+void
+generic_memtx_index_end_build(struct index *index)
+{
+	(void)index;
+}

--- a/src/box/memtx_index.h
+++ b/src/box/memtx_index.h
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2025, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "index.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/** Virtual function table for memtx-specific index operations. */
+struct memtx_index_vtab {
+	/** Base index virtual table for common index operations. */
+	struct index_vtab base;
+	/**
+	 * Main entrance point for changing data in index. Once built and
+	 * before deletion this is the only way to insert, replace and delete
+	 * data from the index.
+	 * @param mode - @sa dup_replace_mode description
+	 * @param result - here the replaced or deleted tuple is placed.
+	 * @param successor - if the index supports ordering, then in case of
+	 *  insert (!) here the successor tuple is returned. In other words,
+	 *  here will be stored the tuple, before which new tuple is inserted.
+	 *
+	 * NB: do not use the same object for @a result and @a successor - they
+	 *     are different returned values and implementation can rely on it.
+	 */
+	int (*replace)(struct index *index, struct tuple *old_tuple,
+		       struct tuple *new_tuple, enum dup_replace_mode mode,
+		       struct tuple **result, struct tuple **successor);
+	/**
+	 * Two-phase index creation: begin building, add tuples, finish.
+	 */
+	void (*begin_build)(struct index *index);
+	/**
+	 * Optional hint, given to the index, about
+	 * the total size of the index. Called after
+	 * begin_build().
+	 */
+	int (*reserve)(struct index *index, uint32_t size_hint);
+	/** Add one tuple for index build. */
+	int (*build_next)(struct index *index, struct tuple *tuple);
+	/** Finish index build. */
+	void (*end_build)(struct index *index);
+};
+
+static inline int
+memtx_index_replace(struct index *index, struct tuple *old_tuple,
+		    struct tuple *new_tuple, enum dup_replace_mode mode,
+		    struct tuple **result, struct tuple **successor)
+{
+	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
+	return vtab->replace(index, old_tuple, new_tuple, mode, result,
+			     successor);
+}
+
+static inline void
+memtx_index_begin_build(struct index *index)
+{
+	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
+	vtab->begin_build(index);
+}
+
+static inline int
+memtx_index_reserve(struct index *index, uint32_t size_hint)
+{
+	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
+	return vtab->reserve(index, size_hint);
+}
+
+static inline int
+memtx_index_build_next(struct index *index, struct tuple *tuple)
+{
+	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
+	return vtab->build_next(index, tuple);
+}
+
+static inline void
+memtx_index_end_build(struct index *index)
+{
+	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
+	vtab->end_build(index);
+}
+
+/** No-op stub for the `begin_build` operation. */
+void
+generic_memtx_index_begin_build(struct index *index);
+
+/** No-op stub for the `reserve` operation. */
+int
+generic_memtx_index_reserve(struct index *index, uint32_t size_hint);
+
+/**
+ * Generic implementation of the `build_next` operation: reserves space in the
+ * index and inserts the tuple into the index.
+ */
+int
+generic_memtx_index_build_next(struct index *index, struct tuple *tuple);
+
+/** No-op stub for the `end_build` operation. */
+void
+generic_memtx_index_end_build(struct index *index);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -281,7 +281,6 @@ static const struct index_vtab session_settings_index_vtab = {
 	/* .count = */ generic_index_count,
 	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ session_settings_index_get,
-	/* .replace = */ generic_index_replace,
 	/* .create_iterator = */ session_settings_index_create_iterator,
 	/* .create_iterator_with_offset = */
 	generic_index_create_iterator_with_offset,
@@ -290,10 +289,6 @@ static const struct index_vtab session_settings_index_vtab = {
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,
 	/* .reset_stat = */ generic_index_reset_stat,
-	/* .begin_build = */ generic_index_begin_build,
-	/* .reserve = */ generic_index_reserve,
-	/* .build_next = */ generic_index_build_next,
-	/* .end_build = */ generic_index_end_build,
 };
 
 static void

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -206,7 +206,6 @@ static const struct index_vtab sysview_index_vtab = {
 	/* .count = */ generic_index_count,
 	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ sysview_index_get,
-	/* .replace = */ generic_index_replace,
 	/* .create_iterator = */ sysview_index_create_iterator,
 	/* .create_iterator_with_offset = */
 	generic_index_create_iterator_with_offset,
@@ -215,10 +214,6 @@ static const struct index_vtab sysview_index_vtab = {
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,
 	/* .reset_stat = */ generic_index_reset_stat,
-	/* .begin_build = */ generic_index_begin_build,
-	/* .reserve = */ generic_index_reserve,
-	/* .build_next = */ generic_index_build_next,
-	/* .end_build = */ generic_index_end_build,
 };
 
 static void

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4853,7 +4853,6 @@ static const struct index_vtab vinyl_index_vtab = {
 	/* .count = */ generic_index_count,
 	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ vinyl_index_get,
-	/* .replace = */ generic_index_replace,
 	/* .create_iterator = */ vinyl_index_create_iterator,
 	/* .create_iterator_with_offset = */
 	generic_index_create_iterator_with_offset,
@@ -4862,8 +4861,4 @@ static const struct index_vtab vinyl_index_vtab = {
 	/* .stat = */ vinyl_index_stat,
 	/* .compact = */ vinyl_index_compact,
 	/* .reset_stat = */ vinyl_index_reset_stat,
-	/* .begin_build = */ generic_index_begin_build,
-	/* .reserve = */ generic_index_reserve,
-	/* .build_next = */ generic_index_build_next,
-	/* .end_build = */ generic_index_end_build,
 };


### PR DESCRIPTION
This patch encapsulates virtual functions responsible for index updates in memtx.

EE-part: tarantool/tarantool-ee#1606

Closes #11722
Needed for #6385