### PR TITLE
vinyl: check `vy_stmt_new_replace` result in `vy_apply_upsert`

### DIFF
--- a/changelogs/unreleased/ghs-158-vy-apply-upsert-crash-fix.md
+++ b/changelogs/unreleased/ghs-158-vy-apply-upsert-crash-fix.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed a bug when Tarantool crashed instead of raising an error in case it
+  failed to apply an upsert statement (ghs-158).

--- a/test/vinyl-luatest/ghs_158_upsert_error_test.lua
+++ b/test/vinyl-luatest/ghs_158_upsert_error_test.lua
@@ -1,0 +1,30 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_upsert_error = function(cg)
+    cg.server:exec(function()
+        box.cfg({vinyl_max_tuple_size = 100})
+        local s = box.schema.space.create('test', {engine = 'vinyl'})
+        s:create_index('primary')
+        s:insert({1, string.rep('x', 50)})
+        s:upsert({1, 'x'}, {{'!', 3, string.rep('y', 50)}, {'=', 1, 1}})
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'VINYL_MAX_TUPLE_SIZE',
+        }, box.snapshot)
+        box.cfg({vinyl_max_tuple_size = 1000})
+        box.snapshot()
+        s:drop()
+    end)
+end


### PR DESCRIPTION
`vy_stmt_new_replace()` may fail, for example, if the tuple size exceeds the configured limit, but `vy_apply_result_does_cross_pk()` doesn't check its return value. To fix this issue, let's inline this function and reuse the allocated statement because we need to allocate it eventually anyway.

Closes tarantool/security#158