### PR TITLE
datetime: fixed corrupt of dt obj on errors in set()

### DIFF
--- a/changelogs/unreleased/gh-12171-datetime-set-corrupt-on-error.md
+++ b/changelogs/unreleased/gh-12171-datetime-set-corrupt-on-error.md
@@ -1,0 +1,4 @@
+## bugfix/datetime
+
+* Fixed corruption of a datetime object by the `set()` function
+  when an error occurs (gh-12171).

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -400,16 +400,6 @@ local function utc_secs(epoch, tzoffset)
     return epoch - tzoffset * 60
 end
 
-local function time_delocalize(self)
-    self.epoch = local_secs(self)
-    self.tzoffset = 0
-end
-
-local function time_localize(self, offset)
-    self.epoch = utc_secs(self.epoch, offset)
-    self.tzoffset = offset
-end
-
 -- get epoch seconds, shift to the local timezone
 -- adjust from 1970-related to 0000-related time
 -- then return dt in those coordinates (number of days
@@ -1059,21 +1049,19 @@ local function datetime_totable(self)
     }
 end
 
-local function datetime_update_dt(self, dt)
-    local epoch = self.epoch
+local function datetime_update_epoch_dt(epoch, dt)
     local secs_day = epoch % SECS_PER_DAY
-    self.epoch = (dt - DAYS_EPOCH_OFFSET) * SECS_PER_DAY + secs_day
+    return (dt - DAYS_EPOCH_OFFSET) * SECS_PER_DAY + secs_day
 end
 
-local function datetime_ymd_update(self, y, M, d)
+local function datetime_update_epoch_ymd(epoch, y, M, d)
     local dt = dt_from_ymd(y, M, d)
-    datetime_update_dt(self, dt)
+    return datetime_update_epoch_dt(epoch, dt)
 end
 
-local function datetime_hms_update(self, h, m, s)
-    local epoch = self.epoch
+local function datetime_update_epoch_hms(epoch, h, m, s)
     local secs_day = epoch - (epoch % SECS_PER_DAY)
-    self.epoch = secs_day + h * 3600 + m * 60 + s
+    return secs_day + h * 3600 + m * 60 + s
 end
 
 function datetime_set(self, obj)
@@ -1105,35 +1093,34 @@ function datetime_set(self, obj)
     builtin.tnt_dt_to_ymd(dt, y0, M0, d0)
     y0, M0, d0 = y0[0], M0[0], d0[0]
 
+    -- Normalize time to UTC from current timezone,
+    -- lsecs is "normalized" time.
     local lsecs = local_secs(self)
     local h0 = math_floor(lsecs / (60 * 60)) % 24
     local m0 = math_floor(lsecs / 60) % 60
     local s0 = lsecs % 60
 
-    -- normalize time to UTC from current timezone
-    local old_tzoffset = self.tzoffset
-    time_delocalize(self)
-
     -- .year, .month, .day
     if ymd then
-        datetime_ymd_update(self, y or y0, M or M0, d or d0)
+        lsecs = datetime_update_epoch_ymd(lsecs, y or y0, M or M0, d or d0)
     end
 
     -- TODO need to check:
     -- datetime_new() uses epoch_from_dt(dt) as base_epoch, there
-    -- h:m:s = 00:00:00. This differ with self.epoch as base_epoch
+    -- h:m:s = 00:00:00. This differ with lsecs as base_epoch
     -- due to h:m:s may have any proper value.
-    local tzoffset, tzindex = extract_obj_tzoffset_tzindex(obj, self.epoch)
+    local tzoffset, tzindex = extract_obj_tzoffset_tzindex(obj, lsecs)
 
     -- .hour, .minute, .second
     if hms then
-        datetime_hms_update(self, h or h0, m or m0, s or s0)
+        lsecs = datetime_update_epoch_hms(lsecs, h or h0, m or m0, s or s0)
     end
 
     -- denormalize back to local timezone
-    local effective_tzoffset = tzoffset or old_tzoffset
-    time_localize(self, effective_tzoffset)
+    local effective_tzoffset = tzoffset or self.tzoffset
+    self.epoch = utc_secs(lsecs, effective_tzoffset)
     self.nsec = nsec or self.nsec
+    self.tzoffset = effective_tzoffset
     self.tzindex = tzindex or self.tzindex
 
     return self

--- a/test/app-luatest/datetime_test.lua
+++ b/test/app-luatest/datetime_test.lua
@@ -2166,6 +2166,24 @@ end
 
 -- {{{ new() and set() invalid args test.
 
+-- For set() we must fill all components to check possible corruption.
+local SET_BASE_DATE_TIME_UNITS = dt.new({
+    year = 2021, month = 2, day = 3,
+    hour = 12, min = 34, sec = 56,
+    nsec = 123456789, tz = 'Europe/Moscow'}):totable()
+-- Workaround for gh-12619.
+SET_BASE_DATE_TIME_UNITS.timestamp = nil
+
+-- Timestamp fixing for gh-10363 workaround.
+local function to_local_time(timestamp)
+    checks('number')
+    return timestamp + SET_BASE_DATE_TIME_UNITS.tzoffset * 60
+end
+local function to_utc_time(timestamp)
+    checks('number')
+    return timestamp - SET_BASE_DATE_TIME_UNITS.tzoffset * 60
+end
+
 local INVALID_NEW_AND_SET_TIME_UNITS_ERRORS = {
     only_one_of = 'only one of nsec, usec or msecs may be defined'..
         ' simultaneously',
@@ -2214,6 +2232,15 @@ local INVALID_NEW_AND_SET_TIME_UNITS_ERRORS = {
               format(val, key, range[1], range[2])
     end,
 
+    range_check_error_set_timestamp = function(set_arg, range)
+        checks({timestamp = 'number'}, {[1] = 'number', [2] = 'number'})
+        local key, val = get_single_key_val(set_arg, true)
+        -- Workaround for gh-10363.
+        val = to_utc_time(val)
+        return ('value %d of %s is out of allowed range [%d, %d]'):
+              format(val, key, range[1], range[2])
+    end,
+
     range_check_3_error = function(set_arg, range)
         local key, val = get_single_key_val(set_arg, true)
         return ('value %d of %s is out of allowed range [%d, %d..%d]'):
@@ -2236,6 +2263,13 @@ local INVALID_NEW_AND_SET_TIME_UNITS_ERRORS = {
         t.fail_if(M == nil, msg)
         t.fail_if(y == nil, msg)
         return ('date %d-%02d-%02d is invalid'):format(y, M, d)
+    end,
+
+    couldnt_parse_tz = function(set_arg, msg_tail)
+        checks('?', '?string')
+        msg_tail = msg_tail or ''
+        local _, val = get_single_key_val(set_arg, true)
+        return ('could not parse \'%s\''):format(val)..msg_tail
     end,
 
     invalid_tzoffset_fmt_error = function(set_arg)
@@ -2420,6 +2454,25 @@ local INVALID_NEW_AND_SET_TIME_UNITS = {
         },
         err_fn = 'invalid_tzoffset_fmt_error',
     },
+    -- Timezone parse tests.
+    {
+        set = {tz = 'zzzYYYwww'},
+        err_fn = 'couldnt_parse_tz',
+    },
+    -- See lib/tzcode/timezones.h for erroneous zones.
+    {
+        -- Zones with TZ_AMBIGUOUS flag.
+        set = {tz = 'ECT'},
+        err_fn = 'couldnt_parse_tz',
+        err_fn_args = {' - ambiguous timezone'},
+    },
+    {
+        -- Zones with TZ_NYI flag.
+        set = {tz = '_'},
+        err_fn = 'couldnt_parse_tz',
+        err_fn_args = {' - nyi timezone'},
+        skip = 'no zones with TZ_NYI flag',
+    },
     -- Single unit range tests.
     {
         set_range = {'year', YEAR_RANGE},
@@ -2451,10 +2504,26 @@ local INVALID_NEW_AND_SET_TIME_UNITS = {
         err_fn = 'range_check_error_string',
         err_fn_args = {SEC_RANGE},
     },
+    -- new() test: we create new datetime object with tzoffset = 0,
+    -- therefore workaround for gh-10363 is not needed.
     {
         set_range = {'timestamp', TIMESTAMP_RANGE},
         err_fn = 'range_check_error_digit',
         err_fn_args = {TIMESTAMP_RANGE},
+        _set = {skip = 'need workaround for gh-10363'},
+    },
+    -- set() test: we use source object with tzoffset ~= 0 and
+    -- workaround for gh-10363 is needed.
+    {
+        set_multiple = {
+            {timestamp = to_local_time(TIMESTAMP_RANGE[1] - 1)},
+            {timestamp = to_local_time(TIMESTAMP_RANGE[1] - 50)},
+            {timestamp = to_local_time(TIMESTAMP_RANGE[2] + 1)},
+            {timestamp = to_local_time(TIMESTAMP_RANGE[2] + 50)},
+        },
+        err_fn = 'range_check_error_set_timestamp',
+        err_fn_args = {TIMESTAMP_RANGE},
+        _new = {skip = 'only set'},
     },
     {
         set_range = {'msec', MSEC_RANGE},
@@ -2552,8 +2621,18 @@ local function test_invalid_new_and_set_time_units(cg, new_test)
     end
     t.skip_if(p.skip ~= nil, p.skip)
 
-    local function new_tester(set) dt.new(set) end
-    local function set_tester(set) dt.new():set(set) end
+    local function new_tester(set, expected_error)
+        checks('?', 'string')
+        t.assert_error_msg_contains(expected_error, dt.new, set)
+    end
+    local function set_tester(set, expected_error)
+        checks('?', 'string')
+        local d = dt.new(SET_BASE_DATE_TIME_UNITS)
+        local before = d:totable()
+        t.assert_error_msg_contains(expected_error, d.set, d, set)
+        local after = d:totable()
+        t.assert_equals(after, before, 'd was changed')
+    end
     local tester = new_test and new_tester or set_tester
 
     local function single_test(set)
@@ -2572,7 +2651,7 @@ local function test_invalid_new_and_set_time_units(cg, new_test)
             t.fail('misconfig')
         end
         -- Check for required error.
-        t.assert_error_msg_contains(error, tester, set)
+        tester(set, error)
     end
 
     local function multiple_test(set_multiple)

--- a/test/app-luatest/datetime_test.lua
+++ b/test/app-luatest/datetime_test.lua
@@ -2237,6 +2237,11 @@ local INVALID_NEW_AND_SET_TIME_UNITS_ERRORS = {
         t.fail_if(y == nil, msg)
         return ('date %d-%02d-%02d is invalid'):format(y, M, d)
     end,
+
+    invalid_tzoffset_fmt_error = function(set_arg)
+        local _, val = get_single_key_val(set_arg, true)
+        return ('invalid time-zone format %s'):format(val)
+    end,
 }
 
 local INVALID_NEW_AND_SET_TIME_UNITS = {
@@ -2399,6 +2404,21 @@ local INVALID_NEW_AND_SET_TIME_UNITS = {
         set = {tz = 400},
         err_fn = 'expected_type',
         err_fn_args = {'string', 'parse_tzname()'},
+    },
+    -- Tzoffset parse tests.
+    {
+        set_multiple = {
+            {tzoffset = '+03:00 what?'},
+            {tzoffset = '-0000 '},
+            {tzoffset = '+0000 '},
+            {tzoffset = 'bogus'},
+            {tzoffset = '0100'},
+            {tzoffset = '+-0100'},
+            {tzoffset = '+25:00'},
+            {tzoffset = '+9900'},
+            {tzoffset = '-99:00'},
+        },
+        err_fn = 'invalid_tzoffset_fmt_error',
     },
     -- Single unit range tests.
     {

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -9,7 +9,7 @@ local msgpack = require('msgpack')
 local TZ = date.TZ
 local compat = require('compat')
 
-test:plan(42)
+test:plan(41)
 
 local INT_MAX = 2147483647
 local INT_MIN = -2147483648
@@ -72,10 +72,6 @@ end
 local function ival_overflow(op, name, value, max)
     return ('%s moves value %s of %s out of allowed range [%s, %s]'):
             format(op, value, name, -max, max)
-end
-
-local function invalid_tz_fmt_error(val)
-    return ('invalid time-zone format %s'):format(val)
 end
 
 local function invalid_date_fmt_error(str)
@@ -2844,38 +2840,6 @@ test:test("Check :set{} and .new{} equal for all attributes", function(test)
     test:is_deeply(ts:totable(), ts2:totable(),
                    ':totable() equals:'..
                    json.encode({ts:totable(), ts2:totable()}))
-end)
-
-test:test("Time invalid tzoffset in :set{} operations", function(test)
-    test:plan(13)
-
-    local ts = date.new{}
-    local bad_strings = {
-        '+03:00 what?',
-        '-0000 ',
-        '+0000 ',
-        'bogus',
-        '0100',
-        '+-0100',
-        '+25:00',
-        '+9900',
-        '-99:00',
-    }
-    for _, val in ipairs(bad_strings) do
-        assert_raises(test, invalid_tz_fmt_error(val),
-                      function() ts:set{ tzoffset = val } end)
-    end
-
-    local bad_numbers = {
-        880,
-        -800,
-        10000,
-        -10000,
-    }
-    for _, val in ipairs(bad_numbers) do
-        assert_raises(test, range_check_error('tzoffset', val, {-720, 840}),
-                      function() ts:set{ tzoffset = val } end)
-    end
 end)
 
 test:test("Time :set{day = -1} operations", function(test)


### PR DESCRIPTION
`set()` calculates datetime components locally and sets them after all calculations succedeed (commit - 2).

"Time invalid tzoffset in :set{} operations" test suite was moved from tap to luatest as prerequisite (commit - 1):
- 9 tests are moved.
- 4 duplicated range tests are dropped.

Fixes #12171

NO_DOC=bugfix

----

Waits for #12423 and it's backports #12549 #12550 #12551 #12552 #12553 to be merged.