### PR TITLE
box: remove collation from tuple format

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -576,6 +576,15 @@ space_def_new_from_tuple(struct tuple *tuple, uint32_t errcode,
 			  "formatted field count");
 		return NULL;
 	}
+	for (uint32_t i = 0; i < field_count; i++) {
+		struct field_def *field = &fields[i];
+		if (field->coll_id != COLL_NONE &&
+		    coll_by_id(field->coll_id) == NULL) {
+			diag_set(ClientError, ER_WRONG_COLLATION_OPTIONS,
+				 "collation was not found by ID");
+			return NULL;
+		}
+	}
 	struct space_opts opts;
 	if (space_opts_decode(&opts, space_opts, region) != 0)
 		return NULL;

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -299,9 +299,8 @@ space_pin_collations_helper(struct space *space, uint32_t id,
 void
 space_pin_collations(struct space *space)
 {
-	struct tuple_format *format = space->format;
-	for (uint32_t i = 0; i < tuple_format_field_count(format); i++) {
-		struct tuple_field *field = tuple_format_field(format, i);
+	for (uint32_t i = 0; i < space->def->field_count; i++) {
+		struct field_def *field = &space->def->fields[i];
 		space_pin_collations_helper(space, field->coll_id,
 					    COLL_ID_HOLDER_SPACE_FORMAT);
 	}

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -889,24 +889,10 @@ struct coll *
 sql_column_collation(struct space_def *def, uint32_t column, uint32_t *coll_id)
 {
 	assert(def != NULL);
-	/*
-	 * It is not always possible to fetch collation directly
-	 * from struct space due to its absence in space cache.
-	 * To be more precise when space is ephemeral or it is
-	 * under construction.
-	 *
-	 * In cases mentioned above collation is fetched by id.
-	 */
-	if (def->opts.is_ephemeral) {
-		assert(column < (uint32_t)def->field_count);
-		*coll_id = def->fields[column].coll_id;
-		struct coll_id *collation = coll_by_id(*coll_id);
-		return collation != NULL ? collation->coll : NULL;
-	}
-	struct space *space = space_by_id(def->id);
-	struct tuple_field *field = tuple_format_field(space->format, column);
-	*coll_id = field->coll_id;
-	return field->coll;
+	assert(column < (uint32_t)def->field_count);
+	*coll_id = def->fields[column].coll_id;
+	struct coll_id *collation = coll_by_id(*coll_id);
+	return collation != NULL ? collation->coll : NULL;
 }
 
 void

--- a/src/box/tuple_format.c
+++ b/src/box/tuple_format.c
@@ -32,7 +32,6 @@
 #include "bit/bit.h"
 #include "fiber.h"
 #include "json/json.h"
-#include "coll_id_cache.h"
 #include "trivia/util.h"
 #include "tuple.h"
 #include "tuple_builder.h"
@@ -108,8 +107,6 @@ tuple_format_cmp(const struct tuple_format *format1,
 			tuple_format1_field_by_format2_field(b, field_a);
 		if (field_a->type != field_b->type)
 			return (int)field_a->type - (int)field_b->type;
-		if (field_a->coll_id != field_b->coll_id)
-			return (int)field_a->coll_id - (int)field_b->coll_id;
 		if (field_a->nullable_action != field_b->nullable_action)
 			return (int)field_a->nullable_action -
 				(int)field_b->nullable_action;
@@ -166,7 +163,6 @@ tuple_format_hash(struct tuple_format *format)
 	json_tree_foreach_entry_preorder(f, &format->fields.root,
 					 struct tuple_field, token) {
 		TUPLE_FIELD_MEMBER_HASH(f, type, h, carry, size)
-		TUPLE_FIELD_MEMBER_HASH(f, coll_id, h, carry, size)
 		TUPLE_FIELD_MEMBER_HASH(f, nullable_action, h, carry, size)
 		TUPLE_FIELD_MEMBER_HASH(f, is_key_part, h, carry, size)
 		TUPLE_FIELD_MEMBER_HASH(f, compression_opts, h, carry, size);
@@ -209,7 +205,6 @@ tuple_field_new(void)
 	field->token.type = JSON_TOKEN_END;
 	field->type = FIELD_TYPE_ANY;
 	field->offset_slot = TUPLE_OFFSET_SLOT_NIL;
-	field->coll_id = COLL_NONE;
 	field->nullable_action = ON_CONFLICT_ACTION_NONE;
 	field->multikey_required_fields = NULL;
 	field->constraint_count = 0;
@@ -519,19 +514,6 @@ tuple_format_create(struct tuple_format *format, struct key_def *const *keys,
 		field->type = fields[i].type;
 		field->type_params = fields[i].type_params;
 		field->nullable_action = fields[i].nullable_action;
-		struct coll *coll = NULL;
-		uint32_t cid = fields[i].coll_id;
-		if (cid != COLL_NONE) {
-			struct coll_id *coll_id = coll_by_id(cid);
-			if (coll_id == NULL) {
-				diag_set(ClientError,ER_WRONG_COLLATION_OPTIONS,
-					 "collation was not found by ID");
-				return -1;
-			}
-			coll = coll_id->coll;
-		}
-		field->coll = coll;
-		field->coll_id = cid;
 		/*
 		 * Padding byte values are unspecified on assignment, use memcpy
 		 * so that we can compute hash and compare members as raw values

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -69,7 +69,6 @@ enum { TUPLE_OFFSET_SLOT_NIL = INT32_MAX };
 struct tuple;
 struct tuple_info;
 struct tuple_format;
-struct coll;
 struct mpstream;
 
 /** Engine-specific tuple format methods. */
@@ -144,10 +143,6 @@ struct tuple_field {
 	bool is_multikey_part;
 	/** Action to perform if NULL constraint failed. */
 	enum on_conflict_action nullable_action;
-	/** Collation definition for string comparison */
-	struct coll *coll;
-	/** Collation identifier. */
-	uint32_t coll_id;
 	/** Compression options for this field. */
 	struct compression_opts compression_opts;
 	/**

--- a/test/unit/tuple_format.c
+++ b/test/unit/tuple_format.c
@@ -114,10 +114,9 @@ test_tuple_format_cmp(void)
 	size = mp_format(buf, lengthof(buf), "[{%s%s %s%d}]",
 			 "name", "f", "collation", 2);
 	f2 = runtime_tuple_format_new(buf, size, false);
-	ok(f1 != f2, "tuple formats with different 'collation' definitions "
-	   "are not equal");
+	ok(f1 == f2, "tuple formats with different 'collation' definitions "
+	   "are equal");
 	tuple_format_delete(f1);
-	tuple_format_delete(f2);
 
 	coll_id_cache_delete(coll_id2);
 	coll_id_cache_delete(coll_id1);


### PR DESCRIPTION
It's possible to set a collation for a space format field, in which case it will be used as the default collation when creating an index over this field. Also, it's used for comparison of tuple fields in SQL. We store a collation id not only in `space_def` but also in `tuple_format`, but it's redundant because in all places where we use it, we have a `space_def` object. Let's remove `coll_id` and `coll` from `tuple_format` and use `field_def::coll_id` instead. This a step towards allowing application threads to use tuple formats because now we don't need to access the global collation cache to create a tuple format.

Needed for #12210