### PR TITLE
libeio: fix a descriptor leak in `eio_readdir`

### DIFF
--- a/third_party/libeio/ecb.h
+++ b/third_party/libeio/ecb.h
@@ -874,5 +874,28 @@ ecb_inline ecb_const ecb_bool ecb_little_endian (void) { return ecb_byteorder_he
 
 #endif
 
+/*****************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* a variant of a memory allocation function, calls the original */
+/* function and panics if it fails (i.e. it never returns NULL) */
+#define ecb_alloc(size, func, args...)				\
+  ({								\
+    void *ret = func (args);					\
+    if (ecb_expect_false (ret == 0))				\
+      {								\
+        fprintf (stderr, "Can't allocate %zu bytes at %s:%d",	\
+                 size, __FILE__, __LINE__);			\
+        exit (EXIT_FAILURE);					\
+      }								\
+    ret;							\
+  })
+
+#define ecb_malloc(size)	ecb_alloc ((size), malloc, (size))
+#define ecb_calloc(n, size)	ecb_alloc ((n) * (size), calloc, (n), (size))
+#define ecb_realloc(ptr, size)	ecb_alloc ((size), realloc, (ptr), (size))
+
 #endif
 

--- a/third_party/libeio/etp.c
+++ b/third_party/libeio/etp.c
@@ -94,7 +94,8 @@ etp_tmpbuf_get (struct etp_tmpbuf *buf, int len)
   if (buf->len < len)
     {
       free (buf->ptr);
-      buf->ptr = malloc (buf->len = len);
+      buf->len = len;
+      buf->ptr = ecb_malloc (buf->len);
     }
 
   return buf->ptr;


### PR DESCRIPTION
Fix a potential descriptor leak in `eio__scandir`. This is a dead code not used in Tarantool, but it's considered internal, so let's fix it by making malloc/calloc/realloc in the library non-failing.

Closes tarantool/security#156

NO_DOC=code health
NO_TEST=code health
NO_CHANGELOG=code health
