### PR TITLE
Generate changelog for 3.6.2

### DIFF
--- a/changelogs/3.6.2.md
+++ b/changelogs/3.6.2.md
@@ -1,0 +1,50 @@
+# 3.6.2
+
+Date: 2026-03-05
+Tag: 3.6.2
+
+## Overview
+
+Tarantool 3.x is the recommended release series. Users of Tarantool 2.11 are
+encouraged to update to the latest 3.x release.
+
+This release resolves 4 bugs since 3.6.1.
+
+Please consider the full list of user-visible changes below.
+
+## Compatibility
+
+Tarantool 2.x and 3.x are compatible in the binary data layout, client-server
+protocol, and replication protocol. It means upgrade may be performed with zero
+downtime for read requests and the order-of-network-lag downtime for write
+requests.
+
+Please follow the [upgrade procedure][upgrade] to plan your update actions.
+
+Users of Tarantool 2.x may be interested in the [compat][compat] options that
+allow to imitate some 2.x behavior. This allows to perform application code
+update step-by-step, not all-at-once.
+
+[compat]: https://www.tarantool.io/en/doc/latest/reference/configuration/configuration_reference/#compat
+
+[upgrade]: https://www.tarantool.io/en/doc/latest/book/admin/upgrades/
+
+## Bugs fixed
+
+### Core
+
+* Fixed a crash that could happen if two DDL operations (index build or space
+  format change) were executed on the same space and a WAL write error occurred
+  (gh-11833).
+
+### Vinyl
+
+* Fixed a bug when the dump task scheduler was not unthrottled by
+  `box.snapshot()` (gh-12342).
+* Fixed a bug when Tarantool crashed instead of raising an error in case it
+  failed to apply an upsert statement.
+
+### SQL
+
+* Fixed an issue where no error message would appear when creating
+  a view with duplicate column names (gh-4545).

--- a/changelogs/unreleased/gh-11833-yielding-ddl-dd-order-on-wal-failure.md
+++ b/changelogs/unreleased/gh-11833-yielding-ddl-dd-order-on-wal-failure.md
@@ -1,5 +1,0 @@
-## bugfix/core
-
-* Fixed a crash that could happen if two DDL operations (index build or space
-  format change) were executed on the same space and a WAL write error occurred
-  (gh-11833).

--- a/changelogs/unreleased/gh-12342-vy-scheduler-unthrottle-fix.md
+++ b/changelogs/unreleased/gh-12342-vy-scheduler-unthrottle-fix.md
@@ -1,4 +1,0 @@
-## bugfix/vinyl
-
-* Fixed a bug when the dump task scheduler was not unthrottled by
-  `box.snapshot()` (gh-12342).

--- a/changelogs/unreleased/gh-4545-view-throw-duplicate-column-error.md
+++ b/changelogs/unreleased/gh-4545-view-throw-duplicate-column-error.md
@@ -1,4 +1,0 @@
-## bugfix/sql
-
-* Fixed an issue where no error message would appear when creating
-  a view with duplicate column names (gh-4545).

--- a/changelogs/unreleased/ghs-158-vy-apply-upsert-crash-fix.md
+++ b/changelogs/unreleased/ghs-158-vy-apply-upsert-crash-fix.md
@@ -1,4 +1,0 @@
-## bugfix/vinyl
-
-* Fixed a bug when Tarantool crashed instead of raising an error in case it
-  failed to apply an upsert statement (ghs-158).

--- a/src/box/lua/upgrade.lua
+++ b/src/box/lua/upgrade.lua
@@ -2251,6 +2251,7 @@ local downgrade_versions = {
     "3.5.1",
     "3.6.0",
     "3.6.1",
+    "3.6.2",
     -- DOWNGRADE VERSIONS END
 }
 


### PR DESCRIPTION
Also remove unreleased/ changelog entries and add new 3.6.2 version to the downgrade versions list.

NO_DOC=changelog
NO_TEST=changelog
NO_CHANGELLOG=changelog