### PR TITLE
box: build fix with recent gcc/glibc

### DIFF
--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -3189,7 +3189,7 @@ luaT_netbox_transport_start(struct lua_State *L)
 	struct netbox_transport *transport = luaT_check_netbox_transport(L, 1);
 	assert(transport->worker == NULL);
 	assert(transport->coro_ref == LUA_NOREF);
-	assert(transport->self_ref = LUA_NOREF);
+	assert(transport->self_ref == LUA_NOREF);
 	struct lua_State *fiber_L = lua_newthread(L);
 	transport->coro_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 	transport->self_ref = luaL_ref(L, LUA_REGISTRYINDEX);

--- a/src/box/memtx_sort_data.c
+++ b/src/box/memtx_sort_data.c
@@ -133,7 +133,7 @@ static const char *ENTRY_FMT = "%010u/%010u: %016lx, %016lx, %020ld\n";
 const char *
 memtx_sort_data_filename(const char *snap_filename)
 {
-	char *snap_ext = strrchr(snap_filename, '.');
+	const char *snap_ext = strrchr(snap_filename, '.');
 	assert(snap_ext != NULL);
 	if (strcmp(snap_ext, ".inprogress") == 0) {
 		snap_ext -= strlen(".snap");

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -3646,7 +3646,7 @@ sql_set_boolean_option(int id, bool value)
 static int
 sql_set_string_option(int id, const char *value)
 {
-	assert(sql_session_opts[id - SESSION_SETTING_SQL_BEGIN].field_type =
+	assert(sql_session_opts[id - SESSION_SETTING_SQL_BEGIN].field_type ==
 	       FIELD_TYPE_STRING);
 	assert(id == SESSION_SETTING_SQL_DEFAULT_ENGINE);
 	(void)id;

--- a/src/box/xlog.c
+++ b/src/box/xlog.c
@@ -716,7 +716,7 @@ xdir_remove_file_by_vclock(struct xdir *dir, struct vclock *to_remove)
 static bool
 xlog_file_is_temporary_default(const char *filename)
 {
-	char *ext = strrchr(filename, '.');
+	const char *ext = strrchr(filename, '.');
 	return ext != NULL && strcmp(ext, inprogress_suffix) == 0;
 }
 


### PR DESCRIPTION
There are couple of errors like below and assertions where '=' is used instead of '=='

```
/home/me/dev/tarantool/src/box/memtx_sort_data.c: In function ‘memtx_sort_data_filename’:
/home/me/dev/tarantool/src/box/memtx_sort_data.c:136:26: error: initialization discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
  136 |         char *snap_ext = strrchr(snap_filename, '.');
```