### PR TITLE
config: add env option to `config:get()`

### DIFF
--- a/changelogs/unreleased/gh-9824-opt-to-discard-envs.md
+++ b/changelogs/unreleased/gh-9824-opt-to-discard-envs.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Added the `env` option to `config:get()` to explicitly control whether
+  `TT_*` environment variables are taken into account (gh-9824).

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -457,14 +457,45 @@ end
 -- instance configuration sources (environment variables). The
 -- latter takes into account only cluster configuration, so the
 -- environment variables are ignored.
+--
+-- If opts.env is false, the environment variables are ignored
+-- even when opts.instance is missing. If opts.env is true and
+-- opts.instance is set, an error is raised.
 function methods.get(self, path, opts)
     selfcheck(self, 'get')
     initcheck(self, 'get', 'instance')
 
     opts = opts or {}
 
+    if type(opts) ~= 'table' then
+        error(('Expected table, got %s'):format(type(opts)), 0)
+    end
+    if opts.instance ~= nil and type(opts.instance) ~= 'string' then
+        error(('Expected string, got %s'):format(type(opts.instance)), 0)
+    end
+    if opts.env ~= nil and type(opts.env) ~= 'boolean' then
+        error(('Expected boolean, got %s'):format(type(opts.env)), 0)
+    end
+    if opts.instance ~= nil and opts.env == true then
+        error('config:get: "instance" and "env = true" options can\'t be ' ..
+              'used together, because it is unknown which TT_* environment ' ..
+              'variables were passed to another instance', 0)
+    end
+
+    -- At this point, either:
+    --  * opts.env == true  => lookup in environment/global scope, instance
+    --    must be nil, or
+    --  * opts.env == nil or false => instance-level lookup, instance may be
+    --    explicitly set or unspecified.
+    -- For instance-level lookups, default to the current instance if none is
+    -- provided.
+    local instance = opts.instance
+    if opts.env == false then
+        instance = instance or self._configdata_applied:names().instance_name
+    end
+
     return self._configdata_applied:get(path, {
-        instance = opts.instance,
+        instance = instance,
         use_default = true,
     })
 end

--- a/test/config-luatest/cluster_config_test.lua
+++ b/test/config-luatest/cluster_config_test.lua
@@ -124,10 +124,28 @@ g.test_env = function(g)
         local res = config:get('process.title')
         t.assert_equals(res, 'env')
 
+        res = config:get('process.title', {env = true})
+        t.assert_equals(res, 'env')
+
         -- With the `instance` option the environment variables
         -- are ignored: only cluster configuration has an effect.
-        local res = config:get('process.title', {instance = 'i-001'})
+        res = config:get('process.title', {instance = 'i-001'})
         t.assert_equals(res, 'file')
+
+        res = config:get('process.title', {env = false})
+        t.assert_equals(res, 'file')
+        local res = config:get('process.title', {
+            instance = 'i-001',
+            env = false,
+        })
+        t.assert_equals(res, 'file')
+
+        local err_msg = 'config:get: "instance" and "env = true" options ' ..
+            'can\'t be used together, because it is unknown which TT_* ' ..
+            'environment variables were passed to another instance'
+        t.assert_error_msg_equals(err_msg, function()
+            config:get('process.title', {instance = 'i-001', env = true})
+        end)
     end)
 end
 


### PR DESCRIPTION
This patch adds the env option to `config:get()` to explicitly control whether `TT_*` environment variables are taken into account.

Closes #9824