### PR TITLE
vinyl: move write iterator construction to writer threads

### DIFF
--- a/src/box/vy_mem.h
+++ b/src/box/vy_mem.h
@@ -156,8 +156,10 @@ vy_mem_tree_cmp_key(struct vy_entry entry, struct vy_mem_tree_key *key,
 struct vy_mem {
 	/** Vinyl memory environment. */
 	struct vy_mem_env *env;
-	/** Link in range->sealed list. */
+	/** Link in vy_lsm::sealed. */
 	struct rlist in_sealed;
+	/** Link in vy_task::dumped_mems. */
+	struct rlist in_dump;
 	/** BPS tree */
 	struct vy_mem_tree tree;
 	/* The matras allocator used by the tree. */

--- a/src/box/vy_run.c
+++ b/src/box/vy_run.c
@@ -2810,20 +2810,11 @@ vy_slice_stream_stop(struct vy_stmt_stream *virt_stream)
 	}
 }
 
-static void
-vy_slice_stream_close(struct vy_stmt_stream *virt_stream)
-{
-	assert(virt_stream->iface->close == vy_slice_stream_close);
-	struct vy_slice_stream *stream = (struct vy_slice_stream *)virt_stream;
-	tuple_format_unref(stream->format);
-	tuple_format_unref(stream->key_format);
-}
-
 static const struct vy_stmt_stream_iface vy_slice_stream_iface = {
 	.start = vy_slice_stream_search,
 	.next = vy_slice_stream_next,
 	.stop = vy_slice_stream_stop,
-	.close = vy_slice_stream_close,
+	.close = NULL,
 };
 
 void
@@ -2841,8 +2832,6 @@ vy_slice_stream_open(struct vy_slice_stream *stream, struct vy_slice *slice,
 	stream->slice = slice;
 	stream->cmp_def = cmp_def;
 	stream->format = format;
-	tuple_format_ref(format);
 	stream->key_format = key_format;
-	tuple_format_ref(key_format);
 	stream->is_primary = is_primary;
 }

--- a/src/box/vy_run.h
+++ b/src/box/vy_run.h
@@ -214,6 +214,8 @@ struct vy_slice {
 		/** Link in vy_join_ctx->slices list. */
 		struct rlist in_join;
 	};
+	/** Link in vy_task::compacted_slices. */
+	struct rlist in_compaction;
 	/**
 	 * Indexes of the first and the last page in the run
 	 * that belong to this slice.

--- a/src/box/vy_scheduler.c
+++ b/src/box/vy_scheduler.c
@@ -56,6 +56,7 @@
 #include "vy_mem.h"
 #include "vy_quota.h"
 #include "vy_range.h"
+#include "vy_read_view.h"
 #include "vy_run.h"
 #include "vy_write_iterator.h"
 #include "trivia/util.h"
@@ -188,16 +189,22 @@ struct vy_task {
 	struct vy_range *range;
 	/** Run written by this task. */
 	struct vy_run *new_run;
-	/** Write iterator producing statements for the new run. */
-	struct vy_stmt_stream *wi;
 	/**
-	 * First (newest) and last (oldest) slices to compact.
-	 *
-	 * While a compaction task is in progress, a new slice
-	 * can be added to a range by concurrent dump, so we
-	 * need to remember the slices we are compacting.
+	 * List of in-memory indexes dumped by this task,
+	 * linked by vy_mem::in_dump.
 	 */
-	struct vy_slice *first_slice, *last_slice;
+	struct rlist dumped_mems;
+	/**
+	 * List of run slices compacted by this task,
+	 * linked by vy_slice::in_compaction.
+	 */
+	struct rlist compacted_slices;
+	/** Set if there is no older level than the one we're writing to. */
+	bool is_last_level;
+	/** Array of read view LSNs sorted in the ascending order. */
+	int64_t *vlsns;
+	/** Number of entries in the vlsns array. */
+	int vlsn_count;
 	/**
 	 * Index options may be modified while a task is in
 	 * progress so we save them here to safely access them
@@ -252,8 +259,25 @@ vy_task_new(struct vy_scheduler *scheduler, struct vy_worker *worker,
 	task->key_def = key_def_dup(lsm->key_def);
 	vy_lsm_ref(lsm);
 	diag_create(&task->diag);
+	rlist_create(&task->dumped_mems);
+	rlist_create(&task->compacted_slices);
 	task->deferred_delete_handler.iface = &vy_task_deferred_delete_iface;
 	return task;
+}
+
+/** Initialize the VLSNs array from a read view list. */
+static void
+vy_task_set_read_views(struct vy_task *task, struct rlist *read_views)
+{
+	struct vy_read_view *rv;
+	rlist_foreach_entry(rv, read_views, in_read_views)
+		task->vlsn_count++;
+	if (task->vlsn_count > 0) {
+		task->vlsns = xcalloc(task->vlsn_count, sizeof(*task->vlsns));
+		int i = 0;
+		rlist_foreach_entry(rv, read_views, in_read_views)
+			task->vlsns[i++] = rv->vlsn;
+	}
 }
 
 /** Free a task allocated with vy_task_new(). */
@@ -266,6 +290,7 @@ vy_task_delete(struct vy_task *task)
 	key_def_delete(task->key_def);
 	vy_lsm_unref(task->lsm);
 	diag_destroy(&task->diag);
+	free(task->vlsns);
 	free(task);
 }
 
@@ -1083,13 +1108,16 @@ vy_task_deferred_delete_iface = {
 	.destroy = vy_task_deferred_delete_destroy,
 };
 
+/**
+ * Writes statements returned by a write stream to a new run.
+ */
 static int
-vy_task_write_run(struct vy_task *task, bool no_compression)
+vy_task_write_run(struct vy_task *task, struct vy_stmt_stream *wi,
+		  bool no_compression)
 {
 	enum { YIELD_LOOPS = 32 };
 
 	struct vy_lsm *lsm = task->lsm;
-	struct vy_stmt_stream *wi = task->wi;
 
 	ERROR_INJECT(ERRINJ_VY_RUN_WRITE,
 		     {diag_set(ClientError, ER_INJECTION,
@@ -1147,11 +1175,33 @@ vy_task_dump_execute(struct vy_task *task)
 {
 	ERROR_INJECT_SLEEP(ERRINJ_VY_DUMP_DELAY);
 	/*
+	 * Note, since deferred DELETE are generated on tx commit
+	 * in case the overwritten tuple is found in-memory, no
+	 * deferred DELETE statement should be generated during
+	 * dump so we don't pass a deferred DELETE handler.
+	 */
+	int rc = -1;
+	bool is_primary = (task->lsm->index_id == 0);
+	struct vy_stmt_stream *wi = vy_write_iterator_new(
+			task->cmp_def, is_primary, task->is_last_level,
+			task->vlsns, task->vlsn_count, NULL);
+	if (wi == NULL)
+		goto out;
+	struct vy_mem *mem;
+	rlist_foreach_entry(mem, &task->dumped_mems, in_dump) {
+		if (vy_write_iterator_new_mem(wi, mem) != 0)
+			goto out_close;
+	}
+	/*
 	 * Don't compress L1 runs as they are most frequently read
 	 * and smallest runs at the same time and so we would gain
 	 * nothing by compressing them.
 	 */
-	return vy_task_write_run(task, true);
+	rc = vy_task_write_run(task, wi, true);
+out_close:
+	wi->iface->close(wi);
+out:
+	return rc;
 }
 
 static int
@@ -1276,9 +1326,7 @@ delete_mems:
 	 * LSM tree statistics.
 	 */
 	vy_stmt_counter_reset(&dump_input);
-	rlist_foreach_entry_safe(mem, &lsm->sealed, in_sealed, next_mem) {
-		if (mem->generation > scheduler->dump_generation)
-			continue;
+	rlist_foreach_entry_safe(mem, &task->dumped_mems, in_dump, next_mem) {
 		vy_stmt_counter_add(&dump_input, &mem->count);
 		vy_lsm_delete_mem(lsm, mem);
 	}
@@ -1292,9 +1340,6 @@ delete_mems:
 		scheduler->stat.dump_input += dump_input.bytes;
 	scheduler->stat.dump_output += dump_output.bytes;
 	scheduler->stat.dump_time += dump_time;
-
-	/* The iterator has been cleaned up in a worker thread. */
-	task->wi->iface->close(task->wi);
 
 	lsm->is_dumping = false;
 	vy_scheduler_update_lsm(scheduler, lsm);
@@ -1328,9 +1373,6 @@ vy_task_dump_abort(struct vy_task *task)
 	struct vy_lsm *lsm = task->lsm;
 
 	assert(lsm->is_dumping);
-
-	/* The iterator has been cleaned up in a worker thread. */
-	task->wi->iface->close(task->wi);
 
 	struct error *e = diag_last_error(&task->diag);
 	error_log(e);
@@ -1379,6 +1421,13 @@ vy_task_dump_new(struct vy_scheduler *scheduler, struct vy_worker *worker,
 	if (vy_lsm_rotate_mem_if_required(lsm) != 0)
 		goto err;
 
+	struct vy_task *task = vy_task_new(scheduler, worker, lsm, &dump_ops);
+	if (task == NULL)
+		goto err;
+
+	if (lsm->run_count == 0)
+		task->is_last_level = true;
+
 	/*
 	 * Wait until all active writes to in-memory trees
 	 * eligible for dump are over.
@@ -1398,18 +1447,15 @@ vy_task_dump_new(struct vy_scheduler *scheduler, struct vy_worker *worker,
 			continue;
 		}
 		dump_lsn = MAX(dump_lsn, mem->dump_lsn);
+		rlist_add_tail_entry(&task->dumped_mems, mem, in_dump);
 	}
-
-	if (dump_lsn < 0) {
+	if (rlist_empty(&task->dumped_mems)) {
 		/* Nothing to do, pick another LSM tree. */
 		vy_scheduler_update_lsm(scheduler, lsm);
 		vy_scheduler_complete_dump(scheduler);
+		vy_task_delete(task);
 		return 0;
 	}
-
-	struct vy_task *task = vy_task_new(scheduler, worker, lsm, &dump_ops);
-	if (task == NULL)
-		goto err;
 
 	struct vy_run *new_run = vy_run_prepare(scheduler->run_env, lsm);
 	if (new_run == NULL)
@@ -1418,29 +1464,10 @@ vy_task_dump_new(struct vy_scheduler *scheduler, struct vy_worker *worker,
 	new_run->dump_count = 1;
 	new_run->dump_lsn = dump_lsn;
 
-	/*
-	 * Note, since deferred DELETE are generated on tx commit
-	 * in case the overwritten tuple is found in-memory, no
-	 * deferred DELETE statement should be generated during
-	 * dump so we don't pass a deferred DELETE handler.
-	 */
-	struct vy_stmt_stream *wi;
-	bool is_last_level = (lsm->run_count == 0);
-	wi = vy_write_iterator_new(task->cmp_def, lsm->index_id == 0,
-				   is_last_level, scheduler->read_views, NULL);
-	if (wi == NULL)
-		goto err_wi;
-	rlist_foreach_entry(mem, &lsm->sealed, in_sealed) {
-		if (mem->generation > scheduler->dump_generation)
-			continue;
-		if (vy_write_iterator_new_mem(wi, mem) != 0)
-			goto err_wi_sub;
-	}
-
 	task->new_run = new_run;
-	task->wi = wi;
 	task->bloom_fpr = lsm->opts.bloom_fpr;
 	task->page_size = lsm->opts.page_size;
+	vy_task_set_read_views(task, scheduler->read_views);
 
 	lsm->is_dumping = true;
 	vy_scheduler_update_lsm(scheduler, lsm);
@@ -1462,11 +1489,6 @@ vy_task_dump_new(struct vy_scheduler *scheduler, struct vy_worker *worker,
 	say_verbose("%s: dump started", vy_lsm_name(lsm));
 	*p_task = task;
 	return 0;
-
-err_wi_sub:
-	task->wi->iface->close(wi);
-err_wi:
-	vy_run_discard(new_run);
 err_run:
 	vy_task_delete(task);
 err:
@@ -1479,7 +1501,26 @@ static int
 vy_task_compaction_execute(struct vy_task *task)
 {
 	ERROR_INJECT_SLEEP(ERRINJ_VY_COMPACTION_DELAY);
-	return vy_task_write_run(task, false);
+	int rc = -1;
+	struct vy_lsm *lsm = task->lsm;
+	bool is_primary = (lsm->index_id == 0);
+	struct vy_stmt_stream *wi = vy_write_iterator_new(
+			task->cmp_def, is_primary, task->is_last_level,
+			task->vlsns, task->vlsn_count,
+			is_primary ? &task->deferred_delete_handler : NULL);
+	if (wi == NULL)
+		goto out;
+	struct vy_slice *slice;
+	rlist_foreach_entry(slice, &task->compacted_slices, in_compaction) {
+		if (vy_write_iterator_new_slice(wi, slice, lsm->format,
+						lsm->env->key_format) != 0)
+			goto out_close;
+	}
+	rc = vy_task_write_run(task, wi, false);
+out_close:
+	wi->iface->close(wi);
+out:
+	return rc;
 }
 
 static int
@@ -1492,8 +1533,6 @@ vy_task_compaction_complete(struct vy_task *task)
 	double compaction_time = ev_monotonic_now(loop()) - task->start_time;
 	struct vy_disk_stmt_counter compaction_output = new_run->count;
 	struct vy_disk_stmt_counter compaction_input;
-	struct vy_slice *first_slice = task->first_slice;
-	struct vy_slice *last_slice = task->last_slice;
 	struct vy_slice *slice, *next_slice, *new_slice = NULL;
 	struct vy_run *run;
 
@@ -1528,29 +1567,21 @@ vy_task_compaction_complete(struct vy_task *task)
 	 * as a result of compaction.
 	 */
 	RLIST_HEAD(unused_runs);
-	for (slice = first_slice; ; slice = rlist_next_entry(slice, in_range)) {
+	rlist_foreach_entry(slice, &task->compacted_slices, in_compaction)
 		slice->run->compacted_slice_count++;
-		if (slice == last_slice)
-			break;
-	}
-	for (slice = first_slice; ; slice = rlist_next_entry(slice, in_range)) {
+	rlist_foreach_entry(slice, &task->compacted_slices, in_compaction) {
 		run = slice->run;
 		if (run->compacted_slice_count == run->slice_count)
 			rlist_add_entry(&unused_runs, run, in_unused);
 		slice->run->compacted_slice_count = 0;
-		if (slice == last_slice)
-			break;
 	}
 
 	/*
 	 * Log change in metadata.
 	 */
 	vy_log_tx_begin();
-	for (slice = first_slice; ; slice = rlist_next_entry(slice, in_range)) {
+	rlist_foreach_entry(slice, &task->compacted_slices, in_compaction)
 		vy_log_delete_slice(slice->id);
-		if (slice == last_slice)
-			break;
-	}
 	rlist_foreach_entry(run, &unused_runs, in_unused)
 		vy_log_drop_run(run->id, VY_LOG_GC_LSN_CURRENT);
 	if (new_slice != NULL) {
@@ -1603,18 +1634,16 @@ vy_task_compaction_complete(struct vy_task *task)
 	 * we must insert the new slice at the same position where
 	 * the compacted slices were.
 	 */
-	RLIST_HEAD(compacted_slices);
 	vy_lsm_unacct_range(lsm, range);
-	if (new_slice != NULL)
+	if (new_slice != NULL) {
+		struct vy_slice *first_slice = rlist_first_entry(
+			&task->compacted_slices, typeof(*slice), in_compaction);
 		vy_range_add_slice_before(range, new_slice, first_slice);
+	}
 	vy_disk_stmt_counter_reset(&compaction_input);
-	for (slice = first_slice; ; slice = next_slice) {
-		next_slice = rlist_next_entry(slice, in_range);
+	rlist_foreach_entry(slice, &task->compacted_slices, in_compaction) {
 		vy_range_remove_slice(range, slice);
-		rlist_add_entry(&compacted_slices, slice, in_range);
 		vy_disk_stmt_counter_add(&compaction_input, &slice->count);
-		if (slice == last_slice)
-			break;
 	}
 	range->n_compactions++;
 	vy_range_update_compaction_priority(range, &lsm->opts);
@@ -1631,15 +1660,12 @@ vy_task_compaction_complete(struct vy_task *task)
 	 */
 	rlist_foreach_entry(run, &unused_runs, in_unused)
 		vy_lsm_remove_run(lsm, run);
-	rlist_foreach_entry_safe(slice, &compacted_slices,
-				 in_range, next_slice) {
+	rlist_foreach_entry_safe(slice, &task->compacted_slices,
+				 in_compaction, next_slice) {
 		vy_slice_wait_pinned(slice);
 		vy_slice_delete(slice);
 	}
 out:
-	/* The iterator has been cleaned up in worker. */
-	task->wi->iface->close(task->wi);
-
 	assert(heap_node_is_stray(&range->heap_node));
 	vy_range_heap_insert(&lsm->range_heap, range);
 	vy_scheduler_update_lsm(scheduler, lsm);
@@ -1655,9 +1681,6 @@ vy_task_compaction_abort(struct vy_task *task)
 	struct vy_scheduler *scheduler = task->scheduler;
 	struct vy_lsm *lsm = task->lsm;
 	struct vy_range *range = task->range;
-
-	/* The iterator has been cleaned up in worker. */
-	task->wi->iface->close(task->wi);
 
 	struct error *e = diag_last_error(&task->diag);
 	error_log(e);
@@ -1694,43 +1717,30 @@ vy_task_compaction_new(struct vy_scheduler *scheduler, struct vy_worker *worker,
 	struct vy_task *task = vy_task_new(scheduler, worker, lsm,
 					   &compaction_ops);
 	if (task == NULL)
-		goto err_task;
+		goto err;
 
 	struct vy_run *new_run = vy_run_prepare(scheduler->run_env, lsm);
 	if (new_run == NULL)
 		goto err_run;
 
-	struct vy_stmt_stream *wi;
-	bool is_last_level = (range->compaction_priority == range->slice_count);
-	wi = vy_write_iterator_new(task->cmp_def, lsm->index_id == 0,
-				   is_last_level, scheduler->read_views,
-				   lsm->index_id > 0 ? NULL :
-				   &task->deferred_delete_handler);
-	if (wi == NULL)
-		goto err_wi;
-
 	struct vy_slice *slice;
 	int32_t dump_count = 0;
 	int n = range->compaction_priority;
 	rlist_foreach_entry(slice, &range->slices, in_range) {
-		if (vy_write_iterator_new_slice(wi, slice, lsm->format,
-						lsm->env->key_format) != 0)
-			goto err_wi_sub;
 		new_run->dump_lsn = MAX(new_run->dump_lsn,
 					slice->run->dump_lsn);
 		dump_count += slice->run->dump_count;
-		/* Remember the slices we are compacting. */
-		if (task->first_slice == NULL)
-			task->first_slice = slice;
-		task->last_slice = slice;
-
+		rlist_add_tail_entry(&task->compacted_slices, slice,
+				     in_compaction);
 		if (--n == 0)
 			break;
 	}
 	assert(n == 0);
 	assert(new_run->dump_lsn >= 0);
-	if (range->compaction_priority == range->slice_count)
+	if (range->compaction_priority == range->slice_count) {
 		dump_count -= slice->run->dump_count;
+		task->is_last_level = true;
+	}
 	/*
 	 * Do not update dumps_per_compaction in case compaction
 	 * was triggered manually to avoid unexpected side effects,
@@ -1745,9 +1755,9 @@ vy_task_compaction_new(struct vy_scheduler *scheduler, struct vy_worker *worker,
 
 	task->range = range;
 	task->new_run = new_run;
-	task->wi = wi;
 	task->bloom_fpr = lsm->opts.bloom_fpr;
 	task->page_size = lsm->opts.page_size;
+	vy_task_set_read_views(task, scheduler->read_views);
 
 	/*
 	 * Remove the range we are going to compact from the heap
@@ -1761,14 +1771,9 @@ vy_task_compaction_new(struct vy_scheduler *scheduler, struct vy_worker *worker,
 		    range->compaction_priority, range->slice_count);
 	*p_task = task;
 	return 0;
-
-err_wi_sub:
-	task->wi->iface->close(wi);
-err_wi:
-	vy_run_discard(new_run);
 err_run:
 	vy_task_delete(task);
-err_task:
+err:
 	diag_log();
 	say_error("%s: could not start compacting range %s",
 		  vy_lsm_name(lsm), vy_range_str(range));

--- a/src/box/vy_write_iterator.c
+++ b/src/box/vy_write_iterator.c
@@ -344,7 +344,7 @@ static const struct vy_stmt_stream_iface vy_slice_stream_iface;
  */
 struct vy_stmt_stream *
 vy_write_iterator_new(struct key_def *cmp_def, bool is_primary,
-		      bool is_last_level, struct rlist *read_views,
+		      bool is_last_level, const int64_t *vlsns, int vlsn_count,
 		      struct vy_deferred_delete_handler *handler)
 {
 	/*
@@ -355,12 +355,8 @@ vy_write_iterator_new(struct key_def *cmp_def, bool is_primary,
 	/*
 	 * One is reserved for INT64_MAX - maximal read view.
 	 */
-	int count = 1;
-	struct rlist *unused;
-	rlist_foreach(unused, read_views)
-		++count;
 	size_t size = sizeof(struct vy_write_iterator) +
-		      count * sizeof(struct vy_read_view_stmt);
+		      (vlsn_count + 1) * sizeof(struct vy_read_view_stmt);
 	struct vy_write_iterator *stream =
 		(struct vy_write_iterator *) calloc(1, size);
 	if (stream == NULL) {
@@ -368,19 +364,16 @@ vy_write_iterator_new(struct key_def *cmp_def, bool is_primary,
 		return NULL;
 	}
 	stream->stmt_i = -1;
-	stream->rv_count = count;
+	stream->rv_count = vlsn_count + 1;
 	stream->read_views[0].vlsn = INT64_MAX;
 	stream->read_views[0].entry = vy_entry_none();
-	count--;
-	struct vy_read_view *rv;
 	/* Descending order. */
-	rlist_foreach_entry(rv, read_views, in_read_views) {
+	for (int i = 0; i < vlsn_count; i++) {
 		struct vy_read_view_stmt *p;
-		p = &stream->read_views[count--];
-		p->vlsn = rv->vlsn;
+		p = &stream->read_views[vlsn_count - i];
+		p->vlsn = vlsns[i];
 		p->entry = vy_entry_none();
 	}
-	assert(count == 0);
 
 	stream->base.iface = &vy_slice_stream_iface;
 	vy_source_heap_create(&stream->src_heap);

--- a/src/box/vy_write_iterator.h
+++ b/src/box/vy_write_iterator.h
@@ -32,7 +32,6 @@
  */
 #include "trivia/util.h"
 #include "vy_stmt_stream.h"
-#include "vy_read_view.h"
 #include <stdbool.h>
 #include <pthread.h>
 
@@ -241,7 +240,8 @@ struct vy_deferred_delete_handler {
  * @param cmp_def - key definition for tuple compare.
  * @param LSM tree is_primary - set if this iterator is for a primary index.
  * @param is_last_level - there is no older level than the one we're writing to.
- * @param read_views - Opened read views.
+ * @param vlsns - Array of read view LSNs sorted in the ascending order.
+ * @param vlsn_count - Number of entries in the vlsns array.
  * @param handler - Deferred DELETE handler or NULL if no deferred DELETEs is
  * expected. Only relevant to primary index compaction. For secondary indexes
  * this argument must be set to NULL.
@@ -249,7 +249,7 @@ struct vy_deferred_delete_handler {
  */
 struct vy_stmt_stream *
 vy_write_iterator_new(struct key_def *cmp_def, bool is_primary,
-		      bool is_last_level, struct rlist *read_views,
+		      bool is_last_level, const int64_t *vlsns, int vlsn_count,
 		      struct vy_deferred_delete_handler *handler);
 
 /**

--- a/test/unit/vy_iterators_helper.c
+++ b/test/unit/vy_iterators_helper.c
@@ -198,17 +198,6 @@ vy_cache_on_write_template(struct vy_cache *cache, struct tuple_format *format,
 	tuple_unref(written.stmt);
 }
 
-void
-init_read_views_list(struct rlist *rlist, struct vy_read_view *rvs,
-		     const int *vlsns, int count)
-{
-	rlist_create(rlist);
-	for (int i = 0; i < count; ++i) {
-		rvs[i].vlsn = vlsns[i];
-		rlist_add_tail_entry(rlist, &rvs[i], in_read_views);
-	}
-}
-
 struct vy_mem *
 create_test_mem(struct key_def *def)
 {

--- a/test/unit/vy_iterators_helper.h
+++ b/test/unit/vy_iterators_helper.h
@@ -153,19 +153,6 @@ vy_cache_on_write_template(struct vy_cache *cache, struct tuple_format *format,
 			   const struct vy_stmt_template *templ);
 
 /**
- * Create a list of read views using the specified vlsns.
- *
- * @param rlist[out] Result list of read views.
- * @param rvs[out] Read views array.
- * @param vlsns Array of read view lsns, sorted in ascending
- *        order.
- * @param count Size of the @vlsns.
- */
-void
-init_read_views_list(struct rlist *rlist, struct vy_read_view *rvs,
-		     const int *vlsns, int count);
-
-/**
  * Create vy_mem with the specified key_def, using the @region as
  * allocator.
  *

--- a/test/unit/vy_point_lookup.c
+++ b/test/unit/vy_point_lookup.c
@@ -105,8 +105,6 @@ test_basic()
 	isnt(pk, NULL, "range is not NULL");
 	vy_lsm_add_range(pk, range);
 
-	struct rlist read_views = RLIST_HEAD_INITIALIZER(read_views);
-
 	char dir_tmpl[] = "./vy_point_test.XXXXXX";
 	char *dir_name = mkdtemp(dir_tmpl);
 	isnt(dir_name, NULL, "temp dir name is not NULL");
@@ -195,7 +193,7 @@ test_basic()
 	}
 	struct vy_stmt_stream *write_stream;
 	write_stream = vy_write_iterator_new(pk->cmp_def, true, true,
-					     &read_views, NULL);
+					     NULL, 0, NULL);
 	vy_write_iterator_new_mem(write_stream, run_mem);
 	struct vy_run *run = vy_run_new(&run_env, 1);
 	isnt(run, NULL, "vy_run_new");
@@ -226,7 +224,7 @@ test_basic()
 		vy_mem_insert_template(run_mem, &tmpl_val);
 	}
 	write_stream = vy_write_iterator_new(pk->cmp_def, true, true,
-					     &read_views, NULL);
+					     NULL, 0, NULL);
 	vy_write_iterator_new_mem(write_stream, run_mem);
 	run = vy_run_new(&run_env, 2);
 	isnt(run, NULL, "vy_run_new");

--- a/test/unit/vy_write_iterator.c
+++ b/test/unit/vy_write_iterator.c
@@ -86,7 +86,7 @@ compare_write_iterator_results(const struct vy_stmt_template *content,
 			       int expected_count,
 			       const struct vy_stmt_template *deferred,
 			       int deferred_count,
-			       const int *vlsns, int vlsns_count,
+			       const int64_t *vlsns, int vlsns_count,
 			       bool is_primary, bool is_last_level)
 {
 	uint32_t fields[] = { 0 };
@@ -96,16 +96,13 @@ compare_write_iterator_results(const struct vy_stmt_template *content,
 	struct vy_mem *mem = create_test_mem(key_def);
 	for (int i = 0; i < content_count; ++i)
 		vy_mem_insert_template(mem, &content[i]);
-	struct rlist rv_list;
-	struct vy_read_view *rv_array = malloc(sizeof(*rv_array) * vlsns_count);
-	fail_if(rv_array == NULL);
-	init_read_views_list(&rv_list, rv_array, vlsns, vlsns_count);
 
 	struct test_handler handler;
 	test_handler_create(&handler, mem->format);
 
 	struct vy_stmt_stream *wi;
-	wi = vy_write_iterator_new(key_def, is_primary, is_last_level, &rv_list,
+	wi = vy_write_iterator_new(key_def, is_primary, is_last_level,
+				   vlsns, vlsns_count,
 				   is_primary ? &handler.base : NULL);
 	fail_if(wi == NULL);
 	fail_if(vy_write_iterator_new_mem(wi, mem) != 0);
@@ -143,7 +140,6 @@ compare_write_iterator_results(const struct vy_stmt_template *content,
 	wi->iface->close(wi);
 	vy_mem_delete(mem);
 	box_key_def_delete(key_def);
-	free(rv_array);
 }
 
 void
@@ -174,7 +170,7 @@ test_basic(void)
 	const struct vy_stmt_template expected[] = {
 		content[9], content[7], content[4], content[2]
 	};
-	const int vlsns[] = {7, 9, 12};
+	const int64_t vlsns[] = {7, 9, 12};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int vlsns_count = sizeof(vlsns) / sizeof(vlsns[0]);
@@ -208,7 +204,7 @@ test_basic(void)
 		STMT_TEMPLATE(10, UPSERT, 1, 3),
 		STMT_TEMPLATE(6, UPSERT, 1, 1),
 	};
-	const int vlsns[] = {6, 10, 13};
+	const int64_t vlsns[] = {6, 10, 13};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int vlsns_count = sizeof(vlsns) / sizeof(vlsns[0]);
@@ -236,7 +232,7 @@ test_basic(void)
 		content[3],
 		STMT_TEMPLATE(7, REPLACE, 1, 2)
 	};
-	const int vlsns[] = {7};
+	const int64_t vlsns[] = {7};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int vlsns_count = sizeof(vlsns) / sizeof(vlsns[0]);
@@ -256,7 +252,7 @@ test_basic(void)
 		STMT_TEMPLATE(8, REPLACE, 1, 2),
 	};
 	const struct vy_stmt_template expected[] = { content[1], content[0] };
-	const int vlsns[] = {7, 8};
+	const int64_t vlsns[] = {7, 8};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int vlsns_count = sizeof(vlsns) / sizeof(vlsns[0]);
@@ -280,7 +276,7 @@ test_basic(void)
 		STMT_TEMPLATE(8, REPLACE, 1, 1),
 	};
 	const struct vy_stmt_template expected[] = { content[1] };
-	const int vlsns[] = {7, 8};
+	const int64_t vlsns[] = {7, 8};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int vlsns_count = sizeof(vlsns) / sizeof(vlsns[0]);
@@ -303,7 +299,7 @@ test_basic(void)
 		STMT_TEMPLATE(8, REPLACE, 1, 1),
 	};
 	const struct vy_stmt_template expected[] = { content[1], content[0] };
-	const int vlsns[] = {7, 8};
+	const int64_t vlsns[] = {7, 8};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int vlsns_count = sizeof(vlsns) / sizeof(vlsns[0]);
@@ -330,7 +326,7 @@ test_basic(void)
 	const struct vy_stmt_template expected[] = {
 		content[3], STMT_TEMPLATE(7, UPSERT, 1, 1)
 	};
-	const int vlsns[] = {7};
+	const int64_t vlsns[] = {7};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int vlsns_count = sizeof(vlsns) / sizeof(vlsns[0]);
@@ -358,7 +354,7 @@ test_basic(void)
 	const struct vy_stmt_template expected[] = {
 		content[3], content[2], content[1]
 	};
-	const int vlsns[] = {7, 10, 20, 21, 22, 23};
+	const int64_t vlsns[] = {7, 10, 20, 21, 22, 23};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int vlsns_count = sizeof(vlsns) / sizeof(vlsns[0]);
@@ -388,7 +384,7 @@ test_basic(void)
 		STMT_TEMPLATE(9, DELETE, 1),
 	};
 	const struct vy_stmt_template expected[] = { content[1] };
-	const int vlsns[] = {5, 7, 9};
+	const int64_t vlsns[] = {5, 7, 9};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int vlsns_count = sizeof(vlsns) / sizeof(vlsns[0]);
@@ -420,7 +416,7 @@ test_basic(void)
 		STMT_TEMPLATE(20, DELETE, 1),
 	};
 	const struct vy_stmt_template expected[] = { content[3], content[1] };
-	const int vlsns[] = {5, 11};
+	const int64_t vlsns[] = {5, 11};
 	compare_write_iterator_results(content, lengthof(content),
 				       expected, lengthof(expected), NULL, 0,
 				       vlsns, lengthof(vlsns), true, false);
@@ -459,7 +455,7 @@ test_basic(void)
 		content[6],
 		STMT_TEMPLATE(7, INSERT, 1, 4),
 	};
-	const int vlsns[] = {3, 5, 7, 8, 9};
+	const int64_t vlsns[] = {3, 5, 7, 8, 9};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int vlsns_count = sizeof(vlsns) / sizeof(vlsns[0]);
@@ -499,7 +495,7 @@ test_basic(void)
 		content[4],
 		STMT_TEMPLATE(6, REPLACE, 1, 2),
 	};
-	const int vlsns[] = {6, 7};
+	const int64_t vlsns[] = {6, 7};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int vlsns_count = sizeof(vlsns) / sizeof(vlsns[0]);
@@ -545,7 +541,7 @@ test_basic(void)
 		STMT_TEMPLATE(8, DELETE, 1, 4),
 		STMT_TEMPLATE(5, DELETE, 1, 2),
 	};
-	const int vlsns[] = {5, 7, 11};
+	const int64_t vlsns[] = {5, 7, 11};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int deferred_count = sizeof(deferred) / sizeof(deferred[0]);
@@ -577,7 +573,7 @@ test_basic(void)
 		STMT_TEMPLATE_DEFERRED_DELETE(7, REPLACE, 1, 1),
 	};
 	const struct vy_stmt_template deferred[] = {};
-	const int vlsns[] = {};
+	const int64_t vlsns[] = {};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int deferred_count = sizeof(deferred) / sizeof(deferred[0]);
@@ -609,7 +605,7 @@ test_basic(void)
 		STMT_TEMPLATE_DEFERRED_DELETE(7, REPLACE, 1, 1),
 	};
 	const struct vy_stmt_template deferred[] = {};
-	const int vlsns[] = {7};
+	const int64_t vlsns[] = {7};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int deferred_count = sizeof(deferred) / sizeof(deferred[0]);
@@ -637,7 +633,7 @@ test_basic(void)
 		STMT_TEMPLATE_DEFERRED_DELETE(7, REPLACE, 1, 1),
 	};
 	const struct vy_stmt_template deferred[] = {};
-	const int vlsns[] = {};
+	const int64_t vlsns[] = {};
 	int content_count = sizeof(content) / sizeof(content[0]);
 	int expected_count = sizeof(expected) / sizeof(expected[0]);
 	int deferred_count = sizeof(deferred) / sizeof(deferred[0]);


### PR DESCRIPTION
Currently, a write iterator, which is used for executing dump and compaction tasks, is created by the main thread. It works just fine now, when the write iterator may use tuple formats created in the main thread, but once we make the tuple format registry thread-local, it won't be possible: a writer thread will have to create its own copies of tuple formats for a write iterator. Since tuple formats are passed to a write iterator at construction, we have to move write iterator construction from the main thread to writer threads.

To achieve that, we add lists of dumped in-memory indexes and compacted run slices to the task structure so that a writer thread can add them to a write iterator. This should make the code a bit clearer anyway because currently we use some non-straightforward logic to figure out which mems/slices are included into a task. Also, we have to store the read view LSNs in a task because the read view list may be modified in the main thread while a task is in progress.

Needed for #12210