### PR TITLE
Synchronous Promote - Part 2 - Do not nopify synchro IPROTO commands

### DIFF
--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -1563,7 +1563,7 @@ applier_synchro_filter_tx(struct stailq *rows)
 	req = &item->req.synchro;
 	/* Note! Might be different from row->replica_id. */
 	confirmed_lsn = txn_limbo_replica_confirmed_lsn(&txn_limbo,
-							req->replica_id);
+							req->queue_owner_id);
 	switch (row->type) {
 	case IPROTO_RAFT_PROMOTE:
 	case IPROTO_RAFT_DEMOTE:
@@ -1574,7 +1574,7 @@ applier_synchro_filter_tx(struct stailq *rows)
 		 */
 		return 0;
 	case IPROTO_RAFT_CONFIRM:
-		if (req->lsn > confirmed_lsn)
+		if (req->confirm.lsn > confirmed_lsn)
 			return 0;
 		/*
 		 * A CONFIRM with lsn <= known confirm lsn for this replica may
@@ -1595,7 +1595,7 @@ applier_synchro_filter_tx(struct stailq *rows)
 		 */
 		break;
 	case IPROTO_RAFT_ROLLBACK:
-		if (req->lsn <= confirmed_lsn)
+		if (req->rollback.lsn <= confirmed_lsn)
 			return 0;
 		/*
 		 * Rollback in the current term wants to roll some currently

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -1511,107 +1511,42 @@ fail:
 static int
 applier_synchro_filter_tx(struct stailq *rows)
 {
+	struct xrow_header *row = &stailq_last_entry(
+		rows, struct applier_tx_row, next)->row;
+	if (!iproto_type_is_dml(row->type))
+		return 0;
+
 	txn_limbo_lock(&txn_limbo);
 	auto guard = make_scoped_guard([] {
 		txn_limbo_unlock(&txn_limbo);
 	});
-	struct xrow_header *row;
 	/*
 	 * It may happen that we receive the instance's rows via some third
 	 * node, so cannot check for applier->instance_id here.
 	 */
-	row = &stailq_last_entry(rows, struct applier_tx_row, next)->row;
 	uint64_t term = txn_limbo_replica_term(&txn_limbo, row->replica_id);
-	assert(term <= txn_limbo.term);
-	bool is_current_term = term == txn_limbo.term;
+	if (term == txn_limbo.term)
+		return 0;
+	assert(term < txn_limbo.term);
 	struct applier_tx_row *item;
-	if (iproto_type_is_dml(row->type)) {
-		if (is_current_term)
-			return 0;
-		/*
-		 * Any asynchronous transaction from an obsolete term when limbo
-		 * is claimed by someone is a marker of split-brain by itself:
-		 * consider it a synchronous transaction, which is committed
-		 * with quorum 1.
-		 */
-		if (row->wait_sync)
-			goto nopify;
-		if (txn_limbo.queue.owner_id == REPLICA_ID_NIL)
-			return 0;
-		stailq_foreach_entry(item, rows, next) {
-			row = &item->row;
-			if (row->type == IPROTO_NOP)
-				continue;
-			diag_set(ClientError, ER_SPLIT_BRAIN,
-				 "got an async transaction from an old term");
-			return -1;
-		}
+	if (row->wait_sync)
+		goto nopify;
+	if (txn_limbo.queue.owner_id == REPLICA_ID_NIL)
 		return 0;
-	}
 	/*
-	 * We do not nopify promotion/demotion and most of confirm/rollback.
-	 * Such syncrhonous requests should be filtered by txn_limbo to detect
-	 * possible split brain situations.
-	 *
-	 * This means the only filtered out transactions are synchronous ones or
-	 * the ones depending on them.
+	 * Any asynchronous transaction from an obsolete term when limbo is
+	 * claimed by someone is a marker of split-brain by itself: consider it
+	 * a synchronous transaction, which is committed with quorum 1.
 	 */
-	assert(iproto_type_is_synchro_request(row->type));
-	const struct synchro_request *req;
-	int64_t confirmed_lsn;
-	item = stailq_last_entry(rows, typeof(*item), next);
-	req = &item->req.synchro;
-	/* Note! Might be different from row->replica_id. */
-	confirmed_lsn = txn_limbo_replica_confirmed_lsn(&txn_limbo,
-							req->queue_owner_id);
-	switch (row->type) {
-	case IPROTO_RAFT_PROMOTE:
-	case IPROTO_RAFT_DEMOTE:
-		/*
-		 * Never need to be nopified. Every PROMOTE / DEMOTE is either a
-		 * valid one or is a split brain. There is no such thing as an
-		 * "old already applied promotion".
-		 */
-		return 0;
-	case IPROTO_RAFT_CONFIRM:
-		if (req->confirm.lsn > confirmed_lsn)
-			return 0;
-		/*
-		 * A CONFIRM with lsn <= known confirm lsn for this replica may
-		 * be nopified without a second thought. The transactions it's
-		 * going to confirm were already confirmed by one of the
-		 * PROMOTE/DEMOTE requests in a new term.
-		 *
-		 * See that the CONFIRM can be nopified even in the current term
-		 * if it wants to commit already committed txns. This is a niche
-		 * case which might happen when a replica joins a master and
-		 * receives a valid fully confirmed read-view from it, but some
-		 * CONFIRM WAL entries might have been written by the master
-		 * after the read-view is sent. Then the replica would receive
-		 * those "already known" CONFIRMs during xlogs catch up.
-		 *
-		 * Besides, logically a confirmation of already confirmed txns
-		 * doesn't contradict anything.
-		 */
-		break;
-	case IPROTO_RAFT_ROLLBACK:
-		if (req->rollback.lsn <= confirmed_lsn)
-			return 0;
-		/*
-		 * Rollback in the current term wants to roll some currently
-		 * waiting transactions back. No case when it can be considered
-		 * outdated.
-		 */
-		if (is_current_term)
-			return 0;
-		/*
-		 * In older terms though this is fine to nopify it. Those txns
-		 * must have already been cancelled by the new leader anyway.
-		 */
-		break;
-	default:
-		unreachable();
+	stailq_foreach_entry(item, rows, next) {
+		row = &item->row;
+		if (row->type == IPROTO_NOP)
+			continue;
+		diag_set(ClientError, ER_SPLIT_BRAIN,
+			 "got an async transaction from an old term");
+		return -1;
 	}
+	return 0;
 nopify:
 	stailq_foreach_entry(item, rows, next) {
 		row = &item->row;

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3174,53 +3174,19 @@ box_wait_limbo_acked(double timeout)
 	return wait_lsn;
 }
 
-/** Write and process a PROMOTE request. */
-static int
-box_issue_promote(int64_t promote_lsn)
-{
-	int rc = 0;
-	uint64_t term = box_raft()->term;
-	uint64_t promote_term = txn_limbo.term;
-	assert(promote_lsn >= 0);
-	rc = box_check_election_term_intact(term);
-	if (rc != 0)
-		return rc;
-
-	txn_limbo_begin(&txn_limbo);
-	rc = box_check_election_term_intact(term);
-	if (rc != 0)
-		goto end;
-	rc = box_check_promote_term_intact(promote_term);
-	if (rc != 0)
-		goto end;
-	rc = txn_limbo_write_promote(&txn_limbo, promote_lsn, term);
-
-end:
-	if (rc == 0) {
-		txn_limbo_commit(&txn_limbo);
-		assert(txn_limbo_is_empty(&txn_limbo));
-	} else {
-		txn_limbo_rollback(&txn_limbo);
-	}
-	return rc;
-}
-
 /** A guard to block multiple simultaneous promote()/demote() invocations. */
 static bool is_in_box_promote = false;
 
-/** Write and process a DEMOTE request. */
 static int
-box_issue_demote(int64_t promote_lsn)
+box_change_limbo_ownership(int64_t confirmed_lsn, uint16_t type)
 {
 	int rc = 0;
 	uint64_t term = box_raft()->term;
 	uint64_t promote_term = txn_limbo.term;
-	assert(promote_lsn >= 0);
-
+	assert(confirmed_lsn >= 0);
 	rc = box_check_election_term_intact(term);
 	if (rc != 0)
 		return rc;
-
 	txn_limbo_begin(&txn_limbo);
 	rc = box_check_election_term_intact(term);
 	if (rc != 0)
@@ -3228,8 +3194,7 @@ box_issue_demote(int64_t promote_lsn)
 	rc = box_check_promote_term_intact(promote_term);
 	if (rc != 0)
 		goto end;
-	rc = txn_limbo_write_demote(&txn_limbo, promote_lsn, term);
-
+	rc = txn_limbo_req_promote(&txn_limbo, type, confirmed_lsn, term);
 end:
 	if (rc == 0) {
 		txn_limbo_commit(&txn_limbo);
@@ -3263,7 +3228,7 @@ box_promote_qsync(void)
 		diag_set(ClientError, ER_NOT_LEADER, raft->leader);
 		return -1;
 	}
-	return box_issue_promote(wait_lsn);
+	return box_change_limbo_ownership(wait_lsn, IPROTO_RAFT_PROMOTE);
 }
 
 int
@@ -3337,7 +3302,7 @@ box_promote(void)
 	if (wait_lsn < 0)
 		return -1;
 
-	return box_issue_promote(wait_lsn);
+	return box_change_limbo_ownership(wait_lsn, IPROTO_RAFT_PROMOTE);
 }
 
 int
@@ -3382,7 +3347,7 @@ box_demote(void)
 	int64_t wait_lsn = box_wait_limbo_acked(replication_synchro_timeout);
 	if (wait_lsn < 0)
 		return -1;
-	return box_issue_demote(wait_lsn);
+	return box_change_limbo_ownership(wait_lsn, IPROTO_RAFT_DEMOTE);
 }
 
 int

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -557,7 +557,8 @@ memtx_engine_recover_snapshot_row(struct memtx_engine *memtx,
 			 * a checkpoint, because all its rows have a zero
 			 * replica_id.
 			 */
-			entry->synchro.origin_id = entry->synchro.replica_id;
+			entry->synchro.origin_id =
+				entry->synchro.queue_owner_id;
 			return txn_limbo_process(&txn_limbo, &entry->synchro);
 		}
 		diag_set(ClientError, ER_UNKNOWN_REQUEST_TYPE,

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -495,7 +495,7 @@ send_join_meta(struct xstream *stream, const struct box_checkpoint *ckpt)
 
 	char body[XROW_BODY_LEN_MAX];
 	xrow_encode_synchro(&row, body, &ckpt->limbo);
-	row.replica_id = ckpt->limbo.replica_id;
+	row.replica_id = ckpt->limbo.queue_owner_id;
 	xstream_write(stream, &row);
 }
 
@@ -1351,13 +1351,13 @@ relay_filter_row(struct relay *relay, struct xrow_header *packet)
 		struct synchro_request req;
 		if (xrow_decode_synchro(packet, &req) != 0)
 			diag_raise();
-		while (relay->sent_raft_term < req.term) {
+		while (relay->sent_raft_term < req.promote.term) {
 			if (fiber_is_cancelled()) {
 				diag_set(FiberIsCancelled);
 				diag_raise();
 			}
 			cbus_process(&relay->tx_endpoint);
-			if (relay->sent_raft_term >= req.term)
+			if (relay->sent_raft_term >= req.promote.term)
 				break;
 			fiber_yield();
 		}

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -44,6 +44,54 @@ struct txn_limbo txn_limbo;
  * Private API
  ******************************************************************************/
 
+/**
+ * Stringify the synchro request into the given buffer. Same semantics as
+ * snprintf().
+ */
+static int
+synchro_request_snprint(char *buf, int size, const struct synchro_request *req)
+{
+	int total = 0;
+	if (req->type == IPROTO_RAFT_CONFIRM) {
+		SNPRINT(total, snprintf, buf, size,
+			"CONFIRM{owner: %u, origin: %u, lsn: %lld}",
+			req->queue_owner_id, req->origin_id,
+			(long long)req->confirm.lsn);
+		return total;
+	}
+	if (req->type == IPROTO_RAFT_ROLLBACK) {
+		SNPRINT(total, snprintf, buf, size,
+			"ROLLBACK{owner: %u, origin: %u, lsn: %lld}",
+			req->queue_owner_id, req->origin_id,
+			(long long)req->rollback.lsn);
+		return total;
+	}
+	assert(req->type == IPROTO_RAFT_PROMOTE ||
+	       req->type == IPROTO_RAFT_DEMOTE);
+	SNPRINT(total, snprintf, buf, size,
+		"%s{owner: %u, origin: %u, lsn: %lld, term: %llu",
+		req->type == IPROTO_RAFT_PROMOTE ? "PROMOTE" : "DEMOTE",
+		req->queue_owner_id, req->origin_id,
+		(long long)req->promote.lsn, (long long)req->promote.term);
+	if (vclock_is_set(&req->promote.confirmed_vclock)) {
+		SNPRINT(total, snprintf, buf, size, ", vclock: ");
+		SNPRINT(total, vclock_snprint, buf, size,
+			&req->promote.confirmed_vclock);
+	}
+	SNPRINT(total, snprintf, buf, size, "}");
+	return total;
+}
+
+/** Stringify the synchro request into the static buffer. */
+static const char *
+synchro_request_str(const struct synchro_request *req)
+{
+	char *buf = tt_static_buf();
+	if (synchro_request_snprint(buf, TT_STATIC_BUF_LEN, req) < 0)
+		panic("couldn't stringify a synchro request");
+	return buf;
+}
+
 /** Write the request into the journal. */
 static int
 synchro_request_write(const struct synchro_request *req)
@@ -72,8 +120,8 @@ synchro_request_write_or_panic(const struct synchro_request *req)
 	 * in rollback mode. Then provide a hook to call manually when WAL
 	 * problems are fixed. Or retry automatically with some period.
 	 */
-	panic("Could not write a synchro request to WAL: lsn = %lld, "
-	      "type = %s\n", (long long)req->lsn, iproto_type_name(req->type));
+	panic("Could not write a synchro request to WAL: %s",
+	      synchro_request_str(req));
 }
 
 static void
@@ -94,10 +142,11 @@ txn_limbo_write_confirm(struct txn_limbo *limbo, int64_t lsn)
 	assert(!limbo->is_in_rollback);
 	struct synchro_request req = {
 		.type = IPROTO_RAFT_CONFIRM,
-		.replica_id = limbo->queue.owner_id,
-		.lsn = lsn,
+		.queue_owner_id = limbo->queue.owner_id,
+		.confirm = {
+			.lsn = lsn
+		},
 	};
-	vclock_clear(&req.confirmed_vclock);
 	return synchro_request_write(&req);
 }
 
@@ -114,10 +163,11 @@ txn_limbo_write_rollback(struct txn_limbo *limbo, int64_t lsn)
 	limbo->is_in_rollback = true;
 	struct synchro_request req = {
 		.type = IPROTO_RAFT_ROLLBACK,
-		.replica_id = limbo->queue.owner_id,
-		.lsn = lsn,
+		.queue_owner_id = limbo->queue.owner_id,
+		.rollback = {
+			.lsn = lsn
+		},
 	};
-	vclock_clear(&req.confirmed_vclock);
 	synchro_request_write_or_panic(&req);
 	limbo->is_in_rollback = false;
 }
@@ -369,10 +419,11 @@ txn_limbo_checkpoint(const struct txn_limbo *limbo,
 		     struct synchro_request *req)
 {
 	req->type = IPROTO_RAFT_PROMOTE;
-	req->replica_id = limbo->queue.owner_id;
-	req->lsn = limbo->queue.confirmed_lsn;
-	req->term = limbo->term;
-	vclock_copy(&req->confirmed_vclock, &limbo->queue.confirmed_vclock);
+	req->queue_owner_id = limbo->queue.owner_id;
+	req->promote.lsn = limbo->queue.confirmed_lsn;
+	req->promote.term = limbo->term;
+	vclock_copy(&req->promote.confirmed_vclock,
+		    &limbo->queue.confirmed_vclock);
 }
 
 int
@@ -388,16 +439,18 @@ txn_limbo_write_promote(struct txn_limbo *limbo, int64_t lsn, uint64_t term)
 	(void) e;
 	struct synchro_request req = {
 		.type = IPROTO_RAFT_PROMOTE,
-		.replica_id = limbo->queue.owner_id,
+		.queue_owner_id = limbo->queue.owner_id,
 		.origin_id = instance_id,
-		.lsn = lsn,
-		.term = term,
+		.promote = {
+			.lsn = lsn,
+			.term = term,
+		},
 	};
 	/*
 	 * Confirmed_vclock is only persisted in checkpoints. It doesn't
 	 * appear in WALs and replication.
 	 */
-	vclock_clear(&req.confirmed_vclock);
+	vclock_clear(&req.promote.confirmed_vclock);
 	if (txn_limbo_req_prepare(limbo, &req) < 0)
 		return -1;
 	synchro_request_write_or_panic(&req);
@@ -414,12 +467,14 @@ txn_limbo_write_demote(struct txn_limbo *limbo, int64_t lsn, uint64_t term)
 	(void)e;
 	struct synchro_request req = {
 		.type = IPROTO_RAFT_DEMOTE,
-		.replica_id = limbo->queue.owner_id,
+		.queue_owner_id = limbo->queue.owner_id,
 		.origin_id = instance_id,
-		.lsn = lsn,
-		.term = term,
+		.promote = {
+			.lsn = lsn,
+			.term = term,
+		},
 	};
-	vclock_clear(&req.confirmed_vclock);
+	vclock_clear(&req.promote.confirmed_vclock);
 	if (txn_limbo_req_prepare(limbo, &req) < 0)
 		return -1;
 	synchro_request_write_or_panic(&req);
@@ -471,13 +526,7 @@ txn_limbo_wait_empty(struct txn_limbo *limbo, double timeout)
 static const char *
 reject_str(const struct synchro_request *req)
 {
-	const char *type_name = iproto_type_name(req->type);
-
-	return tt_sprintf("RAFT: rejecting %s (%d) request from origin_id %u "
-			  "replica_id %u term %llu",
-			  type_name ? type_name : "UNKNOWN", req->type,
-			  req->origin_id, req->replica_id,
-			  (long long)req->term);
+	return tt_sprintf("RAFT: rejecting %s", synchro_request_str(req));
 }
 
 /**
@@ -490,11 +539,7 @@ txn_limbo_filter_generic(struct txn_limbo *limbo,
 	txn_limbo_assert_locked(limbo);
 	if (!limbo->do_validate)
 		return 0;
-
-	/*
-	 * Zero replica_id is allowed for PROMOTE packets only.
-	 */
-	if (req->replica_id == REPLICA_ID_NIL) {
+	if (req->queue_owner_id == REPLICA_ID_NIL) {
 		if (req->type != IPROTO_RAFT_PROMOTE) {
 			say_error("%s. Zero replica_id detected",
 				  reject_str(req));
@@ -503,7 +548,7 @@ txn_limbo_filter_generic(struct txn_limbo *limbo,
 			return -1;
 		}
 	}
-	if (req->replica_id != limbo->queue.owner_id) {
+	if (req->queue_owner_id != limbo->queue.owner_id) {
 		/*
 		 * Incoming packets should esteem limbo owner,
 		 * if it doesn't match it means the sender
@@ -529,18 +574,19 @@ txn_limbo_filter_confirm_rollback(struct txn_limbo *limbo,
 	txn_limbo_assert_locked(limbo);
 	assert(limbo->do_validate);
 	(void)limbo;
-	assert(req->type == IPROTO_RAFT_CONFIRM ||
-	       req->type == IPROTO_RAFT_ROLLBACK);
-	/*
-	 * Zero LSN is allowed for PROMOTE and DEMOTE requests only.
-	 */
-	if (req->lsn == 0) {
-		say_error("%s. Zero lsn detected", reject_str(req));
-		diag_set(ClientError, ER_UNSUPPORTED, "Replication",
-			 "zero LSN for CONFIRM/ROLLBACK");
-		return -1;
+	if (req->type == IPROTO_RAFT_CONFIRM) {
+		if (req->confirm.lsn > 0)
+			return 0;
+	} else if (req->type == IPROTO_RAFT_ROLLBACK) {
+		if (req->rollback.lsn > 0)
+			return 0;
+	} else {
+		unreachable();
 	}
-	return 0;
+	say_error("%s. Zero lsn detected", reject_str(req));
+	diag_set(ClientError, ER_UNSUPPORTED, "Replication",
+		 "zero LSN for CONFIRM/ROLLBACK");
+	return -1;
 }
 
 /** A filter PROMOTE and DEMOTE packets. */
@@ -555,7 +601,7 @@ txn_limbo_filter_promote_demote(struct txn_limbo *limbo,
 	 * PROMOTE and DEMOTE packets must not have zero
 	 * term supplied, otherwise it is a broken packet.
 	 */
-	if (req->term == 0) {
+	if (req->promote.term == 0) {
 		say_error("%s. Zero term detected", reject_str(req));
 		diag_set(ClientError, ER_UNSUPPORTED,
 			 "Replication", "PROMOTE/DEMOTE with a zero term");
@@ -568,7 +614,7 @@ txn_limbo_filter_promote_demote(struct txn_limbo *limbo,
 	 * thus been living in subdomain and its data is
 	 * no longer consistent.
 	 */
-	if (limbo->term >= req->term) {
+	if (limbo->term >= req->promote.term) {
 		say_error("%s. Max term seen is %llu", reject_str(req),
 			  (long long)limbo->term);
 		diag_set(ClientError, ER_SPLIT_BRAIN,
@@ -579,11 +625,11 @@ txn_limbo_filter_promote_demote(struct txn_limbo *limbo,
 	 * Explicit split brain situation. Request comes in with an old LSN
 	 * which we've already processed.
 	 */
-	if (limbo->queue.confirmed_lsn > req->lsn) {
+	if (limbo->queue.confirmed_lsn > req->promote.lsn) {
 		say_error("%s. confirmed lsn %lld > request lsn %lld",
 			  reject_str(req),
 			  (long long)limbo->queue.confirmed_lsn,
-			  (long long)req->lsn);
+			  (long long)req->promote.lsn);
 		diag_set(ClientError, ER_SPLIT_BRAIN,
 			 "got a request with lsn from an already "
 			 "processed range");
@@ -594,7 +640,7 @@ txn_limbo_filter_promote_demote(struct txn_limbo *limbo,
 	 * request, everything is consistent. This is allowed only for
 	 * PROMOTE/DEMOTE.
 	 */
-	if (limbo->queue.confirmed_lsn == req->lsn)
+	if (limbo->queue.confirmed_lsn == req->promote.lsn)
 		return 0;
 	/*
 	 * The last case requires a few subcases.
@@ -607,7 +653,7 @@ txn_limbo_filter_promote_demote(struct txn_limbo *limbo,
 		say_error("%s. confirmed lsn %lld < request lsn %lld "
 			  "and empty limbo", reject_str(req),
 			  (long long)limbo->queue.confirmed_lsn,
-			  (long long)req->lsn);
+			  (long long)req->promote.lsn);
 		diag_set(ClientError, ER_SPLIT_BRAIN,
 			 "got a request mentioning future lsn");
 		return -1;
@@ -636,10 +682,10 @@ txn_limbo_filter_promote_demote(struct txn_limbo *limbo,
 	 */
 	int64_t first_lsn, last_lsn;
 	txn_limbo_queue_get_lsn_range(&limbo->queue, &first_lsn, &last_lsn);
-	if (req->lsn < first_lsn || last_lsn < req->lsn) {
+	if (req->promote.lsn < first_lsn || last_lsn < req->promote.lsn) {
 		say_error("%s. request lsn %lld out of range "
 			  "[%lld; %lld]", reject_str(req),
-			  (long long)req->lsn,
+			  (long long)req->promote.lsn,
 			  (long long)first_lsn,
 			  (long long)last_lsn);
 		diag_set(ClientError, ER_SPLIT_BRAIN,
@@ -743,7 +789,7 @@ txn_limbo_req_prepare(struct txn_limbo *limbo,
 		assert(!limbo->is_transition_in_progress);
 		limbo->is_transition_in_progress = true;
 		limbo->svp_confirmed_lsn = limbo->queue.volatile_confirmed_lsn;
-		limbo->queue.volatile_confirmed_lsn = req->lsn;
+		limbo->queue.volatile_confirmed_lsn = req->promote.lsn;
 		txn_limbo_update_system_spaces_is_sync_state(
 			limbo, req, /*is_rollback=*/false);
 		txn_limbo_update_state(limbo);
@@ -787,51 +833,52 @@ txn_limbo_req_rollback(struct txn_limbo *limbo,
 	}
 }
 
-void
-txn_limbo_req_commit(struct txn_limbo *limbo, const struct synchro_request *req)
+/** Commit IPROTO_RAFT_CONFIRM request. */
+static void
+txn_limbo_req_commit_confirm(struct txn_limbo *limbo, const struct synchro_request *req)
 {
 	txn_limbo_assert_locked(limbo);
-	switch (req->type) {
-	case IPROTO_RAFT_PROMOTE:
-	case IPROTO_RAFT_DEMOTE: {
-		assert(limbo->svp_confirmed_lsn >= 0);
-		assert(limbo->is_in_rollback);
-		assert(limbo->is_transition_in_progress);
-		limbo->is_transition_in_progress = false;
-		limbo->svp_confirmed_lsn = -1;
-		limbo->is_in_rollback = false;
-		txn_limbo_update_state(limbo);
-		break;
-	}
-	default: {
-		break;
-	}
-	}
+	assert(req->type == IPROTO_RAFT_CONFIRM);
+	txn_limbo_queue_apply_confirm(&limbo->queue, req->confirm.lsn);
+}
 
-	uint64_t term = req->term;
+/** Commit IPROTO_RAFT_ROLLBACK request. */
+static void
+txn_limbo_req_commit_rollback(struct txn_limbo *limbo, const struct synchro_request *req)
+{
+	txn_limbo_assert_locked(limbo);
+	assert(req->type == IPROTO_RAFT_ROLLBACK);
+	txn_limbo_queue_apply_rollback(&limbo->queue, req->rollback.lsn,
+				       TXN_SIGNATURE_SYNC_ROLLBACK);
+}
+
+/** Commit IPROTO_RAFT_PROMOTE/DEMOTE request. */
+static void
+txn_limbo_req_commit_promote_demote(struct txn_limbo *limbo,
+				    const struct synchro_request *req)
+{
+	txn_limbo_assert_locked(limbo);
+	assert(req->type == IPROTO_RAFT_PROMOTE ||
+	       req->type == IPROTO_RAFT_DEMOTE);
+	assert(limbo->svp_confirmed_lsn >= 0);
+	assert(limbo->is_in_rollback);
+	assert(limbo->is_transition_in_progress);
+	limbo->is_transition_in_progress = false;
+	limbo->svp_confirmed_lsn = -1;
+	limbo->is_in_rollback = false;
+
+	uint64_t term = req->promote.term;
 	uint32_t origin = req->origin_id;
 	if (txn_limbo_replica_term(limbo, origin) < term) {
 		vclock_follow(&limbo->promote_term_map, origin, term);
 		if (term > limbo->term)
 			limbo->term = term;
 	}
-	if (vclock_is_set(&req->confirmed_vclock)) {
+	if (vclock_is_set(&req->promote.confirmed_vclock)) {
 		vclock_copy(&limbo->queue.confirmed_vclock,
-			    &req->confirmed_vclock);
+			    &req->promote.confirmed_vclock);
 	}
-
-	int64_t lsn = req->lsn;
-	if (req->type == IPROTO_RAFT_CONFIRM) {
-		txn_limbo_queue_apply_confirm(&limbo->queue, lsn);
-		return;
-	}
-	if (req->type == IPROTO_RAFT_ROLLBACK) {
-		txn_limbo_queue_apply_rollback(&limbo->queue, lsn,
-					       TXN_SIGNATURE_SYNC_ROLLBACK);
-		return;
-	}
-	assert(req->type == IPROTO_RAFT_PROMOTE ||
-	       req->type == IPROTO_RAFT_DEMOTE);
+	int64_t lsn = req->promote.lsn;
 	uint32_t new_owner = REPLICA_ID_NIL;
 	if (req->type == IPROTO_RAFT_PROMOTE) {
 		if (!limbo->is_in_recovery)
@@ -840,6 +887,21 @@ txn_limbo_req_commit(struct txn_limbo *limbo, const struct synchro_request *req)
 	}
 	txn_limbo_queue_transfer_ownership(&limbo->queue, new_owner, lsn);
 	txn_limbo_update_state(limbo);
+}
+
+void
+txn_limbo_req_commit(struct txn_limbo *limbo, const struct synchro_request *req)
+{
+	txn_limbo_assert_locked(limbo);
+	switch (req->type) {
+	case IPROTO_RAFT_CONFIRM:
+		txn_limbo_req_commit_confirm(limbo, req);
+		return;
+	case IPROTO_RAFT_ROLLBACK:
+		txn_limbo_req_commit_rollback(limbo, req);
+		return;
+	}
+	txn_limbo_req_commit_promote_demote(limbo, req);
 }
 
 int

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -130,6 +130,13 @@ txn_limbo_assert_locked(struct txn_limbo *limbo)
 	VERIFY(latch_is_locked(&limbo->state_latch));
 }
 
+static int64_t
+txn_limbo_replica_confirmed_lsn(const struct txn_limbo *limbo,
+				uint32_t replica_id)
+{
+	return vclock_get(&limbo->queue.confirmed_vclock, replica_id);
+}
+
 /**
  * Write a confirmation entry to the WAL. After it's written all the
  * transactions waiting for confirmation may be finished.
@@ -529,25 +536,14 @@ reject_str(const struct synchro_request *req)
 	return tt_sprintf("RAFT: rejecting %s", synchro_request_str(req));
 }
 
-/**
- * Common filter for any incoming packet.
- */
+/** Ensure request sees the correct limbo owner. */
 static int
-txn_limbo_filter_generic(struct txn_limbo *limbo,
-			 const struct synchro_request *req)
+txn_limbo_filter_owner_match(struct txn_limbo *limbo,
+			     const struct synchro_request *req)
 {
 	txn_limbo_assert_locked(limbo);
 	if (!limbo->do_validate)
 		return 0;
-	if (req->queue_owner_id == REPLICA_ID_NIL) {
-		if (req->type != IPROTO_RAFT_PROMOTE) {
-			say_error("%s. Zero replica_id detected",
-				  reject_str(req));
-			diag_set(ClientError, ER_UNSUPPORTED, "Replication",
-				 "synchronous requests with zero replica_id");
-			return -1;
-		}
-	}
 	if (req->queue_owner_id != limbo->queue.owner_id) {
 		/*
 		 * Incoming packets should esteem limbo owner,
@@ -560,33 +556,112 @@ txn_limbo_filter_generic(struct txn_limbo *limbo,
 			 "got a request from a foreign synchro queue owner");
 		return -1;
 	}
-
 	return 0;
 }
 
-/**
- * Filter CONFIRM and ROLLBACK packets.
- */
+/** Ensure request is expecting a specific limbo owner. */
 static int
-txn_limbo_filter_confirm_rollback(struct txn_limbo *limbo,
-				  const struct synchro_request *req)
+txn_limbo_filter_owner_set(struct txn_limbo *limbo,
+			   const struct synchro_request *req)
 {
 	txn_limbo_assert_locked(limbo);
-	assert(limbo->do_validate);
-	(void)limbo;
-	if (req->type == IPROTO_RAFT_CONFIRM) {
-		if (req->confirm.lsn > 0)
-			return 0;
-	} else if (req->type == IPROTO_RAFT_ROLLBACK) {
-		if (req->rollback.lsn > 0)
-			return 0;
-	} else {
-		unreachable();
+	if (!limbo->do_validate)
+		return 0;
+	if (req->queue_owner_id == REPLICA_ID_NIL) {
+		say_error("%s. Zero replica_id detected",
+			  reject_str(req));
+		diag_set(ClientError, ER_UNSUPPORTED, "Replication",
+			 "synchronous requests with zero replica_id");
+		return -1;
 	}
+	return 0;
+}
+
+/** Ensure the request has a non-zero LSN whatever it is needed for. */
+static int
+txn_limbo_filter_non_zero_lsn(struct txn_limbo *limbo,
+			      const struct synchro_request *req,
+			      int64_t lsn)
+{
+	VERIFY(limbo->do_validate);
+	if (lsn > 0)
+		return 0;
 	say_error("%s. Zero lsn detected", reject_str(req));
 	diag_set(ClientError, ER_UNSUPPORTED, "Replication",
 		 "zero LSN for CONFIRM/ROLLBACK");
 	return -1;
+}
+
+/** Validate CONFIRM request. */
+static int
+txn_limbo_filter_confirm(struct txn_limbo *limbo,
+			 const struct synchro_request *req)
+{
+	txn_limbo_assert_locked(limbo);
+	assert(req->type == IPROTO_RAFT_CONFIRM);
+	assert(limbo->do_validate);
+	if (txn_limbo_filter_owner_set(limbo, req) != 0)
+		return -1;
+	if (txn_limbo_filter_non_zero_lsn(limbo, req, req->confirm.lsn) != 0)
+		return -1;
+	int64_t confirmed_lsn = txn_limbo_replica_confirmed_lsn(
+		limbo, req->queue_owner_id);
+	/*
+	 * Want to confirm something new? - need to own the limbo right now, in
+	 * the latest known term.
+	 */
+	if (req->confirm.lsn > confirmed_lsn)
+		return txn_limbo_filter_owner_match(limbo, req);
+	/*
+	 * A CONFIRM with lsn <= known confirm lsn for this replica may be
+	 * ignored without a second thought. The transactions it's going to
+	 * confirm were already confirmed by one of the PROMOTE/DEMOTE requests
+	 * in a new term.
+	 *
+	 * See that the CONFIRM can be ignored even in the current term if it
+	 * wants to commit already committed txns. This is a niche case which
+	 * might happen when a replica joins a master and receives a valid fully
+	 * confirmed read-view from it, but some CONFIRM WAL entries might have
+	 * been written by the master after the read-view is sent. Then the
+	 * replica would receive those "already known" CONFIRMs during xlogs
+	 * catch up.
+	 *
+	 * Besides, logically a confirmation of already confirmed txns doesn't
+	 * contradict anything.
+	 */
+	return 0;
+}
+
+/** Validate ROLLBACK request. */
+static int
+txn_limbo_filter_rollback(struct txn_limbo *limbo,
+			  const struct synchro_request *req)
+{
+	txn_limbo_assert_locked(limbo);
+	assert(req->type == IPROTO_RAFT_ROLLBACK);
+	assert(limbo->do_validate);
+	if (txn_limbo_filter_owner_set(limbo, req) != 0)
+		return -1;
+	if (txn_limbo_filter_non_zero_lsn(limbo, req, req->rollback.lsn) != 0)
+		return -1;
+	int64_t confirmed_lsn = txn_limbo_replica_confirmed_lsn(
+		limbo, req->queue_owner_id);
+	if (req->rollback.lsn <= confirmed_lsn)
+		return txn_limbo_filter_owner_match(limbo, req);
+	uint64_t origin_term = txn_limbo_replica_term(limbo,
+						      req->origin_id);
+	assert(origin_term <= limbo->term);
+	/*
+	 * Rollback in the current term wants to roll some currently waiting
+	 * transactions back. No case when it can be considered outdated.
+	 */
+	if (origin_term == limbo->term)
+		return txn_limbo_filter_owner_match(limbo, req);
+	/*
+	 * In older terms though this is fine to nopify it. Those txns must have
+	 * already been cancelled by the new leader anyway.
+	 */
+	return 0;
 }
 
 /** A filter PROMOTE and DEMOTE packets. */
@@ -597,6 +672,13 @@ txn_limbo_filter_promote_demote(struct txn_limbo *limbo,
 	txn_limbo_assert_locked(limbo);
 	assert(limbo->do_validate);
 	assert(iproto_type_is_promote_request(req->type));
+	/*
+	 * PROMOTE might be claiming an unclaimed limbo. But DEMOTE can't be
+	 * unclaiming a nobody-owned limbo.
+	 */
+	if (req->type == IPROTO_RAFT_DEMOTE &&
+	    txn_limbo_filter_owner_set(limbo, req) != 0)
+		return -1;
 	/*
 	 * PROMOTE and DEMOTE packets must not have zero
 	 * term supplied, otherwise it is a broken packet.
@@ -711,8 +793,9 @@ txn_limbo_filter_request(struct txn_limbo *limbo,
 		return -1;
 	switch (req->type) {
 	case IPROTO_RAFT_CONFIRM:
+		return txn_limbo_filter_confirm(limbo, req);
 	case IPROTO_RAFT_ROLLBACK:
-		return txn_limbo_filter_confirm_rollback(limbo, req);
+		return txn_limbo_filter_rollback(limbo, req);
 	case IPROTO_RAFT_PROMOTE:
 	case IPROTO_RAFT_DEMOTE:
 		return txn_limbo_filter_promote_demote(limbo, req);
@@ -756,9 +839,6 @@ txn_limbo_req_prepare(struct txn_limbo *limbo,
 		      const struct synchro_request *req)
 {
 	txn_limbo_assert_locked(limbo);
-	if (txn_limbo_filter_generic(limbo, req) < 0)
-		return -1;
-
 	/*
 	 * Guard against new transactions appearing during WAL write. It is
 	 * necessary because otherwise when PROMOTE/DEMOTE would be done and it
@@ -839,6 +919,11 @@ txn_limbo_req_commit_confirm(struct txn_limbo *limbo, const struct synchro_reque
 {
 	txn_limbo_assert_locked(limbo);
 	assert(req->type == IPROTO_RAFT_CONFIRM);
+	/*
+	 * Check if outdated and its effects are nop / already applied before.
+	 */
+	if (req->queue_owner_id != limbo->queue.owner_id)
+		return;
 	txn_limbo_queue_apply_confirm(&limbo->queue, req->confirm.lsn);
 }
 
@@ -848,6 +933,11 @@ txn_limbo_req_commit_rollback(struct txn_limbo *limbo, const struct synchro_requ
 {
 	txn_limbo_assert_locked(limbo);
 	assert(req->type == IPROTO_RAFT_ROLLBACK);
+	/*
+	 * Check if outdated and its effects are nop / already applied before.
+	 */
+	if (req->queue_owner_id != limbo->queue.owner_id)
+		return;
 	txn_limbo_queue_apply_rollback(&limbo->queue, req->rollback.lsn,
 				       TXN_SIGNATURE_SYNC_ROLLBACK);
 }

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -434,7 +434,8 @@ txn_limbo_checkpoint(const struct txn_limbo *limbo,
 }
 
 int
-txn_limbo_write_promote(struct txn_limbo *limbo, int64_t lsn, uint64_t term)
+txn_limbo_req_promote(struct txn_limbo *limbo, uint16_t type, int64_t lsn,
+		      uint64_t term)
 {
 	txn_limbo_assert_locked(limbo);
 	/*
@@ -445,7 +446,7 @@ txn_limbo_write_promote(struct txn_limbo *limbo, int64_t lsn, uint64_t term)
 	assert(e == NULL || e->lsn <= lsn);
 	(void) e;
 	struct synchro_request req = {
-		.type = IPROTO_RAFT_PROMOTE,
+		.type = type,
 		.queue_owner_id = limbo->queue.owner_id,
 		.origin_id = instance_id,
 		.promote = {
@@ -457,30 +458,6 @@ txn_limbo_write_promote(struct txn_limbo *limbo, int64_t lsn, uint64_t term)
 	 * Confirmed_vclock is only persisted in checkpoints. It doesn't
 	 * appear in WALs and replication.
 	 */
-	vclock_clear(&req.promote.confirmed_vclock);
-	if (txn_limbo_req_prepare(limbo, &req) < 0)
-		return -1;
-	synchro_request_write_or_panic(&req);
-	txn_limbo_req_commit(limbo, &req);
-	return 0;
-}
-
-int
-txn_limbo_write_demote(struct txn_limbo *limbo, int64_t lsn, uint64_t term)
-{
-	txn_limbo_assert_locked(limbo);
-	struct txn_limbo_entry *e = txn_limbo_last_synchro_entry(limbo);
-	assert(e == NULL || e->lsn <= lsn);
-	(void)e;
-	struct synchro_request req = {
-		.type = IPROTO_RAFT_DEMOTE,
-		.queue_owner_id = limbo->queue.owner_id,
-		.origin_id = instance_id,
-		.promote = {
-			.lsn = lsn,
-			.term = term,
-		},
-	};
 	vclock_clear(&req.promote.confirmed_vclock);
 	if (txn_limbo_req_prepare(limbo, &req) < 0)
 		return -1;

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -349,18 +349,13 @@ txn_limbo_checkpoint(const struct txn_limbo *limbo,
 		     struct synchro_request *req);
 
 /**
- * Write a PROMOTE request, which has the same effect as CONFIRM(@a lsn) and
- * ROLLBACK(@a lsn + 1) combined.
+ * Write a PROMOTE/DEMOTE request. It will do CONFIRM(@a lsn) +
+ * ROLLBACK(@a lsn + 1) + assign a new owner to the limbo (this node for
+ * PROMOTE, nobody for DEMOTE).
  */
 int
-txn_limbo_write_promote(struct txn_limbo *limbo, int64_t lsn, uint64_t term);
-
-/**
- * Write a DEMOTE request.
- * It has the same effect as PROMOTE and additionally clears limbo ownership.
- */
-int
-txn_limbo_write_demote(struct txn_limbo *limbo, int64_t lsn, uint64_t term);
+txn_limbo_req_promote(struct txn_limbo *limbo, uint16_t type, int64_t lsn,
+		      uint64_t term);
 
 /**
  * Update qsync parameters dynamically.

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -223,16 +223,6 @@ txn_limbo_replica_term(const struct txn_limbo *limbo, uint32_t replica_id)
 }
 
 /**
- * Return the latest confirmed lsn for the replica with id @replica_id.
- */
-static inline int64_t
-txn_limbo_replica_confirmed_lsn(const struct txn_limbo *limbo,
-				uint32_t replica_id)
-{
-	return vclock_get(&limbo->queue.confirmed_vclock, replica_id);
-}
-
-/**
  * Return the last synchronous transaction in the limbo or NULL when it is
  * empty.
  */

--- a/src/box/txn_limbo_queue.c
+++ b/src/box/txn_limbo_queue.c
@@ -629,7 +629,8 @@ txn_limbo_queue_apply_confirm(struct txn_limbo_queue *queue, int64_t lsn)
 {
 	assert(queue->owner_id != REPLICA_ID_NIL ||
 	       txn_limbo_queue_is_empty(queue));
-	assert(queue->confirmed_lsn <= lsn);
+	if (queue->confirmed_lsn >= lsn)
+		return;
 
 	bool queue_was_full = txn_limbo_queue_is_full(queue);
 	struct txn_limbo_entry *e, *next;

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -1315,37 +1315,45 @@ xrow_encode_synchro(struct xrow_header *row, char *body,
 		    const struct synchro_request *req)
 {
 	assert(iproto_type_is_synchro_request(req->type));
-
 	char *pos = body;
-
 	/* Skip one byte for the map. */
 	pos++;
 	uint32_t map_size = 0;
-
-	pos = mp_encode_uint(pos, IPROTO_REPLICA_ID);
-	pos = mp_encode_uint(pos, req->replica_id);
-	map_size++;
-
-	pos = mp_encode_uint(pos, IPROTO_LSN);
-	pos = mp_encode_uint(pos, req->lsn);
-	map_size++;
-
-	if (req->term != 0) {
+	switch (req->type) {
+	case IPROTO_RAFT_CONFIRM:
+		map_size = 2;
+		pos = mp_encode_uint(pos, IPROTO_REPLICA_ID);
+		pos = mp_encode_uint(pos, req->queue_owner_id);
+		pos = mp_encode_uint(pos, IPROTO_LSN);
+		pos = mp_encode_uint(pos, req->confirm.lsn);
+		break;
+	case IPROTO_RAFT_ROLLBACK:
+		map_size = 2;
+		pos = mp_encode_uint(pos, IPROTO_REPLICA_ID);
+		pos = mp_encode_uint(pos, req->queue_owner_id);
+		pos = mp_encode_uint(pos, IPROTO_LSN);
+		pos = mp_encode_uint(pos, req->rollback.lsn);
+		break;
+	case IPROTO_RAFT_PROMOTE:
+	case IPROTO_RAFT_DEMOTE:
+		pos = mp_encode_uint(pos, IPROTO_REPLICA_ID);
+		pos = mp_encode_uint(pos, req->queue_owner_id);
+		pos = mp_encode_uint(pos, IPROTO_LSN);
+		pos = mp_encode_uint(pos, req->promote.lsn);
 		pos = mp_encode_uint(pos, IPROTO_TERM);
-		pos = mp_encode_uint(pos, req->term);
-		map_size++;
+		pos = mp_encode_uint(pos, req->promote.term);
+		if (vclock_is_set(&req->promote.confirmed_vclock)) {
+			map_size = 4;
+			pos = mp_encode_uint(pos, IPROTO_VCLOCK);
+			pos = mp_encode_vclock_ignore0(
+				pos, &req->promote.confirmed_vclock);
+		} else {
+			map_size = 3;
+		}
+		break;
 	}
-
-	if (vclock_is_set(&req->confirmed_vclock)) {
-		pos = mp_encode_uint(pos, IPROTO_VCLOCK);
-		pos = mp_encode_vclock_ignore0(pos, &req->confirmed_vclock);
-		map_size++;
-	}
-
 	mp_encode_map(body, map_size);
-
 	assert(pos - body < XROW_BODY_LEN_MAX);
-
 	memset(row, 0, sizeof(*row));
 	row->type = req->type;
 	row->body[0].iov_base = body;
@@ -1353,24 +1361,11 @@ xrow_encode_synchro(struct xrow_header *row, char *body,
 	row->bodycnt = 1;
 }
 
-int
-xrow_decode_synchro(const struct xrow_header *row, struct synchro_request *req)
+/** Decode IPROTO_RAFT_CONFIRM request. */
+static int
+xrow_decode_synchro_confirm(struct synchro_request *req, const char *d)
 {
-	if (row->bodycnt == 0) {
-		diag_set(ClientError, ER_INVALID_MSGPACK, "request body");
-		return -1;
-	}
-
-	assert(row->bodycnt == 1);
-
-	const char *d = (const char *)row->body[0].iov_base;
-	if (mp_typeof(*d) != MP_MAP) {
-		xrow_on_decode_err(row, ER_INVALID_MSGPACK, "request body");
-		return -1;
-	}
-
-	memset(req, 0, sizeof(*req));
-	vclock_clear(&req->confirmed_vclock);
+	assert(req->type == IPROTO_RAFT_CONFIRM);
 	uint32_t map_size = mp_decode_map(&d);
 	for (uint32_t i = 0; i < map_size; i++) {
 		enum mp_type type = mp_typeof(*d);
@@ -1381,36 +1376,125 @@ xrow_decode_synchro(const struct xrow_header *row, struct synchro_request *req)
 		}
 		uint8_t key = mp_decode_uint(&d);
 		if (key < iproto_key_MAX &&
-		    iproto_key_type[key] != mp_typeof(*d)) {
-bad_msgpack:
-			xrow_on_decode_err(row, ER_INVALID_MSGPACK,
-					   "request body");
+		    iproto_key_type[key] != mp_typeof(*d))
 			return -1;
-		}
 		switch (key) {
 		case IPROTO_REPLICA_ID:
-			req->replica_id = mp_decode_uint(&d);
+			req->queue_owner_id = mp_decode_uint(&d);
 			break;
 		case IPROTO_LSN:
-			req->lsn = mp_decode_uint(&d);
-			break;
-		case IPROTO_TERM:
-			req->term = mp_decode_uint(&d);
-			break;
-		case IPROTO_VCLOCK:
-			if (mp_decode_vclock_ignore0(
-					&d, &req->confirmed_vclock) != 0)
-				goto bad_msgpack;
+			req->confirm.lsn = mp_decode_uint(&d);
 			break;
 		default:
 			mp_next(&d);
 		}
 	}
+	return 0;
+}
 
+/** Decode IPROTO_RAFT_ROLLBACK request. */
+static int
+xrow_decode_synchro_rollback(struct synchro_request *req, const char *d)
+{
+	assert(req->type == IPROTO_RAFT_ROLLBACK);
+	uint32_t map_size = mp_decode_map(&d);
+	for (uint32_t i = 0; i < map_size; i++) {
+		enum mp_type type = mp_typeof(*d);
+		if (type != MP_UINT) {
+			mp_next(&d);
+			mp_next(&d);
+			continue;
+		}
+		uint8_t key = mp_decode_uint(&d);
+		if (key < iproto_key_MAX &&
+		    iproto_key_type[key] != mp_typeof(*d))
+			return -1;
+		switch (key) {
+		case IPROTO_REPLICA_ID:
+			req->queue_owner_id = mp_decode_uint(&d);
+			break;
+		case IPROTO_LSN:
+			req->rollback.lsn = mp_decode_uint(&d);
+			break;
+		default:
+			mp_next(&d);
+		}
+	}
+	return 0;
+}
+
+/** Decode IPROTO_RAFT_PROMOTE/DEMOTE request. */
+static int
+xrow_decode_synchro_promote(struct synchro_request *req, const char *d)
+{
+	assert(req->type == IPROTO_RAFT_PROMOTE ||
+	       req->type == IPROTO_RAFT_DEMOTE);
+	vclock_clear(&req->promote.confirmed_vclock);
+	uint32_t map_size = mp_decode_map(&d);
+	for (uint32_t i = 0; i < map_size; i++) {
+		enum mp_type type = mp_typeof(*d);
+		if (type != MP_UINT) {
+			mp_next(&d);
+			mp_next(&d);
+			continue;
+		}
+		uint8_t key = mp_decode_uint(&d);
+		if (key < iproto_key_MAX &&
+		    iproto_key_type[key] != mp_typeof(*d))
+			return -1;
+		switch (key) {
+		case IPROTO_REPLICA_ID:
+			req->queue_owner_id = mp_decode_uint(&d);
+			break;
+		case IPROTO_LSN:
+			req->promote.lsn = mp_decode_uint(&d);
+			break;
+		case IPROTO_TERM:
+			req->promote.term = mp_decode_uint(&d);
+			break;
+		case IPROTO_VCLOCK:
+			if (mp_decode_vclock_ignore0(
+					&d,
+					&req->promote.confirmed_vclock) != 0)
+				return -1;
+			break;
+		default:
+			mp_next(&d);
+		}
+	}
+	return 0;
+}
+
+int
+xrow_decode_synchro(const struct xrow_header *row, struct synchro_request *req)
+{
+	if (row->bodycnt == 0)
+		goto bad_body;
+	assert(row->bodycnt == 1);
+	const char *d = (const char *)row->body[0].iov_base;
+	if (mp_typeof(*d) != MP_MAP)
+		goto bad_body;
+	memset(req, 0, sizeof(*req));
 	req->type = row->type;
 	req->origin_id = row->replica_id;
-
-	return 0;
+	int rc = 0;
+	switch (row->type) {
+	case IPROTO_RAFT_CONFIRM:
+		rc = xrow_decode_synchro_confirm(req, d);
+		break;
+	case IPROTO_RAFT_ROLLBACK:
+		rc = xrow_decode_synchro_rollback(req, d);
+		break;
+	case IPROTO_RAFT_PROMOTE:
+	case IPROTO_RAFT_DEMOTE:
+		rc = xrow_decode_synchro_promote(req, d);
+		break;
+	}
+	if (rc == 0)
+		return 0;
+bad_body:
+	xrow_on_decode_err(row, ER_INVALID_MSGPACK, "request body");
+	return -1;
 }
 
 void

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -360,37 +360,36 @@ struct synchro_request {
 	 */
 	uint16_t type;
 	/**
-	 * ID of the instance owning the pending transactions.
-	 * Note, it may be not the same instance, who created this
-	 * request. An instance can make an operation on foreign
-	 * synchronous transactions in case a new master tries to
-	 * finish transactions of an old master.
+	 * The latest confirmed ID of the synchronous queue owner from the PoV
+	 * of the request's originator.
 	 */
-	uint32_t replica_id;
+	uint32_t queue_owner_id;
 	/**
 	 * Id of the instance which has issued this request. Only filled on
 	 * decoding, and left blank when encoding a request.
 	 */
 	uint32_t origin_id;
-	/**
-	 * Operation LSN.
-	 * In case of CONFIRM it means 'confirm all
-	 * transactions with lsn <= this value'.
-	 * In case of ROLLBACK it means 'rollback all transactions
-	 * with lsn >= this value'.
-	 * In case of PROMOTE it means CONFIRM(lsn) + ROLLBACK(lsn+1)
-	 */
-	int64_t lsn;
-	/**
-	 * The new term the instance issuing this request is in. Only used for
-	 * PROMOTE and DEMOTE requests.
-	 */
-	uint64_t term;
-	/**
-	 * Confirmed lsns of all the previous limbo owners. Only used for
-	 * PROMOTE and DEMOTE requests.
-	 */
-	struct vclock confirmed_vclock;
+	union {
+		struct {
+			/**
+			 * Confirm all txns with LSN <= this one, and rollback
+			 * all the others.
+			 */
+			int64_t lsn;
+			/** Raft term in which this request was issued. */
+			uint64_t term;
+			/** Confirmed lsns of all the previous limbo owners. */
+			struct vclock confirmed_vclock;
+		} promote;
+		struct {
+			/** Confirm all txns having LSN <= this one. */
+			int64_t lsn;
+		} confirm;
+		struct {
+			/** Rollback all txns having LSN >= this one. */
+			int64_t lsn;
+		} rollback;
+	};
 };
 
 /**

--- a/src/lib/vclock/vclock.c
+++ b/src/lib/vclock/vclock.c
@@ -51,7 +51,7 @@ vclock_follow(struct vclock *vclock, uint32_t replica_id, int64_t lsn)
 	return prev_lsn;
 }
 
-static int
+int
 vclock_snprint(char *buf, int size, const struct vclock *vclock)
 {
 	int total = 0;

--- a/src/lib/vclock/vclock.h
+++ b/src/lib/vclock/vclock.h
@@ -283,6 +283,13 @@ vclock_to_string(const struct vclock *vclock);
 size_t
 vclock_from_string(struct vclock *vclock, const char *str);
 
+/**
+ * Stringify the vclock into the given buffer. Same semantics as
+ * snprintf().
+ */
+int
+vclock_snprint(char *buf, int size, const struct vclock *vclock);
+
 enum { VCLOCK_ORDER_UNDEFINED = INT_MAX };
 
 /**

--- a/test/unit/vclock.cc
+++ b/test/unit/vclock.cc
@@ -405,6 +405,24 @@ test_fromstring_invalid()
 
 #undef test
 
+static int
+test_snprint(void)
+{
+	plan(3);
+	header();
+
+	const char *str = "{0: 1, 2: 10}";
+	struct vclock v;
+	vclock_create(&v);
+	is(vclock_from_string(&v, str), 0, "from string");
+	char buf[1024];
+	is(vclock_snprint(buf, sizeof(buf), &v), (int)strlen(str), "snprint");
+	is(strcmp(str, buf), 0, "correct");
+
+	footer();
+	return check_plan();
+}
+
 #define test(fun, a, b, exp) ({						\
 	struct vclock va;						\
 	vclock_create(&va);						\
@@ -591,13 +609,14 @@ test_count_ge(void)
 int
 main(void)
 {
-	plan(10);
+	plan(11);
 
 	test_compare();
 	test_isearch();
 	test_tostring();
 	test_fromstring();
 	test_fromstring_invalid();
+	test_snprint();
 	test_minmax();
 	test_mp();
 	test_mp_invalid();

--- a/test/unit/vclock.result
+++ b/test/unit/vclock.result
@@ -1,4 +1,4 @@
-1..10
+1..11
     1..40
 	*** test_compare ***
     ok 1 - compare (), () => 0
@@ -147,6 +147,13 @@ ok 4 - subtests
     ok 32 - fromstring "{1:20, 1:10}" => 12
 	*** test_fromstring_invalid: done ***
 ok 5 - subtests
+    1..3
+	*** test_snprint ***
+    ok 1 - from string
+    ok 2 - snprint
+    ok 3 - correct
+	*** test_snprint: done ***
+ok 6 - subtests
     1..6
 	*** test_minmax ***
     ok 1 - max_ignore0 between {0: 1, 1: 17, 2: 3} and {0: 10, 1: 5, 2: 7} is {0: 1, 1: 17, 2: 7}
@@ -156,7 +163,7 @@ ok 5 - subtests
     ok 5 - max between {0: 1, 1: 17, 2: 3} and {0: 10, 1: 5, 2: 7} is {0: 10, 1: 17, 2: 7}
     ok 6 - min between {0: 10, 1: 17, 2: 3} and {0: 1, 1: 5, 2: 7} is {0: 1, 1: 5, 2: 3}
 	*** test_minmax: done ***
-ok 6 - subtests
+ok 7 - subtests
     1..7
 	*** test_mp ***
     ok 1 - Case must pass successfully
@@ -167,7 +174,7 @@ ok 6 - subtests
     ok 6 - Case must pass successfully
     ok 7 - Case must pass successfully
 	*** test_mp: done ***
-ok 7 - subtests
+ok 8 - subtests
     1..8
 	*** test_mp_invalid ***
     ok 1 - Decoder must fail
@@ -179,7 +186,7 @@ ok 7 - subtests
     ok 7 - Decoder must fail
     ok 8 - Decoder must fail
 	*** test_mp_invalid: done ***
-ok 8 - subtests
+ok 9 - subtests
     1..11
 	*** test_nth_element ***
     ok 1 - vclock_nth_element "{0: 1, 2: 3, 5: 7, 10: 3}", 2 => 3
@@ -194,7 +201,7 @@ ok 8 - subtests
     ok 10 - vclock_nth_element "{2: 1, 4: 2, 6: 3, 8: 4, 10: 5}", 1 => 2
     ok 11 - vclock_nth_element "{2: 5, 4: 6, 6: 7, 8: 8, 10: 9}", 5 => -1
 	*** test_nth_element: done ***
-ok 9 - subtests
+ok 10 - subtests
     1..10
 	*** test_count_ge ***
     ok 1 - vclock_count_ge "{0: 1, 2: 3, 5: 7, 10: 3}", 3 => 3
@@ -208,4 +215,4 @@ ok 9 - subtests
     ok 9 - vclock_count_ge "{1: 2, 3: 4, 5: 6, 7: 8, 9: 10}", 5 => 3
     ok 10 - vclock_count_ge "{2: 1, 4: 2, 6: 3, 8: 4, 10: 5}", 3 => 3
 	*** test_count_ge: done ***
-ok 10 - subtests
+ok 11 - subtests


### PR DESCRIPTION
The primary goal of the PR is to encapsulate as much as possible of the untrivial limbo logic inside the limbo's own source code. Even right now it is quite hard to understand, and it will get worse in the future when `PROMOTE` and `CONFIRM` requests handling will get complicated further.

The choice here is made in the direction of minimization of the limbo's public API. Synchro requests can now be applied as `txn_limbo_begin()` + `txn_limbo_req_prepare()` + `txn_limbo_req_commit()` + `txn_limbo_commit()`. And the limbo internally decides which operations are nop and which aren't without needing any action from the caller. Unlike the current situation in the master branch, that the caller needs to be aware of the limbo's internal logic to decide on whether a request must be nopified.

This is not the only way to go though. Technically it is still possible to continue nopification AND encapsulate the logic. For that we could, for example, extend `txn_limbo_req_prepare()` to return not just 0/-1, but one of 3 values, which would be "error", "ok", and "nop", and the caller must turn the request into `IPROTO_NOP` then. I didn't like this solution due to complication of `txn_limbo_req_prepare()` public call.

But I also do not have a strong preference and could keep the nopification. The trade-offs are the following.

**Store as `IPROTO_NOP`**
- ❌ - loses potential debug info in the xlogs.
- ❌ - might mess up replication in theory. If first receiver applied it as nop, but second receiver would actually get a split-brain.
- ✅ - looks a bit more obvious in the logs, that the operation was skipped (we don't know which one though).

**Apply as "nop", but keep the entry**
- ❌ - in the xlog can't tell if it was applied or skipped. Except `CONFIRM` which will be obvious - it either confirms already confirmed stuff, or new stuff, or it fails. Only `PROMOTE` entries might look untrivial in this sense.
- ✅ - preserves the replication flow unchanged.
- ✅ - easier to debug broken replication by reading the xlogs.

I decided to do the "nopification" as "having no effects" instead of "storing it as actual nop".

Description:
```
limbo: do not nopify control commands

Nopification or simple ignorance leads to the same result. Even
for transactions it would not matter if we could still write them
to the journal without attempting to apply their effects.

For the limbo it was relatively easy to nopify outdated synchro
requests together with outdated transactions.

However, this will not hold for long. The logic of PROMOTE and
CONFIRM requests will evolve significantly. Promotions from older
terms will be preserved and may be reapplied, while confirmations
may refer not only to transactions but also to past promotions.

Managing this behavior will be much easier if the logic remains
encapsulated within the limbo rather than leaking into the
applier.

This commit prepares for that by ensuring that control commands
are never nopified. The decision whether to apply or ignore them
is now handled entirely inside the limbo code.

The existing logic is moved without functional changes. The main
difference is that outdated checks are now performed in two
places: during request preparation and during request commit in
the limbo.

Part of #8095

NO_DOC=refactoring
NO_CHANGELOG=refactoring
NO_TEST=refactoring
```