### PR TITLE
box: use enum to combine privileges to check

### DIFF
--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -282,8 +282,10 @@ sysview_space_execute_upsert(struct space *space, struct txn *txn,
  * 7. User is parent for the user/role.
  */
 
-const uint32_t PRIV_WRDA = PRIV_W | PRIV_D | PRIV_A | PRIV_R;
-const uint32_t PRIV_WRDAG = PRIV_WRDA | PRIV_GRANT;
+enum {
+	PRIV_WRDA = PRIV_W | PRIV_D | PRIV_A | PRIV_R,
+	PRIV_WRDAG = PRIV_WRDA | PRIV_GRANT,
+};
 
 static bool
 vspace_filter(struct space *source, struct tuple *tuple)


### PR DESCRIPTION
Using `const uint32_t` for saving combined privilege set does not allow to use the result in other constant expressions on some old compilers. Let's use an enum instead.

Closes #12167

NO_DOC=refactoring
NO_TEST=refactoring
NO_CHANGELOG=refactoring