### PR TITLE
sql: rework 64-bit numeric values in opcodes

### DIFF
--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -1097,11 +1097,9 @@ emitNewSysSequenceRecord(Parse *pParse, int reg_seq_id, const char *seq_name)
 	sqlVdbeAddOp2(v, OP_Integer, 1, first_col + 4);
 
 	/* 5. Minimum  */
-	sqlVdbeAddOp4Dup8(v, OP_Int64, 0, first_col + 5, 0,
-			  (unsigned char *) &min_usigned_long_long, P4_UINT64);
+	sql_vdbe_add_op4_uint64(v, 0, first_col + 5, 0, min_usigned_long_long);
 	/* 6. Maximum  */
-	sqlVdbeAddOp4Dup8(v, OP_Int64, 0, first_col + 6, 0,
-			  (unsigned char *) &max_usigned_long_long, P4_UINT64);
+	sql_vdbe_add_op4_uint64(v, 0, first_col + 6, 0, max_usigned_long_long);
 	/* 7. Start  */
 	sqlVdbeAddOp2(v, OP_Integer, 1, first_col + 7);
 

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -3135,8 +3135,7 @@ codeReal(Vdbe * v, const char *z, int negateFlag, int iMem)
 		assert(!sqlIsNaN(value));	/* The new AtoF never returns NaN */
 		if (negateFlag)
 			value = -value;
-		sqlVdbeAddOp4Dup8(v, OP_Real, 0, iMem, 0, (u8 *) & value,
-				      P4_REAL);
+		sql_vdbe_add_op4_real(v, 0, iMem, 0, value);
 	}
 }
 
@@ -3221,8 +3220,10 @@ expr_code_int(struct Parse *parse, struct Expr *expr, bool is_neg,
 	 */
 	if (is_neg && value != INT64_MIN)
 		value = -value;
-	sqlVdbeAddOp4Dup8(v, OP_Int64, 0, mem, 0, (u8 *) &value,
-			  is_neg ? P4_INT64 : P4_UINT64);
+	if (is_neg)
+		sql_vdbe_add_op4_int64(v, 0, mem, 0, value);
+	else
+		sql_vdbe_add_op4_uint64(v, 0, mem, 0, value);
 }
 
 static void

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -724,8 +724,7 @@ case OP_Bool: {         /* out2 */
  */
 case OP_Int64: {           /* out2 */
 	pOut = vdbe_prepare_null_out(p, pOp->p2);
-	assert(pOp->p4.pI64!=0);
-	mem_set_int_with_sign(pOut, *pOp->p4.pI64, pOp->p4type == P4_INT64);
+	mem_set_int_with_sign(pOut, pOp->p4.i64, pOp->p4type == P4_INT64);
 	break;
 }
 
@@ -737,8 +736,7 @@ case OP_Int64: {           /* out2 */
  */
 case OP_Real: {            /* same as TK_FLOAT, out2 */
 	pOut = vdbe_prepare_null_out(p, pOp->p2);
-	assert(!sqlIsNaN(*pOp->p4.pReal));
-	mem_set_double(pOut, *pOp->p4.pReal);
+	mem_set_double(pOut, pOp->p4.real);
 	break;
 }
 

--- a/src/box/sql/vdbe.h
+++ b/src/box/sql/vdbe.h
@@ -70,8 +70,15 @@ struct VdbeOp {
 		int i;		/* Integer value if p4type==P4_INT32 */
 		void *p;	/* Generic pointer */
 		char *z;	/* Pointer to data for string (char array) types */
-		i64 *pI64;	/* Used when p4type is P4_INT64/UINT64 */
-		double *pReal;	/* Used when p4type is P4_REAL */
+		/**
+		 * Used to store values of type INT64 (if p4type is P4_INT64)
+		 * and UINT64 (if id p4type is P4_UINT64).
+		 */
+		int64_t i64;
+		/**
+		 * Used to store values of type DOUBLE (if p4type is P4_REAL).
+		 */
+		double real;
 		/**
 		 * A pointer to function implementation.
 		 * Used when p4type is P4_FUNC.
@@ -195,8 +202,19 @@ int sqlVdbeLoadString(Vdbe *, int, const char *);
 void sqlVdbeMultiLoad(Vdbe *, int, const char *, ...);
 int sqlVdbeAddOp3(Vdbe *, int, int, int, int);
 int sqlVdbeAddOp4(Vdbe *, int, int, int, int, const char *zP4, int);
-int sqlVdbeAddOp4Dup8(Vdbe *, int, int, int, int, const u8 *, int);
 int sqlVdbeAddOp4Int(Vdbe *, int, int, int, int, int);
+
+/** Add an opcode that includes the p4 value as a 64-bit integer. */
+int
+sql_vdbe_add_op4_int64(Vdbe *, int, int, int, int64_t);
+
+/** Add an opcode that includes the p4 value as a 64-bit unsigned. */
+int
+sql_vdbe_add_op4_uint64(Vdbe *, int, int, int, int64_t);
+
+/** Add an opcode that includes the p4 value as a double. */
+int
+sql_vdbe_add_op4_real(Vdbe *, int, int, int, double);
 void sqlVdbeEndCoroutine(Vdbe *, int);
 void sqlVdbeChangeOpcode(Vdbe *, u32 addr, u8);
 void sqlVdbeChangeP1(Vdbe *, u32 addr, int P1);

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -274,13 +274,6 @@ sql_stmt_est_size(const struct Vdbe *v)
 		case P4_INT32:
 			size += sizeof(v->aOp[i].p4.i);
 			break;
-		case P4_UINT64:
-		case P4_INT64:
-			size += sizeof(*v->aOp[i].p4.pI64);
-			break;
-		case P4_REAL:
-			size += sizeof(*v->aOp[i].p4.pReal);
-			break;
 		case P4_DEC:
 			size += sizeof(*v->aOp[i].p4.dec);
 			break;


### PR DESCRIPTION
This patch improves the storage of INT64, UINT64, and DOUBLE values
in opcodes. Storing them in opcode no longer requires memory allocation.

Closes of #6531

NO_DOC=refactoring
NO_CHANGELOG=refactoring
NO_TEST=refactoring