### PR TITLE
vinyl: fix `vinyl_memory` overrun on recovery

### DIFF
--- a/changelogs/unreleased/gh-12390-vinyl-recovery-memory-limit.md
+++ b/changelogs/unreleased/gh-12390-vinyl-recovery-memory-limit.md
@@ -1,0 +1,4 @@
+## bugfix/vinyl
+
+* Fixed `vinyl_memory` overrun during recovery when the memory limit is lower than
+  at the previous start (gh-12390).

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -857,7 +857,7 @@ vinyl_index_commit_create(struct index *index, int64_t lsn)
 	 */
 	vy_log_tx_begin();
 	vy_log_create_lsm(lsm->id, lsn);
-	vy_log_tx_try_commit();
+	vy_log_tx_try_commit_recoverable();
 }
 
 static void
@@ -912,7 +912,7 @@ vinyl_index_commit_modify(struct index *index, int64_t lsn)
 
 	vy_log_tx_begin();
 	vy_log_modify_lsm(lsm->id, lsm->key_def, lsn);
-	vy_log_tx_try_commit();
+	vy_log_tx_try_commit_recoverable();
 }
 
 static void
@@ -936,7 +936,7 @@ vinyl_index_commit_drop(struct index *index, int64_t lsn)
 
 	vy_log_tx_begin();
 	vy_log_drop_lsm(lsm->id, lsn);
-	vy_log_tx_try_commit();
+	vy_log_tx_try_commit_recoverable();
 }
 
 static void
@@ -2814,18 +2814,6 @@ vy_env_delete(struct vy_env *e)
 	free(e);
 }
 
-/**
- * Called upon local recovery completion to enable memory quota
- * and start the scheduler.
- */
-static void
-vy_env_complete_recovery(struct vy_env *env)
-{
-	vy_scheduler_start(&env->scheduler);
-	vy_quota_enable(&env->quota);
-	vy_regulator_start(&env->regulator);
-}
-
 struct engine *
 vinyl_engine_new(const char *dir, size_t memory,
 		 int read_threads, int write_threads, bool force_recovery)
@@ -3004,8 +2992,10 @@ vinyl_engine_bootstrap(struct engine *engine)
 	assert(e->status == VINYL_OFFLINE);
 	if (vy_log_bootstrap() != 0)
 		return -1;
-	vy_env_complete_recovery(e);
 	e->status = VINYL_ONLINE;
+	vy_scheduler_start(&e->scheduler);
+	vy_quota_enable(&e->quota);
+	vy_regulator_start(&e->regulator);
 	return 0;
 }
 
@@ -3023,25 +3013,16 @@ vinyl_engine_begin_initial_recovery(struct engine *engine,
 						    e->force_recovery);
 		if (e->recovery == NULL)
 			return -1;
-		/*
-		 * We can't schedule any background tasks until
-		 * local recovery is complete, because they would
-		 * disrupt yet to be recovered data stored on disk.
-		 * So we don't start the scheduler fiber or enable
-		 * memory limit until then.
-		 *
-		 * This is OK, because during recovery an instance
-		 * can't consume more memory than it used before
-		 * restart and hence memory dumps are not necessary.
-		 */
 		e->status = VINYL_INITIAL_RECOVERY_LOCAL;
 	} else {
 		if (vy_log_bootstrap() != 0)
 			return -1;
-		vy_env_complete_recovery(e);
 		e->status = VINYL_INITIAL_RECOVERY_REMOTE;
 		e->run_env.initial_join = true;
 	}
+	vy_scheduler_start(&e->scheduler);
+	vy_quota_enable(&e->quota);
+	vy_regulator_start(&e->regulator);
 	return 0;
 }
 
@@ -3116,7 +3097,6 @@ vinyl_engine_end_recovery(struct engine *engine)
 		 */
 		e->xm->lsn = vclock_sum(e->recovery_vclock);
 		e->recovery_vclock = NULL;
-		vy_env_complete_recovery(e);
 		break;
 	case VINYL_FINAL_RECOVERY_REMOTE:
 		break;

--- a/src/box/vy_log.c
+++ b/src/box/vy_log.c
@@ -847,12 +847,7 @@ vy_log_flusher_f(va_list va)
 	(void)va;
 	while (!fiber_is_cancelled()) {
 		fiber_check_gc();
-		/*
-		 * Disable writes during local recovery.
-		 * See vy_log_tx_commit().
-		 */
-		if (vy_log.recovery != NULL ||
-		    stailq_empty(&vy_log.pending_tx)) {
+		if (stailq_empty(&vy_log.pending_tx)) {
 			fiber_cond_wait(&vy_log.flusher_cond);
 			continue;
 		}
@@ -1147,17 +1142,6 @@ vy_log_end_recovery(void)
 {
 	assert(vy_log.recovery != NULL);
 
-	/*
-	 * Update the recovery context with records written during
-	 * recovery - we will need them for garbage collection.
-	 */
-	struct vy_log_tx *tx;
-	stailq_foreach_entry(tx, &vy_log.pending_tx, in_pending) {
-		struct vy_log_record *record;
-		stailq_foreach_entry(record, &tx->records, in_tx)
-			vy_recovery_process_record(vy_log.recovery, record);
-	}
-
 	/* Flush all pending records. */
 	if (vy_log_flush() < 0) {
 		diag_log();
@@ -1299,17 +1283,6 @@ vy_log_tx_begin(void)
 int
 vy_log_tx_commit(void)
 {
-	/*
-	 * During recovery, we may replay records we failed to commit
-	 * before restart (e.g. drop LSM tree). Since the log isn't open
-	 * yet, simply leave them in the tx buffer to be flushed upon
-	 * recovery completion.
-	 */
-	if (vy_log.recovery != NULL) {
-		vy_log_tx_try_commit();
-		return 0;
-	}
-
 	struct vy_log_tx *tx = vy_log.tx;
 	vy_log.tx = NULL;
 	assert(tx != NULL);
@@ -1342,6 +1315,19 @@ vy_log_tx_try_commit(void)
 	fiber_cond_signal(&vy_log.flusher_cond);
 	vy_log.tx = NULL;
 	say_verbose("commit vylog transaction");
+}
+
+void
+vy_log_tx_try_commit_recoverable(void)
+{
+	assert(vy_log.tx != NULL);
+	if (vy_log.recovery != NULL) {
+		struct vy_log_record *record;
+		stailq_foreach_entry(record, &vy_log.tx->records, in_tx)
+			VERIFY(vy_recovery_process_record(vy_log.recovery,
+							  record) == 0);
+	}
+	vy_log_tx_try_commit();
 }
 
 void

--- a/src/box/vy_log.h
+++ b/src/box/vy_log.h
@@ -536,6 +536,17 @@ void
 vy_log_tx_try_commit(void);
 
 /**
+ * Similar vy_log_tx_try_commit() but additionally updates recovery
+ * context during recovery (see vy_log_begin_recovery()), fixing
+ * it with records we fail to save on previous starts.
+ *
+ * It is expected to be called when missing vy_log changes can be recovered
+ * from xlog.
+ */
+void
+vy_log_tx_try_commit_recoverable(void);
+
+/**
  * Write a record to the metadata log.
  *
  * This function simply appends the record to the internal buffer.

--- a/src/box/vy_lsm.c
+++ b/src/box/vy_lsm.c
@@ -329,7 +329,7 @@ vy_lsm_create(struct vy_lsm *lsm)
 	vy_log_prepare_lsm(id, lsm->space_id, lsm->index_id,
 			   lsm->group_id, lsm->key_def);
 	vy_log_insert_range(id, range->id, NULL, NULL);
-	vy_log_tx_try_commit();
+	vy_log_tx_try_commit_recoverable();
 
 	/* Assign the id. */
 	assert(lsm->id < 0);

--- a/src/box/vy_scheduler.c
+++ b/src/box/vy_scheduler.c
@@ -1091,6 +1091,9 @@ vy_task_write_run(struct vy_task *task, bool no_compression)
 	struct vy_lsm *lsm = task->lsm;
 	struct vy_stmt_stream *wi = task->wi;
 
+	ERROR_INJECT_COUNTDOWN(ERRINJ_VY_RUN_WRITE_CRASH_COUNTDOWN, {
+		panic("injected crash");
+	});
 	ERROR_INJECT(ERRINJ_VY_RUN_WRITE,
 		     {diag_set(ClientError, ER_INJECTION,
 			       "vinyl dump"); return -1;});

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -184,6 +184,7 @@ struct errinj {
 	_(ERRINJ_VY_RUN_FILE_RENAME, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VY_RUN_RECOVER_COUNTDOWN, ERRINJ_INT, {.iparam = -1})\
 	_(ERRINJ_VY_RUN_WRITE, ERRINJ_BOOL, {.bparam = false}) \
+	_(ERRINJ_VY_RUN_WRITE_CRASH_COUNTDOWN, ERRINJ_INT, {.iparam = -1}) \
 	_(ERRINJ_VY_RUN_WRITE_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_VY_RUN_WRITE_STMT_TIMEOUT, ERRINJ_DOUBLE, {.dparam = 0}) \
 	_(ERRINJ_VY_SCHED_TIMEOUT, ERRINJ_DOUBLE, {.dparam = 0}) \

--- a/test/unit/vy_log_stub.c
+++ b/test/unit/vy_log_stub.c
@@ -45,6 +45,9 @@ vy_log_tx_begin(void) {}
 void
 vy_log_tx_try_commit(void) {}
 
+void
+vy_log_tx_try_commit_recoverable(void) {}
+
 int
 vy_log_tx_commit(void)
 {

--- a/test/vinyl-luatest/gh_12390_memory_limit_on_recovery_test.lua
+++ b/test/vinyl-luatest/gh_12390_memory_limit_on_recovery_test.lua
@@ -1,0 +1,171 @@
+local server = require('luatest.server')
+local fio = require('fio')
+local t = require('luatest')
+
+local g = t.group()
+
+g.after_each(function(cg)
+    if cg.server ~= nil then
+        cg.server:drop()
+    end
+end)
+
+g.test_recovery_memory_limit = function(cg)
+    cg.server = server:new({box_cfg = {vinyl_memory = 10 * 1024 * 1024}})
+    cg.server:start()
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.schema.create_space('test', {engine = 'vinyl'})
+        s:create_index('pk')
+
+        box.error.injection.set('ERRINJ_VY_RUN_WRITE', true)
+        local d = string.rep('x', 10 * 1024)
+        fiber.set_max_slice(100)
+        for i = 1, 768 do
+            s:insert({i, d})
+        end
+    end)
+    cg.server:restart({box_cfg = {vinyl_memory = 1024 * 1024}})
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local stats = box.info.vinyl()
+        t.assert_ge(stats.scheduler.dump_count, 7)
+
+        local s = box.space.test
+        local d = string.rep('x', 10 * 1024)
+        local expected = {}
+        for i = 1, 768 do
+            table.insert(expected, {i, d})
+        end
+        fiber.set_max_slice(100)
+        t.assert_equals(s:select(), expected)
+    end)
+    cg.server:restart({box_cfg = {vinyl_memory = 1024 * 1024}})
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.space.test
+        local d = string.rep('x', 10 * 1024)
+        local expected = {}
+        for i = 1, 768 do
+            table.insert(expected, {i, d})
+        end
+        fiber.set_max_slice(100)
+        t.assert_equals(s:select(), expected)
+    end)
+end
+
+-- Check that recovery can be continued after crash and there is no stalls.
+g.test_recovery_after_recovery_crash = function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new({box_cfg = {vinyl_memory = 10 * 1024 * 1024}})
+    cg.server:start()
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.schema.create_space('test', {engine = 'vinyl'})
+        s:create_index('pk')
+
+        box.error.injection.set('ERRINJ_VY_RUN_WRITE', true)
+        local d = string.rep('x', 10 * 1024)
+        fiber.set_max_slice(100)
+        for i = 1, 768 do
+            s:insert({i, d})
+        end
+    end)
+
+    local before_box_cfg = [[
+        box.error.injection.set('ERRINJ_VY_RUN_WRITE_CRASH_COUNTDOWN', 3)
+    ]]
+    t.assert_error(cg.server.restart, cg.server, {
+        box_cfg = {vinyl_memory = 1024 * 1024},
+        env = {TARANTOOL_RUN_BEFORE_BOX_CFG = before_box_cfg},
+    })
+    t.helpers.retrying({}, function()
+        t.assert(cg.server:grep_log('injected crash'))
+    end)
+
+    local path = fio.pathjoin(cg.server.workdir, 512, 0)
+    t.assert(fio.path.is_dir(path))
+    local old_files = fio.listdir(path)
+    t.assert_gt(#old_files, 0)
+
+    cg.server:restart({
+        box_cfg = {vinyl_memory = 1024 * 1024},
+        env = {},
+    })
+    -- Check there was no throttling due unexpected run/index files.
+    t.assert_not(cg.server:grep_log('throttling scheduler'))
+
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.space.test
+        local d = string.rep('x', 10 * 1024)
+        local expected = {}
+        for i = 1, 768 do
+            table.insert(expected, {i, d})
+        end
+        fiber.set_max_slice(100)
+        t.assert_equals(s:select(), expected)
+        -- Forget unused run files.
+        -- We may fail to remove them due injected crash.
+        box.snapshot()
+        s:insert({1000})
+        box.snapshot()
+    end)
+
+    local new_files = fio.listdir(path)
+    -- Check old run/index files are deleted.
+    t.assert_items_exclude(new_files, old_files)
+end
+
+g.test_recovery_respect_inprogress_tasks = function(cg)
+    cg.server = server:new({box_cfg = {vinyl_memory = 10 * 1024 * 1024}})
+    cg.server:start()
+    cg.server:exec(function()
+        local fiber = require('fiber')
+
+        local s = box.schema.create_space('test', {engine = 'vinyl'})
+        s:create_index('pk')
+
+        box.error.injection.set('ERRINJ_VY_RUN_WRITE', true)
+        local d = string.rep('x', 10 * 1024)
+        fiber.set_max_slice(100)
+        for i = 1, 768 do
+            s:insert({i, d})
+        end
+    end)
+    -- Slow down so that at the end of the recovery the where inprogress
+    -- tasks.
+    local before_box_cfg = [[
+        box.error.injection.set('ERRINJ_VY_RUN_WRITE_STMT_TIMEOUT', 0.02)
+    ]]
+    cg.server:restart({
+        box_cfg = {vinyl_memory = 1024 * 1024},
+        env = {TARANTOOL_RUN_BEFORE_BOX_CFG = before_box_cfg},
+    })
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        -- Stop slowing down so that inprogress tasks fail in case we
+        -- cleanup their files by mistake at the end of the recovery.
+        box.error.injection.set('ERRINJ_VY_RUN_WRITE_STMT_TIMEOUT', 0)
+
+        local stats = box.info.vinyl()
+        t.assert_ge(stats.scheduler.dump_count, 7)
+
+        local s = box.space.test
+        local d = string.rep('x', 10 * 1024)
+        local expected = {}
+        for i = 1, 768 do
+            table.insert(expected, {i, d})
+        end
+        fiber.set_max_slice(100)
+        t.assert_equals(s:select(), expected)
+    end)
+    -- Check there was no throttling due to errors caused by deleting
+    -- legal inprogress files.
+    t.assert_not(cg.server:grep_log('throttling scheduler'))
+end


### PR DESCRIPTION
Currently we start to apply memory limit only when recovery is finished. So if for example `vinyl_memory` is less than on the previous start then we can overrun the limit. Let's start quota tracking right from the beginning of the recovery.

Closes #12390