### PR TITLE
lua: fix box.error usage in loaders

### DIFF
--- a/src/lua/loaders.lua
+++ b/src/lua/loaders.lua
@@ -238,7 +238,8 @@ local function gen_legacy_loader(searchers, index)
         if loaded then
             return loaded
         else
-            if _G.box and _G.box.error then
+            local box = rawget(_G, 'box')
+            if box ~= nil and box.error ~= nil then
                 box.error(box.error.PROC_LUA, message, 3)
             else
                 error(message, 3)

--- a/test/app-luatest/override_panic_test.lua
+++ b/test/app-luatest/override_panic_test.lua
@@ -64,3 +64,20 @@ g.test_setmodule_panic = function()
             'with another value',
     })
 end
+
+--
+-- Trigger error while loading a built-in module.
+--
+-- To do that, we override 'buffer', which is required by other built-in
+-- modules (for example, string).
+--
+g.test_load_panic = function()
+    local dir = treegen.prepare_directory({}, {})
+    treegen.write_file(dir, 'override/buffer.lua', [[foobar]])
+    treegen.write_file(dir, 'main.lua', '')
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
+    t.assert_covers(res, {exit_code = 1})
+    local pattern = "error loading module 'buffer'.*'=' expected near '<eof>'"
+    t.assert_str_contains(res.stderr, pattern, true)
+end


### PR DESCRIPTION
The Lua module loader users box.error to raise an error if it fails to load a module. The problem is that the box module is undefined at startup when we load built-in modules so it falls back to the plain error. However, the check of box presence might trigger the strict checker failure, which would hide the original error:

```
builtin/internal.loaders.lua:241: variable 'box' is not declared
__index (metamethod), builtin/strict.lua:32
```

Let's fix this by using rawget for checking if box is defined.

Fixes commit 4175ab0545405 ("error: set trace of caller for API in Lua for several modules").

Needed to investigate #12363