### PR TITLE
box: fix memory leak while shutdown replica

### DIFF
--- a/changelogs/unreleased/gh-10881-memory-leak.md
+++ b/changelogs/unreleased/gh-10881-memory-leak.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+Fixed a memory leak when a replica was stopped but transactions were still in
+progress (gh-10881).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6608,6 +6608,9 @@ box_storage_shutdown()
 		diag_log();
 		panic("cannot gracefully shutdown iproto");
 	}
+
+	wal_start_shutdown();
+	txn_shutdown();
 	replication_shutdown();
 	box_raft_shutdown();
 	txn_limbo_shutdown();

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -1799,3 +1799,19 @@ txn_stmt_mark_as_temporary(struct txn *txn, struct txn_stmt *stmt)
 	txn_update_row_counts(txn, stmt, -1);
 	stmt->row = NULL;
 }
+
+void
+txn_shutdown(void)
+{
+	struct txn *txn, *tmp;
+	rlist_foreach_entry_safe_reverse(txn, &txns, in_txns, tmp) {
+		assert(in_txn() == NULL);
+		fiber_set_txn(fiber(), txn);
+		diag_set(ClientError, ER_SHUTDOWN);
+		if (txn->signature > 0)
+			txn_rollback_stmt(txn);
+		else
+			txn_abort(txn);
+		fiber_set_txn(fiber(), NULL);
+	}
+}

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -1093,11 +1093,17 @@ tx_region_acquire(struct txn *txn);
 void
 tx_region_release(struct txn *txn, enum tx_alloc_type alloc_type);
 
-/*
+/**
  * Free txn memory and return it to a cache.
  */
 void
 txn_free(struct txn *txn);
+
+/**
+ * Stop and cancel all the started transactions.
+ */
+void
+txn_shutdown(void);
 
 /**
  * FFI bindings: do not throw exceptions, do not accept extra

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -194,6 +194,11 @@ struct wal_writer
 	 */
 	bool is_in_rollback;
 	/**
+	 * Used to block the acceptance of new transactions
+	 * while the instance is shutting down
+	 */
+	bool is_shutting_down;
+	/**
 	 * WAL watchers, i.e. threads that should be alerted
 	 * whenever there are new records appended to the journal.
 	 * Used for replication relays.
@@ -491,6 +496,7 @@ wal_writer_create(struct wal_writer *writer, enum wal_mode wal_mode,
 
 	stailq_create(&writer->rollback);
 	writer->is_in_rollback = false;
+	writer->is_shutting_down = false;
 
 	writer->checkpoint_wal_size = 0;
 	writer->checkpoint_threshold = INT64_MAX;
@@ -1449,6 +1455,14 @@ wal_write_async(struct journal *journal, struct journal_entry *entry)
 		goto fail;
 	}
 
+	if (writer->is_shutting_down) {
+		say_error("Aborting transaction %lld during "
+			  "sutting down",
+			  (long long)vclock_sum(&writer->vclock));
+		diag_set(ClientError, ER_SHUTDOWN);
+		goto fail;
+	}
+
 	struct wal_msg *batch;
 	if (!stailq_empty(&writer->wal_pipe.input) &&
 	    (batch = wal_msg(stailq_first_entry(&writer->wal_pipe.input,
@@ -1686,4 +1700,23 @@ wal_notify_watchers(struct wal_writer *writer, unsigned events)
 	struct wal_watcher *watcher;
 	rlist_foreach_entry(watcher, &writer->watchers, next)
 		wal_watcher_notify(watcher, events);
+}
+
+void
+wal_start_shutdown(void)
+{
+	struct wal_writer *writer = &wal_writer_singleton;
+	if (writer->wal_mode == WAL_NONE)
+		return;
+
+	writer->is_shutting_down = true;
+
+	/*
+	 * journal_sync() may fail if a rollback is already in progress. In this
+	 * case wait until all the pending transactions are cancelled due to the
+	 * cascading rollback.
+	 */
+
+	while (journal_sync(NULL) != 0)
+		fiber_sleep(0.01);
 }

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -252,6 +252,13 @@ wal_write_vy_log(struct journal_entry *req);
 void
 wal_rotate_vy_log(void);
 
+/**
+ * Make WAL thread stop accepting incoming writes to be able
+ * to perform shutdown correctly.
+ */
+void
+wal_start_shutdown(void);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/test/replication-luatest/gh_10881_memory_leak_test.lua
+++ b/test/replication-luatest/gh_10881_memory_leak_test.lua
@@ -1,0 +1,61 @@
+local server = require("luatest.server")
+local cluster = require("luatest.replica_set")
+local t = require("luatest")
+
+local g = t.group('gh_asan_leak_on_shutdown')
+
+g.before_each(function(g)
+    t.tarantool.skip_if_not_debug()
+
+    g.cluster = cluster:new{}
+
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri("master", g.cluster.id),
+            server.build_listen_uri("replica", g.cluster.id),
+        },
+    }
+    g.master = g.cluster:build_and_add_server({
+        alias = "master",
+        box_cfg = box_cfg,
+    })
+    box_cfg.read_only = true
+    g.replica = g.cluster:build_and_add_server({
+        alias = "replica",
+        box_cfg = box_cfg,
+    })
+    g.cluster:start()
+end)
+
+g.after_each(function(g)
+    g.cluster:drop()
+end)
+
+g.test_replica_shutdown_leak = function()
+    local wal_cnt = g.replica:exec(function()
+        return box.error.injection.get('ERRINJ_WAL_WRITE_COUNT')
+    end)
+    -- Make sure that the next running transaction freezes.
+    g.replica:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_DURATION', 2)
+    end)
+
+    local replica_id = g.replica:get_instance_id()
+    -- Starting a transaction that will take a long time to complete.
+    g.master:exec(function(replica_id)
+        box.space._cluster:delete{replica_id}
+    end, {replica_id})
+    -- Waiting for the moment when the WAL write attempt counter
+    -- on the replica increases.
+    g.replica:exec(function(wal_cnt)
+        t.helpers.retrying(
+            {timeout=50},
+            function()
+                t.assert_gt(
+                    box.error.injection.get('ERRINJ_WAL_WRITE_COUNT'),wal_cnt
+                )
+        end)
+    end, {wal_cnt})
+    -- Expecting memory leak detection by asan on replica stop.
+    g.replica:stop()
+end


### PR DESCRIPTION
Bug: When a replica is stopped but transactions are still in progress, a memory leak occurs.
This patch terminates all active transactions on the instance, writes the changes to WAL, and only then stops the instance.

Closes #10881