### PR TITLE
[backport release/2.11] ci: fix integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,11 +49,11 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'full-ci') ||
           contains(github.event.pull_request.labels.*.name, 'integration-ci') )
 
-    uses: tarantool/tarantool/.github/workflows/reusable_build.yml@master
+    uses: ./.github/workflows/reusable_build.yml
     with:
       ref: ${{ inputs.submodule && 'release/2.11' || github.ref }}
       os: ubuntu
-      dist: focal
+      dist: noble
       submodule: ${{ inputs.submodule }}
       revision: ${{ inputs.revision }}
 
@@ -61,99 +61,103 @@ jobs:
     needs: tarantool
     uses: tarantool/vshard/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   cartridge:
     needs: tarantool
     uses: tarantool/cartridge/.github/workflows/reusable-backend-test.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
-  expirationd:
-    needs: tarantool
-    uses: tarantool/expirationd/.github/workflows/reusable_testing.yml@master
-    with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+  # FIXME: Disabled due to tarantool/expirationd#176.
+  # expirationd:
+  #   needs: tarantool
+  #   uses: tarantool/expirationd/.github/workflows/reusable_testing.yml@master
+  #   with:
+  #     artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
+
   smtp:
     needs: tarantool
     uses: tarantool/smtp/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   memcached:
     needs: tarantool
     uses: tarantool/memcached/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   metrics:
     needs: tarantool
     uses: tarantool/metrics/.github/workflows/reusable-test.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   avro-schema:
     needs: tarantool
     uses: tarantool/avro-schema/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   queue:
     needs: tarantool
     uses: tarantool/queue/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   checks:
     needs: tarantool
     uses: tarantool/checks/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   mysql:
     needs: tarantool
     uses: tarantool/mysql/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   tarantool-c:
     needs: tarantool
     uses: tarantool/tarantool-c/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
-  tarantool-python:
-    needs: tarantool
-    uses: tarantool/tarantool-python/.github/workflows/reusable_testing.yml@master
-    with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+  # FIXME: Disabled due to tarantool/tarantool-python#334.
+  # tarantool-python:
+  #   needs: tarantool
+  #   uses: tarantool/tarantool-python/.github/workflows/reusable_testing.yml@master
+  #   with:
+  #     artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   php-client:
     needs: tarantool
     uses: tarantool-php/client/.github/workflows/reusable_qa.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   php-queue:
     needs: tarantool
     uses: tarantool-php/queue/.github/workflows/reusable_qa.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   go-tarantool:
     needs: tarantool
     uses: tarantool/go-tarantool/.github/workflows/reusable_testing.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   crud:
     needs: tarantool
     uses: tarantool/crud/.github/workflows/reusable_test.yml@master
     with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
-  ddl:
-    needs: tarantool
-    uses: tarantool/ddl/.github/workflows/reusable_test.yml@master
-    with:
-      artifact_name: tarantool-ubuntu-focal-${{ needs.tarantool.outputs.sha }}
+  # FIXME: Disabled due to tarantool/ddl#130.
+  # ddl:
+  #   needs: tarantool
+  #   uses: tarantool/ddl/.github/workflows/reusable_test.yml@master
+  #   with:
+  #     artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -16,7 +16,7 @@ on:
         type: string
       dist:
         description: 'The version of the OS'
-        default: focal
+        default: noble
         required: false
         type: string
       submodule:
@@ -34,7 +34,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
       OS: ${{ inputs.os }}


### PR DESCRIPTION
The `ubuntu-20.04 (focal)` image is no longer supported, so the build using this image returns the following error:

| This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner | will be removed on 2025-04-01.

See [1] for the details.

This patch bumps the used version to the ubuntu-24.04 (noble). Also, it forces the use of the branch version of the reusable_build workflow to allow testing its changes.

The following modules should be fixed first before enabling the integration with them back:
* tarantool/ddl
* tarantool/expirationd
* tarantool/tarantool-python

[1]: https://github.com/actions/runner-images/issues/11101

Relates to tarantool/ddl#130
Relates to tarantool/expirationd#176
Relates to tarantool/tarantool-python#334

NO_CHANGELOG=ci
NO_DOC=ci
NO_TEST=ci

(cherry picked from commit 75c8e9e610c63bbef1e82e85ee87f29be82aa7b4)