### PR TITLE
changelog: cleanup 3.6.2 changelogs

### DIFF
--- a/changelogs/unreleased/gh-11833-yielding-ddl-dd-order-on-wal-failure.md
+++ b/changelogs/unreleased/gh-11833-yielding-ddl-dd-order-on-wal-failure.md
@@ -1,5 +1,0 @@
-## bugfix/core
-
-* Fixed a crash that could happen if two DDL operations (index build or space
-  format change) were executed on the same space and a WAL write error occurred
-  (gh-11833).

--- a/changelogs/unreleased/gh-12342-vy-scheduler-unthrottle-fix.md
+++ b/changelogs/unreleased/gh-12342-vy-scheduler-unthrottle-fix.md
@@ -1,4 +1,0 @@
-## bugfix/vinyl
-
-* Fixed a bug when the dump task scheduler was not unthrottled by
-  `box.snapshot()` (gh-12342).

--- a/changelogs/unreleased/gh-4545-view-throw-duplicate-column-error.md
+++ b/changelogs/unreleased/gh-4545-view-throw-duplicate-column-error.md
@@ -1,4 +1,0 @@
-## bugfix/sql
-
-* Fixed an issue where no error message would appear when creating
-  a view with duplicate column names (gh-4545).

--- a/changelogs/unreleased/ghs-158-vy-apply-upsert-crash-fix.md
+++ b/changelogs/unreleased/ghs-158-vy-apply-upsert-crash-fix.md
@@ -1,4 +1,0 @@
-## bugfix/vinyl
-
-* Fixed a bug when Tarantool crashed instead of raising an error in case it
-  failed to apply an upsert statement (ghs-158).

--- a/src/box/lua/upgrade.lua
+++ b/src/box/lua/upgrade.lua
@@ -2251,6 +2251,7 @@ local downgrade_versions = {
     "3.5.1",
     "3.6.0",
     "3.6.1",
+    "3.6.2",
     -- DOWNGRADE VERSIONS END
 }
 


### PR DESCRIPTION
Remove all changelog entries reported in release notes for 3.6.2.

Also add new 3.6.2 version to the downgrade versions list.

NO_DOC=changelog
NO_TEST=changelog
NO_CHANGELLOG=changelog