### PR TITLE
vinyl: unthrottle scheduler for checkpoint

### DIFF
--- a/changelogs/unreleased/gh-12342-vy-scheduler-unthrottle-fix.md
+++ b/changelogs/unreleased/gh-12342-vy-scheduler-unthrottle-fix.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed a bug when the dump task scheduler was not unthrottled by
+  `box.snapshot()` (gh-12342).

--- a/src/box/vy_scheduler.c
+++ b/src/box/vy_scheduler.c
@@ -728,8 +728,12 @@ vy_scheduler_begin_checkpoint(struct vy_scheduler *scheduler)
 	}
 	scheduler->generation++;
 	scheduler->checkpoint_in_progress = true;
-	scheduler->is_throttled = false;
 	fiber_cond_signal(&scheduler->scheduler_cond);
+	if (scheduler->is_throttled) {
+		say_info("unthrottling scheduler for checkpoint");
+		scheduler->is_throttled = false;
+		fiber_wakeup(scheduler->scheduler_fiber);
+	}
 	say_info("vinyl checkpoint started");
 	return 0;
 }

--- a/test/vinyl-luatest/gh_12342_scheduler_unthrottle_test.lua
+++ b/test/vinyl-luatest/gh_12342_scheduler_unthrottle_test.lua
@@ -1,0 +1,32 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_scheduler_unthrottle = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test', {engine = 'vinyl'})
+        s:create_index('primary')
+        s:insert({1})
+        box.error.injection.set('ERRINJ_VY_SCHED_TIMEOUT', 9000)
+        box.error.injection.set('ERRINJ_VY_RUN_WRITE', true)
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'INJECTION',
+            details = 'vinyl dump',
+        }, box.snapshot)
+        box.error.injection.set('ERRINJ_VY_RUN_WRITE', false)
+        box.snapshot()
+        s:drop()
+    end)
+end


### PR DESCRIPTION
The scheduler is throttled after a dump/compaction error to avoid spamming logs in case of a repetitive disk error, like running out of disk space. However, if the user calls `box.snapshot()` it must be unthrottled. Although we do clear the `is_throttled` flag, we don't wake up the scheduler fiber so this doesn't work as expected. Fix it.

BTW this should speed up those Vinyl tests that use error injections for failing dump/compaction tasks.

Closes #12342