### PR TITLE
limbo: don't wait for volatiles on promote/demote

### DIFF
--- a/changelogs/unreleased/gh-12205-promote-deadlock.md
+++ b/changelogs/unreleased/gh-12205-promote-deadlock.md
@@ -1,0 +1,7 @@
+## bugfix/replication
+
+* Fixed a bug where the replication could get stuck upon receipt
+  of a 'promote' entry from a newly elected leader. This was
+  likely to happen when the receiver itself had been a leader not
+  long ago and still had some transactions in the synchro queue
+  not yet written to the journal (gh-12205).

--- a/src/box/txn_limbo_queue.h
+++ b/src/box/txn_limbo_queue.h
@@ -278,9 +278,13 @@ txn_limbo_queue_wait_last_txn(struct txn_limbo_queue *queue, bool *is_rollback,
 int
 txn_limbo_queue_wait_empty(struct txn_limbo_queue *queue, double timeout);
 
-/** Wait until all the entries receive an lsn. */
+/**
+ * Wait until all the entries, that are submitted to the journal, come back from
+ * it with LSNs. After this call the queue has no unfinished business with the
+ * journal. All entries are either not even sent there (volatile) or have LSNs.
+ */
 int
-txn_limbo_queue_wait_persisted(struct txn_limbo_queue *queue);
+txn_limbo_queue_wait_writes_finished(struct txn_limbo_queue *queue);
 
 /** Rollback all the volatile txns. See more in the limbo doc. */
 void

--- a/test/replication-luatest/gh_12205_qsync_replication_deadlock_test.lua
+++ b/test/replication-luatest/gh_12205_qsync_replication_deadlock_test.lua
@@ -1,0 +1,113 @@
+local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
+local t = require('luatest')
+local g = t.group()
+
+--
+-- gh-12205: volatile limbo transactions couldn't be rolled back by an external
+-- PROMOTE coming from a new leader. That PROMOTE tried to wait for all entries
+-- being persisted before rolling anything back. And the last entries couldn't
+-- be persisted because they were waiting for the older txns to get finished.
+-- Which in turn would never happen, since these older txns were supposed to get
+-- rolled back by this stuck PROMOTE. This was a deadlock.
+--
+g.before_all(function(cg)
+    cg.replica_set = replica_set:new()
+    cg.replication = {
+        server.build_listen_uri('instance1', cg.replica_set.id),
+        server.build_listen_uri('instance2', cg.replica_set.id),
+    }
+    local box_cfg = {
+        replication = cg.replication,
+        replication_timeout = 0.1,
+        replication_synchro_queue_max_size = 1,
+        replication_synchro_timeout = 1000,
+        election_mode = 'manual',
+    }
+    cg.instance1 = cg.replica_set:build_and_add_server{
+        alias = 'instance1',
+        box_cfg = box_cfg,
+    }
+    box_cfg.election_mode = 'voter'
+    cg.instance2 = cg.replica_set:build_and_add_server{
+        alias = 'instance2',
+        box_cfg = box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.instance1:exec(function()
+        box.ctl.promote()
+        box.schema.space.create('test', {is_sync = true})
+        box.space.test:create_index('pk')
+    end)
+    cg.instance2:wait_for_vclock_of(cg.instance1)
+end)
+
+g.after_all(function(cg)
+    cg.replica_set:drop()
+end)
+
+g.test_case = function(cg)
+    --
+    -- Old leader spawns some transactions, some of which get stuck in volatile
+    -- states.
+    --
+    cg.instance1:exec(function()
+        local fiber = require('fiber')
+        local s = box.space.test
+        -- Make sure no CONFIRM happens.
+        box.cfg{replication_synchro_quorum = 3}
+        rawset(_G, 'f1', fiber.new(s.insert, s, {1}))
+        _G.f1:set_joinable(true)
+        rawset(_G, 'f2', fiber.new(s.insert, s, {2}))
+        _G.f2:set_joinable(true)
+        rawset(_G, 'f3', fiber.new(s.insert, s, {3}))
+        _G.f3:set_joinable(true)
+        fiber.yield()
+        -- 1 is waiting for quorum, 2 are volatile.
+        t.assert_equals(box.info.synchro.queue.len, 1)
+    end)
+    cg.instance2:wait_for_vclock_of(cg.instance1)
+    --
+    -- New leader gets elected. It will confirm one txn that it actually saw.
+    -- The other txns (the volatile ones) the old leader must rollback.
+    --
+    cg.instance2:exec(function()
+        box.cfg{election_mode = 'manual'}
+        t.helpers.retrying({timeout = 120}, box.ctl.promote)
+        t.assert_equals(box.space.test:select(), {{1}})
+    end)
+    cg.instance1:wait_for_vclock_of(cg.instance2)
+    cg.instance1:exec(function()
+        local function join_as_rollback(f)
+            local timeout = 120
+            local ok, err = f:join(timeout)
+            t.assert_not(ok)
+            t.assert_equals(err.code, box.error.SYNC_ROLLBACK)
+        end
+        -- This was confirmed by the new leader.
+        t.assert((_G.f1:join()))
+        -- These never even reached the journal.
+        join_as_rollback(_G.f2)
+        join_as_rollback(_G.f3)
+        t.assert_equals(box.info.synchro.queue.len, 0)
+        t.assert_equals(box.space.test:select(), {{1}})
+    end)
+    --
+    -- Make sure the replication still works.
+    --
+    cg.instance2:exec(function()
+        box.space.test:replace{4}
+    end)
+    cg.instance1:wait_for_vclock_of(cg.instance2)
+    cg.instance1:exec(function()
+        box.cfg{replication_synchro_quorum = box.NULL}
+        t.assert_equals(box.space.test:select(), {{1}, {4}})
+        t.helpers.retrying({timeout = 120}, box.ctl.promote)
+        box.space.test:replace{5}
+    end)
+    cg.instance1:wait_for_vclock_of(cg.instance1)
+    cg.instance2:exec(function()
+        t.assert_equals(box.space.test:select(), {{1}, {4}, {5}})
+    end)
+end


### PR DESCRIPTION
PROMOTE/DEMOTE requests on prepare tried to wait for all limbo entries to get fully persisted before the requests could be applied.

The reason was that these requests are checking if their LSNs actually do the expected thing. That is, either match the already confirmed LSN, or affect some pending transactions.

The situation when a PROMOTE/DEMOTE has LSN > confirmed LSN but there are no transactions affected by that usually means that such transactions existed, but the current instance got them already rolled back. Which in turn looks like a split-brain.

The waiting though also happened on the volatile entries. The ones which were not even submitted to the journal anyway. And that could lead to a deadlock. It was happening when the old leader had some pending volatile txns in the limbo, got PROMOTE from a newer leader, this PROMOTE started waiting on all the limbo entries to get persisted, and these entries in turn couldn't make progress either, because the current instance can't finish them on its own.

As a temporary solution it should be enough to simply not wait for the volatile entries. It is safe to roll them back anyway, and no need to know their LSNs for that.

As an actual solution the limbo must get rid of any rollbacks that aren't done by PROMOTE/DEMOTE. Which means removal of rollback by timeout. This is the only case when the mentioned situation of "old leader rolled something back on its own" can happen. This can only be done starting 4.x.

Closes #12205

NO_DOC=bugfix