### PR TITLE
config/schema: deep set/delete for `any` type

### DIFF
--- a/changelogs/unreleased/gh-10204-set-del-in-any-schema.md
+++ b/changelogs/unreleased/gh-10204-set-del-in-any-schema.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Now it is allowed to assign and delete nested fields inside schema nodes
+  of the `any` type using deep paths (gh-10204).


### PR DESCRIPTION
This patch adds support for assigning and deleting nested fields inside schema scalar nodes of the `any` type using deep paths.

Previously, attempts to set a nested field past an `any` scalar resulted in a type error. Now such nodes are treated as schemaless containers, and intermediate tables are created automatically when needed.

Closes #10204