### PR TITLE
fix(core): preserve entry order in box.info.listen

### DIFF
--- a/src/lib/core/evio.c
+++ b/src/lib/core/evio.c
@@ -338,7 +338,7 @@ static void
 evio_service_add_entry(struct evio_service *dst,
 		       struct evio_service_entry *entry)
 {
-	rlist_add_entry(&dst->entries, entry, link);
+	rlist_add_tail_entry(&dst->entries, entry, link);
 	++dst->entry_count;
 }
 


### PR DESCRIPTION
Commit 4c8463cc ("core: bind to all addresses") changed evio to bind all addresses returned by getaddrinfo. However, entries were added to the service list using rlist_add_entry which prepends to the head, causing box.info.listen to contain entries in reverse order compared to box.cfg.listen.

Change to rlist_add_tail_entry to append entries at the tail, preserving the original order so that box.info.listen[i] corresponds to box.cfg.listen[i].

Follows up #7152