### PR TITLE
config: support config-based fail_if expressions

### DIFF
--- a/changelogs/unreleased/gh-11759-fail_if-config-vars.md
+++ b/changelogs/unreleased/gh-11759-fail_if-config-vars.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* Support `config.<path>` variables in `fail_if` metadata expressions for apps and roles.

--- a/changelogs/unreleased/gh-11759-fail_if-unary-not.md
+++ b/changelogs/unreleased/gh-11759-fail_if-unary-not.md
@@ -1,0 +1,3 @@
+## feature/config
+
+* Support logical NOT operator (`!`) in `fail_if` metadata expressions for apps and roles.

--- a/src/box/lua/config/applier/app.lua
+++ b/src/box/lua/config/applier/app.lua
@@ -1,11 +1,9 @@
 local log = require('internal.config.utils.log')
 local utils_file = require('internal.config.utils.file')
 local expression = require('internal.config.utils.expression')
+local TARANTOOL_VERSION = _TARANTOOL:match('^%d+%.%d+%.%d+')
+assert(TARANTOOL_VERSION ~= nil)
 
-local fail_if_vars = {
-    tarantool_version = _TARANTOOL:match('^%d+%.%d+%.%d+'),
-}
-assert(fail_if_vars.tarantool_version ~= nil)
 
 local app_state = {
     -- This variable is used to track the app loaded before the box.cfg() call.
@@ -16,6 +14,11 @@ local app_state = {
 
 local function run(config, opts)
     local configdata = config._configdata
+    local iconfig_def = configdata._iconfig_def
+    local fail_if_vars = {
+        tarantool_version = TARANTOOL_VERSION,
+        config = iconfig_def,
+    }
     local file = configdata:get('app.file', {use_default = true})
     local module = configdata:get('app.module', {use_default = true})
 

--- a/src/box/lua/config/applier/roles.lua
+++ b/src/box/lua/config/applier/roles.lua
@@ -4,10 +4,8 @@ local expression = require('internal.config.utils.expression')
 local fiber = require('fiber')
 local health = require('internal.healthcheck')
 
-local fail_if_vars = {
-    tarantool_version = _TARANTOOL:match('^%d+%.%d+%.%d+'),
-}
-assert(fail_if_vars.tarantool_version ~= nil)
+local TARANTOOL_VERSION = _TARANTOOL:match('^%d+%.%d+%.%d+')
+assert(TARANTOOL_VERSION ~= nil)
 
 local roles_state = {
     -- Loaded roles, where the key is the role name and the value is the
@@ -144,6 +142,24 @@ local function box_status_watcher()
     end)
 end
 
+local function fail_if_check(role_names, fail_if_vars)
+    for _, role_name in ipairs(role_names) do
+        local md = roles_state.metadata[role_name]
+        if md ~= nil and md['fail_if'] ~= nil then
+            local expr = md['fail_if']
+            local ok, res = pcall(expression.eval, expr, fail_if_vars)
+            if not ok then
+                error(('Role %q has invalid "fail_if" expression: %s')
+                    :format(role_name, res), 0)
+            end
+            if res then
+                error(('Role %q failed the "fail_if" check: %q')
+                    :format(role_name, expr), 0)
+            end
+        end
+    end
+end
+
 -- This function will be called once before the box.cfg is applied and on every
 -- config reload before post_apply.
 -- Starts background watchers and triggers, collect roles information, load
@@ -182,6 +198,11 @@ local function preload(config)
 
     -- Get the list of roles from the config.
     local configdata = config._configdata
+    local iconfig_def = configdata._iconfig_def
+    local fail_if_vars = {
+        tarantool_version = TARANTOOL_VERSION,
+        config = iconfig_def,
+    }
     local role_names = configdata:get('roles', {use_default = true})
     if role_names == nil then
         role_names = {}
@@ -191,24 +212,8 @@ local function preload(config)
     roles_state.metadata = {}
     update_roles_metadata(role_names)
 
-    -- Check `fail_if` tag for roles and raise an error if the check fails.
-    for _, role_name in ipairs(role_names) do
-        local md = roles_state.metadata[role_name]
-        if md ~= nil and md['fail_if'] ~= nil then
-            local expr = md['fail_if']
-            local ok, res = pcall(expression.eval, expr, fail_if_vars)
-
-            if not ok then
-                error(('Role %q has invalid "fail_if" expression: %s')
-                    :format(role_name, res), 0)
-            end
-
-            if res then
-                error(('Role %q failed the "fail_if" check: %q')
-                    :format(role_name, expr), 0)
-            end
-        end
-    end
+    -- Check `fail_if` for roles before loading/applying them.
+    fail_if_check(role_names, fail_if_vars)
 
     -- Get roles with the 'early_load' metadata tag set to `true`.
     -- early_load_roles will contain role names in the same order as in
@@ -376,6 +381,11 @@ end
 -- event.
 local function post_apply(config)
     local configdata = config._configdata
+    local iconfig_def = configdata._iconfig_def
+    local fail_if_vars = {
+        tarantool_version = TARANTOOL_VERSION,
+        config = iconfig_def,
+    }
     local role_names = configdata:get('roles', {use_default = true})
     if role_names == nil or next(role_names) == nil then
         stop_roles()
@@ -391,6 +401,10 @@ local function post_apply(config)
         end
         roles[role_name] = true
     end
+
+    -- Re-check `fail_if` after config is applied,
+    -- because it may depend on config options.
+    fail_if_check(role_names, fail_if_vars)
 
     -- Stop removed roles.
     stop_roles(roles)

--- a/src/box/lua/config/utils/expression.lua
+++ b/src/box/lua/config/utils/expression.lua
@@ -7,18 +7,22 @@
 -- version constraints in the declarative configuration module.
 -- (`conditional[N].if`).
 --
--- The module support one data type: version. A value may be
--- referenced in two ways:
+-- Supported value kinds:
 --
--- 1. Version literal: 1.2.3 (always three components).
--- 2. Variable: foo, x23, _foo_bar and so.
+-- 1. Version literal: `1.2.3` (always exactly three numeric components).
+-- 2. Variable:
+--    - starts with [A-Za-z_];
+--    - continues with [A-Za-z0-9_];
+--    - may contain dot-separated segments (e.g. `foo.bar_baz`), where each
+--      dot must be followed by [A-Za-z0-9_].
 --
 -- The operations are the following.
 --
 -- 1. Logical OR: ||
 -- 2. Logical AND: &&
--- 3. Compare: >, <, >=, <=, !=, ==
--- 4. Parentheses: (, )
+-- 3. Logical NOT: !
+-- 4. Compare: >, <, >=, <=, !=, ==
+-- 5. Parentheses: (, )
 
 local expression_lexer = require('internal.config.utils.expression_lexer')
 
@@ -45,12 +49,25 @@ local right_bpower_map = {
     ['=='] = 6,
 }
 
+local prefix_bpower_map = {
+    ['!'] = 7,
+}
+
 local function parse_expr(lexer, min_bpower)
     local left
 
     local token = lexer:next()
     if token == nil then
         error('Unexpected end of an expression', 0)
+    elseif token.type == 'operation' and
+        prefix_bpower_map[token.value] ~= nil then
+        local rbp = prefix_bpower_map[token.value]
+        local expr = parse_expr(lexer, rbp)
+        left = {
+            type = 'unary',
+            value = token.value,
+            expr = expr,
+        }
     elseif token.type == 'version_literal' then
         left = token
     elseif token.type == 'variable' then
@@ -78,12 +95,18 @@ local function parse_expr(lexer, min_bpower)
             error(('Expected an operation, got %q'):format(op.value), 0)
         end
         local left_bpower = left_bpower_map[op.value]
+        if left_bpower == nil then
+            error(('Unknown operation %q'):format(op.value), 0)
+        end
         if left_bpower < min_bpower then
             break
         end
 
         lexer:next()
         local right_bpower = right_bpower_map[op.value]
+        if right_bpower == nil then
+            error(('Unknown operation %q'):format(op.value), 0)
+        end
         local right = parse_expr(lexer, right_bpower)
 
         left = {
@@ -126,14 +149,54 @@ local function parse(s)
     return ast
 end
 
-local function validate_expr(node, vars)
-    -- luacheck: ignore 542 empty if branch
+local logical_binary_operators = {
+    ['||'] = true,
+    ['&&'] = true,
+}
+
+local compare_binary_operators = {
+    ['<'] = true,
+    ['>'] = true,
+    ['<='] = true,
+    ['>='] = true,
+    ['=='] = true,
+    ['!='] = true,
+}
+
+local unary_operators = {
+    ['!'] = true,
+}
+
+local function resolve_var(vars, name)
+    if type(vars) ~= 'table' then
+        return nil
+    end
+
+    -- Split the name by dots (e.g., 'foo.bar' -> {'foo', 'bar'}).
+    -- [^%.]+ matches one or more non-dot characters.
+    local cur = vars
+    for part in name:gmatch('[^%.]+') do
+        if type(cur) ~= 'table' then
+            return nil
+        end
+        cur = cur[part]
+    end
+    return cur
+end
+
+-- Infer node result type: 'version' or 'boolean'.
+-- Also validates variable existence and its runtime type.
+local function node_type(node, vars)
+    assert(node ~= nil)
     if node.type == 'version_literal' then
-        -- Nothing to validate.
+        return 'version'
     elseif node.type == 'variable' then
-        local var = vars[node.value]
+        local var = resolve_var(vars, node.value)
         if type(var) == 'nil' then
             error(('Unknown variable: %q'):format(node.value), 0)
+        end
+        if type(var) == 'boolean' then
+            return 'boolean'
         end
         if type(var) ~= 'string' then
             error(('Variable %q has type %s, expected string'):format(
@@ -154,41 +217,70 @@ local function validate_expr(node, vars)
             error(('Expected a three component version in variable %q, got ' ..
                 '%d components'):format(node.value, #components), 0)
         end
+        return 'version'
+    elseif node.type == 'unary' then
+        if unary_operators[node.value] then
+            return 'boolean'
+        end
+        error(('Unknown unary operator %q'):format(node.value), 0)
     elseif node.type == 'operation' then
-        local lbool = node.left.type == 'operation'
-        local rbool = node.right.type == 'operation'
-
-        local requires_boolean = {
-            ['||'] = true,
-            ['&&'] = true,
-        }
-        if requires_boolean[node.value] and not (lbool and rbool) then
-            error('A logical operator (&& or ||) accepts only boolean ' ..
-                'expressions as arguments', 0)
+        local op = node.value
+        if logical_binary_operators[node.value] or
+        compare_binary_operators[node.value] then
+            return 'boolean'
         end
+        error(('Unknown operation %q'):format(op), 0)
+    else
+        assert(false)
+    end
+end
 
-        local requires_version_values = {
-            ['<'] = true,
-            ['>'] = true,
-            ['<='] = true,
-            ['>='] = true,
-            ['!='] = true,
-            ['=='] = true,
-        }
-        if requires_version_values[node.value] and (lbool or rbool) then
-            error('A comparison operator (<, >, <=, >=, !=, ==) requires ' ..
-                'version literals or variables as arguments', 0)
+local function validate_expr(node, vars)
+    -- luacheck: ignore 542 empty if branch
+    if node.type == 'version_literal' then
+        -- Nothing to validate.
+    elseif node.type == 'variable' then
+        node_type(node, vars)
+    elseif node.type == 'unary' then
+        if not unary_operators[node.value] then
+            error(('Unknown unary operator %q'):format(node.value), 0)
         end
-
+        local t = node_type(node.expr, vars)
+        if t ~= 'boolean' then
+            error('Unary "!" accepts only boolean expressions', 0)
+        end
+        validate_expr(node.expr, vars)
+    elseif node.type == 'operation' then
         validate_expr(node.left, vars)
         validate_expr(node.right, vars)
+        local op = node.value
+        local lt = node_type(node.left, vars)
+        local rt = node_type(node.right, vars)
+
+        if logical_binary_operators[op] then
+            if lt ~= 'boolean' or rt ~= 'boolean' then
+                error('A logical operator (&& or ||) accepts only boolean ' ..
+                    'expressions as arguments', 0)
+            end
+            return
+        end
+
+        if compare_binary_operators[op] then
+            if lt ~= 'version' or rt ~= 'version' then
+                error('A comparison operator (<, >, <=, >=, !=, ==) ' ..
+                    'requires version literals or variables as arguments', 0)
+            end
+            return
+        end
+
+        error(('Unknown operation %q'):format(op), 0)
     else
         assert(false)
     end
 end
 
 local function validate(node, vars)
-    if node.type ~= 'operation' then
+    if node.type ~= 'operation' and node.type ~= 'unary' then
         error(('An expression should be a predicate, got %s'):format(
             node.type), 0)
     end
@@ -237,11 +329,21 @@ local operations = {
     end,
 }
 
+local unary_operations = {
+    ['!'] = function (a)
+        return not a
+    end,
+}
+
 local function evaluate(node, vars)
     if node.type == 'version_literal' then
         return node.value
     elseif node.type == 'variable' then
-        return vars[node.value]
+        return resolve_var(vars, node.value)
+    elseif node.type == 'unary' then
+        local op = unary_operations[node.value]
+        local expr = evaluate(node.expr, vars)
+        return op(expr)
     elseif node.type == 'operation' then
         local left = evaluate(node.left, vars)
         local op = operations[node.value]

--- a/src/box/lua/config/utils/expression.lua
+++ b/src/box/lua/config/utils/expression.lua
@@ -184,8 +184,10 @@ local function resolve_var(vars, name)
     return cur
 end
 
--- Infer node result type: 'version' or 'boolean'.
+-- Infer node result type: 'version', 'boolean' or 'string'.
 -- Also validates variable existence and its runtime type.
+--
+-- A non-version string is allowed only as a truthy/falsy predicate.
 local function node_type(node, vars)
     assert(node ~= nil)
     if node.type == 'version_literal' then
@@ -198,26 +200,28 @@ local function node_type(node, vars)
         if type(var) == 'boolean' then
             return 'boolean'
         end
+        if var == box.NULL then
+            return 'boolean'
+        end
         if type(var) ~= 'string' then
             error(('Variable %q has type %s, expected string'):format(
                 node.value, type(var)), 0)
         end
         if var == '' then
-            error(('Expected a version in variable %q, got an empty ' ..
-                'string'):format(node.value), 0)
+            return 'string'
         end
         local components = var:split('.')
+        local is_version = #components == 3
         for _, v in ipairs(components) do
             if not v:match('^[0-9]+$') then
-                error(('Variable %q is not a version string'):format(
-                    node.value), 0)
+                is_version = false
+                break
             end
         end
-        if #components ~= 3 then
-            error(('Expected a three component version in variable %q, got ' ..
-                '%d components'):format(node.value, #components), 0)
+        if is_version then
+            return 'version'
         end
-        return 'version'
+        return 'string'
     elseif node.type == 'unary' then
         if unary_operators[node.value] then
             return 'boolean'
@@ -246,8 +250,9 @@ local function validate_expr(node, vars)
             error(('Unknown unary operator %q'):format(node.value), 0)
         end
         local t = node_type(node.expr, vars)
-        if t ~= 'boolean' then
-            error('Unary "!" accepts only boolean expressions', 0)
+        if t ~= 'boolean' and t ~= 'string' then
+            error('Unary "!" accepts only boolean or string ' ..
+                'expressions', 0)
         end
         validate_expr(node.expr, vars)
     elseif node.type == 'operation' then
@@ -258,9 +263,10 @@ local function validate_expr(node, vars)
         local rt = node_type(node.right, vars)
 
         if logical_binary_operators[op] then
-            if lt ~= 'boolean' or rt ~= 'boolean' then
+            if (lt ~= 'boolean' and lt ~= 'string') or
+               (rt ~= 'boolean' and rt ~= 'string') then
                 error('A logical operator (&& or ||) accepts only boolean ' ..
-                    'expressions as arguments', 0)
+                    'or string expressions as arguments', 0)
             end
             return
         end
@@ -280,6 +286,10 @@ local function validate_expr(node, vars)
 end
 
 local function validate(node, vars)
+    if node.type == 'variable' then
+        node_type(node, vars)
+        return
+    end
     if node.type ~= 'operation' and node.type ~= 'unary' then
         error(('An expression should be a predicate, got %s'):format(
             node.type), 0)
@@ -339,7 +349,11 @@ local function evaluate(node, vars)
     if node.type == 'version_literal' then
         return node.value
     elseif node.type == 'variable' then
-        return resolve_var(vars, node.value)
+        local var = resolve_var(vars, node.value)
+        if var == box.NULL or var == '' then
+            return false
+        end
+        return var
     elseif node.type == 'unary' then
         local op = unary_operations[node.value]
         local expr = evaluate(node.expr, vars)

--- a/src/box/lua/config/utils/expression_lexer.c
+++ b/src/box/lua/config/utils/expression_lexer.c
@@ -28,7 +28,7 @@
  *
  * {
  *     -- The value is one of '>=', '<=', '>', '<', '!=', '==',
- *     -- '&&', '||'.
+ *     -- '&&', '||', '!'.
  *     type = 'operation',
  *     value = <string>,
  * }
@@ -247,6 +247,19 @@ luaT_expression_lexer_split(struct lua_State *L)
 			/* !<eof> or =<eof> is an error. */
 			if (*s == '\0')
 				return ERROR("truncated expression");
+			/* Handle '!' as either '!=' or unary '!'. */
+			if (*(s - 1) == '!') {
+				if (*s == '=') {
+					/* != */
+					PUSH_TOKEN("operation", s - 1, s);
+					state = START;
+					break;
+				}
+				/* unary ! */
+				PUSH_TOKEN("operation", s - 1, s - 1);
+				state = START;
+				continue;
+			}
 			/*
 			 * Anything other than != and == is an
 			 * error.

--- a/test/config-luatest/app_test.lua
+++ b/test/config-luatest/app_test.lua
@@ -201,3 +201,64 @@ g.test_tarantool_version_check = function(g)
         setsearchroot = false,
     })
 end
+
+g.test_fail_if_config_check = function(g)
+    local ok_when_enabled = [[-- --- #tarantool.metadata.v1
+-- fail_if: "!config.database.use_mvcc_engine"
+-- ...
+    ]]
+
+    local invalid_expr = [[-- --- #tarantool.metadata.v1
+-- fail_if: "config.database.use_mvcc_engine ! tarantool_version"
+-- ...
+    ]]
+
+    local version_and_config_check = [[-- --- #tarantool.metadata.v1
+-- fail_if: "tarantool_version < 0.0.0 || !config.database.use_mvcc_engine"
+-- ...
+    ]]
+
+    helpers.success_case(g, {
+        script = ok_when_enabled,
+        options = {
+            ['app.file'] = 'main.lua',
+            ['database.use_mvcc_engine'] = true,
+        },
+        verify = function() end,
+    })
+
+    helpers.failure_case({
+        script = invalid_expr,
+        options = {['app.file'] = 'main.lua'},
+        exp_err = 'App "main.lua" has invalid "fail_if" expression: ' ..
+                  'Unknown operation "!"',
+    })
+
+    helpers.failure_case({
+        script = invalid_expr,
+        options = {['app.module'] = 'main'},
+        setsearchroot = false,
+        exp_err = 'App "main" has invalid "fail_if" expression: ' ..
+                  'Unknown operation "!"',
+    })
+
+    -- tarantool_version < 0.0.0 is always false, so result depends on config.
+    helpers.success_case(g, {
+        script = version_and_config_check,
+        options = {
+            ['app.file'] = 'main.lua',
+            ['database.use_mvcc_engine'] = true,
+        },
+        verify = function() end,
+    })
+
+    helpers.failure_case({
+        script = version_and_config_check,
+        options = {
+            ['app.file'] = 'main.lua',
+            ['database.use_mvcc_engine'] = false,
+        },
+        exp_err = 'App "main.lua" failed the "fail_if" check: ' ..
+        '"tarantool_version < 0.0.0 || !config.database.use_mvcc_engine"',
+    })
+end

--- a/test/config-luatest/conditional_section_test.lua
+++ b/test/config-luatest/conditional_section_test.lua
@@ -136,8 +136,8 @@ g.test_validation = function()
     end)
 
     -- The 'if' expression should be correct.
-    local exp_err = '[cluster_config] conditional[1]: An expression should ' ..
-        'be a predicate, got variable'
+    local exp_err = '[cluster_config] conditional[1]: Unknown variable: ' ..
+        '"incorrect"'
     t.assert_error_msg_equals(exp_err, function()
         cluster_config:validate({
             ['conditional'] = {

--- a/test/config-luatest/expression_test.lua
+++ b/test/config-luatest/expression_test.lua
@@ -509,6 +509,144 @@ g.test_parse_basic = function()
     })
 end
 
+g.test_parse_unary = function()
+    t.assert_equals(expression.parse('!x'), {
+        type = 'unary',
+        value = '!',
+        expr = {
+            type = 'variable',
+            value = 'x'
+        },
+    })
+    t.assert_equals(expression.parse('!!x'), {
+        type = 'unary',
+        value = '!',
+        expr = {
+            type = 'unary',
+            value = '!',
+            expr = {
+                type = 'variable',
+                value = 'x'
+            },
+        },
+    })
+    t.assert_equals(expression.parse('!(x < 2.0.0)'), {
+        type = 'unary',
+        value = '!',
+        expr = {
+            type = 'operation',
+            value = '<',
+            left = {
+                type = 'variable',
+                value = 'x'
+            },
+            right = {
+                type = 'version_literal',
+                value = '2.0.0'
+            },
+        },
+    })
+    -- Unary binds tighter than infix operators.
+    -- Parsed as: (!x) && (y > z)
+    t.assert_equals(expression.parse('!x && y > z'), {
+        type = 'operation',
+        value = '&&',
+        left = {
+            type = 'unary',
+            value = '!',
+            expr = {
+                type = 'variable',
+                value = 'x'
+            },
+        },
+        right = {
+            type = 'operation',
+            value = '>',
+            left = {
+                type = 'variable',
+                value = 'y'
+            },
+            right = {
+                type = 'variable',
+                value = 'z'
+            },
+        },
+    })
+    -- Unary on the right side of infix.
+    t.assert_equals(expression.parse('a > b || !c'), {
+        type = 'operation',
+        value = '||',
+        left = {
+            type = 'operation',
+            value = '>',
+            left = {
+                type = 'variable',
+                value = 'a'
+            },
+            right = {
+                type = 'variable',
+                value = 'b'
+            },
+        },
+        right = {
+            type = 'unary',
+            value = '!',
+            expr = {
+                type = 'variable',
+                value = 'c'
+            },
+        },
+    })
+
+    t.assert_equals(expression.parse('!(a || b)'), {
+        type = 'unary',
+        value = '!',
+        expr = {
+            type = 'operation',
+            value = '||',
+            left = {type = 'variable', value = 'a'},
+            right = {type = 'variable', value = 'b'},
+        },
+    })
+end
+
+g.test_parse_dotted_variable = function()
+    t.assert_equals(expression.parse('!config.database.use_mvcc_engine'), {
+        type = 'unary',
+        value = '!',
+        expr = {
+            type = 'variable',
+            value = 'config.database.use_mvcc_engine',
+        },
+    })
+    t.assert_equals(expression.parse(
+        'tarantool_version < 3.5.0 || !config.database.use_mvcc_engine'),
+        {
+            type = 'operation',
+            value = '||',
+            left = {
+                type = 'operation',
+                value = '<',
+                left = {
+                    type = 'variable',
+                    value = 'tarantool_version'
+                },
+                right = {
+                    type = 'version_literal',
+                    value = '3.5.0'
+                },
+            },
+            right = {
+                type = 'unary',
+                value = '!',
+                expr = {
+                    type = 'variable',
+                    value = 'config.database.use_mvcc_engine'
+                },
+            },
+        })
+end
+
 -- A couple of incorrect expressions.
 g.test_parse_failure = function()
     t.assert_error_msg_equals('Expected a string as an expression, got nil',
@@ -529,6 +667,13 @@ g.test_parse_failure = function()
         expression.parse, '>')
     t.assert_error_msg_equals('Expected end of an expression, got ")"',
         expression.parse, '5.0.0 < 6.0.0)')
+    t.assert_error_msg_equals('Unknown operation "!"',
+        expression.parse, 'x ! y')
+    t.assert_error_msg_equals('Unknown operation "!"',
+        expression.parse, 'a > b ! c')
+    t.assert_error_msg_equals('Unexpected token ")"',
+        expression.parse, '(!)')
+
 end
 
 g.test_validate_success = function()
@@ -537,6 +682,26 @@ g.test_validate_success = function()
         j = v}
     local ast = expression.parse(
         '(a > b || c < d) && e <= 1.0.0 || 2.3.4 >= f || g != h && i == j')
+    expression.validate(ast, vars)
+
+    -- Unary over boolean variable.
+    local vars = {flag = true}
+    local ast = expression.parse('!flag')
+    expression.validate(ast, vars)
+
+    -- Unary over a boolean expression (comparison).
+    local vars = {v = '3.4.0'}
+    local ast = expression.parse('!(v < 3.5.0)')
+    expression.validate(ast, vars)
+
+    -- Combined with logical operators.
+    local vars = {v = '3.6.0', flag = false}
+    local ast = expression.parse('v < 3.5.0 || !flag')
+    expression.validate(ast, vars)
+
+    -- Dotted variable name (lexer+parser integration).
+    local vars = {config = {database = {use_mvcc_engine = true}}}
+    local ast = expression.parse('!config.database.use_mvcc_engine')
     expression.validate(ast, vars)
 end
 
@@ -565,8 +730,7 @@ g.test_validate_failure = function()
     t.assert_error_msg_equals(exp_err, expression.validate, ast, {})
 
     local ast = expression.parse('x && 2.0.0')
-    local exp_err = 'A logical operator (&& or ||) accepts only boolean ' ..
-        'expressions as arguments'
+    local exp_err = 'Unknown variable: "x"'
     t.assert_error_msg_equals(exp_err, expression.validate, ast, {})
 
     local ast = expression.parse('x > 0.0.0')
@@ -597,6 +761,21 @@ g.test_validate_failure = function()
             '"x", got %d components'):format((#x + 1) / 2)
         t.assert_error_msg_equals(exp_err, expression.validate, ast, vars)
     end
+
+    local vars = {v = '1.0.0'}
+    local ast = expression.parse('!v')
+    local exp_err = 'Unary "!" accepts only boolean expressions'
+    t.assert_error_msg_equals(exp_err, expression.validate, ast, vars)
+
+    local ast = expression.parse('!1.0.0')
+    local exp_err = 'Unary "!" accepts only boolean expressions'
+    t.assert_error_msg_equals(exp_err, expression.validate, ast, {})
+
+    local vars = {v = '1.0.0', flag = true}
+    local ast = expression.parse('v && flag')
+    local exp_err = 'A logical operator (&& or ||) accepts only boolean ' ..
+        'expressions as arguments'
+    t.assert_error_msg_equals(exp_err, expression.validate, ast, vars)
 end
 
 g.test_evaluate = function()
@@ -649,4 +828,56 @@ g.test_evaluate = function()
     t.assert_equals(eval(expr, {v = '5.1.0'}), true)
 
     t.assert_equals(eval('1.10.0 > 1.2.0', {}), true)
+
+    t.assert_equals(eval('!flag', {flag = true}), false)
+    t.assert_equals(eval('!flag', {flag = false}), true)
+
+    t.assert_equals(eval('!!flag', {flag = true}), true)
+    t.assert_equals(eval('!!flag', {flag = false}), false)
+
+    t.assert_equals(eval('!(v < 3.5.0)', {v = '3.4.0'}), false)
+    t.assert_equals(eval('!(v < 3.5.0)', {v = '3.5.0'}), true)
+
+    -- Precedence check: '!' binds tighter than '&&' and '||'.
+    local expr = 'v < 3.5.0 || !flag'
+    t.assert_equals(eval(expr, {v = '3.4.0', flag = true}), true)
+    t.assert_equals(eval(expr, {v = '3.5.0', flag = true}), false)
+    t.assert_equals(eval(expr, {v = '3.5.0', flag = false}), true)
+
+    local expr = '!flag && v >= 3.5.0'
+    t.assert_equals(eval(expr, {flag = false, v = '3.5.0'}), true)
+    t.assert_equals(eval(expr, {flag = true, v = '3.5.0'}), false)
+    t.assert_equals(eval(expr, {flag = false, v = '3.4.0'}), false)
+
+    local vars = {config = {database = {use_mvcc_engine = true}}}
+    t.assert_equals(eval('!config.database.use_mvcc_engine', vars), false)
+    local vars = {config = {database = {use_mvcc_engine = false}}}
+    t.assert_equals(eval('!config.database.use_mvcc_engine', vars), true)
+
+    -- Full example from metadata.
+    local vars = {
+        tarantool_version = '3.4.0',
+        config = {database = {use_mvcc_engine = true}}}
+    local expr = 'tarantool_version < 3.5.0 || !config.database.use_mvcc_engine'
+    t.assert_equals(eval(expr, vars), true)
+
+    local vars = {
+        tarantool_version = '3.5.0',
+        config = {database = {use_mvcc_engine = true}}}
+    local expr = 'tarantool_version < 3.5.0 || !config.database.use_mvcc_engine'
+    t.assert_equals(eval(expr, vars), false)
+
+    local vars = {
+        tarantool_version = '3.5.0',
+        config = {database = {use_mvcc_engine = false}}}
+    local expr = 'tarantool_version < 3.5.0 || !config.database.use_mvcc_engine'
+    t.assert_equals(eval(expr, vars), true)
+
+    local vars = {
+        tarantool_version = '3.5.0',
+        config = {database = {use_mvcc_engine = false}}
+    }
+    local expr = '!(tarantool_version > 3.5.0 || ' ..
+                 'config.database.use_mvcc_engine)'
+    t.assert_equals(eval(expr, vars), true)
 end

--- a/test/config-luatest/expression_test.lua
+++ b/test/config-luatest/expression_test.lua
@@ -198,11 +198,34 @@ g.test_lexer = function()
     t.assert_error_msg_equals(exp_err(1, 2, 'truncated expression'),
         lexer.split, '!')
 
+    -- Dotted variables: allowed only when '.' is followed by [A-Za-z0-9_].
+    t.assert_equals(lexer.split('config.database.use_mvcc_engine'), {
+        {type = 'variable', value = 'config.database.use_mvcc_engine'},
+    })
+    t.assert_equals(lexer.split('a._b'), {
+        {type = 'variable', value = 'a._b'},
+    })
+    t.assert_equals(lexer.split('a.1_b'), {
+        {type = 'variable', value = 'a.1_b'},
+    })
+
     -- A separator should follow a version literal or a variable.
     t.assert_error_msg_equals(exp_err(1, 6, 'invalid token'),
         lexer.split, '0.1.2x')
+
+    -- Dot at end is forbidden.
     t.assert_error_msg_equals(exp_err(1, 2, 'invalid token'),
         lexer.split, 'x.')
+
+    -- Two dots in a row are forbidden.
+    t.assert_error_msg_equals(exp_err(1, 2, 'invalid token'),
+        lexer.split, 'x..y')
+
+    -- Dot before operator is forbidden.
+    t.assert_error_msg_equals(exp_err(1, 2, 'invalid token'),
+        lexer.split, 'x.!')
+    t.assert_error_msg_equals(exp_err(1, 2, 'invalid token'),
+        lexer.split, 'x.)')
 
     -- | and & are invalid operators.
     t.assert_error_msg_equals(exp_err(1, 3, 'invalid token'),
@@ -228,6 +251,17 @@ g.test_lexer = function()
     t.assert_error_msg_equals(exp_err(1, 8, 'invalid version literal: ' ..
         'expected 3 components, got 4'),
         lexer.split, '1.2.3.4')
+
+    -- Full example from metadata.
+    t.assert_equals(lexer.split(
+    'tarantool_version < 3.5.0 || !config.database.use_mvcc_engine'), {
+        {type = 'variable', value = 'tarantool_version'},
+        {type = 'operation', value = '<'},
+        {type = 'version_literal', value = '3.5.0'},
+        {type = 'operation', value = '||'},
+        {type = 'operation', value = '!'},
+        {type = 'variable', value = 'config.database.use_mvcc_engine'}
+    })
 
     -- Lexer-level corner cases around '!'.
     --
@@ -259,6 +293,21 @@ g.test_lexer = function()
         {type = 'operation', value = '>'},
         {type = 'version_literal', value = '1.0.0'}
     })
+
+    t.assert_equals(lexer.split('x.y.z>1.0.0'), {
+        {type = 'variable', value = 'x.y.z'},
+        {type = 'operation', value = '>'},
+        {type = 'version_literal', value = '1.0.0'}
+    })
+
+    t.assert_error_msg_equals(exp_err(1, 2, 'invalid token'),
+    lexer.split, 'x. y')
+
+    t.assert_error_msg_equals(exp_err(1, 1, 'invalid token'),
+        lexer.split, '.')
+
+    t.assert_error_msg_equals(exp_err(1, 3, 'invalid token'),
+        lexer.split, 'x!.')
 end
 
 -- Verify AST generation.

--- a/test/config-luatest/expression_test.lua
+++ b/test/config-luatest/expression_test.lua
@@ -166,11 +166,37 @@ g.test_lexer = function()
     t.assert_error_msg_equals(exp_err(1, 3, 'truncated expression'),
         lexer.split, 'x=')
 
-    -- =x and !x are forbidden.
-    t.assert_error_msg_equals(exp_err(1, 2, 'invalid token'),
-        lexer.split, '!x')
+    -- =x is forbidden.
     t.assert_error_msg_equals(exp_err(1, 2, 'invalid token'),
         lexer.split, '=x')
+
+    -- Unary ! is allowed.
+    t.assert_equals(lexer.split('!x'), {
+        {type = 'operation', value = '!'},
+        {type = 'variable', value = 'x'},
+    })
+    t.assert_equals(lexer.split('!(x<2.0.0)'), {
+        {type = 'operation', value = '!'},
+        {type = 'grouping', value = '('},
+        {type = 'variable', value = 'x'},
+        {type = 'operation', value = '<'},
+        {type = 'version_literal', value = '2.0.0'},
+        {type = 'grouping', value = ')'},
+    })
+    t.assert_equals(lexer.split('!(x > 1.0.0 || b)'), {
+        {type = 'operation', value = '!'},
+        {type = 'grouping', value = '('},
+        {type = 'variable', value = 'x'},
+        {type = 'operation', value = '>'},
+        {type = 'version_literal', value = '1.0.0'},
+        {type = 'operation', value = '||'},
+        {type = 'variable', value = 'b'},
+        {type = 'grouping', value = ')'},
+    })
+
+    -- Standalone '!' is a truncated expression (missing operand).
+    t.assert_error_msg_equals(exp_err(1, 2, 'truncated expression'),
+        lexer.split, '!')
 
     -- A separator should follow a version literal or a variable.
     t.assert_error_msg_equals(exp_err(1, 6, 'invalid token'),
@@ -202,6 +228,37 @@ g.test_lexer = function()
     t.assert_error_msg_equals(exp_err(1, 8, 'invalid version literal: ' ..
         'expected 3 components, got 4'),
         lexer.split, '1.2.3.4')
+
+    -- Lexer-level corner cases around '!'.
+    --
+    -- Note: syntactically "x ! config" is not a valid expression for parser,
+    -- but lexer should still tokenize it consistently.
+    t.assert_equals(lexer.split('x ! config'), {
+        {type = 'variable', value = 'x'},
+        {type = 'operation', value = '!'},
+        {type = 'variable', value = 'config'},
+    })
+
+    t.assert_equals(lexer.split('x!=!y'), {
+        {type = 'variable', value = 'x'},
+        {type = 'operation', value = '!='},
+        {type = 'operation', value = '!'},
+        {type = 'variable', value = 'y'},
+    })
+
+    t.assert_equals(lexer.split('x>=!y'), {
+        {type = 'variable', value = 'x'},
+        {type = 'operation', value = '>='},
+        {type = 'operation', value = '!'},
+        {type = 'variable', value = 'y'},
+    })
+
+    t.assert_equals(lexer.split('!x>1.0.0'), {
+        {type = 'operation', value = '!'},
+        {type = 'variable', value = 'x'},
+        {type = 'operation', value = '>'},
+        {type = 'version_literal', value = '1.0.0'}
+    })
 end
 
 -- Verify AST generation.

--- a/test/config-luatest/expression_test.lua
+++ b/test/config-luatest/expression_test.lua
@@ -703,13 +703,14 @@ g.test_validate_success = function()
     local vars = {config = {database = {use_mvcc_engine = true}}}
     local ast = expression.parse('!config.database.use_mvcc_engine')
     expression.validate(ast, vars)
+
+    -- A non-version string can be used as a predicate.
+    local vars = {config = {database = {mode = 'ro'}}}
+    local ast = expression.parse('config.database.mode')
+    expression.validate(ast, vars)
 end
 
 g.test_validate_failure = function()
-    local ast = expression.parse('a')
-    local exp_err = 'An expression should be a predicate, got variable'
-    t.assert_error_msg_equals(exp_err, expression.validate, ast, {})
-
     local ast = expression.parse('1.0.0')
     local exp_err = 'An expression should be a predicate, got version_literal'
     t.assert_error_msg_equals(exp_err, expression.validate, ast, {})
@@ -742,39 +743,28 @@ g.test_validate_failure = function()
     local exp_err = 'Variable "x" has type number, expected string'
     t.assert_error_msg_equals(exp_err, expression.validate, ast, vars)
 
-    local vars = {x = ''}
-    local ast = expression.parse('x > 0.0.0')
-    local exp_err = 'Expected a version in variable "x", got an empty string'
-    t.assert_error_msg_equals(exp_err, expression.validate, ast, vars)
-
-    for _, x in ipairs({'.1', '1.', 'x', ' 1', '1 ', '1..2'}) do
+    for _, x in ipairs({'', '.1', '1.', 'x', ' 1', '1 ', '1..2',
+                         '1', '1.2', '1.2.3.4', '1.2.3.4.5'}) do
         local vars = {x = x}
         local ast = expression.parse('x > 0.0.0')
-        local exp_err = 'Variable "x" is not a version string'
-        t.assert_error_msg_equals(exp_err, expression.validate, ast, vars)
-    end
-
-    for _, x in ipairs({'1', '1.2', '1.2.3.4', '1.2.3.4.5'}) do
-        local vars = {x = x}
-        local ast = expression.parse('x > 0.0.0')
-        local exp_err = ('Expected a three component version in variable ' ..
-            '"x", got %d components'):format((#x + 1) / 2)
+        local exp_err = 'A comparison operator (<, >, <=, >=, !=, ==) ' ..
+            'requires version literals or variables as arguments'
         t.assert_error_msg_equals(exp_err, expression.validate, ast, vars)
     end
 
     local vars = {v = '1.0.0'}
     local ast = expression.parse('!v')
-    local exp_err = 'Unary "!" accepts only boolean expressions'
+    local exp_err = 'Unary "!" accepts only boolean or string expressions'
     t.assert_error_msg_equals(exp_err, expression.validate, ast, vars)
 
     local ast = expression.parse('!1.0.0')
-    local exp_err = 'Unary "!" accepts only boolean expressions'
+    local exp_err = 'Unary "!" accepts only boolean or string expressions'
     t.assert_error_msg_equals(exp_err, expression.validate, ast, {})
 
     local vars = {v = '1.0.0', flag = true}
     local ast = expression.parse('v && flag')
     local exp_err = 'A logical operator (&& or ||) accepts only boolean ' ..
-        'expressions as arguments'
+        'or string expressions as arguments'
     t.assert_error_msg_equals(exp_err, expression.validate, ast, vars)
 end
 

--- a/test/config-luatest/roles_test.lua
+++ b/test/config-luatest/roles_test.lua
@@ -1422,3 +1422,110 @@ g.test_tarantool_version_check = function(g)
         setsearchroot = false,
     })
 end
+
+g.test_role_fail_if_config_check = function(g)
+    local role_config_only = [[-- --- #tarantool.metadata.v1
+-- fail_if: "!config.database.use_mvcc_engine"
+-- ...
+
+        return {
+            validate = function() end,
+            apply = function() end,
+            stop = function() end,
+        }
+    ]]
+
+    local role_version_and_config = [[-- --- #tarantool.metadata.v1
+-- fail_if: "tarantool_version < 0.0.0 || !config.database.use_mvcc_engine"
+-- ...
+
+        return {
+            validate = function() end,
+            apply = function() end,
+            stop = function() end,
+        }
+    ]]
+
+    local cases = {
+        {
+            name = 'config-only: enabled -> success',
+            role = role_config_only,
+            mvcc = true,
+            ok = true,
+        },
+        {
+            name = 'config-only: disabled -> failure',
+            role = role_config_only,
+            mvcc = false,
+            ok = false,
+            exp_err = 'Role "r" failed the "fail_if" check: ' ..
+                      '"!config.database.use_mvcc_engine"',
+        },
+        {
+            name = 'version+config: enabled -> success',
+            role = role_version_and_config,
+            mvcc = true,
+            ok = true,
+        },
+        {
+            name = 'version+config: disabled -> failure',
+            role = role_version_and_config,
+            mvcc = false,
+            ok = false,
+            exp_err = 'Role "r" failed the "fail_if" check: ' ..
+            '"tarantool_version < 0.0.0 || !config.database.use_mvcc_engine"',
+        },
+    }
+
+    for _, c in ipairs(cases) do
+        local opts = {
+            ['roles'] = {'r'},
+            ['database.use_mvcc_engine'] = c.mvcc,
+        }
+
+        if c.ok then
+            helpers.success_case(g, {
+                roles = {r = c.role},
+                options = opts,
+                verify = function() end,
+            })
+        else
+            helpers.failure_case({
+                roles = {r = c.role},
+                options = opts,
+                setsearchroot = false,
+                exp_err = c.exp_err,
+            })
+        end
+    end
+end
+
+g.test_role_fail_if_config_check_box_null = function(g)
+    local role = [[-- --- #tarantool.metadata.v1
+-- fail_if: "config.database.mode"
+-- ...
+
+        return {
+            validate = function() end,
+            apply = function() end,
+            stop = function() end,
+        }
+    ]]
+
+    helpers.success_case(g, {
+        roles = {r = role},
+        options = {roles = {'r'}},
+        verify = function() end,
+    })
+
+    helpers.failure_case({
+        roles = {r = role},
+        options = {
+            roles = {'r'},
+            ['database.mode'] = 'ro',
+        },
+        setsearchroot = false,
+        exp_err = 'Role "r" failed the "fail_if" check: ' ..
+                  '"config.database.mode"',
+    })
+end


### PR DESCRIPTION
`fail_if` expressions are extended to support config-based predicates. Now an expression may reference configuration options via `config.<path>` and negate boolean predicates using unary `!`. 

Example:

``` yaml
--- #tarantool.metadata.v1
fail_if: "tarantool_version < 3.5.0 || !config.database.use_mvcc_engine"

```

The expression language supports:

* logical operators: `||`, `&&`, `!`
* comparisons for versions: `<`, `>`, `<=`, `>=`, `==`, `!=`
* parentheses for grouping: `(`, `)`

Supported variables:

* `tarantool_version`: current Tarantool version (three-component format, for example, `3.5.0`)
* `config.<path>`: a configuration option value (for example, `config.database.use_mvcc_engine`)

fail_if is evaluated for apps and roles. If it evaluates to true, the corresponding app/role loading fails with an error.

Closes tarantool#11759