### PR TITLE
box: add new errcode for dictionary overflow

### DIFF
--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -445,6 +445,7 @@ struct errcode_record {
 	_(ER_INVALID_SORTDATA_FILE, 298,	"Invalid MemTX sort data file", "path", STRING, "details", STRING) \
 	_(ER_NO_SUCH_THREAD, 299,		"Thread does not exist", "thread_id", UINT) \
 	_(ER_UNABLE_TO_PROCESS_IN_THREAD, 300,	"Unable to process request in thread", "request", STRING, "thread_id", UINT) \
+	_(ER_DICT_OVERFLOW, 301,		"Dictionary has no space - too many unique values are used", "max_size", UINT) \
 	TEST_ERROR_CODES(_) /** This one should be last. */
 
 /*

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -509,6 +509,7 @@ t;
  |   298: box.error.INVALID_SORTDATA_FILE
  |   299: box.error.NO_SUCH_THREAD
  |   300: box.error.UNABLE_TO_PROCESS_IN_THREAD
+ |   301: box.error.DICT_OVERFLOW
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
It is needed for MemCS dictionary-encoded columns in Tarantool EE.

Part of tarantool/tarantool-ee#969

EE part: https://github.com/tarantool/tarantool-ee/pull/1626