### PR TITLE
netbox: do not convert cdata to table in self:call

### DIFF
--- a/changelogs/unreleased/gh-11624-netbox-remote-and-local-call-consistency.md
+++ b/changelogs/unreleased/gh-11624-netbox-remote-and-local-call-consistency.md
@@ -1,0 +1,4 @@
+## bugfix/netbox
+
+* Fixed inconsistent return types between net.box.self:call and remote call
+  (gh-11624).

--- a/changelogs/unreleased/gh-12421-netbox-local-call-argument-loss-with-nil.md
+++ b/changelogs/unreleased/gh-12421-netbox-local-call-argument-loss-with-nil.md
@@ -1,0 +1,4 @@
+## bugfix/netbox
+
+* Fixed argument loss if function return table with nil in
+  net.box.self:call(gh-12421).

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -7,6 +7,7 @@ local urilib   = require('uri')
 local internal = require('net.box.lib')
 local trigger  = require('internal.trigger')
 local utils    = require('internal.utils')
+local compat   = require('compat')
 
 local this_module
 
@@ -1384,18 +1385,43 @@ local function rollback()
     end
 end
 
+local decode_func = nil
+
+local update_decode_func = function(is_new)
+    if is_new then
+        decode_func = function(...) return ... end
+    else
+        decode_func = function(...)
+            local size = select('#', ...)
+            if size == 0 then
+                return
+            end
+            local args = {...}
+            for i = 1, size do
+                if is_tuple(args[i]) then
+                    args[i] = msgpack.decode(msgpack.encode(args[i]))
+                end
+            end
+            return unpack(args, 1, size)
+        end
+    end
+end
+
+update_decode_func(compat.box_tuple_extension:is_new())
+
+local opts = compat._options()
+local orig_action = opts.box_tuple_extension.action
+opts.box_tuple_extension.action = function(is_new)
+    orig_action(is_new)
+    update_decode_func(is_new)
+end
+
 local function handle_eval_result(status, ...)
     if not status then
         rollback()
         return box.error(E_PROC_LUA, (...))
     end
-    local results = {...}
-    for i = 1, select('#', ...) do
-        if type(results[i]) == 'cdata' then
-            results[i] = msgpack.decode(msgpack.encode(results[i]))
-        end
-    end
-    return unpack(results)
+    return decode_func(...)
 end
 
 this_module.self = {

--- a/test/box-luatest/gh_11624_net_box_self_call_return_type_test.lua
+++ b/test/box-luatest/gh_11624_net_box_self_call_return_type_test.lua
@@ -1,0 +1,39 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    cg.server:exec(function()
+        rawset(_G, 'return_tuple', function()
+            return box.tuple.new({1, 2, 3})
+        end)
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+local test_net_box_call_types_template = function(cg, option, expected_type)
+    cg.server:exec(function(option, expected_type)
+        local net_box = require('net.box')
+        local compat = require('compat')
+        compat.box_tuple_extension = option
+        local listen_uri = box.cfg.listen
+        local conn_self = net_box.self
+
+        local conn_remote = net_box.connect(listen_uri)
+        local res_remote = conn_remote:call('return_tuple')
+        local res_self = conn_self:call('return_tuple')
+        t.assert_equals(type(res_self), type(res_remote))
+        t.assert_equals(type(res_self), expected_type)
+        conn_remote:close()
+    end, {option, expected_type})
+end
+
+g.test_net_box_self_tuple_types = function(cg)
+    test_net_box_call_types_template(cg, 'new', 'cdata')
+    test_net_box_call_types_template(cg, 'old', 'table')
+end

--- a/test/box-luatest/gh_12421_net_box_self_call_nil_unpack_test.lua
+++ b/test/box-luatest/gh_12421_net_box_self_call_nil_unpack_test.lua
@@ -1,0 +1,33 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    cg.server:exec(function()
+        rawset(_G, 'return_with_nil', function()
+            return 1, nil, 3
+        end)
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_net_box_return_with_nil = function(cg)
+    cg.server:exec(function()
+        local net_box = require('net.box')
+        local listen_uri = box.cfg.listen
+        local conn_self = net_box.self
+
+        local conn_remote = net_box.connect(listen_uri)
+        local res_remote = {conn_remote:call('return_with_nil')}
+        local res_self = {conn_self:call('return_with_nil')}
+        conn_remote:close()
+
+        t.assert_equals(res_self, {1, nil, 3})
+        t.assert_equals(res_remote, {1, nil, 3})
+    end)
+end


### PR DESCRIPTION
Previously, net.box.self:call() converted cdata into Lua tables using msgpack encode/decode. This workaround was introduced to make the local self call behaviour consistent with the remote call behaviour.

However, remote call behaviour has changed since the workaround introduction. Since commit cf484f071b67 ("box: support tuple formats in IPROTO responses"), remote calls return cdata tuples, but the local call was left behind, still converting cdata to Lua tables.

This patch drops the unconditional msgpack conversion from net.box.self:call. Local calls will now return cdata tuples, only converting them through msgpack if the compat.box_tuple_extension:is_old() option is set, matching the remote call behaviour.

Msgpack conversion also degrades perf a lot, so removing it should fix the performance drop, described in #11624.

Fixes #11624
Fixes #12421
Fixes #12441 

NO_DOC=bugfix