### PR TITLE
Generate changelog for 3.6.1

### DIFF
--- a/changelogs/3.6.1.md
+++ b/changelogs/3.6.1.md
@@ -1,0 +1,47 @@
+# 3.6.1
+
+Date: 2026-01-27
+Tag: 3.6.1
+
+## Overview
+
+Tarantool 3.x is the recommended release series. Users of Tarantool 2.11 are
+encouraged to update to the latest 3.x release.
+
+This release resolves 3 bugs since 3.6.0.
+
+Please consider the full list of user-visible changes below.
+
+## Compatibility
+
+Tarantool 2.x and 3.x are compatible in the binary data layout, client-server
+protocol, and replication protocol. It means upgrade may be performed with zero
+downtime for read requests and the order-of-network-lag downtime for write
+requests.
+
+Please follow the [upgrade procedure][upgrade] to plan your update actions.
+
+Users of Tarantool 2.x may be interested in the [compat][compat] options that
+allow to imitate some 2.x behavior. This allows to perform application code
+update step-by-step, not all-at-once.
+
+[compat]: https://www.tarantool.io/en/doc/latest/reference/configuration/configuration_reference/#compat
+
+[upgrade]: https://www.tarantool.io/en/doc/latest/book/admin/upgrades/
+
+## Bugs fixed
+
+### Core
+
+* Tarantool does not rename user threads anymore (gh-12175).
+* Fixed a crash with a transactional trigger on the `_space` space (gh-11766).
+
+### Metrics
+
+* Updated the metrics submodule to 1.6.2.
+
+  Changes in 1.6.2:
+
+  - The `error` message level displayed when the `/proc/<pid>/stat` file is missing has been changed to `verbose` ([gh-536][mgh-536]).
+
+[mgh-536]: https://github.com/tarantool/metrics/pull/536

--- a/changelogs/unreleased/bump-metrics-to-1.6.2.md
+++ b/changelogs/unreleased/bump-metrics-to-1.6.2.md
@@ -1,9 +1,0 @@
-## feature/metrics
-
-* Updated the metrics submodule to 1.6.2.
-
-  Changes in 1.6.2:
-
-  - The `error` message level displayed when the `/proc/<pid>/stat` file is missing has been changed to `verbose` ([gh-536][mgh-536]).
-
-[mgh-536]: https://github.com/tarantool/metrics/pull/536

--- a/changelogs/unreleased/gh-11766-system-space-txn-trigger.md
+++ b/changelogs/unreleased/gh-11766-system-space-txn-trigger.md
@@ -1,3 +1,0 @@
-## bugfix/box
-
-* Fixed a crash with transactional trigger on the `_space` space (gh-11766).

--- a/changelogs/unreleased/gh-12175-do-not-rename-user-threads.md
+++ b/changelogs/unreleased/gh-12175-do-not-rename-user-threads.md
@@ -1,3 +1,0 @@
-## bugfix/core
-
-* Tarantool does not rename user threads anymore (gh-12175).

--- a/src/box/lua/upgrade.lua
+++ b/src/box/lua/upgrade.lua
@@ -2250,6 +2250,7 @@ local downgrade_versions = {
     "3.5.0",
     "3.5.1",
     "3.6.0",
+    "3.6.1",
     -- DOWNGRADE VERSIONS END
 }
 


### PR DESCRIPTION
Also remove unreleased/ changelog entries and add new 3.6.1 version to the downgrade versions list.

NO_DOC=changelog
NO_TEST=changelog
NO_CHANGELOG=changelog