### PR TITLE
cmake: set `HAVE_MALLOC_TRIM` if `malloc_trim` exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ check_function_exists(setprogname HAVE_SETPROGNAME)
 check_function_exists(getprogname HAVE_GETPROGNAME)
 
 check_symbol_exists(malloc_info malloc.h HAVE_MALLOC_INFO)
+check_symbol_exists(malloc_trim malloc.h HAVE_MALLOC_TRIM)
 
 #
 # Enable 'make tags' target.

--- a/src/trivia/config.h.cmake
+++ b/src/trivia/config.h.cmake
@@ -229,6 +229,7 @@
 #cmakedefine HAVE_GETPROGNAME 1
 
 #cmakedefine HAVE_MALLOC_INFO 1
+#cmakedefine HAVE_MALLOC_TRIM 1
 
 /*
  * Defined if ICU library has ucol_strcollUTF8 method.


### PR DESCRIPTION
Needed for tarantool/tarantool-ee#1687