### PR TITLE
Revert "ci: bump cmake version to 3.26 in install-deps-debian action"

### DIFF
--- a/.github/actions/install-deps-debian/action.yml
+++ b/.github/actions/install-deps-debian/action.yml
@@ -17,6 +17,7 @@ runs:
         apt-get -y -f install \
           build-essential \
           ninja-build \
+          cmake \
           lua5.1 \
           lcov \
           ruby-dev \
@@ -26,15 +27,8 @@ runs:
           automake \
           libtool \
           util-linux \
-          tt \
-          python3-pip
+          tt
         tt rocks install luatest 1.2.1
         tt rocks install luacheck 0.26.0
         gem install coveralls-lcov
-
-        apt-get purge --auto-remove cmake -y
-        # ubuntu 20.04 repos do not contain cmake 3.26.0
-        # thus we require an alternative way of installing
-        # this version
-        pip install cmake==3.26.0
       shell: bash


### PR DESCRIPTION
This PR is a revert of https://github.com/tarantool/tarantool/pull/12152 to fix CI. A proper solution is worked on in scope of https://github.com/tarantool/tarantool/pull/12221
Backports to 3.3 - 3.6 weren't pushed yet, so no reverts are necessary there.

This reverts commit 0b3ea3920453cc47e0f4cb1b451809b3381ea720.

The chosen solution broke the `perf_micro` workflow. Let's revert it until a proper fix is found to unblock further pushes to master.

NO_DOC=CI
NO_TEST=CI
NO_CHANGELOG=CI