### PR TITLE
datetime: fixed MIN/MAX timezone offsets

### DIFF
--- a/changelogs/unreleased/gh-12417-datetime-fixed-tzoffset-range.md
+++ b/changelogs/unreleased/gh-12417-datetime-fixed-tzoffset-range.md
@@ -1,0 +1,5 @@
+## bugfix/datetime
+
+* Fixed errors on creating dates with historically valid timezone offset
+  values, which are out of modern standard range of [-12:00, +14:00]
+  (gh-12417).

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -1080,7 +1080,7 @@ datetime_from_fields(struct datetime *dt, const struct dt_fields *fields)
 		      fields->nsec;
 	if (nsec < 0 || nsec >= MAX_NANOS_PER_SEC)
 		return -1;
-	if (fields->tzoffset < -720 || fields->tzoffset > 840)
+	if (fields->tzoffset < MIN_TZOFFSET || fields->tzoffset > MAX_TZOFFSET)
 		return -1;
 	if (fields->timestamp < (double)INT32_MIN * SECS_PER_DAY ||
 	    fields->timestamp > (double)INT32_MAX * SECS_PER_DAY)

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -63,12 +63,9 @@ struct tnt_tm;
 #define MIN_EPOCH_SECS_VALUE    \
 	(MIN_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_1970_OFFSET)
 
-/**
- * At the moment the range of known timezones is UTC-12:00..UTC+14:00
- * https://en.wikipedia.org/wiki/List_of_UTC_time_offsets
- */
-#define MAX_TZOFFSET (14L * 60)
-#define MIN_TZOFFSET (-12L * 60)
+/** See https://github.com/tarantool/tarantool/wiki/datetime%E2%80%90calc%E2%80%90tzoffset%E2%80%90range. */
+#define MAX_TZOFFSET 913
+#define MIN_TZOFFSET (-956)
 
 /**
  * Actually we have lesser number of generated timezones, but 1024

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -63,12 +63,9 @@ struct tnt_tm;
 #define MIN_EPOCH_SECS_VALUE    \
 	(MIN_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_1970_OFFSET)
 
-/**
- * At the moment the range of known timezones is UTC-12:00..UTC+14:00
- * https://en.wikipedia.org/wiki/List_of_UTC_time_offsets
- */
-#define TZOFFSET_MAX (14L * 60)
-#define TZOFFSET_MIN (-12L * 60)
+/** See https://github.com/tarantool/tarantool/wiki/datetime%E2%80%90calc%E2%80%90tzoffset%E2%80%90range. */
+#define TZOFFSET_MAX 913
+#define TZOFFSET_MIN (-956)
 
 /**
  * Actually we have lesser number of generated timezones, but 1024

--- a/src/lib/tzcode/strptime.c
+++ b/src/lib/tzcode/strptime.c
@@ -110,7 +110,7 @@ tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
 	char c;
 	int day_offset, wday_offset;
 	int week_offset;
-	int i, len;
+	int i, j, len;
 	int Ealternative, Oalternative;
 	enum flags flags = FLAG_NONE;
 	int century = -1;
@@ -600,11 +600,24 @@ tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
 					return NULL;
 			}
 
-			if (i > 1400 || (sign == -1 && i > 1200) ||
-			    (i % 100) >= 60)
+			if (i % 100 >= 60)
 				return NULL;
-			tm->tm_gmtoff =
-				sign * ((i / 100) * 3600 + i % 100 * 60);
+
+			/* Min/max as in datetime.h, converted to sec. */
+			#define MAX_TZOFFSET_SEC (14L * 60) * 60
+			#define MIN_TZOFFSET_SEC (-12L * 60) * 60
+			/*
+			 * TODO: This check must be moved to datetime.c,
+			 * where the range is defined. Here we must
+			 * check max range [-23:59..+23:59] as in
+			 * dt_parse_iso_zone_lenient.
+			 */
+			j = sign * ((i / 100) * 3600 + i % 100 * 60);
+			if (j < MIN_TZOFFSET_SEC || j > MAX_TZOFFSET_SEC)
+				return NULL;
+			tm->tm_gmtoff = j;
+			#undef MAX_TZOFFSET_SEC
+			#undef MIN_TZOFFSET_SEC
 		} break;
 
 		case 'n':

--- a/src/lib/tzcode/strptime.c
+++ b/src/lib/tzcode/strptime.c
@@ -604,8 +604,8 @@ tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
 				return NULL;
 
 			/* Min/max as in datetime.h, converted to sec. */
-			#define MAX_TZOFFSET_SEC (14L * 60) * 60
-			#define MIN_TZOFFSET_SEC (-12L * 60) * 60
+			#define MAX_TZOFFSET_SEC (913) * 60
+			#define MIN_TZOFFSET_SEC (-956) * 60
 			/*
 			 * TODO: This check must be moved to datetime.c,
 			 * where the range is defined. Here we must

--- a/src/lib/tzcode/strptime.c
+++ b/src/lib/tzcode/strptime.c
@@ -604,8 +604,8 @@ tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
 				return NULL;
 
 			/* Min/max as in datetime.h, converted to sec. */
-			#define TZOFFSET_SEC_MAX (14L * 60) * 60
-			#define TZOFFSET_SEC_MIN (-12L * 60) * 60
+			#define TZOFFSET_SEC_MAX (913) * 60
+			#define TZOFFSET_SEC_MIN (-956) * 60
 			/*
 			 * TODO: This check must be moved to datetime.c,
 			 * where the range is defined. Here we must

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -117,10 +117,9 @@ local TOSTRING_BUFSIZE  = 64
 local IVAL_TOSTRING_BUFSIZE = 96
 local STRFTIME_BUFSIZE  = 128
 
--- At the moment the range of known timezones is UTC-12:00..UTC+14:00. See [1].
--- 1. https://en.wikipedia.org/wiki/List_of_UTC_time_offsets.
-local MIN_TZOFFSET = -12 * 60
-local MAX_TZOFFSET = 14 * 60
+-- See datetime.h.
+local MIN_TZOFFSET = -956
+local MAX_TZOFFSET = 913
 
 -- minimum supported date - -5879610-06-22
 local MIN_DATE_YEAR = -5879610

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -117,6 +117,11 @@ local TOSTRING_BUFSIZE  = 64
 local IVAL_TOSTRING_BUFSIZE = 96
 local STRFTIME_BUFSIZE  = 128
 
+-- At the moment the range of known timezones is UTC-12:00..UTC+14:00. See [1].
+-- 1. https://en.wikipedia.org/wiki/List_of_UTC_time_offsets.
+local MIN_TZOFFSET = -12 * 60
+local MAX_TZOFFSET = 14 * 60
+
 -- minimum supported date - -5879610-06-22
 local MIN_DATE_YEAR = -5879610
 local MIN_DATE_MONTH = 6
@@ -645,9 +650,7 @@ local function extract_obj_tzoffset_tzindex(obj, base_epoch)
     elseif obj_tzoffset ~= nil then
         tzindex = 0
         tzoffset = get_timezone(obj_tzoffset, 'tzoffset', 1)
-        -- at the moment the range of known timezones is UTC-12:00..UTC+14:00
-        -- https://en.wikipedia.org/wiki/List_of_UTC_time_offsets
-        check_range(tzoffset, -720, 840, 'tzoffset', nil, 1)
+        check_range(tzoffset, MIN_TZOFFSET, MAX_TZOFFSET, 'tzoffset', nil, 1)
     end
     return tzoffset, tzindex
 end
@@ -966,7 +969,7 @@ local function datetime_parse_from(str, obj)
 
     if tzoffset ~= nil then
         local offset = get_timezone(tzoffset, 'tzoffset')
-        check_range(offset, -720, 840, 'tzoffset')
+        check_range(offset, MIN_TZOFFSET, MAX_TZOFFSET, 'tzoffset')
     end
 
     if tzname ~= nil then

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -117,10 +117,9 @@ local TOSTRING_BUFSIZE  = 64
 local IVAL_TOSTRING_BUFSIZE = 96
 local STRFTIME_BUFSIZE  = 128
 
--- At the moment the range of known timezones is UTC-12:00..UTC+14:00. See [1].
--- 1. https://en.wikipedia.org/wiki/List_of_UTC_time_offsets.
-local TZOFFSET_MIN = -12 * 60
-local TZOFFSET_MAX = 14 * 60
+-- See datetime.h.
+local TZOFFSET_MIN = -956
+local TZOFFSET_MAX = 913
 
 -- minimum supported date - -5879610-06-22
 local MIN_DATE_YEAR = -5879610

--- a/test/app-luatest/datetime_test.lua
+++ b/test/app-luatest/datetime_test.lua
@@ -26,8 +26,8 @@ local MAX_DATE_YEAR = 5879611
 local MAX_DATE_MONTH = 7
 local MAX_DATE_DAY = 11
 
-local MIN_TZOFFSET = -12 * 60
-local MAX_TZOFFSET = 14 * 60
+local MIN_TZOFFSET = -956
+local MAX_TZOFFSET = 913
 
 local YEAR_RANGE = {MIN_DATE_YEAR, MAX_DATE_YEAR}
 local MONTH_RANGE = {1, 12}
@@ -2707,3 +2707,86 @@ g_fail_time_units.test_set = function(cg)
 end
 
 -- }}} new() and set() invalid args test.
+
+-- {{{ gh-12417 test.
+
+-- See https://github.com/tarantool/tarantool/wiki/datetime%E2%80%90calc%E2%80%90tzoffset%E2%80%90range.
+local HISTORICAL_TZOFFSET_OUT_OF_STD = {
+    {tz = 'Asia/Manila', tzoffset = -956, year = 1844},
+    {tz = 'Pacific/Guam', tzoffset = -861, year = 1844},
+    {tz = 'Pacific/Chuuk', tzoffset = -832, year = 1844},
+    {tz = 'Pacific/Pohnpei', tzoffset = -807, year = 1844},
+    {tz = 'Pacific/Kosrae', tzoffset = -788, year = 1844},
+    {tz = 'Pacific/Palau', tzoffset = -902, year = 1844},
+    {tz = 'America/Juneau', tzoffset = 902, year = 1867},
+    {tz = 'America/Sitka', tzoffset = 898, year = 1867},
+    {tz = 'America/Metlakatla', tzoffset = 913, year = 1867},
+    {tz = 'America/Yakutat', tzoffset = 881, year = 1867},
+}
+local HISTORICAL_TZOFFSET_OUT_OF_STD_REF = {}
+for i, v in ipairs(HISTORICAL_TZOFFSET_OUT_OF_STD) do
+    table.insert(HISTORICAL_TZOFFSET_OUT_OF_STD_REF,
+        {index = i, label = string.gsub(v.tz, '/', '_')})
+end
+
+local g_gh_12417 = t.group('gh-12417', HISTORICAL_TZOFFSET_OUT_OF_STD_REF)
+
+local function test_gh_12417_par(cg)
+    local par = HISTORICAL_TZOFFSET_OUT_OF_STD[cg.params.index]
+    local function check_par(_)
+        checks({tz = 'string', tzoffset = 'number', year = 'number'})
+    end
+    check_par(par)
+    return par
+end
+
+g_gh_12417.test_new = function(cg)
+    local par = test_gh_12417_par(cg)
+    local d1 = dt.new({year = par.year, tz = par.tz})
+    local d2 = dt.new({year = par.year, tzoffset = par.tzoffset})
+    t.assert_equals(d1.tzoffset, par.tzoffset)
+    t.assert_equals(d2.tzoffset, d1.tzoffset)
+end
+
+g_gh_12417.test_set = function(cg)
+    local par = test_gh_12417_par(cg)
+    local d1 = dt.new():set({year = par.year, tz = par.tz})
+    local d2 = dt.new():set({year = par.year, tzoffset = par.tzoffset})
+    t.assert_equals(d1.tzoffset, par.tzoffset)
+    t.assert_equals(d2.tzoffset, d1.tzoffset)
+end
+
+g_gh_12417.test_parse_iso = function(cg)
+    local par = test_gh_12417_par(cg)
+    local iso_str = ('%d-01-01T00:00:00'):format(par.year)
+    local d1 = dt.parse(iso_str, {tz = par.tz})
+    t.assert_equals(d1.tzoffset, par.tzoffset)
+    local d2 = dt.parse(iso_str, {tzoffset = par.tzoffset})
+    t.assert_equals(d2.tzoffset, par.tzoffset)
+    local d3 = dt.parse(iso_str..' '..par.tz)
+    t.assert_equals(d3.tzoffset, par.tzoffset)
+    local offs_str = ('%+03d:%02d')
+        :format(par.tzoffset / 60, math.abs(par.tzoffset) % 60)
+    local d4 = dt.parse(iso_str..' '..offs_str)
+    t.assert_equals(d4.tzoffset, par.tzoffset)
+end
+
+g_gh_12417.test_parse_format = function(cg)
+    local par = test_gh_12417_par(cg)
+    local year_str = ('%04d'):format(par.year)
+    local d1 = dt.parse(year_str, {format = '%Y', tz = par.tz})
+    t.assert_equals(d1.tzoffset, par.tzoffset)
+    local d2 = dt.parse(year_str, {format = '%Y', tzoffset = par.tzoffset})
+    t.assert_equals(d2.tzoffset, par.tzoffset)
+    -- Parsing timezones like 'Europe/Moscow' isn't supported yet,
+    -- the resulting timezone offset shall be wrong.
+    -- See https://github.com/tarantool/tarantool/issues/12560.
+    local d3 = dt.parse(year_str..' '..par.tz, {format = '%Y %Z'})
+    t.assert_not_equals(d3.tzoffset, par.tzoffset)
+    local offs_str = ('%+03d%02d')
+        :format(par.tzoffset / 60, math.abs(par.tzoffset) % 60)
+    local d4 = dt.parse(year_str..' '..offs_str, {format = '%Y %z'})
+    t.assert_equals(d4.tzoffset, par.tzoffset)
+end
+
+-- }}} gh-12417 test.

--- a/test/app-luatest/datetime_test.lua
+++ b/test/app-luatest/datetime_test.lua
@@ -26,8 +26,8 @@ local MAX_DATE_YEAR = 5879611
 local MAX_DATE_MONTH = 7
 local MAX_DATE_DAY = 11
 
-local TZOFFSET_MIN = -12 * 60
-local TZOFFSET_MAX = 14 * 60
+local TZOFFSET_MIN = -956
+local TZOFFSET_MAX = 913
 
 local YEAR_RANGE = {MIN_DATE_YEAR, MAX_DATE_YEAR}
 local MONTH_RANGE = {1, 12}
@@ -2707,3 +2707,86 @@ g_fail_time_units.test_set = function(cg)
 end
 
 -- }}} new() and set() invalid args test.
+
+-- {{{ gh-12417 test.
+
+-- See https://github.com/tarantool/tarantool/wiki/datetime%E2%80%90calc%E2%80%90tzoffset%E2%80%90range.
+local HISTORICAL_TZOFFSET_OUT_OF_STD = {
+    {tz = 'Asia/Manila', tzoffset = -956, year = 1844},
+    {tz = 'Pacific/Guam', tzoffset = -861, year = 1844},
+    {tz = 'Pacific/Chuuk', tzoffset = -832, year = 1844},
+    {tz = 'Pacific/Pohnpei', tzoffset = -807, year = 1844},
+    {tz = 'Pacific/Kosrae', tzoffset = -788, year = 1844},
+    {tz = 'Pacific/Palau', tzoffset = -902, year = 1844},
+    {tz = 'America/Juneau', tzoffset = 902, year = 1867},
+    {tz = 'America/Sitka', tzoffset = 898, year = 1867},
+    {tz = 'America/Metlakatla', tzoffset = 913, year = 1867},
+    {tz = 'America/Yakutat', tzoffset = 881, year = 1867},
+}
+local HISTORICAL_TZOFFSET_OUT_OF_STD_REF = {}
+for i, v in ipairs(HISTORICAL_TZOFFSET_OUT_OF_STD) do
+    table.insert(HISTORICAL_TZOFFSET_OUT_OF_STD_REF,
+        {index = i, label = string.gsub(v.tz, '/', '_')})
+end
+
+local g_gh_12417 = t.group('gh-12417', HISTORICAL_TZOFFSET_OUT_OF_STD_REF)
+
+local function test_gh_12417_par(cg)
+    local par = HISTORICAL_TZOFFSET_OUT_OF_STD[cg.params.index]
+    local function check_par(_)
+        checks({tz = 'string', tzoffset = 'number', year = 'number'})
+    end
+    check_par(par)
+    return par
+end
+
+g_gh_12417.test_new = function(cg)
+    local par = test_gh_12417_par(cg)
+    local d1 = dt.new({year = par.year, tz = par.tz})
+    local d2 = dt.new({year = par.year, tzoffset = par.tzoffset})
+    t.assert_equals(d1.tzoffset, par.tzoffset)
+    t.assert_equals(d2.tzoffset, d1.tzoffset)
+end
+
+g_gh_12417.test_set = function(cg)
+    local par = test_gh_12417_par(cg)
+    local d1 = dt.new():set({year = par.year, tz = par.tz})
+    local d2 = dt.new():set({year = par.year, tzoffset = par.tzoffset})
+    t.assert_equals(d1.tzoffset, par.tzoffset)
+    t.assert_equals(d2.tzoffset, d1.tzoffset)
+end
+
+g_gh_12417.test_parse_iso = function(cg)
+    local par = test_gh_12417_par(cg)
+    local iso_str = ('%d-01-01T00:00:00'):format(par.year)
+    local d1 = dt.parse(iso_str, {tz = par.tz})
+    t.assert_equals(d1.tzoffset, par.tzoffset)
+    local d2 = dt.parse(iso_str, {tzoffset = par.tzoffset})
+    t.assert_equals(d2.tzoffset, par.tzoffset)
+    local d3 = dt.parse(iso_str..' '..par.tz)
+    t.assert_equals(d3.tzoffset, par.tzoffset)
+    local offs_str = ('%+03d:%02d')
+        :format(par.tzoffset / 60, math.abs(par.tzoffset) % 60)
+    local d4 = dt.parse(iso_str..' '..offs_str)
+    t.assert_equals(d4.tzoffset, par.tzoffset)
+end
+
+g_gh_12417.test_parse_format = function(cg)
+    local par = test_gh_12417_par(cg)
+    local year_str = ('%04d'):format(par.year)
+    local d1 = dt.parse(year_str, {format = '%Y', tz = par.tz})
+    t.assert_equals(d1.tzoffset, par.tzoffset)
+    local d2 = dt.parse(year_str, {format = '%Y', tzoffset = par.tzoffset})
+    t.assert_equals(d2.tzoffset, par.tzoffset)
+    -- Parsing timezones like 'Europe/Moscow' isn't supported yet,
+    -- the resulting timezone offset shall be wrong.
+    -- See https://github.com/tarantool/tarantool/issues/12560.
+    local d3 = dt.parse(year_str..' '..par.tz, {format = '%Y %Z'})
+    t.assert_not_equals(d3.tzoffset, par.tzoffset)
+    local offs_str = ('%+03d%02d')
+        :format(par.tzoffset / 60, math.abs(par.tzoffset) % 60)
+    local d4 = dt.parse(year_str..' '..offs_str, {format = '%Y %z'})
+    t.assert_equals(d4.tzoffset, par.tzoffset)
+end
+
+-- }}} gh-12417 test.

--- a/test/sql-luatest/datetime_test.lua
+++ b/test/sql-luatest/datetime_test.lua
@@ -2294,8 +2294,8 @@ end
 --
 g.test_datetime_new_invalid_time_units = function()
     g.server:exec(function()
-        local MIN_TZOFFSET = -12 * 60
-        local MAX_TZOFFSET = 14 * 60
+        local MIN_TZOFFSET = -956
+        local MAX_TZOFFSET = 913
 
         local sql = [[SELECT CAST(#v AS DATETIME);]]
 

--- a/test/sql-luatest/datetime_test.lua
+++ b/test/sql-luatest/datetime_test.lua
@@ -2292,8 +2292,11 @@ end
 -- Make sure an error is thrown if the DATETIME value cannot be constructed from
 -- the corresponding table.
 --
-g.test_datetime_33_2 = function()
+g.test_datetime_new_invalid_time_units = function()
     g.server:exec(function()
+        local MIN_TZOFFSET = -12 * 60
+        local MAX_TZOFFSET = 14 * 60
+
         local sql = [[SELECT CAST(#v AS DATETIME);]]
 
         -- "year" cannot be more than 5879611.
@@ -2408,18 +2411,18 @@ g.test_datetime_33_2 = function()
         res = [[Type mismatch: can not convert map({"nsec": -1}) to datetime]]
         t.assert_equals(err.message, res)
 
-        -- "tzoffset" cannot be more than 840.
-        v = {tzoffset = 841}
+        -- "tzoffset" cannot be more than MAX_TZOFFSET.
+        v = {tzoffset = MAX_TZOFFSET + 1}
         _, err = box.execute(sql, {{['#v'] = v}})
-        res = [[Type mismatch: can not convert map({"tzoffset": 841}) ]]..
-              [[to datetime]]
+        res = ([[Type mismatch: can not convert map({"tzoffset": %d}) ]]
+               ):format(v.tzoffset)..[[to datetime]]
         t.assert_equals(err.message, res)
 
-        -- "tzoffset" cannot be less than -720.
-        v = {tzoffset = -721}
+        -- "tzoffset" cannot be less than MIN_TZOFFSET.
+        v = {tzoffset = MIN_TZOFFSET - 1}
         _, err = box.execute(sql, {{['#v'] = v}})
-        res = [[Type mismatch: can not convert map({"tzoffset": -721}) ]]..
-              [[to datetime]]
+        res = ([[Type mismatch: can not convert map({"tzoffset": %d}) ]]
+               ):format(v.tzoffset)..[[to datetime]]
         t.assert_equals(err.message, res)
 
         -- Only one of "msec", "usec" and "nsec" can be specified.

--- a/test/sql-luatest/datetime_test.lua
+++ b/test/sql-luatest/datetime_test.lua
@@ -2294,8 +2294,8 @@ end
 --
 g.test_datetime_new_invalid_time_units = function()
     g.server:exec(function()
-        local TZOFFSET_MIN = -12 * 60
-        local TZOFFSET_MAX = 14 * 60
+        local TZOFFSET_MIN = -956
+        local TZOFFSET_MAX = 913
 
         local sql = [[SELECT CAST(#v AS DATETIME);]]
 

--- a/tools/tarantool-gdb.py
+++ b/tools/tarantool-gdb.py
@@ -1119,8 +1119,8 @@ if find_type('struct datetime') is not None:
         MAX_EPOCH_SECS_VALUE = MAX_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_1970_OFFSET
         MIN_EPOCH_SECS_VALUE = MIN_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_1970_OFFSET
 
-        MAX_TZOFFSET = 14 * 60
-        MIN_TZOFFSET = -12 * 60
+        MAX_TZOFFSET = 913
+        MIN_TZOFFSET = -956
         MAX_TZINDEX = 1024
 
         def __init__(self, val):

--- a/tools/tarantool-gdb.py
+++ b/tools/tarantool-gdb.py
@@ -1119,8 +1119,8 @@ if find_type('struct datetime') is not None:
         MAX_EPOCH_SECS_VALUE = MAX_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_1970_OFFSET
         MIN_EPOCH_SECS_VALUE = MIN_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_1970_OFFSET
 
-        TZOFFSET_MAX = 14 * 60
-        TZOFFSET_MIN = -12 * 60
+        TZOFFSET_MAX = 913
+        TZOFFSET_MIN = -956
         MAX_TZINDEX = 1024
 
         def __init__(self, val):


### PR DESCRIPTION
There are historical timezone offsets, which are out of modern standard range of [-12:00, +14:00].

Min/max timezone offset constants were adjusted to cover these cases.
To calculate their values and test samples the script [1] was used.

1. https://github.com/tarantool/tarantool/wiki/datetime%E2%80%90calc%E2%80%90tzoffset%E2%80%90range

Fixes #12417