### PR TITLE
config: add `wait_status()` helper

### DIFF
--- a/changelogs/unreleased/gh-12389-wait-config-status-helper.md
+++ b/changelogs/unreleased/gh-12389-wait-config-status-helper.md
@@ -1,0 +1,5 @@
+## feature/config
+
+* Added `config:wait_status(statuses, [timeout])` to wait until the instance
+  reaches one of the specified configuration statuses and returns the actual
+  status observed when the wait finishes (gh-12389).

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -1,3 +1,4 @@
+local fiber = require('fiber')
 local fio = require('fio')
 local instance_config = require('internal.config.instance_config')
 local cluster_config = require('internal.config.cluster_config')
@@ -81,6 +82,41 @@ end
 
 local function broadcast(self)
     box.broadcast('config.info', self:info())
+end
+
+local status_names = {
+    uninitialized = true,
+    startup_in_progress = true,
+    reload_in_progress = true,
+    check_errors = true,
+    check_warnings = true,
+    ready = true,
+}
+
+local function normalize_waited_statuses(statuses)
+    if type(statuses) == 'string' then
+        statuses = {statuses}
+    elseif type(statuses) ~= 'table' then
+        error(('Expected string or table, got %s'):format(type(statuses)), 0)
+    end
+
+    local res = {}
+    for i, status in ipairs(statuses) do
+        if type(status) ~= 'string' then
+            error(('Expected string, got %s at index %d'):format(
+                type(status), i), 0)
+        end
+        if not status_names[status] then
+            error(('Unknown config status %q'):format(status), 0)
+        end
+        res[status] = true
+    end
+
+    if next(res) == nil then
+        error('Expected at least one config status', 0)
+    end
+
+    return res
 end
 
 function methods._meta(self, source_name, key, value)
@@ -561,6 +597,52 @@ function methods.info(self, version)
 
     error(('config:info() expects %s or nil as an argument, got %q'):format(
         table.concat(supported_versions, ', '), version), 0)
+end
+
+function methods.wait_status(self, statuses, timeout)
+    selfcheck(self, 'wait_status')
+
+    local waited_statuses = normalize_waited_statuses(statuses)
+
+    if timeout ~= nil and type(timeout) ~= 'number' then
+        error(('Expected timeout to be a non-negative number or nil, ' ..
+              'got %s'):format(type(timeout)), 0)
+    end
+
+    if timeout ~= nil and timeout < 0 then
+        error('Expected timeout to be a non-negative number or nil, ' ..
+              'got negative number', 0)
+    end
+
+    local actual_status = self._status
+    if waited_statuses[actual_status] then
+        return actual_status
+    end
+
+    local cond = fiber.cond()
+    local watcher = box.watch('config.info', function(_, info)
+        -- Fallback to the status from self._status when config.info is nil,
+        -- as the config may not be initialized yet.
+        actual_status = info and info.status or self._status
+        if waited_statuses[actual_status] then
+            cond:signal()
+        end
+    end)
+
+    local ok, err = pcall(function()
+        local deadline = fiber.clock() + (timeout or math.huge)
+        repeat
+        until waited_statuses[actual_status] or
+            not cond:wait(math.max(0, deadline - fiber.clock()))
+    end)
+
+    watcher:unregister()
+
+    if not ok then
+        error(err, 0)
+    end
+
+    return actual_status
 end
 
 function methods.is_storage(self, opts)

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -296,6 +296,129 @@ g.test_config_broadcast = function()
     t.assert_equals(res.stdout, table.concat(exp, "\n"))
 end
 
+g.test_config_wait_status = function()
+    local dir = treegen.prepare_directory({}, {})
+    local file_config = [[
+        groups:
+          group-001:
+            replicasets:
+              replicaset-001:
+                instances:
+                  instance-001: {}
+    ]]
+    treegen.write_file(dir, 'config.yaml', file_config)
+
+    local script = [[
+        local fiber = require('fiber')
+        local config = require('config')
+
+        config:_startup('instance-001', 'config.yaml')
+        print(config:wait_status({'ready'}))
+        print(config:wait_status({'ready'}, 0))
+
+        local ch = fiber.channel(1)
+        fiber.create(function()
+            ch:put(config:wait_status({'reload_in_progress'}, 60))
+        end)
+        fiber.sleep(0)
+
+        config:reload()
+        print(ch:get())
+        print(config:wait_status({'ready',
+                                  'check_warnings', 'check_errors'}, 0))
+        print(config:wait_status({'check_errors'}, 0.01))
+        os.exit(0)
+    ]]
+    treegen.write_file(dir, 'main.lua', script)
+    local opts = {nojson = true, stderr = false}
+    local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
+    t.assert_equals(res.exit_code, 0)
+    t.assert_equals(res.stdout,
+        table.concat({'ready', 'ready', 'reload_in_progress', 'ready',
+                      'ready'}, "\n"))
+end
+
+g.test_config_wait_status_before_startup = function()
+    local dir = treegen.prepare_directory({}, {})
+    local file_config = [[
+        groups:
+          group-001:
+            replicasets:
+              replicaset-001:
+                instances:
+                  instance-001: {}
+    ]]
+    treegen.write_file(dir, 'config.yaml', file_config)
+
+    local script = [[
+        local fiber = require('fiber')
+        local config = require('config')
+
+        print(config:wait_status({'ready'}, 0.01))
+        print(config:wait_status({'uninitialized'}))
+
+        local ch = fiber.channel(1)
+        fiber.create(function()
+            ch:put(config:wait_status({'ready', 'check_warnings',
+                                       'check_errors'}, 60))
+        end)
+        fiber.sleep(0)
+
+        config:_startup('instance-001', 'config.yaml')
+        print(ch:get())
+        os.exit(0)
+    ]]
+    treegen.write_file(dir, 'main.lua', script)
+    local opts = {nojson = true, stderr = false}
+    local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
+    t.assert_equals(res.exit_code, 0)
+    t.assert_equals(res.stdout,
+        table.concat({'uninitialized', 'uninitialized', 'ready'}, "\n"))
+end
+
+g.test_config_wait_status_negative = function()
+    local dir = treegen.prepare_directory({}, {})
+    local file_config = [[
+        groups:
+          group-001:
+            replicasets:
+              replicaset-001:
+                instances:
+                  instance-001: {}
+    ]]
+    treegen.write_file(dir, 'config.yaml', file_config)
+
+    local script = [[
+        local config = require('config')
+
+        config:_startup('instance-001', 'config.yaml')
+
+        local ok, err = pcall(function()
+            config:wait_status({'ready'}, -1)
+        end)
+
+        print(ok)
+        print(err:match('Expected timeout to be a non%-negative number or ' ..
+              'nil, got negative number') ~= nil)
+
+        ok, err = pcall(function()
+            config:wait_status({'ready'}, 'bad')
+        end)
+
+        print(ok)
+        print(err:match('Expected timeout to be a non%-negative number or ' ..
+              'nil, got string') ~= nil)
+        os.exit(0)
+    ]]
+    treegen.write_file(dir, 'main.lua', script)
+
+    local opts = {nojson = true, stderr = false}
+    local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
+    t.assert_equals(res.exit_code, 0)
+    t.assert_equals(res.stdout,
+                    table.concat({'false', 'true', 'false', 'true'}, "\n"))
+end
+
 g.test_config_option = function()
     local dir = treegen.prepare_directory({}, {})
     local file_config = [[


### PR DESCRIPTION
This patch adds `config:wait_status()`, which waits until the instance reaches one of the specified config statuses and returns the actual status observed when the wait finishes.

Closes #12389

DR: https://github.com/tarantool/doc/issues/5643