### PR TITLE
test/fuzz: update check for profilers support

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,5 +1,12 @@
 std = "luajit"
-globals = {"box", "_TARANTOOL", "tonumber64", "utf8", "package"}
+globals = {
+    "box",
+    "misc",
+    "package",
+    "tonumber64",
+    "utf8",
+    "_TARANTOOL",
+}
 ignore = {
     -- Accessing an undefined field of a global variable <debug>.
     "143/debug",

--- a/test/fuzz/lua/misc_memprof_test.lua
+++ b/test/fuzz/lua/misc_memprof_test.lua
@@ -1,11 +1,11 @@
 local luzer = require("luzer")
 
-local has_memprof, memprof = pcall(require, "misc.memprof")
-if not has_memprof then
-  print("Unsupported version.")
+if not misc.memprof.available then
+  print("memprof is unsupported")
   os.exit(0)
 end
 
+local memprof = misc.memprof
 local MAX_STR_LEN = 1e5
 
 local function TestOneInput(buf)

--- a/test/fuzz/lua/misc_sysprof_test.lua
+++ b/test/fuzz/lua/misc_sysprof_test.lua
@@ -1,11 +1,11 @@
 local luzer = require("luzer")
 
-local has_sysprof, sysprof = pcall(require, "misc.sysprof")
-if not has_sysprof then
-  print("Unsupported version.")
+if not misc.sysprof.available then
+  print("sysprof is unsupported")
   os.exit(0)
 end
 
+local sysprof = misc.sysprof
 local SYSPROF_DEFAULT_INTERVAL = 1 -- ms
 local MAX_STR_LEN = 1e5
 


### PR DESCRIPTION
The patch updates the checks for profilers support in Lua fuzzing tests.

Needed for #11250
Needed for google/oss-fuzz#14656
Follows up #12215

NO_CHANGELOG=testing
NO_DOC=testing