### PR TITLE
config: introduce a failover.iproto.ssl section

### DIFF
--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -1782,6 +1782,33 @@ I['iproto.threads'] = format_text([[
 
 -- }}} iproto configuration
 
+-- {{{ failover.iproto configuration
+
+I['failover.iproto'] = format_text([[
+    IPROTO connection parameters for the failover coordinator. This
+    functionality is available only in Tarantool Enterprise.
+]])
+
+I['failover.iproto.ssl'] = format_text([[
+    SSL parameters used by the failover coordinator to connect to instances
+    over IPROTO when SSL is enabled. This functionality is available only in
+    Tarantool Enterprise.
+]])
+
+I['failover.iproto.ssl.ca_file'] = I['iproto.ssl.ca_file']
+
+I['failover.iproto.ssl.ssl_cert'] = I['iproto.ssl.ssl_cert']
+
+I['failover.iproto.ssl.ssl_key'] = I['iproto.ssl.ssl_key']
+
+I['failover.iproto.ssl.ssl_ciphers'] = I['iproto.ssl.ssl_ciphers']
+
+I['failover.iproto.ssl.ssl_password'] = I['iproto.ssl.ssl_password']
+
+I['failover.iproto.ssl.ssl_password_file'] = I['iproto.ssl.ssl_password_file']
+
+-- }}} failover.iproto configuration
+
 -- {{{ isolated configuration
 
 I['isolated'] = format_text([[

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2166,6 +2166,16 @@ return schema.new('instance_config', schema.record({
         }, {
             validate = validators['failover.metrics'],
         })),
+        iproto = enterprise_edition(schema.record({
+            ssl = schema.record({
+                ca_file = schema.scalar({ type = 'string' }),
+                ssl_cert = schema.scalar({ type = 'string' }),
+                ssl_key = schema.scalar({ type = 'string' }),
+                ssl_ciphers = schema.scalar({ type = 'string' }),
+                ssl_password = schema.scalar({ type = 'string' }),
+                ssl_password_file = schema.scalar({ type = 'string' }),
+            }),
+        })),
     }, {
         validate = validators['failover'],
     }),

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1910,6 +1910,16 @@ g.test_failover = function()
                 },
             },
         }
+        iconfig.failover.iproto = {
+            ssl = {
+                ca_file = 'one',
+                ssl_cert = 'two',
+                ssl_key = 'three',
+                ssl_ciphers = 'four',
+                ssl_password = 'five',
+                ssl_password_file = 'six',
+            },
+        }
     end
 
     instance_config:validate(iconfig)


### PR DESCRIPTION
This PR introduces a new Enterprise Edition-only configuration section
`failover.iproto.ssl`.

The section defines SSL client parameters that may be used by the failover coordinator to connect to instances over IPROTO when `transport: ssl` is used in instance URIs.

Required by tarantool/tarantool-ee#1556