### PR TITLE
recovery: fix big tuples blocking recovery

### DIFF
--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -44,6 +44,7 @@
 #include "replication.h"
 #include "iproto_constants.h"
 #include "watcher.h"
+#include "tweaks.h"
 
 enum {
 	/**

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -62,15 +62,6 @@ enum wal_mode {
 	WAL_MODE_MAX
 };
 
-enum {
-	/**
-	 * Recovery yields once per that number of rows read and
-	 * applied from WAL. It allows not to block the event
-	 * loop for the whole recovery stage.
-	 */
-	WAL_ROWS_PER_YIELD = 1 << 15,
-};
-
 /** String constants for the supported modes. */
 extern const char *wal_mode_STRS[];
 

--- a/src/box/xlog.c
+++ b/src/box/xlog.c
@@ -1942,6 +1942,7 @@ xlog_cursor_next(struct xlog_cursor *cursor,
 		 struct xrow_header *xrow, bool force_recovery)
 {
 	assert(xlog_cursor_is_open(cursor));
+	ERROR_INJECT_SLEEP_FOR(ERRINJ_XLOG_READ_ROW_DELAY);
 	while (true) {
 		int rc;
 		rc = xlog_cursor_next_row(cursor, xrow);

--- a/src/box/xstream.h
+++ b/src/box/xstream.h
@@ -53,6 +53,8 @@ struct xstream {
 	xstream_write_f write;
 	xstream_yield_f yield;
 	uint64_t row_count;
+	/* Number of parsed bytes since last yield. */
+	uint64_t row_bytes_since_yield;
 };
 
 static inline void
@@ -62,12 +64,14 @@ xstream_create(struct xstream *xstream, xstream_write_f write,
 	xstream->write = write;
 	xstream->yield = yield;
 	xstream->row_count = 0;
+	xstream->row_bytes_since_yield = 0;
 }
 
 static inline void
 xstream_yield(struct xstream *stream)
 {
 	stream->yield(stream);
+	stream->row_bytes_since_yield = 0;
 }
 
 static inline void

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -212,6 +212,7 @@ struct errinj {
 	_(ERRINJ_XLOG_GARBAGE, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_XLOG_META, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_XLOG_READ, ERRINJ_INT, {.iparam = -1}) \
+	_(ERRINJ_XLOG_READ_ROW_DELAY, ERRINJ_DOUBLE, {.dparam = 0}) \
 	_(ERRINJ_XLOG_RENAME_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_XLOG_WRITE_CORRUPTED_BODY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_XLOG_WRITE_CORRUPTED_HEADER, ERRINJ_BOOL, {.bparam = false}) \

--- a/test/replication-luatest/gh_12029_big_tuples_replica_subscribe_test.lua
+++ b/test/replication-luatest/gh_12029_big_tuples_replica_subscribe_test.lua
@@ -1,0 +1,57 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.master = server:new({
+        alias = "master",
+        box_cfg = {
+            checkpoint_interval = 0,
+            wal_max_size = 1.0e9,
+            replication_timeout = 1.0,
+        }
+    })
+    cg.master:start()
+    cg.replica = server:new({
+        alias = "replica",
+        box_cfg = {
+            replication = cg.master.net_box_uri,
+            checkpoint_interval = 0,
+            wal_max_size = 1e9,
+            replication_timeout = 1.0,
+        }
+    })
+    cg.replica:start()
+    cg.master:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+        local data = string.rep("a", 4096)
+        for i = 1, 128 do
+            box.space.test:insert({i, data})
+        end
+        box.error.injection.set('ERRINJ_XLOG_READ_ROW_DELAY', 0.1)
+    end)
+    cg.master:exec(function()
+        local tweaks = require('internal.tweaks')
+        tweaks.xlog_row_bytes_per_yield = 1e9
+    end)
+    cg.master:wait_for_downstream_to(cg.replica)
+    cg.replica:update_box_cfg{replication = ""}
+end)
+
+g.after_all(function(cg)
+    cg.replica:update_box_cfg{replication = cg.master.net_box_uri}
+    cg.master:drop()
+    cg.replica:drop()
+end)
+
+g.test_row_bytes_per_yield_tweak = function(cg)
+    cg.master:exec(function()
+        local tweaks = require('internal.tweaks')
+        tweaks.xlog_row_bytes_per_yield = 16384
+        box.space.test:replace{500, 1}
+    end)
+    cg.replica:update_box_cfg{replication = cg.master.net_box_uri}
+    cg.master:wait_for_downstream_to(cg.replica)
+end


### PR DESCRIPTION
Replace constant `WAL_ROWS_PER_YIELD` with `xlog_row_bytes_per_yield`
tweak to ensure that the relay thread does not skip heartbeats while
parsing large tuples, and does not yield too frequently. Introduce
`ERRINJ_XLOG_READ_ROW_DELAY` to emulate the delay when parsing xlogs
consisting of large rows.

Fixes #12029

NO_DOC=bugfix
NO_CHANGELOG=bugfix