### PR TITLE
field_def: fix the field_type_decimal_precision length assert

### DIFF
--- a/src/box/field_def.c
+++ b/src/box/field_def.c
@@ -388,9 +388,9 @@ const int field_type_decimal_precision[] = {
 	/* [FIELD_TYPE_DECIMAL256] = */ 76,
 };
 
-static_assert(lengthof(field_type_is_fixed_decimal) == field_type_MAX,
+static_assert(lengthof(field_type_decimal_precision) == field_type_MAX,
 	      "Each field type must be present in "
-	      "field_type_is_fixed_decimal");
+	      "field_type_decimal_precision");
 
 const char *on_conflict_action_strs[] = {
 	/* [ON_CONFLICT_ACTION_NONE]     = */ "none",


### PR DESCRIPTION
It used to check an array that already had been checked above, let's fix the static assertion.

Closes #12330

NO_DOC=no code changes
NO_TEST=no code changes
NO_CHANGELOG=no code changes