### PR TITLE
coll: deprecate custom collations

### DIFF
--- a/changelogs/unreleased/gh-12209-custom-collation-deprecation.md
+++ b/changelogs/unreleased/gh-12209-custom-collation-deprecation.md
@@ -1,0 +1,5 @@
+## feature/box
+
+* Usage of custom collations is now deprecated. Support for custom collations
+  is scheduled to be dropped in Tarantool 4.0. Newer Tarantool versions will
+  not recover if there are custom collations in the database (gh-12209).

--- a/src/lib/coll/coll.c
+++ b/src/lib/coll/coll.c
@@ -29,6 +29,12 @@
  * SUCH DAMAGE.
  */
 
+#include <assert.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include <PMurHash.h>
 #include <unicode/ucol.h>
 #include <unicode/ucnv.h>
@@ -37,11 +43,111 @@
 #include "coll.h"
 #include "diag.h"
 #include "assoc.h"
+#include "trivia/util.h"
 #include "tt_static.h"
 #include "say.h"
 
 struct UCaseMap *icu_ucase_default_map = NULL;
 struct UConverter *icu_utf8_conv = NULL;
+
+/**
+ * Null-terminated array of locale strings that will be used for creating
+ * predefined collations.
+ */
+static const char * const predefined_locales[] = {
+	"af", /* Afrikaans */
+	"am", /* Amharic (no character changes, just re-ordering) */
+	"ar", /* Arabic (use only "standard") */
+	"as", /* Assamese */
+	"az", /* Azerbaijani (Azeri) */
+	"be", /* Belarusian */
+	"bn", /* Bengali (Bangla actually) */
+	"bs", /* Bosnian (tailored as Croatian) */
+	"bs_Cyrl", /* Bosnian in Cyrillic (tailored as Serbian) */
+	"ca", /* Catalan */
+	"cs", /* Czech */
+	"cy", /* Welsh */
+	"da", /* Danish */
+	"de_DE_u_co_phonebk", /* German (umlaut as 'ae', 'oe', 'ue') */
+	"de_AT_u_co_phonebk", /* Austrian German (umlaut primary greater) */
+	"dsb", /* Lower Sorbian */
+	"ee", /* Ewe */
+	"eo", /* Esperanto */
+	"es", /* Spanish */
+	"es_u_co_trad", /* Spanish ('ch' and 'll' as a grapheme) */
+	"et", /* Estonian */
+	"fa", /* Persian */
+	"fi", /* Finnish (v and w are primary equal) */
+	"fi_u_co_phonebk", /* Finnish (v and w as separate characters) */
+	"fil", /* Filipino */
+	"fo", /* Faroese */
+	"fr_CA", /* Canadian French */
+	"gu", /* Gujarati */
+	"ha", /* Hausa */
+	"haw", /* Hawaiian */
+	"he", /* Hebrew */
+	"hi", /* Hindi */
+	"hr", /* Croatian */
+	"hu", /* Hungarian */
+	"hy", /* Armenian */
+	"ig", /* Igbo */
+	"is", /* Icelandic */
+	"ja", /* Japanese */
+	"kk", /* Kazakh */
+	"kl", /* Kalaallisut */
+	"kn", /* Kannada */
+	"ko", /* Korean */
+	"kok", /* Konkani */
+	"ky", /* Kyrgyz */
+	"lkt", /* Lakota */
+	"ln", /* Lingala */
+	"lt", /* Lithuanian */
+	"lv", /* Latvian */
+	"mk", /* Macedonian */
+	"ml", /* Malayalam */
+	"mr", /* Marathi */
+	"mt", /* Maltese */
+	"nb", /* Norwegian Bokmal */
+	"nn", /* Norwegian Nynorsk */
+	"nso", /* Northern Sotho */
+	"om", /* Oromo */
+	"or", /* Oriya (Odia) */
+	"pa", /* Punjabi */
+	"pl", /* Polish */
+	"ro", /* Romanian */
+	"sa", /* Sanskrit */
+	"se", /* Northern Sami */
+	"si", /* Sinhala */
+	"si_u_co_dict", /* Sinhala (U+0DA5 = U+0DA2,0DCA,0DA4) */
+	"sk", /* Slovak */
+	"sl", /* Slovenian */
+	"sq", /* Albanian (just "standard") */
+	"sr", /* Serbian */
+	"sr_Latn", /* Serbian in Latin (tailored as Croatian) */
+	"sv", /* Swedish (v and w are primary equal) */
+	"sv_u_co_reformed", /* Swedish (v and w as separate characters) */
+	"ta", /* Tamil */
+	"te", /* Telugu */
+	"th", /* Thai */
+	"tn", /* Tswana */
+	"to", /* Tonga */
+	"tr", /* Turkish */
+	"ug", /* Uyghur in Cyrillic - is there such locale? */
+	"uk", /* Ukrainian */
+	"ur", /* Urdu */
+	"vi", /* Vietnamese */
+	"vo", /* Volapük */
+	"wae", /* Walser */
+	"wo", /* Wolof */
+	"yo", /* Yoruba */
+	"zh", /* Chinese */
+	"zh_u_co_big5han", /* Chinese (ideographs: big5 order) */
+	"zh_u_co_gb2312", /* Chinese (ideographs: GB-2312 order) */
+	"zh_u_co_pinyin", /* Chinese (ideographs: pinyin order) */
+	"zh_u_co_stroke", /* Chinese (ideographs: stroke order) */
+	"zh_u_co_zhuyin", /* Chinese (ideographs: zhuyin order) */
+	NULL
+};
 
 #define mh_name _coll
 struct mh_coll_key_t {
@@ -315,14 +421,14 @@ coll_def_snfingerprint(char *buffer, int size, const struct coll_def *def)
 {
 	int total = 0;
 	if (def->type == COLL_TYPE_ICU) {
-		SNPRINT(total, snprintf, buffer, size, "{locale: %s,"\
-			"type = %d, icu: ", def->locale, (int) def->type);
+		SNPRINT(total, snprintf, buffer, size,
+			"{type: icu, locale: '%s', icu: ", def->locale);
 		SNPRINT(total, coll_icu_def_snfingerprint, buffer,
 			size, &def->icu);
 		SNPRINT(total, snprintf, buffer, size, "}");
 	} else {
 		assert(def->type == COLL_TYPE_BINARY);
-		SNPRINT(total, snprintf, buffer, size, "{type = binary}");
+		SNPRINT(total, snprintf, buffer, size, "{type: binary}");
 	}
 	return total;
 }
@@ -351,8 +457,8 @@ coll_can_merge(const struct coll *first, const struct coll *second)
 
 }
 
-struct coll *
-coll_new(const struct coll_def *def)
+static struct coll *
+coll_new_impl(const struct coll_def *def, bool is_predefined)
 {
 	int fingerprint_len = coll_def_snfingerprint(NULL, 0, def);
 	assert(fingerprint_len <= TT_STATIC_BUF_LEN);
@@ -363,7 +469,15 @@ coll_new(const struct coll_def *def)
 	struct mh_coll_key_t key = { fingerprint, fingerprint_len, hash };
 	mh_int_t i = mh_coll_find(coll_cache, &key, NULL);
 	if (i != mh_end(coll_cache)) {
+		assert(!is_predefined);
 		return mh_coll_node(coll_cache, i)->coll;
+	}
+
+	if (!is_predefined) {
+		say_warn_once("Usage of custom collations is deprecated. "
+			      "Tarantool 4.0 and newer will not start if "
+			      "there are custom collations in the database.");
+		say_warn("Creating custom collation %s", fingerprint);
 	}
 
 	int total_size = sizeof(struct coll) + fingerprint_len + 1;
@@ -396,6 +510,24 @@ coll_new(const struct coll_def *def)
 	return coll;
 }
 
+struct coll *
+coll_new(const struct coll_def *def)
+{
+	return coll_new_impl(def, /*is_predefined=*/false);
+}
+
+/**
+ * Creates a new predefined collation and adds it to the cache.
+ */
+static void
+coll_create_predefined(const struct coll_def *def)
+{
+	if (coll_new_impl(def, /*is_predefined=*/true) == NULL) {
+		diag_log();
+		panic("Can not create predefined collation");
+	}
+}
+
 static void
 coll_delete(struct coll *coll)
 {
@@ -412,6 +544,24 @@ coll_init(void)
 	icu_utf8_conv = ucnv_open("utf8", &err);
 	if (icu_ucase_default_map == NULL || icu_utf8_conv == NULL)
 		panic("Can not create system collations cache");
+	/* Create predefined collations. */
+	struct coll_def def;
+	memset(&def, 0, sizeof(def));
+	def.type = COLL_TYPE_BINARY;
+	coll_create_predefined(&def); /* binary */
+	def.type = COLL_TYPE_ICU;
+	def.icu.strength = COLL_ICU_STRENGTH_TERTIARY;
+	coll_create_predefined(&def); /* unicode */
+	def.icu.strength = COLL_ICU_STRENGTH_PRIMARY;
+	coll_create_predefined(&def); /* unicode_ci */
+	for (const char * const *plocale = predefined_locales;
+	     *plocale != NULL; plocale++) {
+		strlcpy(def.locale, *plocale, sizeof(def.locale));
+		for (int strength = 1; strength <= 3; strength++) {
+			def.icu.strength = strength;
+			coll_create_predefined(&def);
+		}
+	}
 }
 
 void

--- a/test/box-luatest/gh_12209_custom_collation_deprecation_test.lua
+++ b/test/box-luatest/gh_12209_custom_collation_deprecation_test.lua
@@ -1,0 +1,63 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local DEPRECATION_WARNING = "Usage of custom collations is deprecated%. " ..
+                            "Tarantool 4%.0 and newer will not start if " ..
+                            "there are custom collations in the database%."
+local CREATION_WARNING = "Creating custom collation .*"
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:drop()
+end)
+
+g.test = function(cg)
+    -- No warning initially.
+    t.assert_not(cg.server:grep_log(DEPRECATION_WARNING))
+    t.assert_not(cg.server:grep_log(CREATION_WARNING))
+
+    -- No warning if the created collation is predefined.
+    cg.server:exec(function()
+        box.internal.collation.create('test1', 'ICU', '',
+                                      {strength = 'primary'})
+        box.internal.collation.create('test2', 'ICU', 'af',
+                                      {strength = 'secondary'})
+    end)
+    t.assert_not(cg.server:grep_log(DEPRECATION_WARNING))
+    t.assert_not(cg.server:grep_log(CREATION_WARNING))
+
+    -- Warning if the created collation is not predefined.
+    cg.server:exec(function()
+        box.internal.collation.create('test3', 'ICU', '',
+                                      {strength = 'secondary'})
+    end)
+    t.assert(cg.server:grep_log(DEPRECATION_WARNING))
+    t.assert_str_contains(cg.server:grep_log(CREATION_WARNING),
+                          ".* locale: '', .* strength: 2", true)
+
+    -- Deprecation warning is logged once while creation warning
+    -- is logged each time.
+    cg.server:exec(function()
+        local log = require('log')
+        for _ = 1, 10 do
+            log.warn(string.rep('x', 1000))
+        end
+        box.internal.collation.create('test4', 'ICU', 'af',
+                                      {alternate_handling = 'shifted'})
+    end)
+    t.helpers.retrying({}, function()
+        t.assert_not(cg.server:grep_log(DEPRECATION_WARNING, 5000))
+        t.assert(cg.server:grep_log(CREATION_WARNING))
+    end)
+
+    -- Warnings are logged during recovery.
+    cg.server:restart()
+    t.assert(cg.server:grep_log(DEPRECATION_WARNING))
+    t.assert(cg.server:grep_log(CREATION_WARNING))
+end

--- a/test/unit/coll.cpp
+++ b/test/unit/coll.cpp
@@ -175,6 +175,7 @@ cache_test()
 int
 main(int, const char**)
 {
+	say_logger_init("/dev/null", S_INFO, 0, "plain");
 	coll_init();
 	memory_init();
 	fiber_init(fiber_c_invoke);
@@ -184,4 +185,5 @@ main(int, const char**)
 	fiber_free();
 	memory_free();
 	coll_free();
+	say_logger_free();
 }


### PR DESCRIPTION
Allowing users to create and modify collations is dangerous because it may change the order of data stored on disk. We shouldn't have allowed it in the first place. Another issue with custom collations is the global collation registry: since it can be modified at any time, we'd have to synchronize access to it in order to allow using tuples in application threads (tuple formats and key definitions refer to collations). Let's deprecate this feature and schedule it for removal in Tarantool 4.0.

The implementation is simple. At startup we create predefined collations (same as those created by box.schema.upgrade) and add them to the collation cache. When a new collation is created, we check if there's already the same collation in the cache and reuse it if so. If there's no collation to reuse, we log a deprecation warning.

Closes #12209