### PR TITLE
[backport 3.3] test: encapsulate test dependencies in test dir as symlinks

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -39,6 +39,8 @@ exclude_files = {
     "test/engine/*.test.lua",
     "test/engine_long/*.test.lua",
     "test/replication/*.test.lua",
+    "test/metrics-luatest/test/*.lua",
+    "test/metrics-luatest/test/**/*.lua",
     "test/sql/**/*.lua",
     "test/swim/*.test.lua",
     "test/var/**/*.lua",

--- a/test/app-luatest/checks_test.lua
+++ b/test/app-luatest/checks_test.lua
@@ -2,8 +2,9 @@
 -- After https://github.com/tarantool/checks/pull/54,
 -- external checks will override built-in one, yet
 -- we want to test built-in one here.
-local rock_utils = require('third_party.checks.test.rock_utils')
+local rock_utils =
+    require('test.app-luatest.third_party_checks_test.rock_utils')
 rock_utils.remove_override('checks')
 rock_utils.assert_builtin('checks')
 
-require('third_party.checks.test.test')
+require('test.app-luatest.third_party_checks_test.test')

--- a/test/app-luatest/http_client_unit_test.lua
+++ b/test/app-luatest/http_client_unit_test.lua
@@ -9,12 +9,16 @@ local ffi = require("ffi")
 
 local g = t.group('http_client_unit')
 
-package.loaded['http.client'] = {
-    new = function() return end
-}
-local driver = package.loaded['http.client'] -- luacheck: no unused
+local source_is_available, httpc = pcall(require, "src.lua.httpc")
+if source_is_available then
+    package.loaded["http.client"] = {
+        new = function() return end
+    }
+    local driver = package.loaded["http.client"] -- luacheck: no unused
+else
+    httpc = require('http.client')
+end
 
-local httpc = require("src.lua.httpc")
 local encode_body = httpc._internal.encode_body
 local decode_body = httpc._internal.decode_body
 local extract_mime_type = httpc._internal.extract_mime_type

--- a/test/app-luatest/third_party_checks_test
+++ b/test/app-luatest/third_party_checks_test
@@ -1,0 +1,1 @@
+../../third_party/checks/test

--- a/test/app-luatest/uri_unit_test.lua
+++ b/test/app-luatest/uri_unit_test.lua
@@ -1,6 +1,8 @@
-local build_path = os.getenv("BUILDDIR")
-package.cpath = build_path .. '/src/lua/?.lua;' .. package.cpath
-local uri = require('src.lua.uri')
+local source_is_available, uri = pcall(require, 'src.lua.uri')
+if not source_is_available then
+    uri = require('uri')
+end
+
 local t = require('luatest')
 
 local decimal = require('decimal')

--- a/test/box-luatest/gh_8192_feedback_daemon_metrics_test.lua
+++ b/test/box-luatest/gh_8192_feedback_daemon_metrics_test.lua
@@ -17,7 +17,8 @@ g.before_all(function()
     }
     g.server:start()
     g.server:exec(function()
-        require('third_party.metrics.test.rock_utils').remove_builtin('metrics')
+        local rocks_utils = 'test.metrics-luatest.test.rock_utils'
+        require(rocks_utils).remove_builtin('metrics')
         box.cfg{feedback_send_metrics = true}
     end)
 end)

--- a/test/config-luatest/basic_test.lua
+++ b/test/config-luatest/basic_test.lua
@@ -74,7 +74,8 @@ end
 
 g.test_example_single = function(g)
     local dir = treegen.prepare_directory({}, {})
-    local config_file = fio.abspath('doc/examples/config/single.yaml')
+    local config_file = fio.abspath('test/config-luatest/examples/config/' ..
+        'single.yaml')
     local opts = {config_file = config_file, chdir = dir}
     g.server = server:new(fun.chain(opts, {alias = 'instance-001'}):tomap())
     g.server:start()
@@ -83,9 +84,11 @@ end
 
 g.test_example_replicaset = function(g)
     local dir = treegen.prepare_directory({}, {})
-    fio.copytree('doc/examples/config/secrets', fio.pathjoin(dir, 'secrets'))
+    fio.copytree('test/config-luatest/examples/config/secrets',
+                  fio.pathjoin(dir, 'secrets'))
 
-    local config_file = fio.abspath('doc/examples/config/replicaset.yaml')
+    local config_file = fio.abspath('test/config-luatest/examples/config/' ..
+        'replicaset.yaml')
     helpers.start_example_replicaset(g, dir, config_file)
 
     -- Verify that the default database mode for a replicaset with
@@ -100,9 +103,10 @@ end
 
 g.test_example_replicaset_manual_failover = function(g)
     local dir = treegen.prepare_directory({}, {})
-    fio.copytree('doc/examples/config/secrets', fio.pathjoin(dir, 'secrets'))
+    fio.copytree('test/config-luatest/examples/config/secrets',
+                 fio.pathjoin(dir, 'secrets'))
 
-    local config_file = fio.abspath('doc/examples/config/' ..
+    local config_file = fio.abspath('test/config-luatest/examples/config/' ..
         'replicaset_manual_failover.yaml')
     helpers.start_example_replicaset(g, dir, config_file)
 
@@ -118,9 +122,10 @@ end
 
 g.test_example_replicaset_election_failover = function(g)
     local dir = treegen.prepare_directory({}, {})
-    fio.copytree('doc/examples/config/secrets', fio.pathjoin(dir, 'secrets'))
+    fio.copytree('test/config-luatest/examples/config/secrets',
+                 fio.pathjoin(dir, 'secrets'))
 
-    local config_file = fio.abspath('doc/examples/config/' ..
+    local config_file = fio.abspath('test/config-luatest/examples/config/' ..
         'replicaset_election_failover.yaml')
     helpers.start_example_replicaset(g, dir, config_file)
 

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -512,7 +512,7 @@ local examples = {
 
 for case, path in pairs(examples) do
     local test_name = ('test_example_%s'):format(case)
-    local config_path = ('doc/examples/config/%s'):format(path)
+    local config_path = ('test/config-luatest/examples/config/%s'):format(path)
     g[test_name] = function()
         local config_file = fio.abspath(config_path)
         local fh = fio.open(config_file, {'O_RDONLY'})
@@ -530,7 +530,7 @@ local enterprise_examples = {
 
 for case, path in pairs(enterprise_examples) do
     local test_name = ('test_example_%s'):format(case)
-    local config_path = ('doc/examples/config/%s'):format(path)
+    local config_path = ('test/config-luatest/examples/config/%s'):format(path)
     g[test_name] = function()
         t.tarantool.skip_if_not_enterprise()
         local config_file = fio.abspath(config_path)

--- a/test/config-luatest/conditional_section_test.lua
+++ b/test/config-luatest/conditional_section_test.lua
@@ -17,7 +17,8 @@ local g = helpers.group()
 -- applied. It sets a custom process title, which is verified here.
 g.test_example = function(g)
     local dir = treegen.prepare_directory({}, {})
-    local config_file = fio.abspath('doc/examples/config/upgrade.yaml')
+    local config_file = fio.abspath('test/config-luatest/examples/config/' ..
+        'upgrade.yaml')
     local opts = {config_file = config_file, chdir = dir}
     g.server = server:new(fun.chain(opts, {alias = 'instance-001'}):tomap())
     g.server:start()

--- a/test/config-luatest/examples
+++ b/test/config-luatest/examples
@@ -1,0 +1,1 @@
+../../doc/examples

--- a/test/config-luatest/sources_test.lua
+++ b/test/config-luatest/sources_test.lua
@@ -17,7 +17,8 @@ g.after_each(function(g)
 end)
 
 g.test_source_file = function()
-    local config = {_config_file = 'doc/examples/config/single.yaml'}
+    local config =
+        {_config_file = 'test/config-luatest/examples/config/single.yaml'}
     source_file:sync(config, {})
     local res = source_file:get()
     local exp = {

--- a/test/metrics-luatest/box_cfg_test.lua
+++ b/test/metrics-luatest/box_cfg_test.lua
@@ -4,7 +4,7 @@ local t = require('luatest')
 local g = t.group('box-cfg-metrics')
 local server = require('luatest.server')
 
-local utils = require('third_party.metrics.test.utils')
+local utils = require('test.metrics-luatest.test.utils')
 
 g.before_all(function()
     g.server = server:new()

--- a/test/metrics-luatest/cfg_test.lua
+++ b/test/metrics-luatest/cfg_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.cfg_test')
+require('test.metrics-luatest.test.cfg_test')

--- a/test/metrics-luatest/collectors_counter_test.lua
+++ b/test/metrics-luatest/collectors_counter_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.collectors.counter_test')
+require('test.metrics-luatest.test.collectors.counter_test')

--- a/test/metrics-luatest/collectors_gauge_test.lua
+++ b/test/metrics-luatest/collectors_gauge_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.collectors.gauge_test')
+require('test.metrics-luatest.test.collectors.gauge_test')

--- a/test/metrics-luatest/collectors_histogram_test.lua
+++ b/test/metrics-luatest/collectors_histogram_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.collectors.histogram_test')
+require('test.metrics-luatest.test.collectors.histogram_test')

--- a/test/metrics-luatest/collectors_latency_observer_test.lua
+++ b/test/metrics-luatest/collectors_latency_observer_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.collectors.latency_observer_test')
+require('test.metrics-luatest.test.collectors.latency_observer_test')

--- a/test/metrics-luatest/collectors_shared_test.lua
+++ b/test/metrics-luatest/collectors_shared_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.collectors.shared_test')
+require('test.metrics-luatest.test.collectors.shared_test')

--- a/test/metrics-luatest/collectors_summary_test.lua
+++ b/test/metrics-luatest/collectors_summary_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.collectors.summary_test')
+require('test.metrics-luatest.test.collectors.summary_test')

--- a/test/metrics-luatest/enable_default_metrics_test.lua
+++ b/test/metrics-luatest/enable_default_metrics_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.enable_default_metrics_test')
+require('test.metrics-luatest.test.enable_default_metrics_test')

--- a/test/metrics-luatest/helper.lua
+++ b/test/metrics-luatest/helper.lua
@@ -8,7 +8,7 @@ local fun = require('fun')
 -- but in case someone has metrics package installed globally
 -- and wants to run the tests with pure luatest, we disable
 -- override here.
-local rock_utils = require('third_party.metrics.test.rock_utils')
+local rock_utils = require('test.metrics-luatest.test.rock_utils')
 rock_utils.remove_override('metrics')
 rock_utils.assert_builtin('metrics')
 
@@ -64,22 +64,22 @@ local function array_to_map(arr)
     return map
 end
 
-local third_party_tests = get_test_modules_list('third_party/metrics/test')
+local third_party_tests = get_test_modules_list('test/metrics-luatest/test')
 local core_tests = get_test_modules_list('test/metrics-luatest')
 
 -- Embedded metrics does not include cartridge role.
 -- We don't check cartridge integration here too, refer to
 -- https://github.com/tarantool/cartridge/pull/2047
 local ignore_tests = {
-    'third_party.metrics.test.integration.cartridge_health_test',
-    'third_party.metrics.test.integration.cartridge_hotreload_test',
-    'third_party.metrics.test.integration.cartridge_metrics_test',
-    'third_party.metrics.test.integration.cartridge_nohttp_test',
-    'third_party.metrics.test.integration.cartridge_role_test',
-    'third_party.metrics.test.integration.highload_test',
-    'third_party.metrics.test.integration.hotreload_test',
-    'third_party.metrics.test.unit.cartridge_issues_test',
-    'third_party.metrics.test.unit.cartridge_role_test',
+    'test.metrics-luatest.test.integration.cartridge_health_test',
+    'test.metrics-luatest.test.integration.cartridge_hotreload_test',
+    'test.metrics-luatest.test.integration.cartridge_metrics_test',
+    'test.metrics-luatest.test.integration.cartridge_nohttp_test',
+    'test.metrics-luatest.test.integration.cartridge_role_test',
+    'test.metrics-luatest.test.integration.highload_test',
+    'test.metrics-luatest.test.integration.hotreload_test',
+    'test.metrics-luatest.test.unit.cartridge_issues_test',
+    'test.metrics-luatest.test.unit.cartridge_role_test',
 }
 
 core_tests = array_to_map(core_tests)
@@ -93,7 +93,7 @@ end
 for third_party_test, _ in pairs(third_party_tests) do
     -- Replace . to _ since tests here is not hierarchic:
     -- test-run does not expect hierarchic structure.
-    local name = third_party_test:gsub('^third_party.metrics.test.', '')
+    local name = third_party_test:gsub('^test.metrics%-luatest.test.', '')
                                  :gsub('%.', '_')
     local core_test = 'test.metrics-luatest.' .. name
 
@@ -104,17 +104,14 @@ end
 -- Workaround paths to reuse existing submodule tests.
 local function workaround_requires(path)
     package.preload[path] = function()
-        return require('third_party.metrics.' .. path)
+        return require('test.metrics-luatest.' .. path)
     end
 end
 
 workaround_requires('test.utils')
 
 require('test.utils')
-local test_root = fio.dirname(
-    fio.dirname(fio.abspath(
-        package.search('third_party.metrics.test.utils')))) -- luacheck: ignore
-
+local test_root = fio.abspath('test/metrics-luatest')
 package.loaded['test.utils'].LUA_PATH = os.getenv('LUA_PATH') ..
     test_root .. '/?.lua;' ..
     test_root .. '/?/init.lua;'

--- a/test/metrics-luatest/http_middleware_test.lua
+++ b/test/metrics-luatest/http_middleware_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.http_middleware_test')
+require('test.metrics-luatest.test.http_middleware_test')

--- a/test/metrics-luatest/metrics_test.lua
+++ b/test/metrics-luatest/metrics_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.metrics_test')
+require('test.metrics-luatest.test.metrics_test')

--- a/test/metrics-luatest/plugins_graphite_test.lua
+++ b/test/metrics-luatest/plugins_graphite_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.plugins.graphite_test')
+require('test.metrics-luatest.test.plugins.graphite_test')

--- a/test/metrics-luatest/plugins_json_test.lua
+++ b/test/metrics-luatest/plugins_json_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.plugins.json_test')
+require('test.metrics-luatest.test.plugins.json_test')

--- a/test/metrics-luatest/plugins_prometheus_test.lua
+++ b/test/metrics-luatest/plugins_prometheus_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.plugins.prometheus_test')
+require('test.metrics-luatest.test.plugins.prometheus_test')

--- a/test/metrics-luatest/psutils_linux_test.lua
+++ b/test/metrics-luatest/psutils_linux_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.psutils_linux_test')
+require('test.metrics-luatest.test.psutils_linux_test')

--- a/test/metrics-luatest/psutils_linux_thread_clean_test.lua
+++ b/test/metrics-luatest/psutils_linux_thread_clean_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.psutils_linux_thread_clean_test')
+require('test.metrics-luatest.test.psutils_linux_thread_clean_test')

--- a/test/metrics-luatest/quantile_test.lua
+++ b/test/metrics-luatest/quantile_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.quantile_test')
+require('test.metrics-luatest.test.quantile_test')

--- a/test/metrics-luatest/tarantool_config_metrics_test.lua
+++ b/test/metrics-luatest/tarantool_config_metrics_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.tarantool.config_metrics_test')
+require('test.metrics-luatest.test.tarantool.config_metrics_test')

--- a/test/metrics-luatest/tarantool_cpu_metrics_test.lua
+++ b/test/metrics-luatest/tarantool_cpu_metrics_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.tarantool.cpu_metrics_test')
+require('test.metrics-luatest.test.tarantool.cpu_metrics_test')

--- a/test/metrics-luatest/tarantool_info_metrics_test.lua
+++ b/test/metrics-luatest/tarantool_info_metrics_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.tarantool.info_metrics_test')
+require('test.metrics-luatest.test.tarantool.info_metrics_test')

--- a/test/metrics-luatest/tarantool_lj_metrics_test.lua
+++ b/test/metrics-luatest/tarantool_lj_metrics_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.tarantool.lj_metrics_test')
+require('test.metrics-luatest.test.tarantool.lj_metrics_test')

--- a/test/metrics-luatest/tarantool_memtx_metrics_test.lua
+++ b/test/metrics-luatest/tarantool_memtx_metrics_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.tarantool.memtx_metrics_test')
+require('test.metrics-luatest.test.tarantool.memtx_metrics_test')

--- a/test/metrics-luatest/tarantool_spaces_test.lua
+++ b/test/metrics-luatest/tarantool_spaces_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.tarantool.spaces_test')
+require('test.metrics-luatest.test.tarantool.spaces_test')

--- a/test/metrics-luatest/tarantool_vinyl_test.lua
+++ b/test/metrics-luatest/tarantool_vinyl_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.tarantool.vinyl_test')
+require('test.metrics-luatest.test.tarantool.vinyl_test')

--- a/test/metrics-luatest/test
+++ b/test/metrics-luatest/test
@@ -1,0 +1,1 @@
+../../third_party/metrics/test

--- a/test/metrics-luatest/utils_test.lua
+++ b/test/metrics-luatest/utils_test.lua
@@ -1,3 +1,3 @@
 require('test.metrics-luatest.helper')
 
-require('third_party.metrics.test.utils_test')
+require('test.metrics-luatest.test.utils_test')


### PR DESCRIPTION
In the scope of introducing GitLab CI for Tarantool EE we're going to build, test, pack and publish the bundles on our own. In addition to the binary bundle, where executable and include files are places, it's required to introduce the new test bundle, which includes all tests in order to allow users to download it and run tests, so that they can make sure, everything works on their own. In that test bundle we place all existing test sources, compiled ctests and so libraries and all the dependencies, needed for running these tests.

However, currently a lot of tests depends on files, which are not located in the `test` directory. It's dirty and difficult to maintain packing a lot of directories to the test bundle, so it was decided to soft link all the test dependencies to the test dir.

This commit implements exactly that. The following tests are changed:

  * `http_client_unit_test` - requires `src/lua/httpc.lua` file;
  * `uri_unit_test` - requires `src/lua/uri.lua` file;
  * config `basic_test` and `sources_test` - requires examples dir;
  * 'checks_test' - requires 'test' dir from third_party;
  * 'metrics-luatest' - same as 'checks'.

The CI itself just does `rsync -L` to copy the test directory and transform all symlinks into referent file/dir.

The `tnt_debug_getsources_test` file is an exception and will be completely excluded from the test bundle, since it requires too many source files and we don't add sources there.

NO_DOC=test
NO_CHANGELOG=test

(cherry picked from commit bd9d8e90201a0b367e51f2083a2d883a2cb305f4)