### PR TITLE
iproto: enable tuple extension for application threads

### DIFF
--- a/src/box/app_threads.c
+++ b/src/box/app_threads.c
@@ -17,6 +17,7 @@
 #include "diag.h"
 #include "fiber.h"
 #include "fiber_pool.h"
+#include "mp_box_ctx.h"
 #include "msgpuck.h"
 #include "port.h"
 #include "say.h"
@@ -97,9 +98,13 @@ app_thread_process_call(struct call_request *request, struct port *port)
 {
 	const char *name = request->name;
 	uint32_t name_len = mp_decode_strl(&name);
+	struct mp_box_ctx ctx;
+	if (mp_box_ctx_create(&ctx, NULL, request->tuple_formats) != 0)
+		return -1;
 	struct port args;
-	port_msgpack_create(&args, request->args,
-			    request->args_end - request->args);
+	port_msgpack_create_with_ctx(&args, request->args,
+				     request->args_end - request->args,
+				     (struct mp_ctx *)&ctx);
 	int rc = app_thread_lua_call(name, name_len, &args, port);
 	port_msgpack_destroy(&args);
 	return rc;
@@ -110,9 +115,13 @@ app_thread_process_eval(struct call_request *request, struct port *port)
 {
 	const char *expr = request->expr;
 	uint32_t expr_len = mp_decode_strl(&expr);
+	struct mp_box_ctx ctx;
+	if (mp_box_ctx_create(&ctx, NULL, request->tuple_formats) != 0)
+		return -1;
 	struct port args;
-	port_msgpack_create(&args, request->args,
-			    request->args_end - request->args);
+	port_msgpack_create_with_ctx(&args, request->args,
+				     request->args_end - request->args,
+				     (struct mp_ctx *)&ctx);
 	int rc = app_thread_lua_eval(expr, expr_len, &args, port);
 	port_msgpack_destroy(&args);
 	return rc;

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -2907,6 +2907,16 @@ srv_process_call(struct cmsg *m)
 	int count;
 	int rc;
 
+	/*
+	 * We access a flag that is set by another thread (tx) but it
+	 * should be fine because the feature bits are initialized once,
+	 * when a connection is established (by the IPROTO_ID request
+	 * handler), and aren't normally changed afterwards.
+	 */
+	bool box_tuple_as_ext = iproto_features_test(
+			&msg->connection->session->meta.features,
+			IPROTO_FEATURE_CALL_RET_TUPLE_EXTENSION);
+
 	struct trigger fiber_on_yield;
 	trigger_create(&fiber_on_yield, srv_process_call_on_yield, msg, NULL);
 	trigger_add(&fiber()->on_yield, &fiber_on_yield);
@@ -2929,14 +2939,27 @@ srv_process_call(struct cmsg *m)
 
 	out = iproto_msg_obuf(msg);
 	iproto_prepare_select(out, &svp);
-	count = port_dump_msgpack(&port, out);
+	if (box_tuple_as_ext) {
+		struct mp_box_ctx ctx;
+		struct mp_ctx *ctx_ref = (struct mp_ctx *)&ctx;
+		mp_box_ctx_create(&ctx, NULL, NULL);
+		count = port_dump_msgpack_with_ctx(&port, out, ctx_ref);
+		if (count >= 0 &&
+		    tuple_format_map_to_iproto_obuf(&ctx.tuple_format_map,
+						    out) != 0) {
+			count = -1;
+		}
+		mp_ctx_destroy(ctx_ref);
+	} else {
+		count = port_dump_msgpack(&port, out);
+	}
 	port_destroy(&port);
 	if (count < 0) {
 		obuf_rollback_to_svp(out, &svp);
 		goto error;
 	}
 	iproto_reply_select(out, &svp, msg->header.sync, /*schema_version=*/0,
-			    count, /*box_tuple_as_ext=*/false);
+			    count, box_tuple_as_ext);
 	iproto_wpos_create(&msg->wpos, out);
 	srv_end_msg(msg);
 	return;

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -890,6 +890,7 @@ static void
 luamp_decode_extension_box(struct lua_State *L, struct luaL_serializer *cfg,
 			   const char **data, struct mp_ctx *ctx)
 {
+	(void)cfg;
 	assert(mp_typeof(**data) == MP_EXT);
 	int8_t ext_type;
 	uint32_t len = mp_decode_extl(data, &ext_type);
@@ -905,11 +906,6 @@ luamp_decode_extension_box(struct lua_State *L, struct luaL_serializer *cfg,
 		break;
 	}
 	case MP_TUPLE: {
-		if (!cord_is_main()) {
-			const char *tuple_data = tuple_unpack_raw(data);
-			luamp_decode_with_ctx(L, cfg, &tuple_data, ctx);
-			break;
-		}
 		struct tuple *tuple;
 		if (ctx == NULL) {
 			tuple = tuple_unpack_without_format(data);

--- a/src/box/mp_tuple.c
+++ b/src/box/mp_tuple.c
@@ -77,16 +77,6 @@ tuple_unpack_without_format(const char **data)
 	return tuple_new(tuple_format_runtime, tuple_data, *data);
 }
 
-const char *
-tuple_unpack_raw(const char **data)
-{
-	/* Ignore the format identifier.  */
-	mp_decode_uint(data);
-	const char *tuple_data = *data;
-	mp_next(data);
-	return tuple_data;
-}
-
 char *
 mp_encode_tuple(char *data, struct tuple *tuple)
 {

--- a/src/box/mp_tuple.h
+++ b/src/box/mp_tuple.h
@@ -53,16 +53,6 @@ struct tuple *
 tuple_unpack_without_format(const char **data);
 
 /**
- * Load a raw tuple value from the buffer.
- *
- * @param data A buffer.
- * @return A pointer to the tuple data in the buffer.
- * @post *data = next value after packed tuple value.
- */
-const char *
-tuple_unpack_raw(const char **data);
-
-/**
  * Encode a tuple value to a buffer.
  *
  * @param data A buffer.

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -133,6 +133,7 @@ g.test_builtin_types_serialization = function(cg)
     check(decimal.new(123))
     check(uuid.new())
     check(varbinary.new('foo'))
+    check(box.tuple.new({1, 2, 3}))
     -- Check errors.
     local err = box.error.new({
         type = 'CustomType',
@@ -144,17 +145,42 @@ g.test_builtin_types_serialization = function(cg)
     t.assert_equals(ret_err:unpack(), err:unpack())
     t.assert_error_covers(err:unpack(), conn.eval, conn, [[error(...)]], {err},
                           {_thread_id = 1})
-    -- Tuples aren't supported yet (serialized as array).
-    local tuple = box.tuple.new({1, 2, 3})
-    local ret_type, ret_tuple = conn:eval([[
-        local tuple = ...
-        return type(tuple), tuple
-    ]], {tuple}, {_thread_id = 1})
-    t.assert_equals(ret_type, 'table')
-    t.assert_equals(type(ret_tuple), 'table')
-    t.assert_equals(ret_tuple, {1, 2, 3})
+    -- Check formatted tuples.
+    local format1 = box.tuple.format.new({
+        {'a', 'unsigned'}, {'b', 'unsigned'}, {'c', 'unsigned'}})
+    local format2 = box.tuple.format.new({
+        {'x', 'string'}, {'y', 'string'},
+    })
+    local tuple1 = box.tuple.new({10, 20, 30}, {format = format1})
+    local tuple2 = box.tuple.new({'foo', 'bar'}, {format = format2})
+    local ret_tuple1, ret_tuple2 = conn:eval([[return ...]], {tuple1, tuple2},
+                                             {_thread_id = 1})
+    t.assert(box.tuple.is(ret_tuple1))
+    t.assert(box.tuple.is(ret_tuple2))
+    t.assert_equals(ret_tuple1:tomap(), tuple1:tomap())
+    t.assert_equals(ret_tuple2:tomap(), tuple2:tomap())
     conn:close()
 end
+
+g.test_call_ret_tuple_extension_unset = function(cg)
+    t.tarantool.skip_if_not_debug()
+    box.error.injection.set('ERRINJ_NETBOX_FLIP_FEATURE',
+                            box.iproto.feature.call_ret_tuple_extension)
+    local conn = net.connect(cg.server.net_box_uri)
+    local tuple = conn:eval([[
+        local format = box.tuple.format.new({
+            {'a', 'unsigned'}, {'b', 'unsigned'},
+        })
+        return box.tuple.new({10, 20}, {format = format})
+    ]], {}, {_thread_id = 1})
+    t.assert_type(tuple, 'table')
+    t.assert_equals(tuple, {10, 20})
+    conn:close()
+end
+
+g.after_test('test_call_ret_tuple_extension_unset', function()
+    box.error.injection.set('ERRINJ_NETBOX_FLIP_FEATURE', -1)
+end)
 
 g.test_os_exit_disabled = function(cg)
     t.assert_error_msg_contains(


### PR DESCRIPTION
Now, that we support tuples in application threads, we should enable the tuple extension for `IPROTO_CALL` arguments and return values.

Closes #12437