### PR TITLE
datetime: fix checking timestamp range in new and set

### DIFF
--- a/changelogs/unreleased/gh-12147-datetime-new-check-timestamp-range.md
+++ b/changelogs/unreleased/gh-12147-datetime-new-check-timestamp-range.md
@@ -1,0 +1,4 @@
+## bugfix/datetime
+
+* Now `datetime.new()` and `datetime_object:set()`
+  check timestamp value to be in valid range (gh-12147).

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -130,12 +130,17 @@ local MAX_DATE_DAY = 11
 local AVERAGE_DAYS_YEAR = 365.25
 local AVERAGE_WEEK_YEAR = AVERAGE_DAYS_YEAR / 7
 local INT_MAX = 2147483647
+local INT_MIN = -2147483648
 -- -5879610-06-22
 local MIN_DATE_TEXT = ('%d-%02d-%02d'):format(MIN_DATE_YEAR, MIN_DATE_MONTH,
                                               MIN_DATE_DAY)
 -- 5879611-07-11
 local MAX_DATE_TEXT = ('%d-%02d-%02d'):format(MAX_DATE_YEAR, MAX_DATE_MONTH,
                                               MAX_DATE_DAY)
+local MIN_DT_DAY_VALUE = INT_MIN
+local MAX_DT_DAY_VALUE = INT_MAX
+local MIN_EPOCH_SECS_VALUE = MIN_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_OFFSET
+local MAX_EPOCH_SECS_VALUE = MAX_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_OFFSET
 local MAX_YEAR_RANGE = MAX_DATE_YEAR - MIN_DATE_YEAR
 local MAX_MONTH_RANGE = MAX_YEAR_RANGE * 12
 local MAX_WEEK_RANGE = MAX_YEAR_RANGE * AVERAGE_WEEK_YEAR
@@ -657,10 +662,12 @@ end
 
 -- Timestamp is erroneously considered as "local", not UTC (gh10363).
 -- Handle this historical case here.
-local function update_epoch(epoch, offset)
+local function check_and_update_epoch(epoch, offset)
     -- Convert "local" timestamp to UTC timestamp.
     -- Removing this adjustment will fix gh10363.
     epoch = utc_secs(epoch, offset)
+    check_range(epoch, MIN_EPOCH_SECS_VALUE, MAX_EPOCH_SECS_VALUE, 'timestamp',
+        nil, 1)
     return epoch
 end
 
@@ -682,7 +689,7 @@ local function datetime_new(obj)
     if epoch ~= nil then
         local tzoffset, tzindex = extract_obj_tzoffset_tzindex(obj, epoch)
         tzoffset, tzindex = tzoffset or 0, tzindex or 0
-        epoch = update_epoch(epoch, tzoffset)
+        epoch = check_and_update_epoch(epoch, tzoffset)
         return datetime_new_raw(epoch, nsec, tzoffset, tzindex)
     end
 
@@ -1080,7 +1087,7 @@ function datetime_set(self, obj)
     if epoch ~= nil then
         local tzoffset, tzindex = extract_obj_tzoffset_tzindex(obj, epoch)
         local effective_tzoffset = tzoffset or self.tzoffset
-        epoch = update_epoch(epoch, effective_tzoffset)
+        epoch = check_and_update_epoch(epoch, effective_tzoffset)
 
         self.epoch = epoch
         self.nsec = nsec

--- a/test/app-luatest/datetime_test.lua
+++ b/test/app-luatest/datetime_test.lua
@@ -6,6 +6,17 @@ local compat = require('compat')
 
 -- {{{ Datetime module and related helper constants.
 
+local INT_MAX = 2147483647
+local INT_MIN = -2147483648
+local SECS_PER_DAY = 86400
+
+local DAYS_EPOCH_OFFSET = 719163
+local SECS_EPOCH_OFFSET = DAYS_EPOCH_OFFSET * SECS_PER_DAY
+local MIN_DT_DAY_VALUE = INT_MIN
+local MAX_DT_DAY_VALUE = INT_MAX
+local MIN_EPOCH_SECS_VALUE = MIN_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_OFFSET
+local MAX_EPOCH_SECS_VALUE = MAX_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_OFFSET
+
 -- Minimum supported date: -5879610-06-22.
 local MIN_DATE_YEAR = -5879610
 local MIN_DATE_MONTH = 6
@@ -24,6 +35,7 @@ local DAY_RANGE = {1, 31}
 local HOUR_RANGE = {0, 23}
 local MINUTE_RANGE = {0, 59}
 local SEC_RANGE = {0, 60}
+local TIMESTAMP_RANGE = {MIN_EPOCH_SECS_VALUE, MAX_EPOCH_SECS_VALUE}
 local MSEC_RANGE = {0, 1E3}
 local USEC_RANGE = {0, 1E6}
 local NSEC_RANGE = {0, 1E9}
@@ -2182,9 +2194,18 @@ local INVALID_NEW_AND_SET_TIME_UNITS_ERRORS = {
         return ("%s: %s expected, but received %s"):format(key, what_expected, val)
     end,
 
-    range_check_error = function(set_arg, range)
+    range_check_error_string = function(set_arg, range)
         local key, val = get_single_key_val(set_arg, true)
         return ('value %s of %s is out of allowed range [%s, %s]'):
+              format(val, key, range[1], range[2])
+    end,
+
+    -- Using %s conversion for large integer values produce
+    -- scientific-format strings. This fn is for the case,
+    -- when precise integer representation is needed.
+    range_check_error_digit = function(set_arg, range)
+        local key, val = get_single_key_val(set_arg, true)
+        return ('value %d of %s is out of allowed range [%d, %d]'):
               format(val, key, range[1], range[2])
     end,
 
@@ -2364,12 +2385,12 @@ local INVALID_NEW_AND_SET_TIME_UNITS = {
     -- Single unit range tests.
     {
         set_range = {'year', YEAR_RANGE},
-        err_fn = 'range_check_error',
+        err_fn = 'range_check_error_string',
         err_fn_args = {YEAR_RANGE},
     },
     {
         set_range = {'month', MONTH_RANGE},
-        err_fn = 'range_check_error',
+        err_fn = 'range_check_error_string',
         err_fn_args = {MONTH_RANGE},
     },
     {
@@ -2379,37 +2400,42 @@ local INVALID_NEW_AND_SET_TIME_UNITS = {
     },
     {
         set_range = {'hour', HOUR_RANGE},
-        err_fn = 'range_check_error',
+        err_fn = 'range_check_error_string',
         err_fn_args = {HOUR_RANGE},
     },
     {
         set_range = {'min', MINUTE_RANGE},
-        err_fn = 'range_check_error',
+        err_fn = 'range_check_error_string',
         err_fn_args = {MINUTE_RANGE},
     },
     {
         set_range = {'sec', SEC_RANGE},
-        err_fn = 'range_check_error',
+        err_fn = 'range_check_error_string',
         err_fn_args = {SEC_RANGE},
     },
     {
+        set_range = {'timestamp', TIMESTAMP_RANGE},
+        err_fn = 'range_check_error_digit',
+        err_fn_args = {TIMESTAMP_RANGE},
+    },
+    {
         set_range = {'msec', MSEC_RANGE},
-        err_fn = 'range_check_error',
+        err_fn = 'range_check_error_string',
         err_fn_args = {MSEC_RANGE},
     },
     {
         set_range = {'usec', USEC_RANGE},
-        err_fn = 'range_check_error',
+        err_fn = 'range_check_error_string',
         err_fn_args = {USEC_RANGE},
     },
     {
         set_range = {'nsec', NSEC_RANGE},
-        err_fn = 'range_check_error',
+        err_fn = 'range_check_error_string',
         err_fn_args = {NSEC_RANGE},
     },
     {
         set_range = {'tzoffset', TZOFFSET_RANGE},
-        err_fn = 'range_check_error',
+        err_fn = 'range_check_error_string',
         err_fn_args = {TZOFFSET_RANGE},
     },
     -- Date range tests.

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -11,6 +11,7 @@ local TZ = date.TZ
 test:plan(42)
 
 local INT_MAX = 2147483647
+local INT_MIN = -2147483648
 
 -- minimum supported date - -5879610-06-22
 local MIN_DATE_YEAR = -5879610
@@ -30,6 +31,13 @@ local MAX_SEC_RANGE = MAX_DAY_RANGE * SECS_PER_DAY
 local MAX_NSEC_RANGE = INT_MAX
 local MAX_USEC_RANGE = math.floor(MAX_NSEC_RANGE / 1e3)
 local MAX_MSEC_RANGE = math.floor(MAX_NSEC_RANGE / 1e6)
+
+local DAYS_EPOCH_OFFSET = 719163
+local SECS_EPOCH_OFFSET = DAYS_EPOCH_OFFSET * SECS_PER_DAY
+local MIN_DT_DAY_VALUE = INT_MIN
+local MAX_DT_DAY_VALUE = INT_MAX
+local MIN_EPOCH_SECS_VALUE = MIN_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_OFFSET
+local MAX_EPOCH_SECS_VALUE = MAX_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_OFFSET
 
 local incompat_types = 'incompatible types for datetime comparison'
 local only_integer_msg = function(key)
@@ -220,7 +228,7 @@ test:test("Default date creation and comparison", function(test)
 end)
 
 test:test("Simple date creation by attributes", function(test)
-    test:plan(17)
+    test:plan(19)
     local ts
     local obj = {}
     local attribs = {
@@ -258,6 +266,11 @@ test:test("Simple date creation by attributes", function(test)
     d2 = date.new({timestamp = d1.timestamp, tz = 'Europe/Moscow'})
     test:is(d1.tzoffset, d2.tzoffset, '{ymd} and {timestamp} tzoffset equals')
     test:is(d1.tzoffset, 240, 'Moscow time on 2012-07-02 is +04:00 to UTC')
+
+    test:is(tostring(date.new{timestamp = MIN_EPOCH_SECS_VALUE}),
+            '-5879610-06-22T00:00:00Z', '{MIN_EPOCH_SECS_VALUE timestamp}')
+    test:is(tostring(date.new{timestamp = MAX_EPOCH_SECS_VALUE}),
+            '5879611-07-11T00:00:00Z', '{MAX_EPOCH_SECS_VALUE timestamp}')
 end)
 
 test:test("Formatting limits", function(test)
@@ -2747,7 +2760,7 @@ test:test("Time :set{} operations", function(test)
 end)
 
 test:test("Check :set{} and .new{} equal for all attributes", function(test)
-    test:plan(15*2)
+    test:plan(17*2)
     local ts, ts2
     local obj = {}
     local attribs = {
@@ -2807,6 +2820,24 @@ test:test("Check :set{} and .new{} equal for all attributes", function(test)
             format(tostring(ts), tostring(ts2)))
     test:is_deeply(ts:totable(), ts2:totable(),
         ':totable() equals:'..json.encode({ts:totable(), ts2:totable()}))
+
+    obj = {timestamp = MIN_EPOCH_SECS_VALUE}
+    ts = date.new(obj)
+    ts2 = date.new():set(obj)
+    test:is(ts, ts2, ('MIN_EPOCH_SECS_VALUE timestamp (%s = %s)'):
+            format(tostring(ts), tostring(ts2)))
+    test:is_deeply(ts:totable(), ts2:totable(),
+                   ':totable() equals:'..
+                   json.encode({ts:totable(), ts2:totable()}))
+
+    obj = {timestamp = MAX_EPOCH_SECS_VALUE}
+    ts = date.new(obj)
+    ts2 = date.new():set(obj)
+    test:is(ts, ts2, ('MAX_EPOCH_SECS_VALUE timestamp (%s = %s)'):
+            format(tostring(ts), tostring(ts2)))
+    test:is_deeply(ts:totable(), ts2:totable(),
+                   ':totable() equals:'..
+                   json.encode({ts:totable(), ts2:totable()}))
 end)
 
 test:test("Time invalid tzoffset in :set{} operations", function(test)


### PR DESCRIPTION
Now `datetime.new()` and `datetime_object:set()`
check timestamp value to be in valid range.
Out of range timestamps produce an error instead of assertion failure.

Fixes #12147

----

Waits for #12423 and it's backports #12549 #12550 #12551 #12552 #12553 to be merged.
