### PR TITLE
test: fix flaky wal_off/alter.test.lua

### DIFF
--- a/test/wal_off/alter.result
+++ b/test/wal_off/alter.result
@@ -89,7 +89,7 @@ mem_after > mem_before -- due to async cleanup
 - true
 ...
 -- Check that async cleanup doesn't leave garbage behind.
-for i = 1, 100 do mem_after = mem_used() if mem_after <= mem_before then break end fiber.sleep(0.01) end
+for i = 1, 30 do mem_after = mem_used() if mem_after <= mem_before then break end fiber.sleep(1) end
 ---
 ...
 mem_after <= mem_before

--- a/test/wal_off/alter.test.lua
+++ b/test/wal_off/alter.test.lua
@@ -48,5 +48,5 @@ test_run:cmd("setopt delimiter ''");
 mem_after > mem_before -- due to async cleanup
 
 -- Check that async cleanup doesn't leave garbage behind.
-for i = 1, 100 do mem_after = mem_used() if mem_after <= mem_before then break end fiber.sleep(0.01) end
+for i = 1, 30 do mem_after = mem_used() if mem_after <= mem_before then break end fiber.sleep(1) end
 mem_after <= mem_before


### PR DESCRIPTION
The test became rather flaky in debug asan workflow in CI. Though I failed to reproduce it locally. The test probably does not get enough time to finish cleanup. Let's give it more time and decrease granularity. The test runs about 10s anyway on my machine.