### PR TITLE
lua: export `key_def` and `merger` to application threads

### DIFF
--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -216,6 +216,8 @@ extern char session_lua[],
 static const char * const lua_sources_minimal[] = {
 	"box/tuple", NULL, tuple_lua,
 	"box/tuple_format", NULL, tuple_format_lua,
+	"box/key_def", "key_def", key_def_lua,
+	"box/merger", "merger", merger_lua,
 	NULL
 };
 
@@ -237,8 +239,6 @@ static const char * const lua_sources_main[] = {
 	"box/net_box", "net.box", net_box_lua,
 	"box/net_replicaset", "internal.net.replicaset", net_replicaset_lua,
 	"box/console", "console", console_lua,
-	"box/key_def", "key_def", key_def_lua,
-	"box/merger", "merger", merger_lua,
 	"box/iproto", "iproto", iproto_lua,
 	/*
 	 * To support tarantool-only types with checks, the module
@@ -942,6 +942,10 @@ box_lua_init_minimal(struct lua_State *L)
 	box_lua_tuple_init(L);
 	box_lua_call_init(L);
 
+	luaopen_key_def(L);
+	lua_pop(L, 1);
+	luaopen_merger(L);
+	lua_pop(L, 1);
 	load_lua_sources(L, lua_sources_minimal);
 
 	assert(lua_gettop(L) == 0);
@@ -993,10 +997,6 @@ box_lua_init(struct lua_State *L)
 	luaopen_net_box(L);
 	lua_pop(L, 1);
 	tarantool_lua_console_init(L);
-	lua_pop(L, 1);
-	luaopen_key_def(L);
-	lua_pop(L, 1);
-	luaopen_merger(L);
 	lua_pop(L, 1);
 
 	luamp_set_encode_extension(luamp_encode_extension_box);

--- a/src/box/lua/key_def.c
+++ b/src/box/lua/key_def.c
@@ -38,7 +38,7 @@
 #include "misc.h"
 #include "tuple.h"
 
-static uint32_t CTID_STRUCT_KEY_DEF_REF = 0;
+static __thread uint32_t CTID_STRUCT_KEY_DEF_REF = 0;
 
 /**
  * Free a key_def from a Lua code.

--- a/src/box/lua/merger.c
+++ b/src/box/lua/merger.c
@@ -58,7 +58,7 @@
 
 #include "box/merger.h"      /* merge_source_*, merger_*() */
 
-static uint32_t CTID_STRUCT_MERGE_SOURCE_REF = 0;
+static __thread uint32_t CTID_STRUCT_MERGE_SOURCE_REF = 0;
 
 /**
  * A type of a function to create a source from a Lua iterator on

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -225,6 +225,8 @@ g.test_builtin_modules = function(cg)
     check_module('msgpackffi')
     check_module('yaml')
     check_module('json')
+    check_module('key_def')
+    check_module('merger')
     t.assert_covers(eval([[
         local e = box.error.new({type = 'MyError', name = 'FooBar'})
         return e:unpack()
@@ -496,4 +498,42 @@ g.test_tuple = function(cg)
             message = err,
         }, eval, [[box.tuple.format.new(...)]], {format})
     end
+end
+
+g.test_key_def = function(cg)
+    local function eval(expr, args)
+        return cg.server:eval(expr, args or {}, {_thread_id = 1})
+    end
+    t.assert_equals(eval([[
+        local key_def_lib = require('key_def')
+        local key_def = key_def_lib.new({
+            {fieldno = 1, type = 'string', collation = 'unicode_ci'},
+            {fieldno = 3, type = 'unsigned'},
+        })
+        return key_def:compare(
+            box.tuple.new({'FOO', 10, 20}),
+            box.tuple.new({'foo', 10, 30})
+        )
+    ]]), -1)
+    t.assert_equals(eval([[
+        local merger_lib = require('merger')
+        local key_def_lib = require('key_def')
+        local key_def = key_def_lib.new({
+            {fieldno = 1, type = 'unsigned'},
+            {fieldno = 2, type = 'unsigned'},
+        })
+        local merger = merger_lib.new(key_def, {
+            merger_lib.new_source_fromtable({
+                {1, 10}, {1, 30}, {1, 50},
+                {2, 10}, {2, 30}, {2, 50},
+            }),
+            merger_lib.new_source_fromtable({
+                {1, 20}, {1, 40}, {2, 20}, {2, 40},
+            }),
+        })
+        return merger:select()
+    ]]), {
+        {1, 10}, {1, 20}, {1, 30}, {1, 40}, {1, 50},
+        {2, 10}, {2, 20}, {2, 30}, {2, 40}, {2, 50},
+    })
 end


### PR DESCRIPTION
`key_def` is safe to create and use from other threads as long as the collation registry is static, and it will be made static in Tarantool 4.0, see commit fdb1023c49ce. We just need to make variables storing ctype ids thread local.

Closes #12378