### PR TITLE
box: make tuple format registry thread-local

### DIFF
--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -2221,6 +2221,13 @@ memtx_tree_index_build_array_deduplicate(
 	index->build_array_size = w_idx + 1;
 }
 
+static void
+memtx_sort_thread_init(void *arg)
+{
+	struct tuple_format **formats = (struct tuple_format **)arg;
+	tuple_formats_inherit(formats);
+}
+
 template <bool USE_HINT>
 static void
 memtx_tree_index_end_build(struct index *base)
@@ -2230,8 +2237,10 @@ memtx_tree_index_end_build(struct index *base)
 	struct key_def *cmp_def = memtx_tree_cmp_def(&index->tree);
 	struct memtx_engine *memtx = (struct memtx_engine *)base->engine;
 	tt_sort(index->build_array, index->build_array_size,
-		sizeof(index->build_array[0]), memtx_tree_qcompare<USE_HINT>,
-		cmp_def, memtx->sort_threads);
+		sizeof(index->build_array[0]),
+		memtx_tree_qcompare<USE_HINT>, cmp_def,
+		memtx_sort_thread_init, tuple_formats,
+		memtx->sort_threads);
 	if (cmp_def->is_multikey || cmp_def->for_func_index) {
 		/*
 		 * Multikey index may have equal(in terms of

--- a/src/box/tuple_format.c
+++ b/src/box/tuple_format.c
@@ -42,12 +42,12 @@
 
 #include <PMurHash.h>
 
-/** Global table of tuple formats */
-struct tuple_format *tuple_formats[FORMAT_ID_MAX + 1];
-static intptr_t recycled_format_ids = FORMAT_ID_NIL;
+__thread struct tuple_format **tuple_formats;
+__thread bool tuple_formats_inherited;
 
-static uint32_t formats_size = 0;
-static uint64_t formats_epoch = 0;
+static __thread intptr_t recycled_format_ids = FORMAT_ID_NIL;
+static __thread uint32_t formats_size = 0;
+static __thread uint64_t formats_epoch = 0;
 
 /**
  * Find in format1::fields the field by format2_field's JSON path.
@@ -190,7 +190,7 @@ tuple_format_hash(struct tuple_format *format)
 #define mh_cmp_key(a, b, arg) (tuple_format_cmp((a), *(b)))
 #include "salad/mhash.h"
 
-static struct mh_tuple_format_t *tuple_formats_hash = NULL;
+static __thread struct mh_tuple_format_t *tuple_formats_hash = NULL;
 
 static struct tuple_field *
 tuple_field_new(void)
@@ -647,6 +647,7 @@ out:
 							constraint_count);
 
 	format->hash = tuple_format_hash(format);
+	format->owner = cord();
 	return 0;
 }
 
@@ -832,6 +833,7 @@ tuple_format_remove_from_hash(struct tuple_format *format)
 void
 tuple_format_delete(struct tuple_format *format)
 {
+	assert(!tuple_formats_inherited);
 	tuple_format_remove_from_hash(format);
 	tuple_format_deregister(format);
 	tuple_format_destroy(format);
@@ -848,6 +850,7 @@ tuple_format_new(struct tuple_format_vtab *vtab, void *engine,
 		 uint32_t constraint_count, const char *format_data,
 		 size_t format_data_len)
 {
+	assert(!tuple_formats_inherited);
 	struct tuple_format *format =
 		tuple_format_alloc(keys, key_count, space_field_count, dict);
 	if (format == NULL)
@@ -1214,6 +1217,8 @@ tuple_format_min_field_count(struct key_def * const *keys, uint16_t key_count,
 void
 tuple_format_init()
 {
+	assert(tuple_formats == NULL);
+	tuple_formats = xcalloc(FORMAT_ID_MAX + 1, sizeof(*tuple_formats));
 	tuple_formats_hash = mh_tuple_format_new();
 	recycled_format_ids = FORMAT_ID_NIL;
 	formats_size = 0;
@@ -1223,6 +1228,7 @@ tuple_format_init()
 void
 tuple_format_free()
 {
+	assert(!tuple_formats_inherited);
 	/* Clear recycled ids. */
 	while (recycled_format_ids != FORMAT_ID_NIL) {
 		uint16_t id = (uint16_t) recycled_format_ids;
@@ -1237,7 +1243,16 @@ tuple_format_free()
 			free(*format);
 		}
 	}
+	free(tuple_formats);
 	mh_tuple_format_delete(tuple_formats_hash);
+}
+
+void
+tuple_formats_inherit(struct tuple_format **formats)
+{
+	assert(tuple_formats == NULL);
+	tuple_formats = formats;
+	tuple_formats_inherited = true;
 }
 
 void

--- a/src/box/tuple_format.h
+++ b/src/box/tuple_format.h
@@ -314,6 +314,11 @@ struct tuple_format {
 	char *data;
 	/** Length of MsgPack encoding. */
 	size_t data_len;
+	/**
+	 * Thread that created this tuple format. Only the thread that created
+	 * a format may use it for creating and destroying tuples.
+	 */
+	struct cord *owner;
 };
 
 /**
@@ -360,19 +365,26 @@ tuple_format_field(struct tuple_format *format, uint32_t fieldno)
 	return tuple_format_field_by_path(format, fieldno, NULL, 0, 0);
 }
 
-extern struct tuple_format *tuple_formats[];
+/** Global table of tuple formats. */
+extern __thread struct tuple_format **tuple_formats;
+
+/** Set if the tuple format table was inherited from another thread. */
+extern __thread bool tuple_formats_inherited;
 
 static inline uint32_t
 tuple_format_id(struct tuple_format *format)
 {
 	assert(tuple_formats[format->id] == format);
+	assert(tuple_formats_inherited || format->owner == cord());
 	return format->id;
 }
 
 static inline struct tuple_format *
 tuple_format_by_id(uint32_t tuple_format_id)
 {
-	return tuple_formats[tuple_format_id];
+	struct tuple_format *format = tuple_formats[tuple_format_id];
+	assert(tuple_formats_inherited || format->owner == cord());
+	return format;
 }
 
 /** Delete a format with zero ref count. */
@@ -382,6 +394,7 @@ tuple_format_delete(struct tuple_format *format);
 static inline void
 tuple_format_ref(struct tuple_format *format)
 {
+	assert(format->owner == cord());
 	assert((uint64_t)format->refs + 1 <= FORMAT_REF_MAX);
 	format->refs++;
 }
@@ -389,6 +402,7 @@ tuple_format_ref(struct tuple_format *format)
 static inline void
 tuple_format_unref(struct tuple_format *format)
 {
+	assert(format->owner == cord());
 	assert(format->refs >= 1);
 	if (--format->refs == 0)
 		tuple_format_delete(format);
@@ -557,6 +571,24 @@ tuple_field_map_create(struct tuple_format *format, const char *tuple,
  */
 void
 tuple_format_init();
+
+/**
+ * Inherit a tuple format table from another thread.
+ *
+ * The tuple format table is thread-local and normally a thread may only
+ * access tuple formats that were created by it. However, sometimes its
+ * useful to access tuple formats created by another thread, for example,
+ * to sort tuples in helper threads. To let it happen, a thread is supposed
+ * to call tuple_formats_inherit() instead of tuple_format_init() passing
+ * a pointer to the tuple format table from another thread. A thread that
+ * inherited tuple formats may lookup a tuple format by id but it may not
+ * create, destroy, reference, or unreference tuple formats (asserted). In
+ * particular, this means that it may not create or destroy tuples. The main
+ * thread must ensure that formats that can be used by an inheriting thread
+ * will not be freed.
+ */
+void
+tuple_formats_inherit(struct tuple_format **formats);
 
 
 /** Tuple format iterator flags to configure parse mode. */

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -609,15 +609,6 @@ vinyl_engine_check_space_def(struct space_def *def)
 	return 0;
 }
 
-/** Create a vinyl space statement format. */
-static struct tuple_format *
-vy_space_stmt_format_new(struct vy_stmt_env *env, struct key_def *const *keys,
-			 uint16_t key_count, struct space_def *space_def)
-{
-	return space_tuple_format_new(&env->tuple_format_vtab,
-				      env, keys, key_count, space_def);
-}
-
 static struct space *
 vinyl_engine_create_space(struct engine *engine, struct space_def *def,
 			  struct rlist *key_list)
@@ -736,8 +727,8 @@ vinyl_space_create_index(struct space *space, struct index_def *index_def)
 		assert(pk != NULL);
 	}
 	struct vy_lsm *lsm = vy_lsm_new(&env->lsm_env, &env->cache_env,
-					&env->mem_env, index_def, space->format,
-					pk, space_group_id(space));
+					&env->mem_env, index_def, space->def,
+					space->format, pk);
 	if (lsm == NULL)
 		return NULL;
 
@@ -1218,6 +1209,7 @@ vinyl_space_swap_index(struct space *old_space, struct space *new_space,
 				 old_index_id, new_index_id);
 
 	SWAP(old_lsm, new_lsm);
+	SWAP(old_lsm->space_def, new_lsm->space_def);
 	SWAP(old_lsm->format, new_lsm->format);
 
 	/* Update pointer to the primary key. */

--- a/src/box/vy_lsm.c
+++ b/src/box/vy_lsm.c
@@ -42,6 +42,7 @@
 #include "errcode.h"
 #include "histogram.h"
 #include "index_def.h"
+#include "space_def.h"
 #include "say.h"
 #include "schema.h"
 #include "tuple.h"
@@ -122,7 +123,8 @@ vy_lsm_mem_tree_size(struct vy_lsm *lsm)
 struct vy_lsm *
 vy_lsm_new(struct vy_lsm_env *lsm_env, struct vy_cache_env *cache_env,
 	   struct vy_mem_env *mem_env, struct index_def *index_def,
-	   struct tuple_format *format, struct vy_lsm *pk, uint32_t group_id)
+	   struct space_def *space_def, struct tuple_format *format,
+	   struct vy_lsm *pk)
 {
 	static int64_t run_buckets[] = {
 		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 50, 100,
@@ -201,13 +203,14 @@ vy_lsm_new(struct vy_lsm_env *lsm_env, struct vy_cache_env *cache_env,
 	lsm->pk = pk;
 	if (pk != NULL)
 		vy_lsm_ref(pk);
+	lsm->space_def = space_def_dup(space_def);
 	lsm->format = format;
 	tuple_format_ref(lsm->format);
 	heap_node_create(&lsm->in_dump);
 	heap_node_create(&lsm->in_compaction);
 	lsm->space_id = index_def->space_id;
 	lsm->index_id = index_def->iid;
-	lsm->group_id = group_id;
+	lsm->group_id = space_def->opts.group_id;
 	lsm->opts = index_def->opts;
 	vy_lsm_read_set_new(&lsm->read_set);
 	rlist_create(&lsm->on_destroy);
@@ -279,6 +282,7 @@ vy_lsm_delete(struct vy_lsm *lsm)
 	histogram_delete(lsm->run_hist);
 	vy_lsm_stat_destroy(&lsm->stat);
 	vy_cache_destroy(&lsm->cache);
+	space_def_delete(lsm->space_def);
 	tuple_format_unref(lsm->format);
 	TRASH(lsm);
 	free(lsm);

--- a/src/box/vy_lsm.h
+++ b/src/box/vy_lsm.h
@@ -52,6 +52,7 @@ extern "C" {
 #endif /* defined(__cplusplus) */
 
 struct histogram;
+struct space_def;
 struct tuple;
 struct tuple_format;
 struct vy_lsm;
@@ -207,6 +208,8 @@ struct vy_lsm {
 	 * to a primary index.
 	 */
 	struct key_def *pk_in_cmp_def;
+	/** Copy of the space definition. */
+	struct space_def *space_def;
 	/** Tuple format of the space this LSM tree belongs to. */
 	struct tuple_format *format;
 	/**
@@ -336,7 +339,8 @@ vy_lsm_mem_tree_size(struct vy_lsm *lsm);
 struct vy_lsm *
 vy_lsm_new(struct vy_lsm_env *lsm_env, struct vy_cache_env *cache_env,
 	   struct vy_mem_env *mem_env, struct index_def *index_def,
-	   struct tuple_format *format, struct vy_lsm *pk, uint32_t group_id);
+	   struct space_def *space_def, struct tuple_format *format,
+	   struct vy_lsm *pk);
 
 /** Free an LSM tree object. */
 void

--- a/src/box/vy_mem.c
+++ b/src/box/vy_mem.c
@@ -675,7 +675,8 @@ vy_mem_stream_next(struct vy_stmt_stream *virt_stream, struct vy_entry *ret)
 	if (res == NULL) {
 		stream->entry = vy_entry_none();
 	} else {
-		stream->entry.stmt = vy_stmt_dup(res->stmt);
+		stream->entry.stmt = vy_stmt_new_copy(stream->format,
+						      res->stmt);
 		if (stream->entry.stmt == NULL)
 			return -1;
 		stream->entry.hint = res->hint;
@@ -706,12 +707,14 @@ static const struct vy_stmt_stream_iface vy_mem_stream_iface = {
 };
 
 void
-vy_mem_stream_open(struct vy_mem_stream *stream, struct vy_mem *mem)
+vy_mem_stream_open(struct vy_mem_stream *stream, struct vy_mem *mem,
+		   struct tuple_format *format)
 {
 	stream->base.iface = &vy_mem_stream_iface;
 	stream->mem = mem;
 	stream->curr_pos = vy_mem_tree_first(&mem->tree);
 	stream->entry = vy_entry_none();
+	stream->format = format;
 }
 
 /* }}} vy_mem_iterator API implementation */

--- a/src/box/vy_mem.h
+++ b/src/box/vy_mem.h
@@ -442,13 +442,16 @@ struct vy_mem_stream {
 	struct vy_mem_tree_iterator curr_pos;
 	/** The last tuple returned to user */
 	struct vy_entry entry;
+	/** Format for allocating tuples fetched from the in-memory index. */
+	struct tuple_format *format;
 };
 
 /**
  * Open a mem stream. Use vy_stmt_stream api for further work.
  */
 void
-vy_mem_stream_open(struct vy_mem_stream *stream, struct vy_mem *mem);
+vy_mem_stream_open(struct vy_mem_stream *stream, struct vy_mem *mem,
+		   struct tuple_format *format);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/box/vy_scheduler.c
+++ b/src/box/vy_scheduler.c
@@ -180,6 +180,19 @@ struct vy_task {
 	/** LSM tree this task is for. */
 	struct vy_lsm *lsm;
 	/**
+	 * Pointer to the statement environment. Used for creating
+	 * tuple formats in the writer thread.
+	 */
+	struct vy_stmt_env *stmt_env;
+	/**
+	 * Copy of the space definition. We use it to create a copy
+	 * of the space format in the writer thread. We can't just use
+	 * a simple format created from the key definition because
+	 * we still have to check tuple fields while applying UPSERT
+	 * statements.
+	 */
+	struct space_def *space_def;
+	/**
 	 * Copies of lsm->key/cmp_def to protect from
 	 * multithread read/write on alter.
 	 */
@@ -255,6 +268,8 @@ vy_task_new(struct vy_scheduler *scheduler, struct vy_worker *worker,
 	task->worker = worker;
 	task->start_time = ev_monotonic_now(loop());
 	task->lsm = lsm;
+	task->stmt_env = lsm->format->engine;
+	task->space_def = space_def_dup(lsm->space_def);
 	task->cmp_def = key_def_dup(lsm->cmp_def);
 	task->key_def = key_def_dup(lsm->key_def);
 	vy_lsm_ref(lsm);
@@ -288,6 +303,7 @@ vy_task_delete(struct vy_task *task)
 	assert(task->deferred_delete_in_progress == 0);
 	key_def_delete(task->cmp_def);
 	key_def_delete(task->key_def);
+	space_def_delete(task->space_def);
 	vy_lsm_unref(task->lsm);
 	diag_destroy(&task->diag);
 	free(task->vlsns);
@@ -1182,15 +1198,20 @@ vy_task_dump_execute(struct vy_task *task)
 	 */
 	int rc = -1;
 	bool is_primary = (task->lsm->index_id == 0);
+	struct tuple_format *format = vy_space_stmt_format_new(
+			task->stmt_env, &task->cmp_def, 1, task->space_def);
+	if (format == NULL)
+		goto out;
+	tuple_format_ref(format);
 	struct vy_stmt_stream *wi = vy_write_iterator_new(
 			task->cmp_def, is_primary, task->is_last_level,
 			task->vlsns, task->vlsn_count, NULL);
 	if (wi == NULL)
-		goto out;
+		goto out_delete_format;
 	struct vy_mem *mem;
 	rlist_foreach_entry(mem, &task->dumped_mems, in_dump) {
-		if (vy_write_iterator_new_mem(wi, mem) != 0)
-			goto out_close;
+		if (vy_write_iterator_new_mem(wi, mem, format) != 0)
+			goto out_close_wi;
 	}
 	/*
 	 * Don't compress L1 runs as they are most frequently read
@@ -1198,8 +1219,10 @@ vy_task_dump_execute(struct vy_task *task)
 	 * nothing by compressing them.
 	 */
 	rc = vy_task_write_run(task, wi, true);
-out_close:
+out_close_wi:
 	wi->iface->close(wi);
+out_delete_format:
+	tuple_format_unref(format);
 out:
 	return rc;
 }
@@ -1502,23 +1525,36 @@ vy_task_compaction_execute(struct vy_task *task)
 {
 	ERROR_INJECT_SLEEP(ERRINJ_VY_COMPACTION_DELAY);
 	int rc = -1;
-	struct vy_lsm *lsm = task->lsm;
-	bool is_primary = (lsm->index_id == 0);
+	bool is_primary = (task->lsm->index_id == 0);
+	struct tuple_format *format = vy_space_stmt_format_new(
+			task->stmt_env, &task->cmp_def, 1, task->space_def);
+	if (format == NULL)
+		goto out;
+	tuple_format_ref(format);
+	struct tuple_format *key_format = vy_simple_stmt_format_new(
+			task->stmt_env, NULL, 0);
+	if (key_format == NULL)
+		goto out_delete_format;
+	tuple_format_ref(key_format);
 	struct vy_stmt_stream *wi = vy_write_iterator_new(
 			task->cmp_def, is_primary, task->is_last_level,
 			task->vlsns, task->vlsn_count,
 			is_primary ? &task->deferred_delete_handler : NULL);
 	if (wi == NULL)
-		goto out;
+		goto out_delete_key_format;
 	struct vy_slice *slice;
 	rlist_foreach_entry(slice, &task->compacted_slices, in_compaction) {
-		if (vy_write_iterator_new_slice(wi, slice, lsm->format,
-						lsm->env->key_format) != 0)
-			goto out_close;
+		if (vy_write_iterator_new_slice(wi, slice, format,
+						key_format) != 0)
+			goto out_close_wi;
 	}
 	rc = vy_task_write_run(task, wi, false);
-out_close:
+out_close_wi:
 	wi->iface->close(wi);
+out_delete_key_format:
+	tuple_format_unref(key_format);
+out_delete_format:
+	tuple_format_unref(format);
 out:
 	return rc;
 }
@@ -2159,6 +2195,8 @@ vy_worker_f(va_list ap)
 	struct vy_worker *worker = va_arg(ap, struct vy_worker *);
 	struct cbus_endpoint endpoint;
 
+	tuple_format_init();
+
 	cpipe_create(&worker->tx_pipe, "tx");
 	cbus_endpoint_create(&endpoint, cord_name(&worker->cord),
 			     fiber_schedule_cb, fiber());
@@ -2178,5 +2216,7 @@ vy_worker_f(va_list ap)
 	}
 	cbus_endpoint_destroy(&endpoint, cbus_process);
 	cpipe_destroy(&worker->tx_pipe);
+
+	tuple_format_free();
 	return 0;
 }

--- a/src/box/vy_stmt.c
+++ b/src/box/vy_stmt.c
@@ -41,6 +41,7 @@
 #include <small/lsregion.h>
 
 #include "error.h"
+#include "space_def.h"
 #include "tuple_bloom.h"
 #include "tuple_format.h"
 #include "xrow.h"
@@ -153,6 +154,14 @@ vy_simple_stmt_format_new(struct vy_stmt_env *env,
 {
 	return simple_tuple_format_new(&env->tuple_format_vtab,
 				       env, keys, key_count);
+}
+
+struct tuple_format *
+vy_space_stmt_format_new(struct vy_stmt_env *env, struct key_def *const *keys,
+			 uint16_t key_count, const struct space_def *space_def)
+{
+	return space_tuple_format_new(&env->tuple_format_vtab,
+				      env, keys, key_count, space_def);
 }
 
 bool
@@ -417,6 +426,35 @@ vy_stmt_new_delete(struct tuple_format *format, const char *tuple_begin,
 {
 	return vy_stmt_new_with_ops(format, tuple_begin, tuple_end,
 				    NULL, 0, IPROTO_DELETE);
+}
+
+struct tuple *
+vy_stmt_new_copy(struct tuple_format *format, struct tuple *stmt)
+{
+	const char *data;
+	uint32_t data_size;
+	int ops_cnt = 0;
+	struct iovec ops;
+	enum iproto_type type = vy_stmt_type(stmt);
+	if (type == IPROTO_UPSERT) {
+		data = vy_upsert_data_range(stmt, &data_size);
+		uint32_t ops_size;
+		ops.iov_base = (void *)vy_stmt_upsert_ops(stmt, &ops_size);
+		ops.iov_len = ops_size;
+		ops_cnt = 1;
+	} else {
+		data = tuple_data_range(stmt, &data_size);
+	}
+	struct tuple *copy = vy_stmt_new_with_ops(format, data,
+						  data + data_size,
+						  &ops, ops_cnt, type);
+	if (copy != NULL) {
+		/* Copy vy_stmt fields. */
+		size_t offset = sizeof(struct tuple);
+		memcpy((void *)copy + offset, (void *)stmt + offset,
+		       sizeof(struct vy_stmt) - offset);
+	}
+	return copy;
 }
 
 struct tuple *

--- a/src/box/vy_stmt.h
+++ b/src/box/vy_stmt.h
@@ -49,6 +49,7 @@ extern "C" {
 
 struct xrow_header;
 struct region;
+struct space_def;
 struct tuple_format;
 struct tuple_dictionary;
 struct tuple_bloom;
@@ -93,6 +94,11 @@ vy_stmt_env_destroy(struct vy_stmt_env *env);
 struct tuple_format *
 vy_simple_stmt_format_new(struct vy_stmt_env *env,
 			  struct key_def *const *keys, uint16_t key_count);
+
+/** Create a vinyl space statement format. */
+struct tuple_format *
+vy_space_stmt_format_new(struct vy_stmt_env *env, struct key_def *const *keys,
+			 uint16_t key_count, const struct space_def *space_def);
 
 /** Statement flags. */
 enum {
@@ -535,6 +541,16 @@ struct tuple *
 vy_stmt_new_upsert(struct tuple_format *format,
 		   const char *tuple_begin, const char *tuple_end,
 		   struct iovec *operations, uint32_t ops_cnt);
+
+/**
+ * Create a copy of a statement using a new format.
+ *
+ * @param stmt statement
+ * @param format new statement format
+ * @return new statement of the same type with the same data.
+ */
+struct tuple *
+vy_stmt_new_copy(struct tuple_format *format, struct tuple *stmt);
 
 /**
  * Create REPLACE statement from UPSERT statement.

--- a/src/box/vy_write_iterator.c
+++ b/src/box/vy_write_iterator.c
@@ -467,13 +467,14 @@ vy_write_iterator_close(struct vy_stmt_stream *vstream)
  * @return 0 on success or -1 on error (diag is set).
  */
 NODISCARD int
-vy_write_iterator_new_mem(struct vy_stmt_stream *vstream, struct vy_mem *mem)
+vy_write_iterator_new_mem(struct vy_stmt_stream *vstream, struct vy_mem *mem,
+			  struct tuple_format *format)
 {
 	struct vy_write_iterator *stream = (struct vy_write_iterator *)vstream;
 	struct vy_write_src *src = vy_write_iterator_new_src(stream);
 	if (src == NULL)
 		return -1;
-	vy_mem_stream_open(&src->mem_stream, mem);
+	vy_mem_stream_open(&src->mem_stream, mem, format);
 	return 0;
 }
 
@@ -952,16 +953,11 @@ vy_read_view_merge(struct vy_write_iterator *stream, struct vy_entry prev,
 		 * so as not to trigger optimization #5 on the next
 		 * compaction.
 		 */
-		struct tuple *copy = vy_stmt_dup(rv->entry.stmt);
-		if (copy == NULL)
-			return -1;
 		if (is_first_insert)
-			vy_stmt_set_type(copy, IPROTO_INSERT);
+			vy_stmt_set_type(rv->entry.stmt, IPROTO_INSERT);
 		else
-			vy_stmt_set_type(copy, IPROTO_REPLACE);
-		vy_stmt_set_lsn(copy, vy_stmt_lsn(rv->entry.stmt));
-		tuple_unref(rv->entry.stmt);
-		rv->entry.stmt = copy;
+			vy_stmt_set_type(rv->entry.stmt, IPROTO_REPLACE);
+		vy_stmt_set_lsn(rv->entry.stmt, vy_stmt_lsn(rv->entry.stmt));
 	}
 	return 0;
 }

--- a/src/box/vy_write_iterator.h
+++ b/src/box/vy_write_iterator.h
@@ -257,7 +257,8 @@ vy_write_iterator_new(struct key_def *cmp_def, bool is_primary,
  * @return 0 on success, -1 on error (diag is set).
  */
 NODISCARD int
-vy_write_iterator_new_mem(struct vy_stmt_stream *stream, struct vy_mem *mem);
+vy_write_iterator_new_mem(struct vy_stmt_stream *stream, struct vy_mem *mem,
+			  struct tuple_format *format);
 
 /**
  * Add a run slice as a source to the iterator.

--- a/src/lib/core/tt_sort.c
+++ b/src/lib/core/tt_sort.c
@@ -38,6 +38,10 @@ struct sort_data {
 	tt_sort_compare_f cmp;
 	/** Extra argument for `cmp` function. */
 	void *cmp_arg;
+	/** Function for sorter thread initialization. */
+	tt_sort_init_f init;
+	/** Extra argument for `init` function. */
+	void *init_arg;
 	/**
 	 * Number of threads to run sort on. It is equal to number of
 	 * buckets we divide the data to.
@@ -90,6 +94,13 @@ struct sort_worker {
 	size_t bucket_size;
 };
 
+static void
+sort_thread_init(struct sort_data *sort)
+{
+	if (sort->init != NULL)
+		sort->init(sort->init_arg);
+}
+
 /**
  * Find bucket for element using binary search among sorted in ascending
  * order splitters.
@@ -131,6 +142,8 @@ calc_elem_bucket(va_list ap)
 	struct sort_worker *worker = va_arg(ap, typeof(worker));
 	struct sort_data *sort = worker->sort;
 
+	sort_thread_init(sort);
+
 	void *pos = sort->data + worker->begin * sort->elem_size;
 	for (size_t i = worker->begin; i < worker->end; i++) {
 		int b = find_bucket(sort, pos);
@@ -153,6 +166,8 @@ split_to_buckets(va_list ap)
 	struct sort_worker *worker = va_arg(ap, typeof(worker));
 	struct sort_data *sort = worker->sort;
 
+	sort_thread_init(sort);
+
 	void *pos = sort->data + worker->begin * sort->elem_size;
 	for (size_t i = worker->begin; i < worker->end; i++) {
 		int b = sort->elem_bucket[i];
@@ -174,6 +189,8 @@ sort_bucket(va_list ap)
 {
 	struct sort_worker *worker = va_arg(ap, typeof(worker));
 	struct sort_data *sort = worker->sort;
+
+	sort_thread_init(sort);
 
 	/* Sort this worker bucket. */
 	qsort_arg(sort->buffer + worker->bucket_begin * sort->elem_size,
@@ -276,6 +293,8 @@ check_presorted(va_list ap)
 	struct sort_data *sort = worker->sort;
 	worker->presorted = true;
 
+	sort_thread_init(sort);
+
 	ERROR_INJECT_SLEEP_FOR(ERRINJ_TT_SORT_CHECK_PRESORTED_DELAY);
 	void *pos = sort->data + worker->begin * sort->elem_size;
 	void *limit = sort->data + (worker->end - 1) * sort->elem_size;
@@ -294,6 +313,8 @@ static int
 sort_all(va_list ap)
 {
 	struct sort_data *sort = va_arg(ap, typeof(sort));
+
+	sort_thread_init(sort);
 
 	qsort_arg(sort->data, sort->elem_count, sort->elem_size, sort->cmp,
 		  sort->cmp_arg);
@@ -318,7 +339,8 @@ sort_single_thread(struct sort_data *sort)
 
 void
 tt_sort(void *data, size_t elem_count, size_t elem_size,
-	tt_sort_compare_f cmp, void *cmp_arg, int thread_count)
+	tt_sort_compare_f cmp, void *cmp_arg,
+	tt_sort_init_f init, void *init_arg, int thread_count)
 {
 	struct sort_data sort;
 	double time_start, time_finish;
@@ -370,6 +392,8 @@ tt_sort(void *data, size_t elem_count, size_t elem_size,
 	sort.elem_size = elem_size;
 	sort.cmp = cmp;
 	sort.cmp_arg = cmp_arg;
+	sort.init = init;
+	sort.init_arg = init_arg;
 	sort.thread_count = thread_count;
 
 	if (thread_count == 1) {

--- a/src/lib/core/tt_sort.h
+++ b/src/lib/core/tt_sort.h
@@ -16,6 +16,9 @@ extern "C" {
 typedef int
 (*tt_sort_compare_f)(const void *a, const void *b, void *arg);
 
+typedef void
+(*tt_sort_init_f)(void *arg);
+
 /**
  * A variant of sample sort algorithm. Sort is executed in multiple threads.
  * The calling thread itself does not take a working load and yields while
@@ -27,12 +30,15 @@ typedef int
  *  elem_size    - sizeof of single data element
  *  cmp          - comparison function with usual semantics (as in qsort(3)) and
  *                 extra argument
- *  arg          - extra argument to be passed to comparison function
+ *  cmp_arg      - extra argument to be passed to comparison function
+ *  init         - if not NULL, function called in each thread at start
+ *  init_arg     - extra argument to be passed to the initialization function
  *  thread_count - number of threads to execute the sort in
  */
 void
 tt_sort(void *data, size_t elem_count, size_t elem_size,
-	tt_sort_compare_f cmp, void *cmp_arg, int thread_count);
+	tt_sort_compare_f cmp, void *cmp_arg,
+	tt_sort_init_f init, void *init_arg, int thread_count);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/test/unit/tt_sort.cc
+++ b/test/unit/tt_sort.cc
@@ -48,7 +48,7 @@ test_no_extra_threads(void)
 			v = gen();
 
 		tt_sort(data.data(), N, sizeof(data[0]), cmp_testing,
-			nullptr, 4);
+			nullptr, nullptr, nullptr, 4);
 
 		ok(std::is_sorted(data.begin(), data.end()), "Must be sorted");
 	}
@@ -70,19 +70,22 @@ test_no_extra_threads_presorted(void)
 	/* All elements are equal. */
 	for (auto &v : data)
 		v = 1;
-	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing, nullptr, 4);
+	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing,
+		nullptr, nullptr, nullptr, 4);
 	ok(std::is_sorted(data.begin(), data.end()), "Must be sorted");
 
 	/* Data is presorted. */
 	for (int i = 0; i < N; i++)
 		data[i] = i;
-	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing, nullptr, 4);
+	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing,
+		nullptr, nullptr, nullptr, 4);
 	ok(std::is_sorted(data.begin(), data.end()), "Must be sorted");
 
 	/* Data is presorted but in descending order. */
 	for (int i = 0; i < N; i++)
 		data[i] = N - i;
-	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing, nullptr, 4);
+	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing,
+		nullptr, nullptr, nullptr, 4);
 	ok(std::is_sorted(data.begin(), data.end()), "Must be sorted");
 
 	footer();
@@ -112,7 +115,7 @@ test_multi_threaded(void)
 				v = gen();
 
 			tt_sort(data.data(), N, sizeof(data[0]), cmp_testing,
-				nullptr, t);
+				nullptr, nullptr, nullptr, t);
 
 			ok(std::is_sorted(data.begin(), data.end()),
 			   "Must be sorted");
@@ -136,19 +139,22 @@ test_presorted()
 	/* All elements are equal. */
 	for (auto &v : data)
 		v = 1;
-	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing, nullptr, 4);
+	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing,
+		nullptr, nullptr, nullptr, 4);
 	ok(std::is_sorted(data.begin(), data.end()), "Must be sorted");
 
 	/* Data is presorted. */
 	for (int i = 0; i < N; i++)
 		data[i] = i;
-	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing, nullptr, 4);
+	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing,
+		nullptr, nullptr, nullptr, 4);
 	ok(std::is_sorted(data.begin(), data.end()), "Must be sorted");
 
 	/* Data is presorted but in descending order. */
 	for (int i = 0; i < N; i++)
 		data[i] = N - i;
-	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing, nullptr, 4);
+	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing,
+		nullptr, nullptr, nullptr, 4);
 	ok(std::is_sorted(data.begin(), data.end()), "Must be sorted");
 
 	/*
@@ -159,7 +165,8 @@ test_presorted()
 		data[i] = i;
 	for (int i = 0; i < N / 2; i++)
 		data[N / 2 + i] = i;
-	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing, nullptr, 2);
+	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing,
+		nullptr, nullptr, nullptr, 2);
 	ok(std::is_sorted(data.begin(), data.end()), "Must be sorted");
 
 	/*
@@ -169,7 +176,8 @@ test_presorted()
 	for (int i = 0; i < N; i++)
 		data[i] = i;
 	data[N / 4] = 0;
-	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing, nullptr, 2);
+	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing,
+		nullptr, nullptr, nullptr, 2);
 	ok(std::is_sorted(data.begin(), data.end()), "Must be sorted");
 
 	footer();
@@ -194,7 +202,8 @@ test_degenerated_bucket()
 	for (int i = 0; i < N; i++)
 		data[i] = i % 7 == 0 ? gen() : 0;
 
-	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing, nullptr, 4);
+	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing,
+		nullptr, nullptr, nullptr, 4);
 
 	ok(std::is_sorted(data.begin(), data.end()), "Must be sorted");
 
@@ -219,7 +228,8 @@ test_extra_argument()
 		v = gen();
 
 	int arg;
-	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing, &arg, 3);
+	tt_sort(data.data(), N, sizeof(data[0]), cmp_testing, &arg,
+		nullptr, nullptr, 3);
 	std::reverse(data.begin(), data.end());
 	ok(std::is_sorted(data.begin(), data.end()), "Must be sorted");
 

--- a/test/unit/vy_iterators_helper.c
+++ b/test/unit/vy_iterators_helper.c
@@ -14,6 +14,11 @@ struct vy_cache_env cache_env;
 struct mempool history_node_pool;
 struct vy_stmt_counter dummy_count;
 
+struct tuple_format *
+space_tuple_format_new(struct tuple_format_vtab *vtab, void *engine,
+		       struct key_def *const *keys, uint16_t key_count,
+		       const struct space_def *def) { return NULL; }
+
 void
 vy_iterator_C_test_init(size_t cache_size)
 {

--- a/test/unit/vy_point_lookup.c
+++ b/test/unit/vy_point_lookup.c
@@ -9,6 +9,7 @@
 #include "vy_iterators_helper.h"
 #include "vy_write_iterator.h"
 #include "identifier.h"
+#include "space_def.h"
 
 uint64_t schema_version;
 uint32_t space_cache_version;
@@ -18,6 +19,10 @@ struct space *
 space_by_id_slow(uint32_t id) { return NULL; }
 struct vy_lsm *vy_lsm(struct index *index) { return NULL; }
 void index_delete(struct index *index) { unreachable(); }
+struct space_def *
+space_def_dup(const struct space_def *space_def) { return NULL; }
+void
+space_def_delete(struct space_def *space_def) {}
 
 static int
 write_run(struct vy_run *run, const char *dir_name,
@@ -95,8 +100,10 @@ test_basic()
 			      NULL, NULL, TREE,
 			      &index_opts, key_def, NULL);
 
+	struct space_def space_def;
+	memset(&space_def, 0, sizeof(space_def));
 	struct vy_lsm *pk = vy_lsm_new(&lsm_env, &cache_env, &mem_env,
-				       index_def, format, NULL, 0);
+				       index_def, &space_def, format, NULL);
 	isnt(pk, NULL, "lsm is not NULL");
 
 	struct vy_range *range = vy_range_new(1, vy_entry_none(),
@@ -194,7 +201,7 @@ test_basic()
 	struct vy_stmt_stream *write_stream;
 	write_stream = vy_write_iterator_new(pk->cmp_def, true, true,
 					     NULL, 0, NULL);
-	vy_write_iterator_new_mem(write_stream, run_mem);
+	vy_write_iterator_new_mem(write_stream, run_mem, run_mem->format);
 	struct vy_run *run = vy_run_new(&run_env, 1);
 	isnt(run, NULL, "vy_run_new");
 
@@ -225,7 +232,7 @@ test_basic()
 	}
 	write_stream = vy_write_iterator_new(pk->cmp_def, true, true,
 					     NULL, 0, NULL);
-	vy_write_iterator_new_mem(write_stream, run_mem);
+	vy_write_iterator_new_mem(write_stream, run_mem, run_mem->format);
 	run = vy_run_new(&run_env, 2);
 	isnt(run, NULL, "vy_run_new");
 

--- a/test/unit/vy_write_iterator.c
+++ b/test/unit/vy_write_iterator.c
@@ -105,7 +105,7 @@ compare_write_iterator_results(const struct vy_stmt_template *content,
 				   vlsns, vlsns_count,
 				   is_primary ? &handler.base : NULL);
 	fail_if(wi == NULL);
-	fail_if(vy_write_iterator_new_mem(wi, mem) != 0);
+	fail_if(vy_write_iterator_new_mem(wi, mem, mem->format) != 0);
 
 	struct vy_entry ret;
 	fail_if(wi->iface->start(wi) != 0);


### PR DESCRIPTION
In order to be able to create tuples in application threads, we need to make the tuple registry thread-local. To achieve that, we make all related global variables thread-local and add some debug checks ensuring that a format is used only from the thread that created that.

There are two subsystems in Tarantool that rely upon the tuple format registry being the same in all threads. The first one is Vinyl: it references space formats by pointer in writer threads. To make it compatible with thread-local formats, we patch Vinyl to create a thread-local copy of the space format for each dump/compaction task. Note that we can't just create a simple tuple format from the key definition because we still have to check tuple fields while applying updates. So we pass the space definition via the dump/compaction task object.

The second subsystem that needs to be patched is the memtx tuple sorter executed at recovery completion to build secondary indexes. We fix it by inheriting the tuple format table from the main thread in each sorter thread. A thread inheriting a tuple format table may look up tuple formats by id but it may not create, destroy, reference, or unreference tuple formats. In particular, it means that it may not create or destroy tuples. Basically, it's useful only for tuple comparison.

Closes #12210