### PR TITLE
memtx: factor out multikey loop from regular and functional `replace`

### DIFF
--- a/src/box/field_map.h
+++ b/src/box/field_map.h
@@ -1,5 +1,3 @@
-#ifndef TARANTOOL_BOX_FIELD_MAP_H_INCLUDED
-#define TARANTOOL_BOX_FIELD_MAP_H_INCLUDED
 /*
  * Copyright 2010-2019, Tarantool AUTHORS, please see AUTHORS file.
  *
@@ -30,6 +28,8 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+#pragma once
+
 #include <assert.h>
 #include <stdint.h>
 #include <stddef.h>
@@ -254,8 +254,6 @@ field_map_build_size(struct field_map_builder *builder)
  */
 void
 field_map_build(struct field_map_builder *builder, char *buffer);
-
-#endif /* TARANTOOL_BOX_FIELD_MAP_H_INCLUDED */
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -280,22 +280,27 @@ make_key(const char *field, uint32_t *key_len)
 	}
 }
 
+/** Replace old tuple with new tuple in the index. */
 static int
-memtx_bitset_index_replace(struct index *base, struct tuple *old_tuple,
-			   struct tuple *new_tuple, enum dup_replace_mode mode,
-			   struct tuple **result, struct tuple **successor)
+memtx_bitset_index_replace(struct index *base,
+			   struct memtx_index_entry old_entry,
+			   struct memtx_index_entry new_entry,
+			   enum dup_replace_mode mode,
+			   struct memtx_index_entry *result,
+			   struct memtx_index_entry *successor)
 {
 	struct memtx_bitset_index *index = (struct memtx_bitset_index *)base;
 
 	/* BITSET index doesn't support ordering. */
-	*successor = NULL;
-
+	*successor = memtx_index_entry_null;
+	struct tuple *old_tuple = old_entry.tuple;
+	struct tuple *new_tuple = new_entry.tuple;
 	assert(!base->def->opts.is_unique);
 	assert(!base->def->key_def->is_multikey);
 	assert(old_tuple != NULL || new_tuple != NULL);
 	(void) mode;
 
-	*result = NULL;
+	*result = memtx_index_entry_null;
 
 	if (old_tuple != NULL) {
 #ifndef OLD_GOOD_BITSET
@@ -305,7 +310,7 @@ memtx_bitset_index_replace(struct index *base, struct tuple *old_tuple,
 #endif /* #ifndef OLD_GOOD_BITSET */
 		if (tt_bitset_index_contains_value(&index->index,
 						   (size_t) value)) {
-			*result = old_tuple;
+			result->tuple = old_tuple;
 
 			assert(old_tuple != new_tuple);
 			tt_bitset_index_remove_value(&index->index, value);
@@ -327,7 +332,7 @@ memtx_bitset_index_replace(struct index *base, struct tuple *old_tuple,
 			 * have just deregistered the old one - it will be moved
 			 * to the spare list and reused.
 			 */
-			assert(*result == NULL);
+			assert(result->tuple == NULL);
 			return -1;
 		}
 		uint32_t value = memtx_bitset_index_tuple_to_value(index, new_tuple);

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -871,11 +871,10 @@ memtx_engine_rollback_statement(struct engine *engine, struct txn *txn,
 		panic("transaction rolled back during snapshot recovery");
 
 	for (uint32_t i = 0; i < index_count; i++) {
-		struct tuple *unused;
 		struct index *index = space->index[i];
 		/* Rollback must not fail. */
-		if (memtx_index_replace(index, new_tuple, old_tuple, DUP_INSERT,
-					&unused, &unused) != 0) {
+		if (memtx_index_replace(index, new_tuple, old_tuple,
+					DUP_INSERT) != 0) {
 			diag_log();
 			unreachable();
 			panic("failed to rollback change");

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -441,15 +441,22 @@ fail:
 	return -1;
 }
 
+/** Replace old tuple with new tuple in the index. */
 static int
-memtx_hash_index_replace(struct index *base, struct tuple *old_tuple,
-			 struct tuple *new_tuple, enum dup_replace_mode mode,
-			 struct tuple **result, struct tuple **successor)
+memtx_hash_index_replace(struct index *base,
+			 struct memtx_index_entry old_entry,
+			 struct memtx_index_entry new_entry,
+			 enum dup_replace_mode mode,
+			 struct memtx_index_entry *result,
+			 struct memtx_index_entry *successor)
 {
 	struct memtx_hash_index *index = (struct memtx_hash_index *)base;
 
 	/* HASH index doesn't support ordering. */
-	*successor = NULL;
+	*successor = memtx_index_entry_null;
+	struct tuple *old_tuple = old_entry.tuple;
+	struct tuple *new_tuple = new_entry.tuple;
+	*result = memtx_index_entry_null;
 
 	if (new_tuple != NULL) {
 		struct tuple *dup_tuple;
@@ -467,7 +474,7 @@ memtx_hash_index_replace(struct index *base, struct tuple *old_tuple,
 		}
 
 		if (dup_tuple) {
-			*result = dup_tuple;
+			result->tuple = dup_tuple;
 			return 0;
 		}
 	}
@@ -480,7 +487,7 @@ memtx_hash_index_replace(struct index *base, struct tuple *old_tuple,
 			return -1;
 		}
 	}
-	*result = old_tuple;
+	result->tuple = old_tuple;
 	return 0;
 }
 

--- a/src/box/memtx_index.c
+++ b/src/box/memtx_index.c
@@ -5,6 +5,390 @@
  */
 #include "memtx_index.h"
 
+#include "key_list.h"
+#include "memtx_engine.h"
+#include "memtx_tx.h"
+#include "tuple.h"
+
+static int
+memtx_index_replace_impl(struct index *index,
+			 struct memtx_index_entry old_entry,
+			 struct memtx_index_entry new_entry,
+			 enum dup_replace_mode mode,
+			 struct memtx_index_entry *result,
+			 struct memtx_index_entry *successor)
+{
+	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
+	return vtab->replace(index, old_entry, new_entry, mode, result,
+			     successor);
+}
+
+/**
+ * Rollback the sequence of memtx_tree_index_replace_multikey_one
+ * insertions with multikey indexes [0, new_tuple_err_mk_idx - 1]
+ * where the err_multikey_idx is the first multikey index where
+ * error has been raised.
+ *
+ * This routine can't fail because all replaced_tuple (when
+ * specified) nodes in tree are already allocated (they might be
+ * overridden with new_tuple, but they definitely present) and
+ * delete operation is fault-tolerant.
+ */
+static void
+memtx_index_replace_multikey_rollback(struct index *index,
+				      struct tuple *new_tuple,
+				      uint32_t new_tuple_err_mk_idx,
+				      struct tuple *replaced)
+{
+	struct key_def *cmp_def = index->def->cmp_def;
+	struct memtx_index_entry entry = {
+		.tuple = new_tuple,
+		.hint = MULTIKEY_NONE,
+	};
+	struct memtx_index_entry unused;
+	if (new_tuple != NULL) {
+		/*
+		 * Rollback new_tuple insertion by multikey index
+		 * [0, multikey_idx).
+		 */
+		for (; new_tuple_err_mk_idx > 0; --new_tuple_err_mk_idx) {
+			entry.hint = new_tuple_err_mk_idx - 1;
+			VERIFY(memtx_index_replace_impl(index, entry,
+							memtx_index_entry_null,
+							DUP_INSERT, &unused,
+							&unused) == 0);
+		}
+	}
+	if (replaced == NULL)
+		return;
+	/* Restore replaced tuple index occurrences. */
+	entry.tuple = replaced;
+	uint32_t mk_count = tuple_multikey_count(replaced, cmp_def);
+	for (uint32_t mk_idx = 0; mk_idx < mk_count; ++mk_idx) {
+		entry.hint = mk_idx;
+		VERIFY(memtx_index_replace_impl(index, memtx_index_entry_null,
+						entry, DUP_INSERT, &unused,
+						&unused) == 0);
+	}
+}
+
+/**
+ * :replace() function for a multikey index: replace old tuple
+ * index entries with ones from the new tuple.
+ *
+ * In a multikey index a single tuple is associated with 0..N keys
+ * of the b+*tree. Imagine old tuple key set is called "old_keys"
+ * and a new tuple set is called "new_keys". This function must
+ * 1) delete all removed keys: (old_keys \ new_keys)
+ * 2) update tuple pointer in all preserved keys: (old_keys & new_keys)
+ * 3) insert data for all new keys (new_keys \ old_keys).
+ *
+ * Compare with a standard unique or non-unique index, when a key
+ * is present only once, so whenever we encounter a duplicate, it
+ * is guaranteed to point at the old tuple (in non-unique indexes
+ * we augment the secondary key parts with primary key parts, so
+ * b+*tree still contains unique entries only).
+ *
+ * To reduce the number of insert and delete operations on the
+ * tree, this function attempts to optimistically add all keys
+ * from the new tuple to the tree first.
+ *
+ * When this step finds a duplicate, it's either of the following:
+ * - for a unique multikey index, it may be the old tuple or
+ *   some other tuple. Since unique index forbids duplicates,
+ *   this branch ends with an error unless we found the old tuple.
+ * - for a non-unique multikey index, both secondary and primary
+ *   key parts must match, so it's guaranteed to be the old tuple.
+ *
+ * In other words, when an optimistic insert finds a duplicate,
+ * it's either an error, in which case we roll back all the new
+ * keys from the tree and abort the procedure, or the old tuple,
+ * which we save to get back to, later.
+ *
+ * When adding new keys finishes, we have completed steps
+ * 2) and 3):
+ * - added set (new_keys - old_keys) to the index
+ * - updated set (new_keys ^ old_keys) with a new tuple pointer.
+ *
+ * We now must perform 1), which is remove (old_keys - new_keys).
+ *
+ * This is done by using the old tuple pointer saved from the
+ * previous step. To not accidentally delete the common key
+ * set of the old and the new tuple, we don't use key parts alone
+ * to compare - we also look at b+* tree value that has the tuple
+ * pointer, and delete old tuple entries only.
+ */
+static int
+memtx_index_replace_multikey(struct index *index, struct tuple *old_tuple,
+			     struct tuple *new_tuple,
+			     enum dup_replace_mode mode, struct tuple **result)
+{
+	struct key_def *cmp_def = index->def->cmp_def;
+	uint32_t new_tuple_mk_idx = 0;
+	struct memtx_index_entry old_entry = {
+		.tuple = old_tuple,
+		.hint = MULTIKEY_NONE,
+	};
+	struct memtx_index_entry new_entry = {
+		.tuple = new_tuple,
+		.hint = MULTIKEY_NONE,
+	};
+	*result = NULL;
+	struct memtx_index_entry unused;
+
+	if (new_tuple != NULL) {
+		uint32_t mk_count = tuple_multikey_count(new_tuple, cmp_def);
+		for (new_tuple_mk_idx = 0; new_tuple_mk_idx < mk_count;
+		     ++new_tuple_mk_idx) {
+			new_entry.hint = new_tuple_mk_idx;
+			struct memtx_index_entry replaced;
+			if (memtx_index_replace_impl(index, old_entry,
+						     new_entry, mode, &replaced,
+						     &unused) != 0) {
+				memtx_index_replace_multikey_rollback(
+					index, new_tuple, new_tuple_mk_idx,
+					*result);
+				return -1;
+			}
+			assert(replaced.tuple == NULL ||
+			       replaced.tuple == old_tuple);
+			if (replaced.tuple != NULL) {
+				assert(*result == NULL ||
+				       *result == replaced.tuple);
+				*result = replaced.tuple;
+			}
+		}
+		assert(*result == NULL || old_tuple == NULL ||
+		       old_tuple == *result);
+	}
+	if (old_tuple == NULL)
+		return 0;
+	uint32_t mk_count = tuple_multikey_count(old_tuple, cmp_def);
+	for (size_t old_tuple_mk_idx = 0; old_tuple_mk_idx < mk_count;
+	     ++old_tuple_mk_idx) {
+		old_entry.hint = old_tuple_mk_idx;
+		if (memtx_index_replace_impl(index, old_entry,
+					     memtx_index_entry_null,
+					     DUP_INSERT, &unused,
+					     &unused) != 0) {
+			memtx_index_replace_multikey_rollback(index, new_tuple,
+							      new_tuple_mk_idx,
+							      old_tuple);
+			return -1;
+		}
+	}
+	*result = old_tuple;
+	return 0;
+}
+
+/**
+ * An undo entry for multikey functional index replace operation.
+ * Used to roll back a failed insert/replace and restore the
+ * original key_hint(s) and to commit a completed insert/replace
+ * and destruct old tuple key_hint(s).
+ */
+struct func_key_undo {
+	/** A link to organize entries in list. */
+	struct rlist link;
+	/** An inserted record copy. */
+	struct memtx_index_entry entry;
+};
+
+/**
+ * Use the functional index function from the key definition
+ * to build a key list. Then each returned key is reallocated in
+ * engine's memory as key_hint object and is used as comparison
+ * hint.
+ * To release key_hint memory in case of replace failure
+ * we use a list of undo records which are allocated on region.
+ * It is used to restore the original b+* entries with their
+ * original key_hint(s) pointers in case of failure and release
+ * the now useless hints of old items in case of success.
+ */
+static int
+memtx_index_replace_func(struct index *index, struct tuple *old_tuple,
+			 struct tuple *new_tuple, enum dup_replace_mode mode,
+			 struct tuple **result, struct tuple **successor)
+{
+	struct memtx_engine *memtx = (struct memtx_engine *)index->engine;
+	struct index_def *index_def = index->def;
+	assert(index_def->key_def->for_func_index);
+	/* Make sure that key_def is not multikey - we rely on it below. */
+	assert(!index_def->key_def->is_multikey);
+
+	int rc = -1;
+	struct region *region = &fiber()->gc;
+	size_t region_svp = region_used(region);
+	struct key_list_iterator it;
+	struct rlist old_entries, new_entries;
+	rlist_create(&old_entries);
+	rlist_create(&new_entries);
+	struct func_key_undo *undo;
+	struct memtx_index_entry unused;
+	struct func_key_undo *entry;
+
+	struct memtx_index_entry old_entry = {
+		.tuple = old_tuple,
+		.hint = MULTIKEY_NONE,
+	};
+	struct memtx_index_entry new_entry = {
+		.tuple = new_tuple,
+		.hint = MULTIKEY_NONE,
+	};
+	*result = NULL;
+	if (new_tuple != NULL) {
+		if (key_list_iterator_create(&it, new_tuple, index_def, true,
+					     memtx->func_key_format) != 0)
+			goto end;
+		int err = 0;
+		struct tuple *key;
+		struct func_key_undo *undo;
+		struct key_def *key_def = index_def->key_def;
+		while ((err = key_list_iterator_next(&it, &key)) == 0 &&
+		       key != NULL) {
+			/* Save functional key to MVCC, even excluded one. */
+			memtx_tx_save_func_key(new_tuple, index, key);
+			if (tuple_key_is_excluded(key, key_def, MULTIKEY_NONE))
+				continue;
+			new_entry.hint = (uint64_t)key;
+			struct memtx_index_entry replaced;
+			struct memtx_index_entry successor_entry;
+			err = memtx_index_replace_impl(index, old_entry,
+						       new_entry, mode,
+						       &replaced,
+						       &successor_entry);
+			if (err != 0)
+				break;
+			if (!it.func_is_multikey)
+				*successor = successor_entry.tuple;
+			bool is_mk_conflict =
+				replaced.tuple == new_entry.tuple;
+			undo = xregion_alloc_object(region, typeof(*undo));
+			tuple_ref(key);
+			undo->entry.tuple = new_tuple;
+			undo->entry.hint = (uint64_t)key;
+			rlist_add(&new_entries, &undo->link);
+			if (replaced.tuple != NULL && !is_mk_conflict) {
+				undo = xregion_alloc_object(region,
+							    typeof(*undo));
+				undo->entry.tuple = replaced.tuple;
+				undo->entry.hint = replaced.hint;
+				rlist_add(&old_entries, &undo->link);
+				assert(*result == NULL ||
+				       *result == replaced.tuple);
+				*result = replaced.tuple;
+			} else if (is_mk_conflict) {
+				/*
+				 * Remove the replaced tuple undo
+				 * from undo list.
+				 */
+				tuple_unref((struct tuple *)replaced.hint);
+				rlist_foreach_entry(undo, &new_entries, link) {
+					if (undo->entry.hint == replaced.hint) {
+						rlist_del(&undo->link);
+						break;
+					}
+				}
+			}
+		}
+		assert(key == NULL || err != 0);
+		if (err != 0)
+			goto rollback;
+		assert(*result == NULL || old_tuple == NULL ||
+		       old_tuple == *result);
+	}
+	if (old_tuple == NULL)
+		goto commit;
+	/*
+	 * Use the runtime format to avoid OOM while deleting a tuple
+	 * from a space. It's okay, because we are not going to store
+	 * the keys in the index.
+	 */
+	if (key_list_iterator_create(&it, old_tuple, index_def, false,
+				     tuple_format_runtime) != 0)
+		goto end;
+	struct tuple *key;
+	while (key_list_iterator_next(&it, &key) == 0 && key != NULL) {
+		old_entry.hint = (uint64_t)key;
+		struct memtx_index_entry deleted;
+		deleted.tuple = NULL;
+		if (memtx_index_replace_impl(index, old_entry,
+					     memtx_index_entry_null, DUP_INSERT,
+					     &deleted, &unused) != 0)
+			goto rollback;
+		if (deleted.tuple != NULL) {
+			struct func_key_undo *undo =
+			xregion_alloc_object(region,
+					     typeof(*undo));
+			undo->entry.tuple = deleted.tuple;
+			undo->entry.hint = deleted.hint;
+			rlist_add(&old_entries, &undo->link);
+		}
+	}
+	assert(key == NULL);
+	*result = old_tuple;
+commit:
+	/*
+	 * Commit changes: release hints for
+	 * replaced entries.
+	 */
+	rlist_foreach_entry(undo, &old_entries, link)
+		tuple_unref((struct tuple *)undo->entry.hint);
+	rc = 0;
+	goto end;
+rollback:
+	rlist_foreach_entry(entry, &new_entries, link) {
+		VERIFY(memtx_index_replace_impl(index, entry->entry,
+						memtx_index_entry_null,
+						DUP_INSERT, &unused,
+						&unused) == 0);
+		tuple_unref((struct tuple *)entry->entry.hint);
+	}
+	rlist_foreach_entry(entry, &old_entries, link) {
+		VERIFY(memtx_index_replace_impl(index, memtx_index_entry_null,
+						entry->entry, DUP_INSERT,
+						&unused, &unused) == 0);
+	}
+end:
+	region_truncate(region, region_svp);
+	return rc;
+}
+
+int
+memtx_index_replace(struct index *index, struct tuple *old_tuple,
+		    struct tuple *new_tuple, enum dup_replace_mode mode,
+		    struct tuple **result, struct tuple **successor)
+{
+	int rc;
+	if (index->def->key_def->is_multikey) {
+		/* MUTLIKEY doesn't support successor for now. */
+		*successor = NULL;
+		return memtx_index_replace_multikey(index, old_tuple, new_tuple,
+						    mode, result);
+	}
+	if (index->def->key_def->for_func_index) {
+		/* Successor will be set only if function is not multikey. */
+		*successor = NULL;
+		return memtx_index_replace_func(index, old_tuple, new_tuple,
+						mode, result, successor);
+	}
+
+	struct memtx_index_entry old_entry = {
+		.tuple = old_tuple,
+		.hint = MULTIKEY_NONE,
+	};
+	struct memtx_index_entry new_entry = {
+		.tuple = new_tuple,
+		.hint = MULTIKEY_NONE,
+	};
+	struct memtx_index_entry result_entry, successor_entry;
+	int rc = memtx_index_replace_impl(index, old_entry, new_entry, mode,
+					  &result_entry, &successor_entry);
+	*result = result_entry.tuple;
+	*successor = successor_entry.tuple;
+	return rc;
+}
+
 void
 generic_memtx_index_begin_build(struct index *index)
 {

--- a/src/box/memtx_index.c
+++ b/src/box/memtx_index.c
@@ -355,22 +355,38 @@ end:
 }
 
 int
-memtx_index_replace(struct index *index, struct tuple *old_tuple,
-		    struct tuple *new_tuple, enum dup_replace_mode mode,
-		    struct tuple **result, struct tuple **successor)
+memtx_index_replace_with_results(struct index *index, struct tuple *old_tuple,
+				 struct tuple *new_tuple,
+				 enum dup_replace_mode mode,
+				 struct tuple **result,
+				 struct tuple **successor)
 {
-	int rc;
 	if (index->def->key_def->is_multikey) {
 		/* MUTLIKEY doesn't support successor for now. */
-		*successor = NULL;
-		return memtx_index_replace_multikey(index, old_tuple, new_tuple,
-						    mode, result);
+		if (successor != NULL)
+			*successor = NULL;
+		struct tuple *replaced;
+		int rc = memtx_index_replace_multikey(index, old_tuple,
+						      new_tuple, mode,
+						      &replaced);
+		if (result != NULL)
+			*result = replaced;
+		return rc;
 	}
 	if (index->def->key_def->for_func_index) {
 		/* Successor will be set only if function is not multikey. */
-		*successor = NULL;
-		return memtx_index_replace_func(index, old_tuple, new_tuple,
-						mode, result, successor);
+		if (successor != NULL)
+			*successor = NULL;
+		struct tuple *replaced;
+		struct tuple *successor_value = NULL;
+		int rc = memtx_index_replace_func(index, old_tuple, new_tuple,
+						  mode, &replaced,
+						  &successor_value);
+		if (result != NULL)
+			*result = replaced;
+		if (successor != NULL)
+			*successor = successor_value;
+		return rc;
 	}
 
 	struct memtx_index_entry old_entry = {
@@ -384,8 +400,10 @@ memtx_index_replace(struct index *index, struct tuple *old_tuple,
 	struct memtx_index_entry result_entry, successor_entry;
 	int rc = memtx_index_replace_impl(index, old_entry, new_entry, mode,
 					  &result_entry, &successor_entry);
-	*result = result_entry.tuple;
-	*successor = successor_entry.tuple;
+	if (result != NULL)
+		*result = result_entry.tuple;
+	if (successor != NULL)
+		*successor = successor_entry.tuple;
 	return rc;
 }
 
@@ -406,7 +424,6 @@ generic_memtx_index_reserve(struct index *index, uint32_t size_hint)
 int
 generic_memtx_index_build_next(struct index *index, struct tuple *tuple)
 {
-	struct tuple *unused;
 	/*
 	 * Note this is not no-op call in case of rtee index:
 	 * reserving 0 bytes is required during rtree recovery.
@@ -414,8 +431,7 @@ generic_memtx_index_build_next(struct index *index, struct tuple *tuple)
 	 */
 	if (memtx_index_reserve(index, 0) != 0)
 		return -1;
-	return memtx_index_replace(index, NULL, tuple, DUP_INSERT, &unused,
-				   &unused);
+	return memtx_index_replace(index, NULL, tuple, DUP_INSERT);
 }
 
 void

--- a/src/box/memtx_index.h
+++ b/src/box/memtx_index.h
@@ -72,11 +72,28 @@ struct memtx_index_vtab {
 	void (*end_build)(struct index *index);
 };
 
-/** Wrapper around `memtx_index_vtab::replace`. */
+/**
+ * Wrapper around `memtx_index_vtab::replace` that collects replaced and
+ * successor tuples.
+ */
 int
+memtx_index_replace_with_results(struct index *index, struct tuple *old_tuple,
+				 struct tuple *new_tuple,
+				 enum dup_replace_mode mode,
+				 struct tuple **result,
+				 struct tuple **successor);
+
+/**
+ * Wrapper around `memtx_index_vtab::replace` that ignores replaced and
+ * successor tuples.
+ */
+static inline int
 memtx_index_replace(struct index *index, struct tuple *old_tuple,
-		    struct tuple *new_tuple, enum dup_replace_mode mode,
-		    struct tuple **result, struct tuple **successor);
+		    struct tuple *new_tuple, enum dup_replace_mode mode)
+{
+	return memtx_index_replace_with_results(index, old_tuple, new_tuple,
+						mode, NULL, NULL);
+}
 
 static inline void
 memtx_index_begin_build(struct index *index)

--- a/src/box/memtx_index.h
+++ b/src/box/memtx_index.h
@@ -6,10 +6,33 @@
 #pragma once
 
 #include "index.h"
+#include "field_map.h"
 
 #if defined(__cplusplus)
 extern "C" {
 #endif /* defined(__cplusplus) */
+
+/**
+ * Generalization of tuple for memtx multikey and functional indexes that allows
+ * to uniquely identify multikey or functional keys.
+ */
+struct memtx_index_entry {
+	/** Tuple for operation. */
+	struct tuple *tuple;
+	/**
+	 * Encoding of key for multikey and functional indexes. For multikey
+	 * indexes it represents the index in the multikey array. For functional
+	 * indexes it represents the pointer to the functional key. For other
+	 * indexes, it is set to `MULTIKEY_NONE`. It is also set to
+	 * `MULTIKEY_NONE` when the `replace` operation only requires the tuple.
+	 */
+	hint_t hint;
+};
+
+static const struct memtx_index_entry memtx_index_entry_null = {
+	.tuple = NULL,
+	.hint = (hint_t)MULTIKEY_NONE,
+};
 
 /** Virtual function table for memtx-specific index operations. */
 struct memtx_index_vtab {
@@ -28,9 +51,11 @@ struct memtx_index_vtab {
 	 * NB: do not use the same object for @a result and @a successor - they
 	 *     are different returned values and implementation can rely on it.
 	 */
-	int (*replace)(struct index *index, struct tuple *old_tuple,
-		       struct tuple *new_tuple, enum dup_replace_mode mode,
-		       struct tuple **result, struct tuple **successor);
+	int (*replace)(struct index *index, struct memtx_index_entry old_entry,
+		       struct memtx_index_entry new_entry,
+		       enum dup_replace_mode mode,
+		       struct memtx_index_entry *result,
+		       struct memtx_index_entry *successor);
 	/**
 	 * Two-phase index creation: begin building, add tuples, finish.
 	 */
@@ -47,15 +72,11 @@ struct memtx_index_vtab {
 	void (*end_build)(struct index *index);
 };
 
-static inline int
+/** Wrapper around `memtx_index_vtab::replace`. */
+int
 memtx_index_replace(struct index *index, struct tuple *old_tuple,
 		    struct tuple *new_tuple, enum dup_replace_mode mode,
-		    struct tuple **result, struct tuple **successor)
-{
-	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
-	return vtab->replace(index, old_tuple, new_tuple, mode, result,
-			     successor);
-}
+		    struct tuple **result, struct tuple **successor);
 
 static inline void
 memtx_index_begin_build(struct index *index)

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -260,13 +260,20 @@ memtx_rtree_index_get_internal(struct index *base, const char *key,
 	return 0;
 }
 
+/** Replace old tuple with new tuple in the index. */
 static int
-memtx_rtree_index_replace(struct index *base, struct tuple *old_tuple,
-			  struct tuple *new_tuple, enum dup_replace_mode mode,
-			  struct tuple **result, struct tuple **successor)
+memtx_rtree_index_replace(struct index *base,
+			  struct memtx_index_entry old_entry,
+			  struct memtx_index_entry new_entry,
+			  enum dup_replace_mode mode,
+			  struct memtx_index_entry *result,
+			  struct memtx_index_entry *successor)
 {
 	(void)mode;
 	struct memtx_rtree_index *index = (struct memtx_rtree_index *)base;
+
+	struct tuple *old_tuple = old_entry.tuple;
+	struct tuple *new_tuple = new_entry.tuple;
 
 	/*
 	 * There's no allocation failure handling in the tree, so it's required
@@ -280,7 +287,8 @@ memtx_rtree_index_replace(struct index *base, struct tuple *old_tuple,
 		return -1;
 
 	/* RTREE index doesn't support ordering. */
-	*successor = NULL;
+	*successor = memtx_index_entry_null;
+	*result = memtx_index_entry_null;
 
 	struct rtree_rect rect;
 	if (new_tuple) {
@@ -294,7 +302,7 @@ memtx_rtree_index_replace(struct index *base, struct tuple *old_tuple,
 		if (!rtree_remove(&index->tree, &rect, old_tuple))
 			old_tuple = NULL;
 	}
-	*result = old_tuple;
+	result->tuple = old_tuple;
 	return 0;
 }
 

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -218,8 +218,9 @@ memtx_space_replace_primary_key(struct space *space, struct tuple *old_tuple,
 				struct tuple **result)
 {
 	struct tuple *successor;
-	if (memtx_index_replace(space->index[0], old_tuple, new_tuple, mode,
-				&old_tuple, &successor) != 0)
+	if (memtx_index_replace_with_results(space->index[0], old_tuple,
+					     new_tuple, mode, &old_tuple,
+					     &successor) != 0)
 		return -1;
 	memtx_space_update_tuple_stat(space, old_tuple, new_tuple);
 	if (new_tuple != NULL)
@@ -1238,15 +1239,12 @@ memtx_build_on_replace_rollback(struct trigger *base, void *event)
 	assert(stmt->old_tuple == NULL ||
 	       memtx_tuple_validate(state->format, stmt->old_tuple) == 0);
 
-	struct tuple *delete = NULL;
-	struct tuple *successor = NULL;
 	/*
 	 * Use DUP_REPLACE_OR_INSERT mode because if we tried to replace a tuple
 	 * with a duplicate at a unique index, this trigger would not be called.
 	 */
 	state->rc = memtx_index_replace(state->index, stmt->new_tuple,
-					stmt->old_tuple, DUP_REPLACE_OR_INSERT,
-					&delete, &successor);
+					stmt->old_tuple, DUP_REPLACE_OR_INSERT);
 	if (state->rc != 0) {
 		diag_move(diag_get(), &state->diag);
 		return 0;
@@ -1304,14 +1302,11 @@ memtx_build_on_replace(struct trigger *trigger, void *event)
 		return 0;
 	}
 
-	struct tuple *delete = NULL;
 	enum dup_replace_mode mode =
 		state->index->def->opts.is_unique ? DUP_INSERT :
 						    DUP_REPLACE_OR_INSERT;
-	struct tuple *successor;
 	state->rc = memtx_index_replace(state->index, stmt->old_tuple,
-					stmt->new_tuple, mode, &delete,
-					&successor);
+					stmt->new_tuple, mode);
 	if (state->rc != 0) {
 		diag_move(diag_get(), &state->diag);
 		return 0;
@@ -1456,14 +1451,9 @@ memtx_space_build_index(struct space *src_space, struct index *new_index,
 		/*
 		 * @todo: better message if there is a duplicate.
 		 */
-		struct tuple *old_tuple;
-		struct tuple *successor;
-		rc = memtx_index_replace(new_index, NULL, tuple, DUP_INSERT,
-					 &old_tuple, &successor);
+		rc = memtx_index_replace(new_index, NULL, tuple, DUP_INSERT);
 		if (rc != 0)
 			break;
-		assert(old_tuple == NULL); /* Guaranteed by DUP_INSERT. */
-		(void) old_tuple;
 		ERROR_INJECT_DOUBLE(ERRINJ_BUILD_INDEX_TIMEOUT, inj->dparam > 0,
 				    thread_sleep(inj->dparam));
 		/*

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1509,45 +1509,93 @@ fail:
 	return -1;
 }
 
+/**
+ * Rollback a failed insertion to the tree.
+ */
+template<bool USE_HINT>
+static void
+memtx_tree_index_insert_rollback(struct memtx_tree_index<USE_HINT> *index,
+				 struct memtx_tree_data<USE_HINT> new_data,
+				 struct memtx_tree_data<USE_HINT> dup_data)
+{
+	VERIFY(memtx_tree_index_delete_impl<USE_HINT>(index, new_data,
+						      NULL) == 0);
+	if (dup_data.tuple != NULL)
+		VERIFY(memtx_tree_index_insert_impl<USE_HINT>(
+			index, dup_data, NULL, NULL) == 0);
+}
+
+/**
+ * Insert new_data, check for duplicate conflicts, and roll back on failure.
+ * If is_multikey_conflict is non-NULL, multikey self-conflict detection is
+ * performed and the result written there; pass NULL to skip that check.
+ */
 template <bool USE_HINT>
 static int
-memtx_tree_index_replace(struct index *base, struct tuple *old_tuple,
-			 struct tuple *new_tuple, enum dup_replace_mode mode,
-			 struct tuple **result, struct tuple **successor)
+memtx_tree_index_insert_and_check_dup(
+	struct memtx_tree_index<USE_HINT> *index, struct tuple *old_tuple,
+	struct tuple *new_tuple, enum dup_replace_mode mode,
+	struct memtx_tree_data<USE_HINT> new_data,
+	struct memtx_index_entry *result, struct memtx_index_entry *successor,
+	bool return_mk_conflict)
+{
+	struct memtx_tree_data<USE_HINT> dup_data, successor_data;
+	dup_data.tuple = NULL;
+	successor_data.tuple = NULL;
+	if (memtx_tree_index_insert_impl(index, new_data, &dup_data,
+					 &successor_data) != 0)
+		return -1;
+	if (dup_data.tuple == new_tuple) {
+		if (return_mk_conflict) {
+			result->tuple = dup_data.tuple;
+			result->hint = dup_data.hint;
+		}
+		return 0;
+	}
+	if (index_check_dup(&index->base, old_tuple, new_tuple,
+			    dup_data.tuple, mode) != 0) {
+		memtx_tree_index_insert_rollback(index, new_data, dup_data);
+		return -1;
+	}
+	if (dup_data.tuple != NULL) {
+		result->tuple = dup_data.tuple;
+		result->hint = dup_data.hint;
+	}
+	successor->tuple = successor_data.tuple;
+	successor->hint = successor_data.hint;
+	return 0;
+}
+
+/** Replace old tuple with new tuple in the index. */
+template<bool USE_HINT>
+static int
+memtx_tree_index_replace(struct index *base,
+			 struct memtx_index_entry old_entry,
+			 struct memtx_index_entry new_entry,
+			 enum dup_replace_mode mode,
+			 struct memtx_index_entry *result,
+			 struct memtx_index_entry *successor)
 {
 	struct memtx_tree_index<USE_HINT> *index =
 		(struct memtx_tree_index<USE_HINT> *)base;
 	struct key_def *key_def = base->def->key_def;
 	struct key_def *cmp_def = memtx_tree_cmp_def(&index->tree);
+	struct tuple *old_tuple = old_entry.tuple;
+	struct tuple *new_tuple = new_entry.tuple;
+	*result = memtx_index_entry_null;
 	if (new_tuple != NULL &&
 	    !tuple_key_is_excluded(new_tuple, key_def, MULTIKEY_NONE)) {
 		struct memtx_tree_data<USE_HINT> new_data;
 		new_data.tuple = new_tuple;
 		if (USE_HINT)
 			new_data.set_hint(tuple_hint(new_tuple, cmp_def));
-		struct memtx_tree_data<USE_HINT> dup_data, suc_data;
-		dup_data.tuple = suc_data.tuple = NULL;
-
-		/* Try to optimistically replace the new_tuple. */
-		if (memtx_tree_index_insert_impl(index, new_data, &dup_data,
-						 &suc_data) != 0)
+		if (memtx_tree_index_insert_and_check_dup(
+				index, old_tuple, new_tuple, mode, new_data,
+				result, successor,
+				/*return_mk_conflict=*/false) != 0)
 			return -1;
-
-		if (index_check_dup(base, old_tuple, new_tuple,
-				    dup_data.tuple, mode) != 0) {
-			VERIFY(memtx_tree_index_delete_impl<USE_HINT>(
-						index, new_data, NULL) == 0);
-			if (dup_data.tuple != NULL)
-				VERIFY(memtx_tree_index_insert_impl<USE_HINT>(
-						index, dup_data, NULL,
-						NULL) == 0);
-			return -1;
-		}
-		*successor = suc_data.tuple;
-		if (dup_data.tuple != NULL) {
-			*result = dup_data.tuple;
+		if (result->tuple != NULL)
 			return 0;
-		}
 	}
 	if (old_tuple != NULL &&
 	    !tuple_key_is_excluded(old_tuple, key_def, MULTIKEY_NONE)) {
@@ -1570,402 +1618,107 @@ memtx_tree_index_replace(struct index *base, struct tuple *old_tuple,
 			}
 			return -1;
 		}
-		*result = old_tuple;
+		result->tuple = old_tuple;
 	} else {
-		*result = NULL;
+		result->tuple = NULL;
 	}
 	return 0;
 }
 
 /**
- * Perform tuple insertion by given multikey index.
- * In case of replacement, all old tuple entries are deleted
- * by all it's multikey indexes.
+ * Delete an old value from the tree.
  */
 static int
-memtx_tree_index_replace_multikey_one(struct memtx_tree_index<true> *index,
-			struct tuple *old_tuple, struct tuple *new_tuple,
-			enum dup_replace_mode mode, hint_t hint,
-			struct memtx_tree_data<true> *replaced_data,
-			struct memtx_tree_data<true> *successor_data,
-			bool *is_multikey_conflict)
+memtx_tree_index_delete_old_value(struct memtx_tree_index<true> *index,
+				  struct memtx_index_entry old_entry,
+				  struct memtx_index_entry *result)
 {
-	struct memtx_tree_data<true> new_data, dup_data;
-	new_data.tuple = new_tuple;
-	new_data.hint = hint;
-	dup_data.tuple = NULL;
-	*is_multikey_conflict = false;
-	if (memtx_tree_index_insert_impl(index, new_data, &dup_data,
-					 successor_data) != 0)
+	struct memtx_tree_data<true> old_data;
+	old_data.tuple = old_entry.tuple;
+	old_data.set_hint(old_entry.hint);
+	struct memtx_tree_data<true> deleted_data;
+	deleted_data.tuple = NULL;
+	if (memtx_tree_index_delete_value_impl<true>(index, old_data,
+						     &deleted_data) != 0)
 		return -1;
-	if (dup_data.tuple == new_tuple) {
-		/*
-		 * When tuple contains the same key multiple
-		 * times, the previous key occurrence is pushed
-		 * out of the index.
-		 */
-		*is_multikey_conflict = true;
-	} else if (index_check_dup(&index->base, old_tuple, new_tuple,
-				   dup_data.tuple, mode) != 0) {
-		/* Rollback replace. */
-		VERIFY(memtx_tree_index_delete_impl<true>(
-				index, new_data, NULL) == 0);
-		if (dup_data.tuple != NULL)
-			VERIFY(memtx_tree_index_insert_impl<true>(
-					index, dup_data, NULL, NULL) == 0);
-		return -1;
+	if (deleted_data.tuple != NULL) {
+		result->tuple = deleted_data.tuple;
+		result->hint = deleted_data.hint;
 	}
-	*replaced_data = dup_data;
 	return 0;
 }
 
 /**
- * Rollback the sequence of memtx_tree_index_replace_multikey_one
- * insertions with multikey indexes [0, err_multikey_idx - 1]
- * where the err_multikey_idx is the first multikey index where
- * error has been raised.
- *
- * This routine can't fail because all replaced_tuple (when
- * specified) nodes in tree are already allocated (they might be
- * overridden with new_tuple, but they definitely present) and
- * delete operation is fault-tolerant.
- */
-static void
-memtx_tree_index_replace_multikey_rollback(struct memtx_tree_index<true> *index,
-			struct tuple *new_tuple, struct tuple *replaced_tuple,
-			int err_multikey_idx)
-{
-	struct key_def *key_def = index->base.def->key_def;
-	struct memtx_tree_data<true> data;
-	if (replaced_tuple != NULL) {
-		/* Restore replaced tuple index occurrences. */
-		struct key_def *cmp_def = memtx_tree_cmp_def(&index->tree);
-		data.tuple = replaced_tuple;
-		uint32_t multikey_count =
-			tuple_multikey_count(replaced_tuple, cmp_def);
-		for (int i = 0; (uint32_t) i < multikey_count; i++) {
-			if (tuple_key_is_excluded(replaced_tuple, key_def, i))
-				continue;
-			data.hint = i;
-			VERIFY(memtx_tree_index_insert_impl<true>(
-					index, data, NULL, NULL) == 0);
-		}
-	}
-	if (new_tuple == NULL)
-		return;
-	/*
-	 * Rollback new_tuple insertion by multikey index
-	 * [0, multikey_idx).
-	 */
-	data.tuple = new_tuple;
-	for (int i = 0; i < err_multikey_idx; i++) {
-		if (tuple_key_is_excluded(new_tuple, key_def, i))
-			continue;
-		data.hint = i;
-		VERIFY(memtx_tree_index_delete_value_impl<true>(
-					index, data, NULL) == 0);
-	}
-}
-
-/**
- * :replace() function for a multikey index: replace old tuple
- * index entries with ones from the new tuple.
- *
- * In a multikey index a single tuple is associated with 0..N keys
- * of the b+*tree. Imagine old tuple key set is called "old_keys"
- * and a new tuple set is called "new_keys". This function must
- * 1) delete all removed keys: (new_keys - old_keys)
- * 2) update tuple pointer in all preserved keys: (old_keys ^ new_keys)
- * 3) insert data for all new keys (new_keys - old_keys).
- *
- * Compare with a standard unique or non-unique index, when a key
- * is present only once, so whenever we encounter a duplicate, it
- * is guaranteed to point at the old tuple (in non-unique indexes
- * we augment the secondary key parts with primary key parts, so
- * b+*tree still contains unique entries only).
- *
- * To reduce the number of insert and delete operations on the
- * tree, this function attempts to optimistically add all keys
- * from the new tuple to the tree first.
- *
- * When this step finds a duplicate, it's either of the following:
- * - for a unique multikey index, it may be the old tuple or
- *   some other tuple. Since unique index forbids duplicates,
- *   this branch ends with an error unless we found the old tuple.
- * - for a non-unique multikey index, both secondary and primary
- *   key parts must match, so it's guaranteed to be the old tuple.
- *
- * In other words, when an optimistic insert finds a duplicate,
- * it's either an error, in which case we roll back all the new
- * keys from the tree and abort the procedure, or the old tuple,
- * which we save to get back to, later.
- *
- * When adding new keys finishes, we have completed steps
- * 2) and 3):
- * - added set (new_keys - old_keys) to the index
- * - updated set (new_keys ^ old_keys) with a new tuple pointer.
- *
- * We now must perform 1), which is remove (old_keys - new_keys).
- *
- * This is done by using the old tuple pointer saved from the
- * previous step. To not accidentally delete the common key
- * set of the old and the new tuple, we don't using key parts alone
- * to compare - we also look at b+* tree value that has the tuple
- * pointer, and delete old tuple entries only.
+ * Common replace logic for regular and functional multikey tree index variants.
  */
 static int
-memtx_tree_index_replace_multikey(struct index *base, struct tuple *old_tuple,
-			struct tuple *new_tuple, enum dup_replace_mode mode,
-			struct tuple **result, struct tuple **successor)
+memtx_tree_index_replace_multikey_impl(struct index *base,
+				       struct memtx_index_entry old_entry,
+				       struct memtx_index_entry new_entry,
+				       enum dup_replace_mode mode,
+				       struct memtx_index_entry *result,
+				       struct memtx_index_entry *successor,
+				       bool check_if_excluded,
+				       bool return_mk_conflict)
 {
 	struct memtx_tree_index<true> *index =
 		(struct memtx_tree_index<true> *)base;
-
-	/* MUTLIKEY doesn't support successor for now. */
-	*successor = NULL;
-
 	struct key_def *key_def = base->def->key_def;
-	struct key_def *cmp_def = memtx_tree_cmp_def(&index->tree);
-	*result = NULL;
-	if (new_tuple != NULL) {
-		int multikey_idx = 0, err = 0;
-		uint32_t multikey_count =
-			tuple_multikey_count(new_tuple, cmp_def);
-		for (; (uint32_t) multikey_idx < multikey_count;
-		     multikey_idx++) {
-			if (tuple_key_is_excluded(new_tuple, key_def,
-						  multikey_idx))
-				continue;
-			bool is_multikey_conflict;
-			struct memtx_tree_data<true> replaced_data;
-			err = memtx_tree_index_replace_multikey_one(index,
-						old_tuple, new_tuple, mode,
-						multikey_idx, &replaced_data,
-						NULL, &is_multikey_conflict);
-			if (err != 0)
-				break;
-			if (replaced_data.tuple != NULL &&
-			    !is_multikey_conflict) {
-				assert(*result == NULL ||
-				       *result == replaced_data.tuple);
-				*result = replaced_data.tuple;
-			}
-		}
-		if (err != 0) {
-			memtx_tree_index_replace_multikey_rollback(index,
-					new_tuple, *result, multikey_idx);
+	struct tuple *old_tuple = old_entry.tuple;
+	struct tuple *new_tuple = new_entry.tuple;
+	if (new_tuple != NULL && (!check_if_excluded ||
+				  !tuple_key_is_excluded(new_tuple, key_def,
+							 new_entry.hint))) {
+		struct memtx_tree_data<true> new_data;
+		new_data.tuple = new_tuple;
+		new_data.set_hint(new_entry.hint);
+		if (memtx_tree_index_insert_and_check_dup(
+				index, old_tuple, new_tuple, mode, new_data,
+				result, successor, return_mk_conflict) != 0)
 			return -1;
-		}
-		if (*result != NULL) {
-			assert(old_tuple == NULL || old_tuple == *result);
-			old_tuple = *result;
-		}
 	}
-	if (old_tuple != NULL) {
-		struct memtx_tree_data<true> data;
-		data.tuple = old_tuple;
-		uint32_t multikey_count =
-			tuple_multikey_count(old_tuple, cmp_def);
-		for (int i = 0; (uint32_t) i < multikey_count; i++) {
-			if (tuple_key_is_excluded(old_tuple, key_def, i))
-				continue;
-			data.hint = i;
-			if (memtx_tree_index_delete_value_impl<true>(
-					index, data, NULL) != 0) {
-				uint32_t multikey_count = 0;
-				if (new_tuple != 0)
-					multikey_count =
-						tuple_multikey_count(new_tuple,
-								     cmp_def);
-				memtx_tree_index_replace_multikey_rollback(
-					index, new_tuple, old_tuple,
-					multikey_count);
-				return -1;
-			}
-		}
-		*result = old_tuple;
-	}
+	if (new_tuple != NULL)
+		return 0;
+	if (old_tuple != NULL && (!check_if_excluded ||
+				  !tuple_key_is_excluded(old_tuple, key_def,
+							 old_entry.hint)))
+		return memtx_tree_index_delete_old_value(index, old_entry,
+							 result);
 	return 0;
 }
 
 /**
- * An undo entry for multikey functional index replace operation.
- * Used to roll back a failed insert/replace and restore the
- * original key_hint(s) and to commit a completed insert/replace
- * and destruct old tuple key_hint(s).
-*/
-struct func_key_undo {
-	/** A link to organize entries in list. */
-	struct rlist link;
-	/** An inserted record copy. */
-	struct memtx_tree_data<true> key;
-};
-
-/**
- * Rollback a sequence of memtx_tree_index_replace_multikey_one
- * insertions for functional index. Routine uses given list to
- * return a given index object in it's original state.
+ * Replace logic for the regular (cf. functional) multikey tree index variant.
  */
-static void
-memtx_tree_func_index_replace_rollback(struct memtx_tree_index<true> *index,
-				       struct rlist *old_keys,
-				       struct rlist *new_keys)
+static int
+memtx_tree_index_replace_multikey(struct index *base,
+				  struct memtx_index_entry old_entry,
+				  struct memtx_index_entry new_entry,
+				  enum dup_replace_mode mode,
+				  struct memtx_index_entry *result,
+				  struct memtx_index_entry *successor)
 {
-	struct func_key_undo *entry;
-	rlist_foreach_entry(entry, new_keys, link) {
-		VERIFY(memtx_tree_index_delete_value_impl<true>(
-					index, entry->key, NULL) == 0);
-		tuple_unref((struct tuple *)entry->key.hint);
-	}
-	rlist_foreach_entry(entry, old_keys, link)
-		VERIFY(memtx_tree_index_insert_impl<true>(
-				index, entry->key, NULL, NULL) == 0);
+	*result = memtx_index_entry_null;
+	return memtx_tree_index_replace_multikey_impl(
+		base, old_entry, new_entry, mode, result, successor,
+		/*check_if_excluded=*/true, /*return_mk_conflict=*/false);
 }
 
 /**
- * @sa memtx_tree_index_replace_multikey().
- * Use the functional index function from the key definition
- * to build a key list. Then each returned key is reallocated in
- * engine's memory as key_hint object and is used as comparison
- * hint.
- * To release key_hint memory in case of replace failure
- * we use a list of undo records which are allocated on region.
- * It is used to restore the original b+* entries with their
- * original key_hint(s) pointers in case of failure and release
- * the now useless hints of old items in case of success.
+ * Replace logic for the functional (multikey) tree index variant.
  */
 static int
-memtx_tree_func_index_replace(struct index *base, struct tuple *old_tuple,
-			struct tuple *new_tuple, enum dup_replace_mode mode,
-			struct tuple **result, struct tuple **successor)
+memtx_tree_func_index_replace(struct index *base,
+			      struct memtx_index_entry old_entry,
+			      struct memtx_index_entry new_entry,
+			      enum dup_replace_mode mode,
+			      struct memtx_index_entry *result,
+			      struct memtx_index_entry *successor)
 {
-	/* The successor will be set only if the function is not multikey. */
-	*successor = NULL;
-
-	struct memtx_engine *memtx = (struct memtx_engine *)base->engine;
-	struct memtx_tree_index<true> *index =
-		(struct memtx_tree_index<true> *)base;
-	struct index_def *index_def = index->base.def;
-	assert(index_def->key_def->for_func_index);
-	/* Make sure that key_def is not multikey - we rely on it below. */
-	assert(!index_def->key_def->is_multikey);
-
-	int rc = -1;
-	struct region *region = &fiber()->gc;
-	size_t region_svp = region_used(region);
-
-	*result = NULL;
-	struct key_list_iterator it;
-	struct rlist old_keys, new_keys;
-	rlist_create(&old_keys);
-	rlist_create(&new_keys);
-	if (new_tuple != NULL) {
-		if (key_list_iterator_create(&it, new_tuple, index_def, true,
-					     memtx->func_key_format) != 0)
-			goto end;
-		int err = 0;
-		struct tuple *key;
-		struct func_key_undo *undo;
-		struct key_def *key_def = index_def->key_def;
-		while ((err = key_list_iterator_next(&it, &key)) == 0 &&
-			key != NULL) {
-			/* Save functional key to MVCC, even excluded one. */
-			memtx_tx_save_func_key(new_tuple, base, key);
-			if (tuple_key_is_excluded(key, key_def, MULTIKEY_NONE))
-				continue;
-			/* Perform insertion, log it in list. */
-			undo = xregion_alloc_object(region, typeof(*undo));
-			tuple_ref(key);
-			undo->key.tuple = new_tuple;
-			undo->key.hint = (hint_t)key;
-			rlist_add(&new_keys, &undo->link);
-			bool is_multikey_conflict;
-			struct memtx_tree_data<true> old_data, successor_data;
-			old_data.tuple = NULL;
-			successor_data.tuple = NULL;
-			err = memtx_tree_index_replace_multikey_one(index,
-						old_tuple, new_tuple,
-						mode, (hint_t)key, &old_data,
-						&successor_data,
-						&is_multikey_conflict);
-			if (err != 0)
-				break;
-			if (!it.func_is_multikey)
-				*successor = successor_data.tuple;
-			if (old_data.tuple != NULL && !is_multikey_conflict) {
-				undo = xregion_alloc_object(region,
-							    typeof(*undo));
-				undo->key = old_data;
-				rlist_add(&old_keys, &undo->link);
-				*result = old_data.tuple;
-			} else if (old_data.tuple != NULL &&
-				   is_multikey_conflict) {
-				/*
-				 * Remove the replaced tuple undo
-				 * from undo list.
-				 */
-				tuple_unref((struct tuple *)old_data.hint);
-				rlist_foreach_entry(undo, &new_keys, link) {
-					if (undo->key.hint == old_data.hint) {
-						rlist_del(&undo->link);
-						break;
-					}
-				}
-			}
-		}
-		if (key != NULL || err != 0) {
-			memtx_tree_func_index_replace_rollback(index,
-						&old_keys, &new_keys);
-			goto end;
-		}
-		if (*result != NULL) {
-			assert(old_tuple == NULL || old_tuple == *result);
-			old_tuple = *result;
-		}
-	}
-	if (old_tuple != NULL) {
-		/*
-		 * Use the runtime format to avoid OOM while deleting a tuple
-		 * from a space. It's okay, because we are not going to store
-		 * the keys in the index.
-		 */
-		if (key_list_iterator_create(&it, old_tuple, index_def, false,
-					     tuple_format_runtime) != 0)
-			goto end;
-		struct memtx_tree_data<true> data, deleted_data;
-		data.tuple = old_tuple;
-		struct tuple *key;
-		while (key_list_iterator_next(&it, &key) == 0 && key != NULL) {
-			data.hint = (hint_t) key;
-			deleted_data.tuple = NULL;
-			if (memtx_tree_index_delete_value_impl(
-					index, data, &deleted_data) != 0) {
-				memtx_tree_func_index_replace_rollback(
-					index, &old_keys, &new_keys);
-				return -1;
-			}
-			if (deleted_data.tuple != NULL) {
-				*result = old_tuple;
-				struct func_key_undo *undo =
-					xregion_alloc_object(region,
-							     typeof(*undo));
-				undo->key = deleted_data;
-				rlist_add(&old_keys, &undo->link);
-			}
-		}
-		assert(key == NULL);
-	}
-	/*
-	 * Commit changes: release hints for
-	 * replaced entries.
-	 */
-	struct func_key_undo *undo;
-	rlist_foreach_entry(undo, &old_keys, link)
-		tuple_unref((struct tuple *)undo->key.hint);
-	rc = 0;
-end:
-	region_truncate(region, region_svp);
-	return rc;
+	*result = memtx_index_entry_null;
+	return memtx_tree_index_replace_multikey_impl(
+		base, old_entry, new_entry, mode, result, successor,
+		/*check_if_excluded=*/false, /*return_mk_conflict=*/true);
 }
 
 template <bool USE_HINT>
@@ -2319,18 +2072,19 @@ memtx_tree_disabled_index_build_next(struct index *index, struct tuple *tuple)
 }
 
 static int
-memtx_tree_disabled_index_replace(struct index *index, struct tuple *old_tuple,
-				  struct tuple *new_tuple,
+memtx_tree_disabled_index_replace(struct index *index,
+				  struct memtx_index_entry old_entry,
+				  struct memtx_index_entry new_entry,
 				  enum dup_replace_mode mode,
-				  struct tuple **result,
-				  struct tuple **successor)
+				  struct memtx_index_entry *result,
+				  struct memtx_index_entry *successor)
 {
 	(void)index;
-	(void)old_tuple;
-	(void)new_tuple;
+	(void)old_entry;
+	(void)new_entry;
 	(void)mode;
-	*result = NULL;
-	*successor = NULL;
+	*result = memtx_index_entry_null;
+	*successor = memtx_index_entry_null;
 	return 0;
 }
 

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -1395,8 +1395,10 @@ memtx_tx_story_link_top(struct memtx_story *new_top,
 		/* Make the change in index. */
 		struct index *index = old_link->in_index;
 		struct tuple *removed, *unused;
-		if (memtx_index_replace(index, old_top->tuple, new_top->tuple,
-					DUP_REPLACE, &removed, &unused) != 0) {
+		if (memtx_index_replace_with_results(index, old_top->tuple,
+						     new_top->tuple,
+						     DUP_REPLACE, &removed,
+						     &unused) != 0) {
 			diag_log();
 			unreachable();
 			panic("failed to rebind story in index");
@@ -1583,10 +1585,10 @@ memtx_tx_story_full_unlink_story_gc_step(struct memtx_story *story)
 			if (story->del_psn > 0 && link->in_index != NULL) {
 				struct index *index = link->in_index;
 				struct tuple *removed, *unused;
-				if (memtx_index_replace(index, story->tuple,
-							NULL, DUP_INSERT,
-							&removed,
-							&unused) != 0) {
+				if (memtx_index_replace_with_results(
+						index, story->tuple, NULL,
+						DUP_INSERT, &removed,
+						&unused) != 0) {
 					diag_log();
 					unreachable();
 					panic("failed to rollback change");
@@ -2490,10 +2492,10 @@ memtx_tx_add_stmt(struct space *space, struct tuple *old_tuple,
 	 * defer conflict resolution to `memtx_tx_add_insert_stmt`.
 	 */
 	uint32_t i = 0;
-	if (memtx_index_replace(pk, use_mvcc ? NULL : old_tuple, new_tuple,
-				use_mvcc ? DUP_REPLACE_OR_INSERT : mode,
-				&directly_replaced[i],
-				&direct_successor[i]) != 0)
+	if (memtx_index_replace_with_results(
+			pk, use_mvcc ? NULL : old_tuple, new_tuple,
+			use_mvcc ? DUP_REPLACE_OR_INSERT : mode,
+			&directly_replaced[i], &direct_successor[i]) != 0)
 		goto rollback;
 	assert(directly_replaced[i] || new_tuple);
 
@@ -2509,13 +2511,12 @@ memtx_tx_add_stmt(struct space *space, struct tuple *old_tuple,
 	 */
 	for (i++; i < space->index_count; i++) {
 		struct index *index = space->index[i];
-		if (memtx_index_replace(index,
-					use_mvcc ? NULL : directly_replaced[0],
-					new_tuple,
-					use_mvcc ? DUP_REPLACE_OR_INSERT
-						: DUP_INSERT,
-					&directly_replaced[i],
-					&direct_successor[i]) != 0)
+		if (memtx_index_replace_with_results(
+				index, use_mvcc ? NULL : directly_replaced[0],
+				new_tuple,
+				use_mvcc ? DUP_REPLACE_OR_INSERT : DUP_INSERT,
+				&directly_replaced[i],
+				&direct_successor[i]) != 0)
 			goto rollback;
 	}
 
@@ -2549,12 +2550,10 @@ rollback:
 	 * Rollback index changes.
 	 */
 	for (; i > 0; i--) {
-		struct tuple *delete;
-		struct tuple *successor;
 		struct index *index = space->index[i - 1];
 		if (memtx_index_replace(index, new_tuple,
-					directly_replaced[i - 1], DUP_INSERT,
-					&delete, &successor) != 0) {
+					directly_replaced[i - 1],
+					DUP_INSERT) != 0) {
 			diag_log();
 			unreachable();
 			panic("failed to rollback change");
@@ -2872,10 +2871,9 @@ memtx_tx_history_rollback_empty_stmt(struct txn_stmt *stmt)
 	    (old_tuple == NULL && new_tuple == NULL))
 		return;
 	for (size_t i = 0; i < stmt->space->index_count; i++) {
-		struct tuple *unused;
 		if (memtx_index_replace(stmt->space->index[i], new_tuple,
-					old_tuple, DUP_REPLACE_OR_INSERT,
-					&unused, &unused) != 0) {
+					old_tuple,
+					DUP_REPLACE_OR_INSERT) != 0) {
 			panic("failed to rebind story in index on "
 			      "rollback of statement without story");
 		}
@@ -3547,10 +3545,8 @@ memtx_tx_invalidate_space(struct space *space, struct txn *ddl_owner)
 			if (new_tuple == story->tuple)
 				continue;
 
-			struct tuple *unused;
 			if (memtx_index_replace(index, story->tuple, new_tuple,
-						DUP_REPLACE, &unused,
-						&unused) != 0) {
+						DUP_REPLACE) != 0) {
 				diag_log();
 				unreachable();
 				panic("failed to rebind story in index on "


### PR DESCRIPTION
This patchset refactors memtx index `replace` code to simplify implementation of #6385.

Closes #12386
Closes #12387