### PR TITLE
console: add xdg state directory support

### DIFF
--- a/changelogs/unreleased/gh-12356-xdg-state-history.md
+++ b/changelogs/unreleased/gh-12356-xdg-state-history.md
@@ -1,0 +1,8 @@
+## feature/core
+
+* Added support for the XDG Base Directory specification for the console history
+  file. The history file is now searched for in `$XDG_STATE_HOME/tarantool` and
+  `$HOME/.local/state/tarantool` directories, with the legacy
+  `$HOME/.tarantool_history` location taking priority to ensure seamless migration.
+  On fresh installations, the XDG-compliant state directory is created
+  automatically (gh-12356).

--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -30,6 +30,7 @@ local net_box = require('net.box')
 local help = require('help').help
 local utils = require('internal.utils')
 local tarantool = require('tarantool')
+local fio = require('fio')
 
 local DEFAULT_CONNECT_TIMEOUT = 10
 local PUSH_TAG_HANDLE = '!push!'
@@ -81,6 +82,9 @@ local default_local_eos = ''
 
 -- Each but the last string of multiline command should end with this string.
 local continuation_symbol = '\\'
+
+-- History file name.
+local HISTORY_FILE_NAME = '.tarantool_history'
 
 output_handlers["yaml"] = function(status, _opts, ...)
     local err, ok, res
@@ -1031,15 +1035,80 @@ end
 -- Start REPL on stdin
 --
 local started = false
+
+--
+-- Determine the history file path following XDG Base Directory specification.
+--
+-- The function checks for the history file in the following order:
+-- 1. $HOME/.tarantool_history (if it exists - takes priority for migration)
+-- 2. $XDG_STATE_HOME/tarantool/.tarantool_history (if XDG_STATE_HOME is set
+--    and the directory exists)
+-- 3. $HOME/.local/state/tarantool/.tarantool_history (if the directory exists)
+--
+-- If none of the above exist (fresh install), the function creates the
+-- XDG-compliant state directory and returns a path inside it:
+-- 4. $XDG_STATE_HOME/tarantool/.tarantool_history (if XDG_STATE_HOME is set)
+-- 5. $HOME/.local/state/tarantool/.tarantool_history (default)
+--
+-- Returns nil only if HOME is not set.
+--
+local function get_history_file_path()
+    local xdg_state_home = os.getenv('XDG_STATE_HOME')
+    local home_dir = os.getenv('HOME')
+
+    -- Legacy path takes priority for seamless migration.
+    if home_dir then
+        local home_history = fio.pathjoin(home_dir, HISTORY_FILE_NAME)
+        if fio.path.exists(home_history) then
+            return home_history
+        end
+    end
+
+    -- $XDG_STATE_HOME/tarantool/ directory already exists.
+    if xdg_state_home then
+        local xdg_history_dir = fio.pathjoin(xdg_state_home, 'tarantool')
+        if fio.path.exists(xdg_history_dir) then
+            return fio.pathjoin(xdg_history_dir, HISTORY_FILE_NAME)
+        end
+    end
+
+    -- $HOME/.local/state/tarantool/ directory already exists.
+    if home_dir then
+        local home_state_dir = fio.pathjoin(home_dir, '.local', 'state',
+                                            'tarantool')
+        if fio.path.exists(home_state_dir) then
+            return fio.pathjoin(home_state_dir, HISTORY_FILE_NAME)
+        end
+    end
+
+    -- Fresh install: create the XDG-compliant state directory.
+    if xdg_state_home then
+        local xdg_history_dir = fio.pathjoin(xdg_state_home, 'tarantool')
+        if fio.mktree(xdg_history_dir) then
+            return fio.pathjoin(xdg_history_dir, HISTORY_FILE_NAME)
+        end
+    end
+
+    if home_dir then
+        local home_state_dir = fio.pathjoin(home_dir, '.local', 'state',
+                                            'tarantool')
+        if fio.mktree(home_state_dir) then
+            return fio.pathjoin(home_state_dir, HISTORY_FILE_NAME)
+        end
+    end
+
+    return nil
+end
+
 function M.start()
     if started then
         error("console is already started")
     end
     started = true
     local self = setmetatable({ running = true }, repl_mt)
-    local home_dir = os.getenv('HOME')
-    if home_dir then
-        self.history_file = home_dir .. '/.tarantool_history'
+    local history_file = get_history_file_path()
+    if history_file then
+        self.history_file = history_file
         internal.load_history(self.history_file)
     end
     session_internal.create(1, "repl") -- stdin fileno

--- a/src/box/lua/console.lua
+++ b/src/box/lua/console.lua
@@ -30,6 +30,7 @@ local net_box = require('net.box')
 local help = require('help').help
 local utils = require('internal.utils')
 local tarantool = require('tarantool')
+local fio = require('fio')
 
 local DEFAULT_CONNECT_TIMEOUT = 10
 local PUSH_TAG_HANDLE = '!push!'
@@ -81,6 +82,9 @@ local default_local_eos = ''
 
 -- Each but the last string of multiline command should end with this string.
 local continuation_symbol = '\\'
+
+-- History file name.
+local HISTORY_FILE_NAME = '.tarantool_history'
 
 output_handlers["yaml"] = function(status, _opts, ...)
     local err, ok, res
@@ -1031,15 +1035,85 @@ end
 -- Start REPL on stdin
 --
 local started = false
+
+--
+-- Determine the history file path following XDG Base Directory specification.
+--
+-- The function checks for the history file in the following order:
+-- 1. $HOME/.tarantool_history (if it exists - takes priority for migration)
+-- 2. $XDG_STATE_HOME/tarantool/.tarantool_history (if XDG_STATE_HOME is set
+--    and the directory exists)
+-- 3. $HOME/.local/state/tarantool/.tarantool_history (if the directory exists)
+--
+-- If none of the above exist (fresh install), the function creates the
+-- XDG-compliant state directory and returns a path inside it:
+-- 4. $XDG_STATE_HOME/tarantool/.tarantool_history (if XDG_STATE_HOME is set)
+-- 5. $HOME/.local/state/tarantool/.tarantool_history (default)
+--
+-- Returns nil only if HOME is not set.
+--
+local function get_history_file_path()
+    local xdg_state_home = os.getenv('XDG_STATE_HOME')
+    -- Per the XDG Base Directory specification, an empty value must be
+    -- treated the same as unset.
+    if xdg_state_home == '' then
+        xdg_state_home = nil
+    end
+    local home_dir = os.getenv('HOME')
+
+    -- Legacy path takes priority for seamless migration.
+    if home_dir then
+        local home_history = fio.pathjoin(home_dir, HISTORY_FILE_NAME)
+        if fio.path.exists(home_history) then
+            return home_history
+        end
+    end
+
+    -- $XDG_STATE_HOME/tarantool/ directory already exists.
+    if xdg_state_home then
+        local xdg_history_dir = fio.pathjoin(xdg_state_home, 'tarantool')
+        if fio.path.is_dir(xdg_history_dir) then
+            return fio.pathjoin(xdg_history_dir, HISTORY_FILE_NAME)
+        end
+    end
+
+    -- $HOME/.local/state/tarantool/ directory already exists.
+    if home_dir then
+        local home_state_dir = fio.pathjoin(home_dir, '.local', 'state',
+                                            'tarantool')
+        if fio.path.is_dir(home_state_dir) then
+            return fio.pathjoin(home_state_dir, HISTORY_FILE_NAME)
+        end
+    end
+
+    -- Fresh install: create the XDG-compliant state directory.
+    if xdg_state_home then
+        local xdg_history_dir = fio.pathjoin(xdg_state_home, 'tarantool')
+        if fio.mktree(xdg_history_dir) then
+            return fio.pathjoin(xdg_history_dir, HISTORY_FILE_NAME)
+        end
+    end
+
+    if home_dir then
+        local home_state_dir = fio.pathjoin(home_dir, '.local', 'state',
+                                            'tarantool')
+        if fio.mktree(home_state_dir) then
+            return fio.pathjoin(home_state_dir, HISTORY_FILE_NAME)
+        end
+    end
+
+    return nil
+end
+
 function M.start()
     if started then
         error("console is already started")
     end
     started = true
     local self = setmetatable({ running = true }, repl_mt)
-    local home_dir = os.getenv('HOME')
-    if home_dir then
-        self.history_file = home_dir .. '/.tarantool_history'
+    local history_file = get_history_file_path()
+    if history_file then
+        self.history_file = history_file
         internal.load_history(self.history_file)
     end
     session_internal.create(1, "repl") -- stdin fileno

--- a/test/app-luatest/console_xdg_state_test.lua
+++ b/test/app-luatest/console_xdg_state_test.lua
@@ -1,0 +1,216 @@
+local t = require('luatest')
+local fio = require('fio')
+local it = require('test.interactive_tarantool')
+
+local g = t.group()
+
+local function write_file(path, content)
+    local fh = fio.open(path, {'O_WRONLY', 'O_CREAT', 'O_TRUNC'},
+                         tonumber('0600', 8))
+    fh:write(content)
+    fh:close()
+end
+
+local function file_contains(path, needle)
+    local fh = fio.open(path, {'O_RDONLY'})
+    if fh == nil then
+        return false
+    end
+    local content = fh:read(65536)
+    fh:close()
+
+    if content == nil then
+        return false
+    end
+    return content:find(needle, 1, true) ~= nil
+end
+
+-- Execute a unique marker command in the interactive console and return
+-- the marker string. The history file in use will contain this marker.
+local function execute_marker(instance)
+    local marker = 'history_marker_' .. tostring(math.random(100000, 999999))
+    instance:roundtrip("'" .. marker .. "'", marker)
+    return marker
+end
+
+g.after_each(function(g)
+    if g.it ~= nil then
+        g.it:close()
+        g.it = nil
+    end
+    if g.temp_dir ~= nil then
+        fio.rmtree(g.temp_dir)
+        g.temp_dir = nil
+    end
+end)
+
+-- When $HOME/.tarantool_history exists, it takes priority over
+-- XDG_STATE_HOME and $HOME/.local/state paths.
+g.test_legacy_home_history_takes_priority = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+    local xdg_state_home = fio.pathjoin(g.temp_dir, 'xdg_state')
+    local xdg_tarantool_dir = fio.pathjoin(xdg_state_home, 'tarantool')
+    local home_state_dir = fio.pathjoin(home_dir, '.local', 'state',
+                                        'tarantool')
+
+    fio.mktree(home_dir)
+    fio.mktree(xdg_tarantool_dir)
+    fio.mktree(home_state_dir)
+
+    local home_history = fio.pathjoin(home_dir, '.tarantool_history')
+    local xdg_history = fio.pathjoin(xdg_tarantool_dir, '.tarantool_history')
+
+    write_file(home_history, 'legacy_cmd\n')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+            XDG_STATE_HOME = xdg_state_home,
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(home_history, marker),
+             'history should be saved to $HOME/.tarantool_history')
+    t.assert_not(file_contains(xdg_history, marker),
+                 'history must not be saved to XDG path when legacy exists')
+end
+
+-- When $HOME/.tarantool_history does not exist but
+-- $XDG_STATE_HOME/tarantool/ directory does, history is saved there.
+g.test_xdg_state_home_dir_used = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+    local xdg_state_home = fio.pathjoin(g.temp_dir, 'xdg_state')
+    local xdg_tarantool_dir = fio.pathjoin(xdg_state_home, 'tarantool')
+
+    fio.mktree(home_dir)
+    fio.mktree(xdg_tarantool_dir)
+
+    local xdg_history = fio.pathjoin(xdg_tarantool_dir,
+                                     '.tarantool_history')
+    local home_history = fio.pathjoin(home_dir, '.tarantool_history')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+            XDG_STATE_HOME = xdg_state_home,
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(xdg_history, marker),
+             'history should be saved to $XDG_STATE_HOME/tarantool/')
+    t.assert_not(fio.path.exists(home_history),
+                 'legacy history file must not be created')
+end
+
+-- When neither legacy file nor XDG dir exist, but
+-- $HOME/.local/state/tarantool/ directory exists, history is saved there.
+g.test_home_local_state_fallback = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+    local home_state_dir = fio.pathjoin(home_dir, '.local', 'state',
+                                        'tarantool')
+
+    fio.mktree(home_state_dir)
+
+    local state_history = fio.pathjoin(home_state_dir, '.tarantool_history')
+    local home_history = fio.pathjoin(home_dir, '.tarantool_history')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(state_history, marker),
+             'history should be saved to $HOME/.local/state/tarantool/')
+    t.assert_not(fio.path.exists(home_history),
+                 'legacy history file must not be created')
+end
+
+-- When XDG_STATE_HOME is set but the tarantool subdirectory does not exist,
+-- fall back to $HOME/.tarantool_history if it exists.
+g.test_xdg_nonexistent_dir_falls_back_to_legacy = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+    local xdg_state_home = fio.pathjoin(g.temp_dir, 'xdg_state')
+
+    fio.mktree(home_dir)
+
+    local home_history = fio.pathjoin(home_dir, '.tarantool_history')
+    write_file(home_history, 'old_cmd\n')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+            XDG_STATE_HOME = xdg_state_home,
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(home_history, marker),
+             'history should fall back to $HOME/.tarantool_history')
+    t.assert_not(fio.path.exists(fio.pathjoin(xdg_state_home, 'tarantool')),
+                 'non-existent XDG dir must not be created')
+end
+
+-- Fresh install with XDG_STATE_HOME set: directory is created and history
+-- is saved to $XDG_STATE_HOME/tarantool/.tarantool_history.
+g.test_fresh_install_creates_xdg_dir = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+    local xdg_state_home = fio.pathjoin(g.temp_dir, 'xdg_state')
+
+    fio.mktree(home_dir)
+
+    local xdg_history = fio.pathjoin(xdg_state_home, 'tarantool',
+                                     '.tarantool_history')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+            XDG_STATE_HOME = xdg_state_home,
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(xdg_history, marker),
+             'history should be saved to newly created XDG dir')
+    t.assert_not(fio.path.exists(fio.pathjoin(home_dir, '.tarantool_history')),
+                 'legacy history file must not be created')
+end
+
+-- Fresh install without XDG_STATE_HOME: directory is created and history
+-- is saved to $HOME/.local/state/tarantool/.tarantool_history.
+g.test_fresh_install_creates_home_state_dir = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+
+    fio.mktree(home_dir)
+
+    local state_history = fio.pathjoin(home_dir, '.local', 'state',
+                                       'tarantool', '.tarantool_history')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(state_history, marker),
+             'history should be saved to newly created state dir')
+    t.assert_not(fio.path.exists(fio.pathjoin(home_dir,
+                                              '.tarantool_history')),
+                 'legacy history file must not be created')
+end

--- a/test/app-luatest/console_xdg_state_test.lua
+++ b/test/app-luatest/console_xdg_state_test.lua
@@ -1,0 +1,273 @@
+local t = require('luatest')
+local fio = require('fio')
+local it = require('test.interactive_tarantool')
+
+local g = t.group()
+
+local function write_file(path, content)
+    local fh = fio.open(path, {'O_WRONLY', 'O_CREAT', 'O_TRUNC'},
+                         tonumber('0600', 8))
+    fh:write(content)
+    fh:close()
+end
+
+local function file_contains(path, needle)
+    local fh = fio.open(path, {'O_RDONLY'})
+    if fh == nil then
+        return false
+    end
+    local content = fh:read(65536)
+    fh:close()
+
+    if content == nil then
+        return false
+    end
+    return content:find(needle, 1, true) ~= nil
+end
+
+-- Execute a unique marker command in the interactive console and return
+-- the marker string. The history file in use will contain this marker.
+local function execute_marker(instance)
+    local marker = 'history_marker_' .. tostring(math.random(100000, 999999))
+    instance:roundtrip("'" .. marker .. "'", marker)
+    return marker
+end
+
+g.after_each(function(g)
+    if g.it ~= nil then
+        g.it:close()
+        g.it = nil
+    end
+    if g.temp_dir ~= nil then
+        fio.rmtree(g.temp_dir)
+        g.temp_dir = nil
+    end
+end)
+
+-- When $HOME/.tarantool_history exists, it takes priority over
+-- XDG_STATE_HOME and $HOME/.local/state paths.
+g.test_legacy_home_history_takes_priority = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+    local xdg_state_home = fio.pathjoin(g.temp_dir, 'xdg_state')
+    local xdg_tarantool_dir = fio.pathjoin(xdg_state_home, 'tarantool')
+    local home_state_dir = fio.pathjoin(home_dir, '.local', 'state',
+                                        'tarantool')
+
+    fio.mktree(home_dir)
+    fio.mktree(xdg_tarantool_dir)
+    fio.mktree(home_state_dir)
+
+    local home_history = fio.pathjoin(home_dir, '.tarantool_history')
+    local xdg_history = fio.pathjoin(xdg_tarantool_dir, '.tarantool_history')
+
+    write_file(home_history, 'legacy_cmd\n')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+            XDG_STATE_HOME = xdg_state_home,
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(home_history, marker),
+             'history should be saved to $HOME/.tarantool_history')
+    t.assert_not(file_contains(xdg_history, marker),
+                 'history must not be saved to XDG path when legacy exists')
+end
+
+-- When $HOME/.tarantool_history does not exist but
+-- $XDG_STATE_HOME/tarantool/ directory does, history is saved there.
+g.test_xdg_state_home_dir_used = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+    local xdg_state_home = fio.pathjoin(g.temp_dir, 'xdg_state')
+    local xdg_tarantool_dir = fio.pathjoin(xdg_state_home, 'tarantool')
+
+    fio.mktree(home_dir)
+    fio.mktree(xdg_tarantool_dir)
+
+    local xdg_history = fio.pathjoin(xdg_tarantool_dir,
+                                     '.tarantool_history')
+    local home_history = fio.pathjoin(home_dir, '.tarantool_history')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+            XDG_STATE_HOME = xdg_state_home,
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(xdg_history, marker),
+             'history should be saved to $XDG_STATE_HOME/tarantool/')
+    t.assert_not(fio.path.exists(home_history),
+                 'legacy history file must not be created')
+end
+
+-- When neither legacy file nor XDG dir exist, but
+-- $HOME/.local/state/tarantool/ directory exists, history is saved there.
+g.test_home_local_state_fallback = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+    local home_state_dir = fio.pathjoin(home_dir, '.local', 'state',
+                                        'tarantool')
+
+    fio.mktree(home_state_dir)
+
+    local state_history = fio.pathjoin(home_state_dir, '.tarantool_history')
+    local home_history = fio.pathjoin(home_dir, '.tarantool_history')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(state_history, marker),
+             'history should be saved to $HOME/.local/state/tarantool/')
+    t.assert_not(fio.path.exists(home_history),
+                 'legacy history file must not be created')
+end
+
+-- When XDG_STATE_HOME is set but the tarantool subdirectory does not exist,
+-- fall back to $HOME/.tarantool_history if it exists.
+g.test_xdg_nonexistent_dir_falls_back_to_legacy = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+    local xdg_state_home = fio.pathjoin(g.temp_dir, 'xdg_state')
+
+    fio.mktree(home_dir)
+
+    local home_history = fio.pathjoin(home_dir, '.tarantool_history')
+    write_file(home_history, 'old_cmd\n')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+            XDG_STATE_HOME = xdg_state_home,
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(home_history, marker),
+             'history should fall back to $HOME/.tarantool_history')
+    t.assert_not(fio.path.exists(fio.pathjoin(xdg_state_home, 'tarantool')),
+                 'non-existent XDG dir must not be created')
+end
+
+-- Fresh install with XDG_STATE_HOME set: directory is created and history
+-- is saved to $XDG_STATE_HOME/tarantool/.tarantool_history.
+g.test_fresh_install_creates_xdg_dir = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+    local xdg_state_home = fio.pathjoin(g.temp_dir, 'xdg_state')
+
+    fio.mktree(home_dir)
+
+    local xdg_history = fio.pathjoin(xdg_state_home, 'tarantool',
+                                     '.tarantool_history')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+            XDG_STATE_HOME = xdg_state_home,
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(xdg_history, marker),
+             'history should be saved to newly created XDG dir')
+    t.assert_not(fio.path.exists(fio.pathjoin(home_dir, '.tarantool_history')),
+                 'legacy history file must not be created')
+end
+
+-- Per the XDG Base Directory specification, an empty XDG_STATE_HOME must be
+-- treated the same as unset. On a fresh install with XDG_STATE_HOME='' the
+-- history is saved to $HOME/.local/state/tarantool/, not at root-level
+-- '/tarantool/'.
+g.test_xdg_state_home_empty_treated_as_unset = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+
+    fio.mktree(home_dir)
+
+    local state_history = fio.pathjoin(home_dir, '.local', 'state',
+                                       'tarantool', '.tarantool_history')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+            XDG_STATE_HOME = '',
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(state_history, marker),
+             'empty XDG_STATE_HOME must behave the same as unset')
+    t.assert_not(fio.path.exists('/tarantool'),
+                 'empty XDG_STATE_HOME must not produce a root-level path')
+end
+
+-- If $XDG_STATE_HOME/tarantool is a regular file rather than a directory,
+-- skip it and fall back to $HOME/.local/state/tarantool/.
+g.test_xdg_state_home_path_is_file = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+    local xdg_state_home = fio.pathjoin(g.temp_dir, 'xdg_state')
+
+    fio.mktree(home_dir)
+    fio.mktree(xdg_state_home)
+    -- Place a regular file at $XDG_STATE_HOME/tarantool to simulate the
+    -- pathological case where the expected directory name is occupied.
+    write_file(fio.pathjoin(xdg_state_home, 'tarantool'), '')
+
+    local state_history = fio.pathjoin(home_dir, '.local', 'state',
+                                       'tarantool', '.tarantool_history')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+            XDG_STATE_HOME = xdg_state_home,
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(state_history, marker),
+             'history should fall back when XDG path is a regular file')
+end
+
+-- Fresh install without XDG_STATE_HOME: directory is created and history
+-- is saved to $HOME/.local/state/tarantool/.tarantool_history.
+g.test_fresh_install_creates_home_state_dir = function(g)
+    g.temp_dir = fio.tempdir()
+    local home_dir = fio.pathjoin(g.temp_dir, 'home')
+
+    fio.mktree(home_dir)
+
+    local state_history = fio.pathjoin(home_dir, '.local', 'state',
+                                       'tarantool', '.tarantool_history')
+
+    g.it = it.new({
+        env = {
+            HOME = home_dir,
+        }
+    })
+
+    local marker = execute_marker(g.it)
+
+    t.assert(file_contains(state_history, marker),
+             'history should be saved to newly created state dir')
+    t.assert_not(fio.path.exists(fio.pathjoin(home_dir,
+                                              '.tarantool_history')),
+                 'legacy history file must not be created')
+end


### PR DESCRIPTION
Add support for XDG Base Directory specification for console history file.

Closes #12356

NO_DOC=console history file location is an internal implementation detail