### PR TITLE
box: delete .inprogress files from wal_dir

### DIFF
--- a/changelogs/unreleased/gh-12081-delete-xlog-inprogress.md
+++ b/changelogs/unreleased/gh-12081-delete-xlog-inprogress.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug where `.xlog.inprogress` files were not automatically deleted
+  during server startup if the `wal_dir` value was not the default (gh-12081).

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -649,6 +649,8 @@ wal_enable(void)
 	if (xdir_scan(&writer->wal_dir, true))
 		return -1;
 
+	xdir_remove_temporary_files(&writer->wal_dir);
+
 	/* Open the most recent WAL file. */
 	if (wal_open(writer) != 0)
 		return -1;

--- a/test/box-luatest/gh-12081-delete-xlog-inprogress-custom-wal-dir_test.lua
+++ b/test/box-luatest/gh-12081-delete-xlog-inprogress-custom-wal-dir_test.lua
@@ -1,0 +1,42 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(g)
+    g.server = server:new()
+    -- Start the server so workdir is created.
+    g.server:start()
+end)
+
+g.after_all(function(g)
+    g.server:drop()
+end)
+
+g.test_function_delete_inprogress_custom_location = function(g)
+    local fio = require("fio")
+    local wal_dir = fio.pathjoin(g.server.workdir, "custom_wal_dir")
+    fio.mktree(wal_dir)
+    g.server:restart(
+        {box_cfg = {wal_dir = wal_dir}}, {wait_until_ready = true}
+    )
+    g.server:exec(function()
+        box.space._schema:replace{'test'}
+    end)
+    g.server:stop()
+    -- The magical vclock below is due to the server restart.
+    local xlog_path = fio.pathjoin(
+        wal_dir, "00000000000000000002.xlog"
+    )
+    t.assert(fio.path.exists(xlog_path))
+    local inprogress_path = fio.pathjoin(
+        wal_dir, "00000000000000000002.xlog.inprogress"
+    )
+    fio.rename(xlog_path, inprogress_path)
+    t.assert(fio.path.exists(inprogress_path))
+    g.server:restart({}, {wait_until_ready = true})
+    g.server:exec(function()
+        box.space._schema:replace{'test'}
+    end)
+    t.assert_not(fio.path.exists(inprogress_path))
+end


### PR DESCRIPTION
In tarantool, each engine maintains its own files including
`.inprogress`. However, `.xlog` files  do not belong to any particular
engine and are common. When `wal_dir` matches `memtx_dir`, xlogs just
happen to be accidentally deleted by memtx engine.

In this patch, `.inprogress` are explicitly deleted from the `wal_dir`
on the server start.

Fixes https://github.com/tarantool/tarantool/issues/12081

NO_DOC=bugfix
