### PR TITLE
coll: drop reference counter

### DIFF
--- a/src/box/coll_id.c
+++ b/src/box/coll_id.c
@@ -61,6 +61,5 @@ void
 coll_id_delete(struct coll_id *coll_id)
 {
 	assert(rlist_empty(&coll_id->cache_pin_list));
-	coll_unref(coll_id->coll);
 	free(coll_id);
 }

--- a/src/box/key_def.c
+++ b/src/box/key_def.c
@@ -127,9 +127,6 @@ key_def_copy_impl(struct key_def *res, const struct key_def *src, size_t sz)
 		size_t path_offset = src->multikey_path - (char *)src;
 		res->multikey_path = (char *)res + path_offset;
 	}
-	for (uint32_t i = 0; i < res->part_count; i++)
-		if (res->parts[i].coll != NULL)
-			coll_ref(res->parts[i].coll);
 	return res;
 }
 
@@ -153,9 +150,6 @@ key_def_dup(const struct key_def *src)
 void
 key_def_delete(struct key_def *def)
 {
-	for (uint32_t i = 0; i < def->part_count; i++)
-		if (def->parts[i].coll != NULL)
-			coll_unref(def->parts[i].coll);
 	TRASH(def);
 	free(def);
 }
@@ -263,8 +257,6 @@ key_def_set_part(struct key_def *def, uint32_t part_no, uint32_t fieldno,
 	def->parts[part_no].type = type;
 	def->parts[part_no].type_params = *type_params;
 	def->parts[part_no].coll = coll;
-	if (coll != NULL)
-		coll_ref(def->parts[part_no].coll);
 	def->parts[part_no].coll_id = coll_id;
 	def->parts[part_no].sort_order = sort_order == SORT_ORDER_DESC ?
 					 SORT_ORDER_DESC : SORT_ORDER_ASC;

--- a/src/lib/coll/coll.c
+++ b/src/lib/coll/coll.c
@@ -363,9 +363,7 @@ coll_new(const struct coll_def *def)
 	struct mh_coll_key_t key = { fingerprint, fingerprint_len, hash };
 	mh_int_t i = mh_coll_find(coll_cache, &key, NULL);
 	if (i != mh_end(coll_cache)) {
-		struct coll *coll = mh_coll_node(coll_cache, i)->coll;
-		coll_ref(coll);
-		return coll;
+		return mh_coll_node(coll_cache, i)->coll;
 	}
 
 	int total_size = sizeof(struct coll) + fingerprint_len + 1;
@@ -375,7 +373,6 @@ coll_new(const struct coll_def *def)
 		return NULL;
 	}
 	memcpy((char *) coll->fingerprint, fingerprint, fingerprint_len + 1);
-	coll->refs = 1;
 	coll->type = def->type;
 	switch (coll->type) {
 	case COLL_TYPE_ICU:
@@ -399,19 +396,11 @@ coll_new(const struct coll_def *def)
 	return coll;
 }
 
-void
-coll_unref(struct coll *coll)
+static void
+coll_delete(struct coll *coll)
 {
-	assert(coll->refs > 0);
-	if (--coll->refs == 0) {
-		int len = strlen(coll->fingerprint);
-		struct mh_coll_node_t node = {
-			len, mh_strn_hash(coll->fingerprint, len), coll
-		};
-		mh_coll_remove(coll_cache, &node, NULL);
-		ucol_close(coll->collator);
-		free(coll);
-	}
+	ucol_close(coll->collator);
+	free(coll);
 }
 
 void
@@ -430,5 +419,10 @@ coll_free(void)
 {
 	ucasemap_close(icu_ucase_default_map);
 	ucnv_close(icu_utf8_conv);
+	mh_int_t i;
+	mh_foreach(coll_cache, i) {
+		struct coll *coll = mh_coll_node(coll_cache, i)->coll;
+		coll_delete(coll);
+	}
 	mh_coll_delete(coll_cache);
 }

--- a/src/lib/coll/coll.h
+++ b/src/lib/coll/coll.h
@@ -79,8 +79,6 @@ struct coll {
 	 * copied. Sort keys may be compared using strcmp().
 	 */
 	coll_hint_f hint;
-	/** Reference counter. */
-	int refs;
 	/**
 	 * Formatted string with collation properties, that
 	 * completely describes how the collation works.
@@ -109,17 +107,6 @@ coll_can_merge(const struct coll *first, const struct coll *second);
  */
 struct coll *
 coll_new(const struct coll_def *def);
-
-/** Increment reference counter. */
-static inline void
-coll_ref(struct coll *coll)
-{
-	++coll->refs;
-}
-
-/** Decrement reference counter. Delete when 0. */
-void
-coll_unref(struct coll *coll);
 
 /** Initialize collations subsystem. */
 void

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -1266,7 +1266,6 @@ tarantool_lua_free()
 
 	builtin_globals_free();
 	builtin_modcache_free();
-	tarantool_lua_utf8_free();
 	/*
 	 * Some part of the start script panicked, and called
 	 * exit().  The call stack in this case leads us back to

--- a/src/lua/utf8.c
+++ b/src/lua/utf8.c
@@ -454,25 +454,12 @@ tarantool_lua_utf8_init(struct lua_State *L)
 	def.icu.strength = COLL_ICU_STRENGTH_TERTIARY;
 	unicode_coll = coll_new(&def);
 	if (unicode_coll == NULL)
-		goto error_coll;
+		luaT_error(L);
 	def.icu.strength = COLL_ICU_STRENGTH_PRIMARY;
 	unicode_ci_coll = coll_new(&def);
 	if (unicode_ci_coll == NULL)
-		goto error_coll;
+		luaT_error(L);
 	luaT_newmodule(L, "utf8", utf8_lib);
 	/* Assign to _G.utf8 for compatibility with Lua 5.3. */
 	lua_setfield(L, LUA_GLOBALSINDEX, "utf8");
-	return;
-error_coll:
-	tarantool_lua_utf8_free();
-	luaT_error(L);
-}
-
-void
-tarantool_lua_utf8_free()
-{
-	if (unicode_coll != NULL)
-		coll_unref(unicode_coll);
-	if (unicode_ci_coll != NULL)
-		coll_unref(unicode_ci_coll);
 }

--- a/src/lua/utf8.h
+++ b/src/lua/utf8.h
@@ -36,7 +36,4 @@ struct lua_State;
 void
 tarantool_lua_utf8_init(struct lua_State *L);
 
-void
-tarantool_lua_utf8_free();
-
 #endif /* TARANTOOL_LUA_UTF8_H_INCLUDED */

--- a/test/unit/coll.cpp
+++ b/test/unit/coll.cpp
@@ -59,7 +59,6 @@ manual_test()
 	assert(coll != NULL);
 	strings = {"Б", "бб", "е", "ЕЕЕЕ", "ё", "Ё", "и", "И", "123", "45" };
 	test_sort_strings(strings, coll);
-	coll_unref(coll);
 
 	cout << " -- --||-- + upper first -- " << endl;
 	def.icu.case_first = COLL_ICU_CF_UPPER_FIRST;
@@ -67,7 +66,6 @@ manual_test()
 	assert(coll != NULL);
 	strings = {"Б", "бб", "е", "ЕЕЕЕ", "ё", "Ё", "и", "И", "123", "45" };
 	test_sort_strings(strings, coll);
-	coll_unref(coll);
 
 	cout << " -- --||-- + lower first -- " << endl;
 	def.icu.case_first = COLL_ICU_CF_LOWER_FIRST;
@@ -75,7 +73,6 @@ manual_test()
 	assert(coll != NULL);
 	strings = {"Б", "бб", "е", "ЕЕЕЕ", "ё", "Ё", "и", "И", "123", "45" };
 	test_sort_strings(strings, coll);
-	coll_unref(coll);
 
 	cout << " -- --||-- + secondary strength + numeric -- " << endl;
 	def.icu.strength = COLL_ICU_STRENGTH_SECONDARY;
@@ -84,7 +81,6 @@ manual_test()
 	assert(coll != NULL);
 	strings = {"Б", "бб", "е", "ЕЕЕЕ", "ё", "Ё", "и", "И", "123", "45" };
 	test_sort_strings(strings, coll);
-	coll_unref(coll);
 
 	cout << " -- --||-- + case level -- " << endl;
 	def.icu.case_level = COLL_ICU_ON;
@@ -92,7 +88,6 @@ manual_test()
 	assert(coll != NULL);
 	strings = {"Б", "бб", "е", "ЕЕЕЕ", "ё", "Ё", "и", "И", "123", "45" };
 	test_sort_strings(strings, coll);
-	coll_unref(coll);
 
 	cout << " -- en_EN -- " << endl;
 	snprintf(def.locale, sizeof(def.locale), "%s", "en_EN-EN");
@@ -100,7 +95,6 @@ manual_test()
 	assert(coll != NULL);
 	strings = {"aa", "bb", "cc", "ch", "dd", "gg", "hh", "ii" };
 	test_sort_strings(strings, coll);
-	coll_unref(coll);
 
 	cout << " -- cs_CZ -- " << endl;
 	snprintf(def.locale, sizeof(def.locale), "%s", "cs_CZ");
@@ -108,7 +102,6 @@ manual_test()
 	assert(coll != NULL);
 	strings = {"aa", "bb", "cc", "ch", "dd", "gg", "hh", "ii" };
 	test_sort_strings(strings, coll);
-	coll_unref(coll);
 
 	footer();
 }
@@ -142,7 +135,6 @@ hash_test()
 	cout << (calc_hash("ае", coll) != calc_hash("аё", coll) ? "OK" : "Fail") << endl;
 	cout << (calc_hash("ае", coll) != calc_hash("аЕ", coll) ? "OK" : "Fail") << endl;
 	cout << (calc_hash("аЕ", coll) != calc_hash("аё", coll) ? "OK" : "Fail") << endl;
-	coll_unref(coll);
 
 	/* Case insensitive */
 	def.icu.strength = COLL_ICU_STRENGTH_SECONDARY;
@@ -152,7 +144,6 @@ hash_test()
 	cout << (calc_hash("ае", coll) != calc_hash("аё", coll) ? "OK" : "Fail") << endl;
 	cout << (calc_hash("ае", coll) == calc_hash("аЕ", coll) ? "OK" : "Fail") << endl;
 	cout << (calc_hash("аЕ", coll) != calc_hash("аё", coll) ? "OK" : "Fail") << endl;
-	coll_unref(coll);
 
 	footer();
 }
@@ -172,13 +163,10 @@ cache_test()
 	struct coll *coll2 = coll_new(&def);
 	is(coll1, coll2,
 	   "collations with the same definition are not duplicated");
-	coll_unref(coll2);
 	snprintf(def.locale, sizeof(def.locale), "%s", "en_EN");
 	coll2 = coll_new(&def);
 	isnt(coll1, coll2,
 	     "collations with different definitions are different objects");
-	coll_unref(coll2);
-	coll_unref(coll1);
 
 	check_plan();
 	footer();


### PR DESCRIPTION
Collations are reusable and the set of used collations is normally stable and quite limited. Besides, there's no official way for the user to drop collations and in the scope of #12376 we're going to hard-code the list of available collations anyway. That said, let's drop the collation reference counter and never delete created collations. This greatly simplifies implementation of #12378 because then we don't need to care about MT-accesses when we create or destroy a key definition object referencing a collation.

Needed for #12378
Part of #12376