### PR TITLE
ci: bump cmake version to 3.26 in install-deps-debian action

### DIFF
--- a/.github/actions/install-deps-debian/action.yml
+++ b/.github/actions/install-deps-debian/action.yml
@@ -28,6 +28,13 @@ runs:
           libtool \
           util-linux \
           tt
+        apt-get purge --auto-remove cmake -y
+        # ubuntu 20.04 repos do not contain cmake 3.26.0
+        # thus we require an alternative way of installing
+        # this version
+        curl -O -L https://github.com/Kitware/CMake/releases/download/v3.26.0/cmake-3.26.0-linux-$(uname -i).tar.gz \
+        && tar -xvf cmake-3.26.0-linux-$(uname -i).tar.gz -C /usr/local --strip-components=1 \
+        && rm cmake-3.26.0-linux-$(uname -i).tar.gz
         tt rocks install luatest 1.2.1
         tt rocks install luacheck 0.26.0
         gem install coveralls-lcov


### PR DESCRIPTION
Bumped cmake version to 3.26 in CI install-deps-debian action.

Required by tarantool/tarantool-ee#1589

NO_TEST=ci
NO_DOC=ci
NO_CHANGELOG=ci