### PR TITLE
core: do not rename user threads

### DIFF
--- a/changelogs/unreleased/gh-12175-do-not-rename-user-threads.md
+++ b/changelogs/unreleased/gh-12175-do-not-rename-user-threads.md
@@ -1,0 +1,3 @@
+## bugfix/core
+
+* Tarantool does not rename user threads anymore (gh-12175).

--- a/src/lib/core/cord_on_demand.cc
+++ b/src/lib/core/cord_on_demand.cc
@@ -32,7 +32,7 @@ private:
 	{
 		cord_ptr = static_cast<struct cord *>(
 				xcalloc(1, sizeof(*cord_ptr)));
-		cord_create(cord_ptr, "unknown");
+		cord_create(cord_ptr, NULL);
 	}
 
 	~CordOnDemand()

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -2236,9 +2236,13 @@ cord_costart(struct cord *cord, const char *name, fiber_func f, void *arg)
 void
 cord_set_name(const char *name)
 {
-	snprintf(cord()->name, sizeof(cord()->name), "%s", name);
-	/* Main thread's name will replace process title in ps, skip it */
-	if (cord_is_main())
+	snprintf(cord()->name, sizeof(cord()->name), "%s",
+		 name != NULL ? name : "unknown");
+	/*
+	 * Main thread's name will replace process title in ps, skip it.
+	 * Also, skip anonymous cord - its thread's name is set by creator.
+	 */
+	if (cord_is_main() || name == NULL)
 		return;
 	tt_pthread_setname(name);
 }

--- a/test/unit/fiber.result
+++ b/test/unit/fiber.result
@@ -42,3 +42,5 @@
 	*** fiber_test_set_system: done ***
 	*** fiber_test_shutdown: done ***
 	*** fiber_test_shutdown ***
+	*** cord_no_user_thread_rename ***
+	*** cord_no_user_thread_rename: done ***


### PR DESCRIPTION
When a user thread uses Tarantool C API functions, user thread can be renamed because of creation of cord on demand. The commit removes thread renaming for these cords.

There is no portable way to set/get thread name, so let's simply run the test only on Linux.

Closes #12175