### PR TITLE
fiber: introduce cord_cancel method

### DIFF
--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -858,7 +858,7 @@ struct cord {
 	char name[FIBER_NAME_INLINE];
 	/** Cord main fiber started in case of cord_costart. */
 	struct fiber *main_fiber;
-	/** An event triggered to cancel cord main fiber. */
+	/** Event used to asynchronously stop this cord. */
 	ev_async cancel_event;
 	/** Number of alive client (non system) fibers. */
 	int client_fiber_count;
@@ -953,6 +953,23 @@ cord_cojoin(struct cord *cord);
  */
 int
 cord_join(struct cord *cord);
+
+/**
+ * Stop a cord running an event loop.
+ *
+ * If the cord was started with cord_costart(), the function cancels
+ * the main fiber. In this case the event loop will be broken and
+ * the cord will exit as soon as the main fiber returns.
+ *
+ * If the cord was started with cord_start(), the function breaks
+ * the event loop immediately. For this to work, the cord function
+ * must run the event loop with ev_run().
+ *
+ * Anyway, cord_cancel() doesn't wait for the cord to exit. Use it in
+ * conjunction with cord_join() or cord_cojoin() to destroy the cord.
+ */
+void
+cord_cancel(struct cord *cord);
 
 void
 cord_set_name(const char *name);

--- a/test/unit/fiber.cc
+++ b/test/unit/fiber.cc
@@ -455,6 +455,30 @@ cord_cojoin_cancel_test(void)
 	footer();
 }
 
+static void *
+event_loop_f(void *ap)
+{
+	ev_run(loop());
+	return NULL;
+}
+
+static void
+cord_cancel_test(void)
+{
+	header();
+
+	struct cord cord;
+	fail_if(cord_start(&cord, "cord", event_loop_f, NULL) != 0);
+	cord_cancel(&cord);
+	fail_if(cord_join(&cord) != 0);
+
+	fail_if(cord_costart(&cord, "cord", wait_cancel_f, NULL) != 0);
+	cord_cancel(&cord);
+	fail_if(cord_cojoin(&cord) != 0);
+
+	footer();
+}
+
 static void
 fiber_test_defaults()
 {
@@ -790,6 +814,7 @@ main_f(va_list ap)
 	fiber_wait_on_deadline_test();
 	cord_cojoin_test();
 	cord_cojoin_cancel_test();
+	cord_cancel_test();
 	fiber_test_defaults();
 	fiber_test_leak_modes();
 	fiber_test_client_fiber_count();

--- a/test/unit/fiber.result
+++ b/test/unit/fiber.result
@@ -30,6 +30,8 @@
 	*** cord_cojoin_test: done ***
 	*** cord_cojoin_cancel_test ***
 	*** cord_cojoin_cancel_test: done ***
+	*** cord_cancel_test ***
+	*** cord_cancel_test: done ***
 	*** fiber_test_defaults ***
 	*** fiber_test_defaults: done ***
 	*** fiber_test_leak ***


### PR DESCRIPTION
The new method sends an event to the given cord, which makes it stop. It works only if the cord is running an event loop, either implicitly, inside the cord_costart() function, or explicitly, by calling ev_run() directly. If the cord was started with cord_costart(), it cancels the main fiber. As soon as the main fiber returns, the event loop running in the cord will be broken and the cord will exit. If the cord was started with cord_start() and is running the event loop explicitly, cord_cancel() will send an event to it that will break the event loop immediately. The function reuses the event introduced for handling the case when cord_cojoin() is cancelled, see commit 6f8b0b6437eaf ("fiber: make cord_cojoin cancellable").