### PR TITLE
vinyl: don't fail checkpoint if scheduler is throttled

### DIFF
--- a/src/box/checkpoint.c
+++ b/src/box/checkpoint.c
@@ -158,11 +158,10 @@ box_checkpoint_build_in_memory(struct box_checkpoint *out)
 }
 
 int
-box_checkpoint_build_on_disk(struct box_checkpoint *out, bool is_scheduled)
+box_checkpoint_build_on_disk(struct box_checkpoint *out)
 {
 	int rc;
 	struct engine_checkpoint_params engine_params = {
-		.is_scheduled = is_scheduled,
 		.box = out,
 	};
 	rc = engine_begin_checkpoint(&engine_params);

--- a/src/box/checkpoint.h
+++ b/src/box/checkpoint.h
@@ -52,7 +52,7 @@ box_checkpoint_build_in_memory(struct box_checkpoint *out);
  * Only one on-disk checkpoint can be in progress.
  */
 int
-box_checkpoint_build_on_disk(struct box_checkpoint *out, bool is_scheduled);
+box_checkpoint_build_on_disk(struct box_checkpoint *out);
 
 /**
  * Extract the checkpoint data from the snapshot having exactly the provided

--- a/src/box/engine.h
+++ b/src/box/engine.h
@@ -110,8 +110,6 @@ struct engine_memory_stat {
 
 /** Parameters passed to the engines on checkpoint start. */
 struct engine_checkpoint_params {
-	/** Flag whether the checkpoint is scheduled or explicitly requested. */
-	bool is_scheduled;
 	/** Global engine-agnostic control states of the instance. */
 	const struct box_checkpoint *box;
 };

--- a/src/box/gc.c
+++ b/src/box/gc.c
@@ -524,13 +524,14 @@ gc_add_checkpoint(const struct vclock *vclock, double timestamp)
 	gc_schedule_cleanup();
 }
 
+/** Actually performs checkpoint. */
 static int
-gc_do_checkpoint(bool is_scheduled)
+gc_do_checkpoint(void)
 {
 	assert(!gc.checkpoint_is_in_progress);
 	gc.checkpoint_is_in_progress = true;
 	struct box_checkpoint checkpoint;
-	int rc = box_checkpoint_build_on_disk(&checkpoint, is_scheduled);
+	int rc = box_checkpoint_build_on_disk(&checkpoint);
 	if (rc == 0) {
 		/*
 		 * Finally, track the newly created checkpoint in the garbage
@@ -566,7 +567,7 @@ gc_checkpoint(void)
 				0);
 	fiber_wakeup(gc.checkpoint_fiber);
 
-	if (gc_do_checkpoint(false) != 0)
+	if (gc_do_checkpoint() != 0)
 		return -1;
 
 	/*
@@ -635,7 +636,7 @@ gc_checkpoint_fiber_f(va_list ap)
 			 */
 			continue;
 		}
-		if (gc_do_checkpoint(true) != 0)
+		if (gc_do_checkpoint() != 0)
 			diag_log();
 	}
 	return 0;

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -2930,6 +2930,7 @@ static int
 vinyl_engine_begin_checkpoint(struct engine *engine,
 			      const struct engine_checkpoint_params *params)
 {
+	(void)params;
 	struct vy_env *env = vy_env(engine);
 	assert(env->status == VINYL_ONLINE);
 	/*
@@ -2939,8 +2940,7 @@ vinyl_engine_begin_checkpoint(struct engine *engine,
 	 */
 	if (lsregion_used(&env->mem_env.allocator) == 0)
 		return 0;
-	if (vy_scheduler_begin_checkpoint(&env->scheduler,
-					  params->is_scheduled) != 0)
+	if (vy_scheduler_begin_checkpoint(&env->scheduler) != 0)
 		return -1;
 	return 0;
 }

--- a/src/box/vy_scheduler.h
+++ b/src/box/vy_scheduler.h
@@ -239,20 +239,20 @@ vy_scheduler_force_compaction(struct vy_scheduler *scheduler,
  * after that.
  */
 int
-vy_scheduler_begin_checkpoint(struct vy_scheduler *, bool);
+vy_scheduler_begin_checkpoint(struct vy_scheduler *scheduler);
 
 /**
  * Wait for checkpoint. Please call vy_scheduler_end_checkpoint()
  * after that.
  */
 int
-vy_scheduler_wait_checkpoint(struct vy_scheduler *);
+vy_scheduler_wait_checkpoint(struct vy_scheduler *scheduler);
 
 /**
  * End checkpoint. Called on both checkpoint commit and abort.
  */
 void
-vy_scheduler_end_checkpoint(struct vy_scheduler *);
+vy_scheduler_end_checkpoint(struct vy_scheduler *scheduler);
 
 #if defined(__cplusplus)
 } /* extern "C" */


### PR DESCRIPTION
Currently we do fail checkpoint if it is done by schedule and not manually. We can try to checkpoint on schedule also, the purpose of throttling is to avoid busy loop on dumping on low vinyl L0 memory condition.