### PR TITLE
ci: bump cmake version to 3.26 in install-deps-debian action

### DIFF
--- a/.github/actions/install-deps-debian/action.yml
+++ b/.github/actions/install-deps-debian/action.yml
@@ -17,7 +17,6 @@ runs:
         apt-get -y -f install \
           build-essential \
           ninja-build \
-          cmake \
           lua5.1 \
           lcov \
           ruby-dev \
@@ -27,8 +26,15 @@ runs:
           automake \
           libtool \
           util-linux \
-          tt
+          tt \
+          python3-pip
         tt rocks install luatest 1.2.1
         tt rocks install luacheck 0.26.0
         gem install coveralls-lcov
+
+        apt-get purge --auto-remove cmake -y
+        # ubuntu 20.04 repos do not contain cmake 3.26.0
+        # thus we require an alternative way of installing
+        # this version
+        pip install cmake==3.26.0
       shell: bash


### PR DESCRIPTION
Bumped cmake version to 3.26 in CI install-deps-debian action.

Required by https://github.com/tarantool/tarantool-ee/pull/1589

NO_TEST=ci
NO_DOC=ci
NO_CHANGELOG=ci