### PR TITLE
[backport 3.3] build: fix use --builddir with absolute path

### DIFF
--- a/.test.mk
+++ b/.test.mk
@@ -20,7 +20,7 @@ N_TRIALS ?= 128
 COMMIT_RANGE ?= master..HEAD
 
 VARDIR ?= /tmp/t
-TEST_RUN_PARAMS = --builddir ${PWD}/${BUILD_DIR}
+TEST_RUN_PARAMS = --builddir $(realpath ${BUILD_DIR})
 
 CMAKE = ${CMAKE_ENV} cmake -S ${SRC_DIR} -B ${BUILD_DIR}
 CMAKE_BUILD = ${CMAKE_BUILD_ENV} cmake --build ${BUILD_DIR} --parallel ${NPROC}


### PR DESCRIPTION
_(This PR is a backport of https://github.com/tarantool/tarantool/pull/12139  to release/3.3)_

---

Before the patch, `test-run.py` used for `--buildir` option the path provided by the user. If the path was relative and `.test.mk` was executed from another directory, `test-run.py` couldn't find Tarantool executable binary. The patch converts the relative path to an absolute one, and this scenario now works.

NO_TEST=internal
NO_CHANGELOG=internal
NO_DOC=internal

(cherry picked from commit 8c590e3d5945422d39f9064c88c9f1c19c3ba792)