### PR TITLE
core: drop the 'error.h' includes where not required

### DIFF
--- a/src/lib/core/opt_def.c
+++ b/src/lib/core/opt_def.c
@@ -33,7 +33,6 @@
 #include "msgpuck.h"
 #include "bit/bit.h"
 #include "small/region.h"
-#include "error.h"
 #include "diag.h"
 #include "tt_static.h"
 

--- a/src/lib/core/tt_compression.c
+++ b/src/lib/core/tt_compression.c
@@ -6,7 +6,6 @@
 #include "tt_compression.h"
 #include "trivia/config.h"
 #include "diag.h"
-#include "error.h"
 #include "msgpuck.h"
 
 #if defined(ENABLE_TUPLE_COMPRESSION)


### PR DESCRIPTION
core: drop the 'error.h' includes where not required

It's a box file and is not required in `tt_compression.c` and `opt_def.c` actually.

Closes #12248

NO_DOC=build
NO_TEST=build
NO_CHANGELOG=build
