### PR TITLE
[backport: release/2.11] ci: don't send coverage results for submodules

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -93,6 +93,8 @@ jobs:
         run: make -f .test.mk test-coverage
 
       - name: Upload coverage results to coveralls.io
+        # Avoid interference with the coverage of a submodule.
+        if: ${{ !inputs.submodule }}
         run: |
           coveralls-lcov \
             --service-name=github \


### PR DESCRIPTION
If coverage workflow is triggered via submodule as a part of integration testing, coverage reports from Tarantool are sent to coveralls as reports from the submodule. Our fork of LuaJIT as well as Tarantool uses Coveralls, this will avoid reporting Tarantool's coverage to LuaJIT's namespace in Coveralls.

To avoid this misbehaviour, run the "upload report" step only when there is no submodule to bump (specified as `inputs.submodule` [1]) as a part of the reusable workflow.

[1]: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#example-specifying-inputs

NO_DOC=CI
NO_TEST=CI
NO_CHANGELOG=CI

(cherry picked from commit 68b73fe7d9bd4ec995fe9bff5539c5ccc5ed0509)