### PR TITLE
http: route libcurl verbose logs to Tarantool log

### DIFF
--- a/changelogs/unreleased/gh-12392-libcurl-verbose-log.md
+++ b/changelogs/unreleased/gh-12392-libcurl-verbose-log.md
@@ -1,0 +1,4 @@
+## feature/log
+
+* With the `verbose` option enabled in `http.client`, libcurl debug logs
+  are now routed to the Tarantool log instead of stderr (gh-12392).

--- a/src/httpc.c
+++ b/src/httpc.c
@@ -36,6 +36,7 @@
 #include "tt_static.h"
 #include "fiber.h"
 #include "errinj.h"
+#include "say.h"
 
 #define MAX_HEADER_LEN 8192
 
@@ -128,6 +129,68 @@ curl_easy_header_cb(char *buffer, size_t size, size_t nitems, void *ctx)
 	}
 	memcpy(p, buffer, bytes);
 	return bytes;
+}
+
+/** Log a single libcurl debug line after trimming trailing CRLF. */
+static void
+httpc_log_libcurl_line(char prefix, const char *data, size_t size)
+{
+	while (size > 0 && (data[size - 1] == '\n' || data[size - 1] == '\r'))
+		--size;
+	say_file_line(S_INFO, NULL, 0, NULL, "libcurl: %c %.*s", prefix,
+		      (int)size, data);
+}
+
+/**
+ * libcurl callback for CURLOPT_DEBUGFUNCTION.
+ * @see https://curl.se/libcurl/c/CURLOPT_DEBUGFUNCTION.html
+ */
+static int
+curl_easy_debug_cb(CURL *easy, curl_infotype type, char *data, size_t size,
+		   void *userptr)
+{
+	(void)easy;
+	(void)userptr;
+
+	switch (type) {
+	case CURLINFO_TEXT:
+	case CURLINFO_HEADER_IN:
+	case CURLINFO_HEADER_OUT: {
+		char prefix = type == CURLINFO_TEXT ? '*' :
+			      type == CURLINFO_HEADER_IN ? '<' :
+			      '>';
+
+		while (size > 0) {
+			char *line_end = memchr(data, '\n', size);
+			size_t line_size = line_end == NULL ? size :
+					   (size_t)(line_end - data + 1);
+			httpc_log_libcurl_line(prefix, data, line_size);
+			data += line_size;
+			size -= line_size;
+		}
+		break;
+	}
+	case CURLINFO_DATA_IN:
+		say_file_line(S_INFO, NULL, 0, NULL,
+			      "libcurl: < [%zu bytes data]", size);
+		break;
+	case CURLINFO_DATA_OUT:
+		say_file_line(S_INFO, NULL, 0, NULL,
+			      "libcurl: > [%zu bytes data]", size);
+		break;
+	case CURLINFO_SSL_DATA_IN:
+		say_file_line(S_INFO, NULL, 0, NULL,
+			      "libcurl: < [%zu bytes ssl data]", size);
+		break;
+	case CURLINFO_SSL_DATA_OUT:
+		say_file_line(S_INFO, NULL, 0, NULL,
+			      "libcurl: > [%zu bytes ssl data]", size);
+		break;
+	default:
+		break;
+	}
+
+	return 0;
 }
 
 int
@@ -355,6 +418,8 @@ httpc_set_low_speed_limit(struct httpc_request *req, long low_speed_limit)
 void
 httpc_set_verbose(struct httpc_request *req, bool curl_verbose)
 {
+	curl_easy_setopt(req->curl_request.easy, CURLOPT_DEBUGFUNCTION,
+			 curl_easy_debug_cb);
 	curl_easy_setopt(req->curl_request.easy, CURLOPT_VERBOSE,
 			 (long) curl_verbose);
 }

--- a/test/app-luatest/http_client_http_version_test.lua
+++ b/test/app-luatest/http_client_http_version_test.lua
@@ -1,11 +1,11 @@
--- This tests are using treegen to catch information about protocol version
--- by catching stderr. Treegen creates and tracks temporary directories, where
--- scripts with testing workloads reside.
+-- These tests use treegen to run a separate tarantool process and check
+-- libcurl verbose output in Tarantool log.
 
 local t = require('luatest')
 local treegen = require('luatest.treegen')
 local justrun = require('luatest.justrun')
 local socket = require('socket')
+local fio = require('fio')
 
 local wrong_version_group = t.group()
 
@@ -54,10 +54,14 @@ http_version_group.after_each(function(g)
 end)
 
 local http_request_script = string.dump(function()
+    local log = require('log')
     local http_client = require('http.client').new()
     local proto = os.getenv('PROTO')
     local port = os.getenv('HTTP_SERVER_PORT')
     local uri = proto .. '://127.0.0.1:' .. port
+
+    log.cfg({log = 'tarantool.log'})
+
     local ok = pcall(http_client.get, http_client, uri, {
         verbose = true,
         http_version = os.getenv('HTTP_VERSION'),
@@ -76,9 +80,15 @@ http_version_group.test_http_version = function(g)
     local env = {HTTP_SERVER_PORT = g.server:name().port}
     env.PROTO = g.params.proto
     env.HTTP_VERSION = g.params.version
-    local res = justrun.tarantool(dir, env, args, opts)
+    justrun.tarantool(dir, env, args, opts)
+
+    local log_path = fio.pathjoin(dir, 'tarantool.log')
+    local log_file = fio.open(log_path)
+    t.assert_not_equals(log_file, nil)
+    local log_data = log_file:read()
+    log_file:close()
     local exp = expected[tostring(g.params.version)][g.params.proto]
-    t.assert_str_contains(res.stderr, exp)
+    t.assert_str_contains(log_data, exp)
 end
 
 wrong_version_group.test_request_wrong_http_version = function()


### PR DESCRIPTION
This patch routes libcurl debug output produced by the `verbose` option in `http.client` through the Tarantool logging system instead of writing it to stderr.

Closes #12392

NO_DOC=internal logging change