### PR TITLE
sio: platform-agnostic getprotobyname/num()

### DIFF
--- a/src/lib/core/sio.c
+++ b/src/lib/core/sio.c
@@ -42,6 +42,7 @@
 #include "exception.h"
 #include "uri/uri.h"
 #include "errinj.h"
+#include "tt_pthread.h"
 
 #if TARGET_OS_DARWIN
 #include <sys/sysctl.h>
@@ -468,4 +469,78 @@ invalid_uri:
 	uri_destroy(&u);
 	diag_set(SocketError, sio_socketname(-1), "invalid uri \"%s\"", uri);
 	return -1;
+}
+
+#ifdef __APPLE__
+/**
+ * 'man' on getprotobyname/number() on MacOS locally says "These functions use
+ * a thread-specific data space". But looking it up online tells a different
+ * thing:
+ *
+ * https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/getprotoent.3.html
+ *
+ * This: "These functions use a static data space".
+ *
+ * To be on the safe side, lets just use a mutex here to ensure not more than
+ * one thread will access this theoretical "static data space". Still, it won't
+ * protect if user code will call the raw functions, but Macs are only used for
+ * development, so it won't be a problem.
+ */
+static pthread_mutex_t protomutex = PTHREAD_MUTEX_INITIALIZER;
+#else
+	enum {
+#ifdef NDEBUG
+		PROTO_START_BUF_LEN = 128,
+#else
+		PROTO_START_BUF_LEN = 2,
+#endif
+	};
+#endif
+
+int
+sio_getprotobyname(const char *name)
+{
+#ifdef __APPLE__
+	tt_pthread_mutex_lock(&protomutex);
+	struct protoent *ent = getprotobyname(name);
+	int rc = ent == NULL ? -1 : ent->p_proto;
+	tt_pthread_mutex_unlock(&protomutex);
+	return rc;
+#else
+	struct protoent pbuf, *p;
+	size_t buflen = PROTO_START_BUF_LEN;
+	char *buf = xmalloc(buflen);
+	while (getprotobyname_r(name, &pbuf, buf, buflen, &p) == ERANGE) {
+		buflen *= 2;
+		buf = xrealloc(buf, buflen);
+	}
+	int rc = p != NULL ? p->p_proto : -1;
+	free(buf);
+	return rc;
+#endif
+}
+
+char *
+sio_getprotobynumber(int proto)
+{
+#ifdef __APPLE__
+	tt_pthread_mutex_lock(&protomutex);
+	struct protoent *ent = getprotobynumber(proto);
+	char *res = ent == NULL ? NULL : xstrdup(ent->p_name);
+	tt_pthread_mutex_unlock(&protomutex);
+	return res;
+#else
+	struct protoent pbuf, *p;
+	size_t buflen = PROTO_START_BUF_LEN;
+	char *buf = xmalloc(buflen);
+	while (getprotobynumber_r(proto, &pbuf, buf, buflen, &p) == ERANGE) {
+		buflen *= 2;
+		buf = xrealloc(buf, buflen);
+	}
+	char *res = NULL;
+	if (p != NULL)
+		res = xstrdup(p->p_name);
+	free(buf);
+	return res;
+#endif
 }

--- a/src/lib/core/sio.h
+++ b/src/lib/core/sio.h
@@ -246,6 +246,21 @@ const char *
 sio_socketname_addr(int fd, const struct sockaddr *base_addr,
 		    socklen_t addrlen);
 
+/**
+ * Get protocol numeric ID on this system by its name.
+ * Platform-agnostic thread-safe version of getprotobyname().
+ */
+int
+sio_getprotobyname(const char *name);
+
+/**
+ * Get protocol name by its numeric ID on this system. The resulting
+ * buffer needs to be freed with free(), when not NULL.
+ * Platform-agnostic thread-safe version of getprotobynumber().
+ */
+char *
+sio_getprotobynumber(int proto);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/lua/socket.c
+++ b/src/lua/socket.c
@@ -612,31 +612,17 @@ lbox_socket_push_family(struct lua_State *L, int family)
 static int
 lbox_socket_push_protocol(struct lua_State *L, int protonumber)
 {
-	enum {
-#ifdef NDEBUG
-		START_BUF_LEN = 128,
-#else
-		START_BUF_LEN = 2,
-#endif
-	};
 	if (protonumber == 0) {
 		lua_pushinteger(L, 0);
 		return 1;
 	}
-	struct protoent pbuf, *p;
-	size_t buflen = START_BUF_LEN;
-	char *buf = xmalloc(buflen);
-	while (getprotobynumber_r(protonumber, &pbuf, buf, buflen,
-				  &p) == ERANGE) {
-		buflen *= 2;
-		buf = xrealloc(buf, buflen);
-	}
-	if (p) {
-		lua_pushstring(L, p->p_name);
+	char *name = sio_getprotobynumber(protonumber);
+	if (name != NULL) {
+		lua_pushstring(L, name);
+		free(name);
 	} else {
 		lua_pushinteger(L, protonumber);
 	}
-	free(buf);
 	return 1;
 }
 
@@ -1012,34 +998,14 @@ lbox_socket_recvfrom(struct lua_State *L)
 	return 2;
 }
 
-/*
- * Lua wrapper around getprotobyname_r(). Takes a protocol name and returns
- * the corresponding protocol number or nil if not found.
- */
 static int
 lbox_socket_getprotobyname(struct lua_State *L)
 {
-	enum {
-#ifdef NDEBUG
-		START_BUF_LEN = 128,
-#else
-		START_BUF_LEN = 2,
-#endif
-	};
-	const char *name = luaL_checkstring(L, 1);
-	struct protoent pbuf, *p;
-	size_t buflen = START_BUF_LEN;
-	char *buf = xmalloc(buflen);
-	while (getprotobyname_r(name, &pbuf, buf, buflen, &p) == ERANGE) {
-		buflen *= 2;
-		buf = xrealloc(buf, buflen);
-	}
-	if (p != NULL) {
-		lua_pushinteger(L, p->p_proto);
-	} else {
+	int proto = sio_getprotobyname(luaL_checkstring(L, 1));
+	if (proto >= 0)
+		lua_pushinteger(L, proto);
+	else
 		lua_pushnil(L);
-	}
-	free(buf);
 	return 1;
 }
 

--- a/test/unit/sio.c
+++ b/test/unit/sio.c
@@ -137,6 +137,23 @@ check_auto_bind(void)
 	footer();
 }
 
+static void
+check_getprotoby(void)
+{
+	header();
+	plan(2);
+
+	is(sio_getprotobyname("tcp"), IPPROTO_TCP, "tcp by name");
+
+	char *name = sio_getprotobynumber(IPPROTO_TCP);
+	fail_unless(name != NULL);
+	is(strcmp(name, "tcp"), 0, "tcp by number");
+	free(name);
+
+	check_plan();
+	footer();
+}
+
 int
 main(void)
 {
@@ -144,10 +161,11 @@ main(void)
 	fiber_init(fiber_c_invoke);
 
 	header();
-	plan(3);
+	plan(4);
 	check_uri_to_addr();
 	check_auto_bind();
 	check_sio_socketname_addr();
+	check_getprotoby();
 	int rc = check_plan();
 	footer();
 


### PR DESCRIPTION
Recently the `lua/socket.c` code started using `getprotobynumber_r()` and `getprotobyname_r()`. They exist on Linux, since the non-reentrant versions of these functions aren't thread-safe.

But on MacOS these calls don't exist, and the default ones are thread-safe out of the box.

Lets make MacOS use the normal versions of these functions, and encapsulate all this behind sio API.

Closes #12362

NO_DOC=bugfix
NO_TEST=tested
NO_CHANGELOG=the bug wasn't released yet