### PR TITLE
libev: fix possible integer overflows in `array_needsize`

### DIFF
--- a/third_party/libev/ev++.h
+++ b/third_party/libev/ev++.h
@@ -570,7 +570,7 @@ namespace ev {
     return ev_embeddable_backends ();
   }
 
-  inline void set_allocator (void *(*cb)(void *ptr, long size) EV_NOEXCEPT) EV_NOEXCEPT
+  inline void set_allocator (void *(*cb)(void *ptr, size_t size) EV_NOEXCEPT) EV_NOEXCEPT
   {
     ev_set_allocator (cb);
   }

--- a/third_party/libev/ev.h
+++ b/third_party/libev/ev.h
@@ -551,7 +551,7 @@ EV_API_DECL void ev_sleep (ev_tstamp delay) EV_NOEXCEPT; /* sleep for a while */
  * or take some potentially destructive action.
  * The default is your system realloc function.
  */
-EV_API_DECL void ev_set_allocator (void *(*cb)(void *ptr, long size) EV_NOEXCEPT) EV_NOEXCEPT;
+EV_API_DECL void ev_set_allocator (void *(*cb)(void *ptr, size_t size) EV_NOEXCEPT) EV_NOEXCEPT;
 
 /* set the callback function to call on a
  * retryable syscall error


### PR DESCRIPTION
Fix potential integer overflows in the `array_needsize` function by aborting if a too big number of objects is to be allocated and casting a value calculated for `ev_realloc` to `long long` (a value definitely bigger than `int`). Make `ev_realloc` consume `long long` by the way.

Closes tarantool/security#159

NO_DOC=code health
NO_TEST=a test approaching INT_MAX pending event/fd/timer/etc. count would be very slow
NO_CHANGELOG=code health