### PR TITLE
cmake: fix Ninja build with enabled fuzzing

### DIFF
--- a/cmake/LibFuzzer.cmake
+++ b/cmake/LibFuzzer.cmake
@@ -78,7 +78,6 @@ function(BuildLibFuzzerSymbols LibFuzzerExports)
   add_custom_command(
     OUTPUT ${LibFuzzerExports}
     COMMAND ${CMAKE_NM} ${NM_OPTIONS} ${LibFuzzerPath} > ${LibFuzzerExports}
-    BYPRODUCTS ${LibFuzzerExports}
     COMMENT "Generate a file with exported libFuzzer symbols"
   )
 endfunction()


### PR DESCRIPTION
The commit 3467991c2323 ("test/fuzz: support Lua coverage-guided testing") added a command that generate a file with libFuzzer symbols. The build using Ninja became broken after aforementioned commit:

ninja: error: build.ninja:23723: multiple rules generate extra/exports_libfuzzer

The patch fixes the issue by removing explicit BYPRODUCTS for the command.

Follows up #11884

NO_CHANGELOG=build
NO_DOC=build
NO_TEST=build