### PR TITLE
[backport 3.3] box: fix yielding DDL ordering on WAL failure

### DIFF
--- a/changelogs/unreleased/gh-11833-yielding-ddl-dd-order-on-wal-failure.md
+++ b/changelogs/unreleased/gh-11833-yielding-ddl-dd-order-on-wal-failure.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed a crash that could happen if two DDL operations (index build or space
+  format change) were executed on the same space and a WAL write error occurred
+  (gh-11833).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -850,14 +850,14 @@ class AlterSpaceLock {
 	uint32_t space_id;
 public:
 	/** Take a lock for the altered space. */
-	AlterSpaceLock(struct alter_space *alter) {
+	AlterSpaceLock(struct space *space) {
 		if (registry == NULL) {
 			registry = mh_i32_new();
 		}
-		space_id = alter->old_space->def->id;
+		space_id = space->def->id;
 		if (mh_i32_find(registry, space_id, NULL) != mh_end(registry)) {
 			tnt_raise(ClientError, ER_ALTER_SPACE,
-				  space_name(alter->old_space),
+				  space_name(space),
 				  "the space is already being modified");
 		}
 		mh_i32_put(registry, &space_id, NULL, NULL);
@@ -1005,7 +1005,7 @@ alter_space_do(struct txn_stmt *stmt, struct alter_space *alter)
 	 * another DDL operation while this one is in progress so
 	 * we lock out all concurrent DDL for this space.
 	 */
-	AlterSpaceLock lock(alter);
+	AlterSpaceLock lock(alter->old_space);
 	/*
 	 * Prepare triggers while we may fail. Note, we don't have to
 	 * free them in case of failure, because they are allocated on
@@ -1107,50 +1107,68 @@ public:
 	virtual void prepare(struct alter_space *alter);
 };
 
+static bool
+alter_yield_allowed()
+{
+	return txn_is_first_statement(in_txn());
+}
+
+/*
+ * Return true if the given space is being altered in another transaction.
+ * This may happen when a previous DDL has released AlterSpaceLock, but hasn't
+ * been written to WAL yet and thus can still be rolled back.
+ */
+static bool
+alter_space_is_being_altered(uint32_t space_id)
+{
+	struct alter_space *alter;
+	rlist_foreach_entry(alter, &alter_space_list, in_list)
+		if (alter->txn != in_txn() &&
+		    alter->old_space->def->id == space_id)
+			return true;
+	return false;
+}
+
+/*
+ * The wait function that blocks execution until all previous alters will be
+ * rolled back or committed so that the space object won't be deleted right
+ * from under our feet. In the case when the previous alters were rolled back
+ * and the space was removed from space cache, this function throws an error.
+ */
+static void
+alter_space_wait_not_being_altered(struct space *old_space)
+{
+	uint32_t space_id = old_space->def->id;
+	while (true) {
+		if (!alter_space_is_being_altered(space_id))
+			break;
+		/*
+		 * Wait for deletion of any alter to check if the
+		 * space is being altered again.
+		 */
+		fiber_cond_wait(&alter_space_delete_cond);
+	}
+	/* Check if the space is still alive. */
+	if (space_by_id(space_id) != old_space) {
+		/* Cannot access the space name since it was deleted. */
+		tnt_raise(ClientError, ER_ALTER_SPACE,
+			  tt_sprintf("%u", space_id),
+			  "the space was concurrently modified");
+	}
+}
+
 /**
  * The object is used to grant ability to yield with RAII approach.
  * Transaction is allowed to yield only on its first statement, so if the
  * statement is not first, it simply does nothing.
- * If it's the first statement, the guard blocks execution until all previous
- * alters will be rolled back or committed so that the space object won't be
- * deleted right from under our feet. In the case when the previous alters were
- * rolled back and the space was removed from space cache, the constructor
- * throws an error.
  */
 class AlterYieldGuard
 {
 public:
-	AlterYieldGuard(struct space *old_space) {
-		if (!txn_is_first_statement(in_txn()))
+	AlterYieldGuard() {
+		if (!alter_yield_allowed())
 			return;
 		txn_can_yield(in_txn(), true);
-		uint32_t space_id = old_space->def->id;
-		while (true) {
-			bool space_is_being_altered = false;
-			struct alter_space *alter;
-			rlist_foreach_entry(alter, &alter_space_list, in_list) {
-				if (alter->txn != in_txn() &&
-				    alter->old_space->def->id == space_id) {
-					space_is_being_altered = true;
-					break;
-				}
-			}
-			if (!space_is_being_altered)
-				break;
-			/*
-			 * Wait for deletion of any alter to check if the
-			 * space is being altered again.
-			 */
-			fiber_cond_wait(&alter_space_delete_cond);
-		}
-		/* Check if the space is still alive. */
-		if (space_by_id(space_id) != old_space) {
-			txn_can_yield(in_txn(), false);
-			/* Cannot access the space name since it was deleted. */
-			tnt_raise(ClientError, ER_ALTER_SPACE,
-				  tt_sprintf("%u", space_id),
-				  "the space was concurrently modified");
-		}
 	}
 
 	~AlterYieldGuard() {
@@ -1162,7 +1180,9 @@ static inline void
 space_check_format_with_yield(struct space *space,
 			      struct tuple_format *format)
 {
-	AlterYieldGuard guard(space);
+	AlterYieldGuard guard;
+	assert(!alter_yield_allowed() ||
+	       !alter_space_is_being_altered(space->def->id));
 	space_check_format_xc(space, format);
 }
 
@@ -1456,7 +1476,9 @@ static inline void
 space_build_index_with_yield(struct space *old_space, struct space *new_space,
 			     struct index *new_index)
 {
-	AlterYieldGuard guard(old_space);
+	AlterYieldGuard guard;
+	assert(!alter_yield_allowed() ||
+	       !alter_space_is_being_altered(old_space->def->id));
 	space_build_index_xc(old_space, new_space, new_index);
 }
 
@@ -2107,6 +2129,64 @@ filter_temporary_ddl_stmt(struct txn *txn, const struct space_def *def)
 }
 
 /**
+ * A trigger invoked before replace in space _space/_index.
+ *
+ * This trigger is used to serialize *yielding* DDL operations on the same
+ * space.
+ *
+ * Some DDL operations (e.g. index build or format checks) may yield *before*
+ * the corresponding _space row is written to WAL but after the DDL request
+ * has already performed a replace in _space and entered the corresponding
+ * on_replace trigger (see @sa on_replace_dd_space() /
+ * @sa on_replace_dd_index()), which starts a yielding work (e.g. via
+ * space_check_format_with_yield() or space_build_index_with_yield()).
+ *
+ * While such an operation is in progress, the first DDL statement may have
+ * already updated _space in-memory, but is still uncommitted and therefore
+ * subject to rollback on WAL failure. If a second DDL updates _space for the
+ * same space concurrently, rollback of the first DDL may break the expected
+ * change order and corrupt the data dictionary.
+ *
+ * To avoid that for such yielding DDLs, we wait before performing the actual
+ * replace into _space (in this before_replace trigger) until all previous
+ * alters on the same space are finished (committed or rolled back) via
+ * @sa AlterYieldGuard.
+ */
+static int
+before_replace_dd_space_index(struct trigger *trigger, void *event)
+{
+	struct txn *txn = (struct txn *)event;
+	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct tuple *old_tuple = stmt->old_tuple;
+	struct tuple *new_tuple = stmt->new_tuple;
+	uint32_t id;
+	uint32_t fieldno;
+	if (trigger == &alter_space_before_replace_space) {
+		fieldno = BOX_SPACE_FIELD_ID;
+	} else if (trigger == &alter_space_before_replace_index) {
+		fieldno = BOX_INDEX_FIELD_SPACE_ID;
+	} else {
+		unreachable();
+	}
+	if (tuple_field_u32(old_tuple ? old_tuple : new_tuple,
+			    fieldno, &id) != 0)
+		return -1;
+	struct space *space = space_by_id(id);
+	if (space == NULL)
+		return 0;
+
+	try {
+		AlterSpaceLock lock(space);
+		AlterYieldGuard guard;
+		if (txn_has_flag(in_txn(), TXN_CAN_YIELD))
+			alter_space_wait_not_being_altered(space);
+	} catch (Exception *e) {
+		return -1;
+	}
+	return 0;
+}
+
+/**
  * A trigger which is invoked on replace in a data dictionary
  * space _space.
  *
@@ -2179,9 +2259,12 @@ on_replace_dd_space(struct trigger * /* trigger */, void *event)
 	 * may have changed space id.
 	 */
 	uint32_t old_id;
-	if (tuple_field_u32(old_tuple ? old_tuple : new_tuple,
-			    BOX_SPACE_FIELD_ID, &old_id) != 0)
-		return -1;
+	/*
+	 * tuple_field_u32() can't fail here: the tuple was already validated
+	 * in before_replace_dd_space_index().
+	 */
+	VERIFY(tuple_field_u32(old_tuple ? old_tuple : new_tuple,
+			       BOX_SPACE_FIELD_ID, &old_id) == 0);
 	struct space *old_space = space_by_id(old_id);
 	struct space_def *def = NULL;
 	if (new_tuple != NULL) {
@@ -2522,9 +2605,12 @@ on_replace_dd_index(struct trigger * /* trigger */, void *event)
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 	uint32_t id, iid;
-	if (tuple_field_u32(old_tuple ? old_tuple : new_tuple,
-			    BOX_INDEX_FIELD_SPACE_ID, &id) != 0)
-		return -1;
+	/*
+	 * tuple_field_u32() can't fail here: the tuple was already validated
+	 * in before_replace_dd_space_index().
+	 */
+	VERIFY(tuple_field_u32(old_tuple ? old_tuple : new_tuple,
+			       BOX_INDEX_FIELD_SPACE_ID, &id) == 0);
 	if (tuple_field_u32(old_tuple ? old_tuple : new_tuple,
 			    BOX_INDEX_FIELD_ID, &iid) != 0)
 		return -1;
@@ -5703,7 +5789,9 @@ on_replace_dd_func_index(struct trigger *trigger, void *event)
 	return 0;
 }
 
+TRIGGER(alter_space_before_replace_space, before_replace_dd_space_index);
 TRIGGER(alter_space_on_replace_space, on_replace_dd_space);
+TRIGGER(alter_space_before_replace_index, before_replace_dd_space_index);
 TRIGGER(alter_space_on_replace_index, on_replace_dd_index);
 TRIGGER(on_replace_truncate, on_replace_dd_truncate);
 TRIGGER(on_replace_schema, on_replace_dd_schema);

--- a/src/box/alter.h
+++ b/src/box/alter.h
@@ -34,7 +34,9 @@
 
 extern struct trigger before_replace_schema;
 
+extern struct trigger alter_space_before_replace_space;
 extern struct trigger alter_space_on_replace_space;
+extern struct trigger alter_space_before_replace_index;
 extern struct trigger alter_space_on_replace_index;
 extern struct trigger on_replace_truncate;
 extern struct trigger on_replace_schema;

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -371,6 +371,9 @@ schema_init(void)
 	/* _space - home for all spaces. */
 	sc_space_new(BOX_SPACE_ID, "_space", key_parts, 1,
 		     &alter_space_on_replace_space);
+	struct space *space = space_by_id(BOX_SPACE_ID);
+	assert(space != NULL);
+	trigger_add(&space->before_replace, &alter_space_before_replace_space);
 
 	/* _truncate - auxiliary space for triggering space truncation. */
 	sc_space_new(BOX_TRUNCATE_ID, "_truncate", key_parts, 1,
@@ -418,6 +421,9 @@ schema_init(void)
 	key_parts[1].type = FIELD_TYPE_UNSIGNED;
 	sc_space_new(BOX_INDEX_ID, "_index", key_parts, 2,
 		     &alter_space_on_replace_index);
+	struct space *index = space_by_id(BOX_INDEX_ID);
+	assert(index != NULL);
+	trigger_add(&index->before_replace, &alter_space_before_replace_index);
 
 	/* _fk_сonstraint - foreign keys constraints. */
 	key_parts[0].fieldno = 0; /* constraint name */

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -571,6 +571,15 @@ space_has_before_replace_triggers(struct space *space)
 }
 
 /**
+ * Check if the space has registered user-defined before_replace triggers.
+ */
+static inline bool
+space_has_before_replace_event_triggers(struct space *space)
+{
+	return space_event_has_triggers(&space->before_replace_event);
+}
+
+/**
  * Run on_replace triggers registered for a space.
  */
 int

--- a/test/box-luatest/gh_11833_two_ddl_of_the_same_space_in_a_row_rollback_test.lua
+++ b/test/box-luatest/gh_11833_two_ddl_of_the_same_space_in_a_row_rollback_test.lua
@@ -1,0 +1,124 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('gh-11833-two-ddl-of-the-same-space-in-a-row-rollback')
+--
+-- gh-11833: two ddl of the same space in a row rollback
+--
+
+g.before_all(function()
+    t.tarantool.skip_if_not_debug()
+
+    g.server = server:new{}
+    g.server:start()
+
+    g.server:exec(function()
+        box.schema.create_space('test')
+        box.space.test:create_index('pk')
+    end)
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+g.after_each(function()
+    g.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_WRITE', false)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end)
+end)
+
+g.test_two_ddl_of_the_same_space_in_a_row_rollback = function()
+    g.server:exec(function()
+        local fiber = require('fiber')
+
+        local format_default = {
+            {'a', 'unsigned'},
+            {'b', 'unsigned'},
+        }
+
+        local format_nullable = {
+            {'a', 'unsigned'},
+            {'b', 'unsigned', is_nullable = true},
+        }
+
+        box.space.test:format(format_default)
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+
+        -- Change format in _space and wait for it to go to WAL.
+        fiber.create(function()
+            box.space.test:format(format_nullable)
+        end)
+
+        -- Change format in _space and wait for the first fiber to complete.
+        local f = fiber.create(function()
+            box.space.test:format(format_default)
+        end)
+        f:set_joinable(true)
+
+        -- WAL write failed so rollback in _space is done for the format
+        -- change from the first fiber which breaks change order.
+        box.error.injection.set('ERRINJ_WAL_WRITE', true)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+
+        local ok, err = f:join()
+        t.assert_not(ok)
+        t.assert_covers(err:unpack(), {
+            type = 'ClientError',
+            code = box.error.ALTER_SPACE,
+            message = string.format("Can't modify space '%d': " ..
+                "the space was concurrently modified", box.space.test.id)
+        })
+    end)
+end
+
+g.test_third_ddl_while_second_waits_in_alter_yield_guard = function()
+    g.server:exec(function()
+        local fiber = require('fiber')
+
+        local format_default = {
+            {'a', 'unsigned'},
+            {'b', 'unsigned'},
+        }
+
+        local format_nullable = {
+            {'a', 'unsigned'},
+            {'b', 'unsigned', is_nullable = true},
+        }
+
+        box.space.test:format(format_default)
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+
+        local f1 = fiber.create(function()
+            box.space.test:format(format_nullable)
+        end)
+        f1:set_joinable(true)
+
+        local f2 = fiber.create(function()
+            box.space.test:format(format_default)
+        end)
+        f2:set_joinable(true)
+
+        local f3 = fiber.new(function()
+            box.space.test:format(format_default)
+        end)
+        f3:set_joinable(true)
+
+        local ok, err = f3:join()
+        t.assert_not(ok)
+        t.assert_covers(err:unpack(), {
+            type = 'ClientError',
+            code = box.error.ALTER_SPACE,
+            message = string.format("Can't modify space 'test': " ..
+                "the space is already being modified")
+        })
+
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+
+        t.assert(f1:join())
+        t.assert(f2:join())
+    end)
+end


### PR DESCRIPTION
*(This PR is a backport of #12007 to `release/3.3` to a future `3.3.5` release.)*

----

Serialize yielding DDL operations on the same space to avoid reordering of data dictionary updates when the first DDL updated _space/_index in-memory and then failed to write to WAL.

To do so, add internal before_replace triggers for _space and _index that wait for completion of previous yielding alters on the same space before applying the next change.

Closes https://github.com/tarantool/tarantool/issues/11833

NO_DOC=bugfix
