### PR TITLE
bps: drop the `BPS_TREE_EXTENT_SIZE`

### DIFF
--- a/perf/bps_tree.cc
+++ b/perf/bps_tree.cc
@@ -18,7 +18,6 @@
 #define tree_i64_key_t int64_t
 #define BPS_TREE_NAME tree_i64_t
 #define BPS_TREE_BLOCK_SIZE 512
-#define BPS_TREE_EXTENT_SIZE tree_i64_EXTENT_SIZE
 #define BPS_TREE_IS_IDENTICAL(a, b) ((a) == (b))
 #define BPS_TREE_COMPARE(a, b, arg) ((a) - (b))
 #define BPS_TREE_COMPARE_KEY(a, b, arg) ((a) - (b))
@@ -27,7 +26,6 @@
 #include "salad/bps_tree.h"
 #undef BPS_TREE_NAME
 #undef BPS_TREE_BLOCK_SIZE
-#undef BPS_TREE_EXTENT_SIZE
 #undef BPS_TREE_IS_IDENTICAL
 #undef BPS_TREE_COMPARE
 #undef BPS_TREE_COMPARE_KEY
@@ -42,7 +40,6 @@
 #define treecc_i64_key_t int64_t
 #define BPS_TREE_NAME treecc_i64_t
 #define BPS_TREE_BLOCK_SIZE 512
-#define BPS_TREE_EXTENT_SIZE treecc_i64_EXTENT_SIZE
 #define BPS_TREE_IS_IDENTICAL(a, b) ((a) == (b))
 #define BPS_TREE_COMPARE(a, b, arg) ((a) - (b))
 #define BPS_TREE_COMPARE_KEY(a, b, arg) ((a) - (b))
@@ -51,7 +48,6 @@
 #include "salad/bps_tree.h"
 #undef BPS_TREE_NAME
 #undef BPS_TREE_BLOCK_SIZE
-#undef BPS_TREE_EXTENT_SIZE
 #undef BPS_TREE_IS_IDENTICAL
 #undef BPS_TREE_COMPARE
 #undef BPS_TREE_COMPARE_KEY
@@ -67,7 +63,6 @@
 #define treeic_i64_key_t int64_t
 #define BPS_TREE_NAME treeic_i64_t
 #define BPS_TREE_BLOCK_SIZE 512
-#define BPS_TREE_EXTENT_SIZE treeic_i64_EXTENT_SIZE
 #define BPS_TREE_IS_IDENTICAL(a, b) ((a) == (b))
 #define BPS_TREE_COMPARE(a, b, arg) ((a) - (b))
 #define BPS_TREE_COMPARE_KEY(a, b, arg) ((a) - (b))
@@ -76,7 +71,6 @@
 #include "salad/bps_tree.h"
 #undef BPS_TREE_NAME
 #undef BPS_TREE_BLOCK_SIZE
-#undef BPS_TREE_EXTENT_SIZE
 #undef BPS_TREE_IS_IDENTICAL
 #undef BPS_TREE_COMPARE
 #undef BPS_TREE_COMPARE_KEY

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -127,7 +127,6 @@ memtx_tree_data_is_equal(const struct memtx_tree_data_common *a,
 #define BPS_INNER_CARD
 #define BPS_TREE_NAME memtx_tree
 #define BPS_TREE_BLOCK_SIZE (512)
-#define BPS_TREE_EXTENT_SIZE MEMTX_EXTENT_SIZE
 #define BPS_TREE_COMPARE(a, b, arg)\
 	tuple_compare((&a)->tuple, (&a)->hint, (&b)->tuple, (&b)->hint, arg)
 #define BPS_TREE_COMPARE_KEY(a, b, arg)\
@@ -159,7 +158,6 @@ memtx_tree_data_is_equal(const struct memtx_tree_data_common *a,
 
 #undef BPS_TREE_NAME
 #undef BPS_TREE_BLOCK_SIZE
-#undef BPS_TREE_EXTENT_SIZE
 #undef BPS_TREE_COMPARE
 #undef BPS_TREE_COMPARE_KEY
 #undef BPS_TREE_IS_IDENTICAL

--- a/src/box/vy_cache.h
+++ b/src/box/vy_cache.h
@@ -109,7 +109,6 @@ vy_cache_tree_key_cmp(struct vy_cache_node *a, struct vy_entry b,
 
 #define BPS_TREE_NAME vy_cache_tree
 #define BPS_TREE_BLOCK_SIZE 512
-#define BPS_TREE_EXTENT_SIZE VY_CACHE_TREE_EXTENT_SIZE
 #define BPS_TREE_COMPARE(a, b, cmp_def) vy_cache_tree_cmp(a, b, cmp_def)
 #define BPS_TREE_COMPARE_KEY(a, b, cmp_def) vy_cache_tree_key_cmp(a, b, cmp_def)
 #define bps_tree_elem_t struct vy_cache_node *
@@ -121,7 +120,6 @@ vy_cache_tree_key_cmp(struct vy_cache_node *a, struct vy_entry b,
 
 #undef BPS_TREE_NAME
 #undef BPS_TREE_BLOCK_SIZE
-#undef BPS_TREE_EXTENT_SIZE
 #undef BPS_TREE_COMPARE
 #undef BPS_TREE_COMPARE_KEY
 #undef bps_tree_elem_t

--- a/src/box/vy_mem.h
+++ b/src/box/vy_mem.h
@@ -118,7 +118,6 @@ vy_mem_tree_cmp_key(struct vy_entry entry, struct vy_mem_tree_key *key,
 
 #define BPS_TREE_NAME vy_mem_tree
 #define BPS_TREE_BLOCK_SIZE 512
-#define BPS_TREE_EXTENT_SIZE VY_MEM_TREE_EXTENT_SIZE
 #define BPS_TREE_COMPARE(a, b, cmp_def) vy_mem_tree_cmp(a, b, cmp_def)
 #define BPS_TREE_COMPARE_KEY(a, b, cmp_def) vy_mem_tree_cmp_key(a, b, cmp_def)
 #define BPS_TREE_IS_IDENTICAL(a, b) vy_entry_is_equal(a, b)
@@ -130,7 +129,6 @@ vy_mem_tree_cmp_key(struct vy_entry entry, struct vy_mem_tree_key *key,
 
 #undef BPS_TREE_NAME
 #undef BPS_TREE_BLOCK_SIZE
-#undef BPS_TREE_EXTENT_SIZE
 #undef BPS_TREE_COMPARE
 #undef BPS_TREE_COMPARE_KEY
 #undef bps_tree_elem_t

--- a/test/unit/bps_tree.cc
+++ b/test/unit/bps_tree.cc
@@ -42,7 +42,6 @@ compare(type_t a, type_t b);
 /* check compiling with another name and settings */
 #define BPS_TREE_NAME testtest
 #define BPS_TREE_BLOCK_SIZE 512
-#define BPS_TREE_EXTENT_SIZE 16*1024
 #define BPS_TREE_IS_IDENTICAL(a, b) (a == b)
 #define BPS_TREE_COMPARE(a, b, arg) compare(a, b)
 #define BPS_TREE_COMPARE_KEY(a, b, arg) compare(a, b)
@@ -52,7 +51,6 @@ compare(type_t a, type_t b);
 #include "salad/bps_tree.h"
 #undef BPS_TREE_NAME
 #undef BPS_TREE_BLOCK_SIZE
-#undef BPS_TREE_EXTENT_SIZE
 #undef BPS_TREE_IS_IDENTICAL
 #undef BPS_TREE_COMPARE
 #undef BPS_TREE_COMPARE_KEY
@@ -61,9 +59,9 @@ compare(type_t a, type_t b);
 #undef bps_tree_arg_t
 
 /* true tree with true settings */
+#define test_TREE_EXTENT_SIZE 2048 /* value is to low specially for tests */
 #define BPS_TREE_NAME test
 #define BPS_TREE_BLOCK_SIZE SMALL_BLOCK_SIZE /* small value for tests */
-#define BPS_TREE_EXTENT_SIZE 2048 /* value is to low specially for tests */
 #define BPS_TREE_IS_IDENTICAL(a, b) (a == b)
 #define BPS_TREE_COMPARE(a, b, arg) compare(a, b)
 #define BPS_TREE_COMPARE_KEY(a, b, arg) compare(a, b)
@@ -74,7 +72,6 @@ compare(type_t a, type_t b);
 #include "salad/bps_tree.h"
 #undef BPS_TREE_NAME
 #undef BPS_TREE_BLOCK_SIZE
-#undef BPS_TREE_EXTENT_SIZE
 #undef BPS_TREE_IS_IDENTICAL
 #undef BPS_TREE_COMPARE
 #undef BPS_TREE_COMPARE_KEY
@@ -86,7 +83,6 @@ compare(type_t a, type_t b);
 #define bx1_TREE_EXTENT_SIZE SMALL_BLOCK_SIZE
 #define BPS_TREE_NAME test_bx1
 #define BPS_TREE_BLOCK_SIZE SMALL_BLOCK_SIZE
-#define BPS_TREE_EXTENT_SIZE bx1_TREE_EXTENT_SIZE
 #define BPS_TREE_IS_IDENTICAL(a, b) ((a) == (b))
 #define BPS_TREE_COMPARE(a, b, arg) compare(a, b)
 #define BPS_TREE_COMPARE_KEY(a, b, arg) compare(a, b)
@@ -96,7 +92,6 @@ compare(type_t a, type_t b);
 #include "salad/bps_tree.h"
 #undef BPS_TREE_NAME
 #undef BPS_TREE_BLOCK_SIZE
-#undef BPS_TREE_EXTENT_SIZE
 #undef BPS_TREE_IS_IDENTICAL
 #undef BPS_TREE_COMPARE
 #undef BPS_TREE_COMPARE_KEY
@@ -108,7 +103,6 @@ compare(type_t a, type_t b);
 #define bx4_TREE_EXTENT_SIZE (SMALL_BLOCK_SIZE * 4)
 #define BPS_TREE_NAME test_bx4
 #define BPS_TREE_BLOCK_SIZE SMALL_BLOCK_SIZE
-#define BPS_TREE_EXTENT_SIZE bx4_TREE_EXTENT_SIZE
 #define BPS_TREE_IS_IDENTICAL(a, b) ((a) == (b))
 #define BPS_TREE_COMPARE(a, b, arg) compare(a, b)
 #define BPS_TREE_COMPARE_KEY(a, b, arg) compare(a, b)
@@ -118,7 +112,6 @@ compare(type_t a, type_t b);
 #include "salad/bps_tree.h"
 #undef BPS_TREE_NAME
 #undef BPS_TREE_BLOCK_SIZE
-#undef BPS_TREE_EXTENT_SIZE
 #undef BPS_TREE_IS_IDENTICAL
 #undef BPS_TREE_COMPARE
 #undef BPS_TREE_COMPARE_KEY
@@ -149,7 +142,6 @@ static int compare_key(const elem_t &a, long b)
 
 #define BPS_TREE_NAME struct_tree
 #define BPS_TREE_BLOCK_SIZE SMALL_BLOCK_SIZE /* small value for tests */
-#define BPS_TREE_EXTENT_SIZE 2048 /* value is to low specially for tests */
 #define BPS_TREE_IS_IDENTICAL(a, b) equal(a, b)
 #define BPS_TREE_COMPARE(a, b, arg) compare(a, b)
 #define BPS_TREE_COMPARE_KEY(a, b, arg) compare_key(a, b)
@@ -159,7 +151,6 @@ static int compare_key(const elem_t &a, long b)
 #include "salad/bps_tree.h"
 #undef BPS_TREE_NAME
 #undef BPS_TREE_BLOCK_SIZE
-#undef BPS_TREE_EXTENT_SIZE
 #undef BPS_TREE_COMPARE
 #undef BPS_TREE_COMPARE_KEY
 #undef BPS_TREE_IS_IDENTICAL
@@ -170,7 +161,6 @@ static int compare_key(const elem_t &a, long b)
 /* tree for approximate_count test */
 #define BPS_TREE_NAME approx
 #define BPS_TREE_BLOCK_SIZE SMALL_BLOCK_SIZE /* small value for tests */
-#define BPS_TREE_EXTENT_SIZE 2048 /* value is to low specially for tests */
 #define BPS_TREE_IS_IDENTICAL(a, b) (a == b)
 #define BPS_TREE_COMPARE(a, b, arg) ((a) < (b) ? -1 : (a) > (b) ? 1 : 0)
 #define BPS_TREE_COMPARE_KEY(a, b, arg) (((a) >> 32) < (b) ? -1 : ((a) >> 32) > (b) ? 1 : 0)
@@ -1176,7 +1166,7 @@ main(void)
 	plan(16);
 	header();
 
-	matras_allocator_create(&allocator, BPS_TREE_EXTENT_SIZE,
+	matras_allocator_create(&allocator, test_TREE_EXTENT_SIZE,
 				extent_alloc, extent_free);
 
 	simple_check();
@@ -1194,7 +1184,7 @@ main(void)
 
 	matras_allocator_destroy(&allocator);
 
-	matras_allocator_create(&allocator, BPS_TREE_EXTENT_SIZE,
+	matras_allocator_create(&allocator, test_TREE_EXTENT_SIZE,
 				extent_alloc, extent_free);
 	gh_11326_oom_on_insertion_test();
 	gh_11788_oom_on_first_insertion_test();

--- a/test/unit/bps_tree_iterator.cc
+++ b/test/unit/bps_tree_iterator.cc
@@ -32,8 +32,8 @@ static int compare_key(const elem_t &a, long b);
  * accidentally and the test passes. To avoid this issue let's make extent and
  * block the same size.
  */
+#define test_TREE_EXTENT_SIZE 256
 #define BPS_TREE_BLOCK_SIZE 256
-#define BPS_TREE_EXTENT_SIZE 256
 #define BPS_TREE_IS_IDENTICAL(a, b) equal(a, b)
 #define BPS_TREE_COMPARE(a, b, arg) compare(a, b)
 #define BPS_TREE_COMPARE_KEY(a, b, arg) compare_key(a, b)
@@ -66,7 +66,7 @@ extent_alloc(struct matras_allocator *allocator)
 {
 	(void)allocator;
 	++total_extents_allocated;
-	return xmalloc(BPS_TREE_EXTENT_SIZE);
+	return xmalloc(test_TREE_EXTENT_SIZE);
 }
 
 static void
@@ -505,7 +505,7 @@ main(void)
 	plan(4);
 	header();
 
-	matras_allocator_create(&allocator, BPS_TREE_EXTENT_SIZE,
+	matras_allocator_create(&allocator, test_TREE_EXTENT_SIZE,
 				extent_alloc, extent_free);
 
 	srand(time(0));

--- a/test/unit/bps_tree_offset_api.cc
+++ b/test/unit/bps_tree_offset_api.cc
@@ -24,9 +24,9 @@
 typedef int64_t type_t;
 #define TYPE_F "%" PRId64
 
+#define test_TREE_EXTENT_SIZE 2048
 #define BPS_TREE_NAME test
 #define BPS_TREE_BLOCK_SIZE 256
-#define BPS_TREE_EXTENT_SIZE 2048
 #define BPS_TREE_IS_IDENTICAL(a, b) ((a) == (b))
 #define BPS_TREE_COMPARE(a, b, arg) ((a) - (b))
 #define BPS_TREE_COMPARE_KEY(a, b, arg) ((a) - (b))
@@ -172,7 +172,7 @@ extent_alloc(struct matras_allocator *allocator)
 {
 	(void)allocator;
 	++extent_count;
-	return xmalloc(BPS_TREE_EXTENT_SIZE);
+	return xmalloc(test_TREE_EXTENT_SIZE);
 }
 
 static void
@@ -458,7 +458,7 @@ main(void)
 	plan(4);
 	header();
 
-	matras_allocator_create(&allocator, BPS_TREE_EXTENT_SIZE,
+	matras_allocator_create(&allocator, test_TREE_EXTENT_SIZE,
 				extent_alloc, extent_free);
 
 	iterator_at();

--- a/test/unit/bps_tree_view.c
+++ b/test/unit/bps_tree_view.c
@@ -20,8 +20,8 @@
  * accidentally and the test passes. To avoid this issue let's make extent and
  * block the same size.
  */
+#define test_TREE_EXTENT_SIZE 256
 #define BPS_TREE_BLOCK_SIZE 256
-#define BPS_TREE_EXTENT_SIZE 256
 #define BPS_TREE_IS_IDENTICAL(a, b) ((a) == (b))
 #define BPS_TREE_COMPARE(a, b, arg) ((a) < (b) ? -1 : ((a) > (b) ? 1 : 0))
 #define BPS_TREE_COMPARE_KEY(a, b, arg) BPS_TREE_COMPARE(a, b, arg)
@@ -43,7 +43,7 @@ static void *
 extent_alloc(struct matras_allocator *allocator)
 {
 	(void)allocator;
-	return xmalloc(BPS_TREE_EXTENT_SIZE);
+	return xmalloc(test_TREE_EXTENT_SIZE);
 }
 
 static void
@@ -492,7 +492,7 @@ main(void)
 	plan(8);
 	header();
 
-	matras_allocator_create(&allocator, BPS_TREE_EXTENT_SIZE,
+	matras_allocator_create(&allocator, test_TREE_EXTENT_SIZE,
 				extent_alloc, extent_free);
 
 	test_size();


### PR DESCRIPTION
It used to be used to calculate the amount of memory used by the matras allocator, but since the commit 7f1b3ef192ce532a6949c3d22f2a3ef2d161461 ("small: bump version") the constant is not required as the information can be acquired directly from the `matras_allocator`. This commit does exactly that.

Closes #12178

NO_DOC=refactoring
NO_TEST=refactoring
NO_CHANGELOG=refactoring