### PR TITLE
relay: track when last WAL row was sent

### DIFF
--- a/changelogs/unreleased/gh-12025-upstream-stuck-in-sync.md
+++ b/changelogs/unreleased/gh-12025-upstream-stuck-in-sync.md
@@ -1,0 +1,7 @@
+## bugfix/replication
+
+* Fixed a bug where a replica on subscribe could get stuck in the `sync` state
+  for the duration of `replication.timeout`. This issue was observable in
+  `box.info.replication[...].upstream` and could lead to temporary
+  inconveniences, such as the inability to run `box.ctl.promote()` (when
+  `election_mode` was not `off`) (gh-12025).

--- a/test/replication-luatest/gh_12025_stuck_in_sync_test.lua
+++ b/test/replication-luatest/gh_12025_stuck_in_sync_test.lua
@@ -1,0 +1,62 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+--
+-- gh-12025: master used to miss attaching the current timestamp to the
+-- heartbeat message when replica subscribes and Raft is actively working.
+--
+g.before_all(function(cg)
+    --
+    -- The test can't use the replica_set LuaTest module. Because it requires
+    -- the nodes to start together in fullmesh. And that sometimes leads to the
+    -- replica connecting to the master too fast, when the master has already
+    -- marked itself "ready", but didn't elect itself a Raft leader yet, thus
+    -- staying "read-only". The replica then can't join, and doesn't seem to
+    -- retry any time soon when replication_timeout is huge. The timeout being
+    -- huge is required for this test to make sense, it can't be lowered.
+    --
+    -- The workaround is to start master first and alone. And then join the
+    -- replica.
+    --
+    -- Master
+    --
+    local cfg = {
+        replication_timeout = 10000,
+        replication_reconnect_timeout = 0.1,
+        election_mode = 'candidate',
+        replication_synchro_timeout = 1000,
+    }
+    cg.master = server:new{
+        alias = 'master',
+        box_cfg = cfg,
+    }
+    cg.master:start()
+    --
+    -- Replica
+    --
+    cfg.election_mode = 'voter'
+    cfg.replication = {cg.master.net_box_uri}
+    cg.replica = server:new{
+        alias = 'replica',
+        box_cfg = cfg,
+    }
+    cg.replica:start()
+end)
+
+g.after_all(function(cg)
+    cg.master:drop()
+    cg.replica:drop()
+end)
+
+g.test_case = function(cg)
+    local replication = {cg.master.net_box_uri, cg.replica.net_box_uri}
+    cg.master:update_box_cfg{replication = replication}
+    cg.replica:update_box_cfg{replication = replication}
+    cg.master:wait_for_vclock_of(cg.replica)
+    cg.replica:wait_for_vclock_of(cg.master)
+    t.helpers.retrying({}, function()
+        cg.master:assert_follows_upstream(cg.replica:get_instance_id())
+        cg.replica:assert_follows_upstream(cg.master:get_instance_id())
+    end)
+end

--- a/test/replication-luatest/gh_8931_box_info_election_leader_name_test.lua
+++ b/test/replication-luatest/gh_8931_box_info_election_leader_name_test.lua
@@ -16,7 +16,13 @@ g.before_all(function(cg)
             server.build_listen_uri('node1', cg.cluster.id),
             server.build_listen_uri('node2', cg.cluster.id)
         },
-        election_mode = 'candidate'
+        election_mode = 'candidate',
+        -- When replica wants to change its name, it will reconnect. There is a
+        -- moment of time when the replica closed the old connection, before it
+        -- made a new one. And the leader might notice that it lost the quorum
+        -- of subscribers, and resign. Then the replica won't be able to change
+        -- its name.
+        election_fencing_mode = 'off',
     }
     cg.node1 = cg.cluster:build_and_add_server({alias = 'node1', box_cfg = cfg})
     cg.node2 = cg.cluster:build_and_add_server({alias = 'node2', box_cfg = cfg})


### PR DESCRIPTION
relay: track when last WAL row was sent

The relay's intention was to mark the heartbeats with timestamps
as soon as no WAL rows are sent since the last heartbeat. First
heartbeat after a last WAL row always has timestamp 0.

It is done so the heartbeats wouldn't inject too new real time
timestamps into the stream, making the lag on replica jump up and
down.

On subscribe one heartbeat is forced to be sent after processing
the journal entries which piled up since the replica connected
last time. It was added in order for the applier to immediately
transition its state from 'sync' to 'follow' if it is up to date.

This step was needed because the last sent WAL row could have a
super old timestamp (if master is mostly idle). Forcing a
heartbeat after that tells the applier that the master actually
has no more rows to send and the lag is good.

This seems to get broken when Raft messages entered the picture.
Raft messages are rows which are sent using relay_send(), but
they have no WAL timestamp (because they aren't from WAL). And
yet they bump last_row_time, which was used by the heartbeats to
understand if they are sent between WAL rows or not.

The patch fixes it by moving the tracking of WAL rows sending into
a separate member of relay, not affected by "in-memory" messages
such as the ones from Raft.

Closes #12025

NO_DOC=bugfix