### PR TITLE
changelog: cleanup 3.6.1 changelogs

### DIFF
--- a/changelogs/unreleased/bump-metrics-to-1.6.2.md
+++ b/changelogs/unreleased/bump-metrics-to-1.6.2.md
@@ -1,9 +1,0 @@
-## feature/metrics
-
-* Updated the metrics submodule to 1.6.2.
-
-  Changes in 1.6.2:
-
-  - The `error` message level displayed when the `/proc/<pid>/stat` file is missing has been changed to `verbose` ([gh-536][mgh-536]).
-
-[mgh-536]: https://github.com/tarantool/metrics/pull/536

--- a/changelogs/unreleased/gh-11766-system-space-txn-trigger.md
+++ b/changelogs/unreleased/gh-11766-system-space-txn-trigger.md
@@ -1,3 +1,0 @@
-## bugfix/box
-
-* Fixed a crash with transactional trigger on the `_space` space (gh-11766).

--- a/changelogs/unreleased/gh-12175-do-not-rename-user-threads.md
+++ b/changelogs/unreleased/gh-12175-do-not-rename-user-threads.md
@@ -1,3 +1,0 @@
-## bugfix/core
-
-* Tarantool does not rename user threads anymore (gh-12175).

--- a/src/box/lua/upgrade.lua
+++ b/src/box/lua/upgrade.lua
@@ -2250,6 +2250,7 @@ local downgrade_versions = {
     "3.5.0",
     "3.5.1",
     "3.6.0",
+    "3.6.1",
     -- DOWNGRADE VERSIONS END
 }
 


### PR DESCRIPTION
Remove all changelog reported in release notes for 3.6.1.

Also add a new downgrade version to the downgrade versions list.

NO_DOC=changelog
NO_TEST=changelog
NO_CHANGELOG=changelog