### PR TITLE
lua: add module for working with application threads

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -24,6 +24,7 @@ lua_source(lua_sources lua/xlog.lua xlog_lua)
 lua_source(lua_sources lua/key_def.lua key_def_lua)
 lua_source(lua_sources lua/merger.lua merger_lua)
 lua_source(lua_sources lua/iproto.lua iproto_lua)
+lua_source(lua_sources lua/app_threads.lua app_threads_lua)
 lua_source(lua_sources lua/version.lua internal_version_lua)
 
 # {{{ config

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -446,6 +446,8 @@ struct errcode_record {
 	_(ER_NO_SUCH_THREAD, 299,		"Thread does not exist", "thread_id", UINT) \
 	_(ER_UNABLE_TO_PROCESS_IN_THREAD, 300,	"Unable to process request in thread", "request", STRING, "thread_id", UINT) \
 	_(ER_DICT_OVERFLOW, 301,		"Dictionary has no space - too many unique values are used", "max_size", UINT) \
+	_(ER_NO_SUCH_THREAD_GROUP, 302,		"Thread group does not exist", "thread_group", STRING) \
+	_(ER_THREADS_NOT_CONFIGURED, 303,	"Threads are not configured") \
 	TEST_ERROR_CODES(_) /** This one should be last. */
 
 /*

--- a/src/box/lua/app_threads.lua
+++ b/src/box/lua/app_threads.lua
@@ -1,0 +1,336 @@
+local errno = require('errno')
+local net = require('net.box')
+local socket = require('socket')
+local utils = require('internal.utils')
+
+-- This module.
+local threads = {}
+
+-- Functions used internally.
+box.internal.threads = {}
+
+-- Configuration of the threads subsystem copied from the global config.
+local threads_cfg
+
+-- Name of the group this thread belongs to.
+local this_group_name
+
+-- Identifier of this thread.
+local this_thread_id
+
+-- Connection used to call threads.
+local threads_conn
+
+-- Map: name -> thread group object.
+local thread_groups = {}
+
+-- Map: name -> function exported with threads.export().
+local exported_functions = {}
+
+--
+-- Creates an IPROTO connection to the local instance over a socket pair.
+-- Returns the socket file descriptor of the other end, which can be passed
+-- to net.box.from_fd().
+--
+local function make_conn_fd()
+    local s1, s2 = socket.socketpair('AF_UNIX', 'SOCK_STREAM', 0)
+    if s1 == nil then
+        error('Failed to create socket pair: ' .. errno.strerror())
+    end
+    local fd1, fd2 = s1:fd(), s2:fd()
+    s1:detach()
+    s2:detach()
+    box.session.new({fd = fd1, user = 'admin'})
+    return fd2
+end
+
+--
+-- Thread group class metatable.
+--
+-- This is a helper class that is used for dispatching function calls to
+-- the threads of a thread group.
+--
+local thread_group_methods = {}
+local thread_group_mt = {__index = thread_group_methods}
+
+--
+-- Creates a thread group that spans the specified range of thread ids.
+-- The new thread group is registered under the given name.
+--
+local function create_thread_group(group_name, first_thread_id, last_thread_id)
+    assert(thread_groups[group_name] == nil)
+    assert(last_thread_id >= first_thread_id)
+    thread_groups[group_name] = setmetatable({
+        first_thread_id = first_thread_id,
+        last_thread_id = last_thread_id,
+    }, thread_group_mt)
+end
+
+--
+-- Returns a thread group with the given name. Raises an error if not found.
+--
+local function find_thread_group(group_name)
+    local group = thread_groups[group_name]
+    if group == nil then
+        box.error(box.error.NO_SUCH_THREAD_GROUP, group_name)
+    end
+    return group
+end
+
+--
+-- Initializes thread groups from the config.
+--
+-- Note that it always creates the 'tx' group with thread 0 for calling
+-- the main thread.
+--
+local function init_thread_groups(cfg)
+    create_thread_group('tx', 0, 0)
+    local thread_id = 1
+    for _, group_cfg in ipairs(cfg.groups) do
+        local first_thread_id = thread_id
+        local last_thread_id = thread_id + group_cfg.size - 1
+        create_thread_group(group_cfg.name, first_thread_id, last_thread_id)
+        thread_id = last_thread_id + 1
+    end
+end
+
+--
+-- Dispatches a callback to this thread group.
+--
+-- The callback is passed the target thread id as the second argument
+-- (the first argument is args). It's supposed to return a net.box
+-- future object.
+--
+-- Available options:
+-- * target := all | any: determines whether the callback is invoked for
+--   all threads of the group or just one picked randomly.
+--
+-- On success returns an array of future results, one for each target thread.
+-- If any of the returned futures fails with an error, re-throws the last
+-- error.
+--
+function thread_group_methods:_dispatch(cb, args, opts)
+    local first_thread_id = self.first_thread_id
+    local last_thread_id = self.last_thread_id
+    if opts.target == 'any' then
+        local thread_id = math.random(first_thread_id, last_thread_id)
+        first_thread_id, last_thread_id = thread_id, thread_id
+    else
+        assert(opts.target == nil or opts.target == 'all')
+    end
+    local futures = {}
+    for thread_id = first_thread_id, last_thread_id do
+        table.insert(futures, cb(args, thread_id))
+    end
+    local last_err
+    local results = {}
+    for i, fut in ipairs(futures) do
+        local ret, err = fut:wait_result()
+        if err == nil then
+            results[i] = ret
+        else
+            last_err = err
+        end
+    end
+    if last_err ~= nil then
+        error(last_err)
+    end
+    return results
+end
+
+--
+-- Callback for thread_group:init().
+--
+local function thread_init_cb(args, thread_id)
+    assert(threads_conn ~= nil)
+    local cfg, group_name = unpack(args)
+    return threads_conn:call('box.internal.threads.init',
+                             {cfg, group_name, thread_id, make_conn_fd()},
+                             {_thread_id = thread_id, is_async = true})
+end
+
+--
+-- Initializes the subsystem in all threads of this group.
+--
+function thread_group_methods:init(cfg, group_name)
+    assert(threads_conn ~= nil)
+    return self:_dispatch(thread_init_cb, {cfg, group_name}, {target = 'all'})
+end
+
+--
+-- Callback for thread_group:call().
+--
+local function thread_call_cb(args, thread_id)
+    assert(threads_conn ~= nil)
+    return threads_conn:call('box.internal.threads.call', args,
+                             {_thread_id = thread_id, is_async = true})
+end
+
+--
+-- Calls a function exported with threads.export() on this thread group.
+--
+-- See thread_group:_dispatch() for the description of available options.
+--
+function thread_group_methods:call(func_name, args, opts)
+    return self:_dispatch(thread_call_cb, {func_name, args}, opts)
+end
+
+--
+-- Callback for thread_group:eval().
+--
+local function thread_eval_cb(args, thread_id)
+    assert(threads_conn ~= nil)
+    return threads_conn:eval(args[1], args[2],
+                             {_thread_id = thread_id, is_async = true})
+end
+
+--
+-- Executes a Lua expression on this thread group.
+--
+-- See thread_group:_dispatch() for the description of available options.
+--
+function thread_group_methods:eval(expr, args, opts)
+    return self:_dispatch(thread_eval_cb, {expr, args}, opts)
+end
+
+--
+-- Initializes the subsystem in the current thread.
+--
+function box.internal.threads.init(cfg, group_name, thread_id, conn_fd)
+    assert(threads_cfg == nil)
+    threads_cfg = cfg
+    this_group_name = group_name
+    this_thread_id = thread_id
+    threads_conn = net.from_fd(conn_fd, {fetch_schema = false})
+    init_thread_groups(cfg)
+end
+
+--
+-- Configures the threads subsystem. Called once from the main thread.
+-- If called without arguments, returns the current configuration.
+--
+function box.internal.threads.cfg(cfg)
+    if cfg == nil then
+        return threads_cfg
+    end
+    assert(threads_cfg == nil)
+    box.internal.threads.init(cfg, 'tx', 0, make_conn_fd())
+    -- Initialize the subsystem in threads.
+    for group_name, group in pairs(thread_groups) do
+        if group_name ~= this_group_name then
+            group:init(cfg, group_name)
+        end
+    end
+end
+
+--
+-- Calls a function exported with threads.export().
+--
+function box.internal.threads.call(func_name, args)
+    local func = exported_functions[func_name]
+    if func == nil then
+        box.error(box.error.NO_SUCH_FUNCTION, func_name)
+    end
+    return func(unpack(args))
+end
+
+--
+-- Exports a function so that it can be executed with threads.call().
+--
+function threads.export(func_name, func)
+    utils.check_param(func_name, 'function name', 'string', 2)
+    utils.check_param(func, 'function object', 'function', 2)
+    if exported_functions[func_name] ~= nil then
+        box.error(box.error.FUNCTION_EXISTS, func_name)
+    end
+    exported_functions[func_name] = func
+end
+
+--
+-- Raises an error if the threads module hasn't been configured.
+--
+local function check_configured()
+    if threads_cfg == nil then
+        box.error(box.error.THREADS_NOT_CONFIGURED, 3)
+    end
+end
+
+-- call/eval options template used with utils.check_param_table().
+local CALL_EVAL_OPTS = {
+    target = 'string',
+}
+
+--
+-- Raises an error if an option passed to call/eval is unknown or has
+-- an invalid type/value.
+--
+local function check_call_eval_opts(opts)
+    utils.check_param_table(opts, CALL_EVAL_OPTS, 3)
+    if opts.target ~= nil and opts.target ~= 'all' and opts.target ~= 'any' then
+        box.error(box.error.ILLEGAL_PARAMS,
+                  "unexpected value for option parameter 'target': " ..
+                  "got '" .. opts.target .. "', expected 'any' or 'all'", 3)
+    end
+end
+
+--
+-- Calls a function on a thread group. The function must be exported with
+-- threads.export() on all target threads.
+--
+-- On success returns an array of results, one per each target thread.
+-- If the function fails on any target thread, the last error is re-thrown.
+--
+-- See thread_group:_dispatch() for the description of available options.
+--
+function threads.call(group_name, func_name, args, opts)
+    args = args or {}
+    opts = opts or {}
+    check_configured()
+    utils.check_param(group_name, 'group name', 'string', 2)
+    utils.check_param(func_name, 'function name', 'string', 2)
+    utils.check_param(args, 'function arguments', 'table', 2)
+    check_call_eval_opts(opts)
+    return find_thread_group(group_name):call(func_name, args, opts)
+end
+
+--
+-- Executes a Lua expression on a thread group.
+--
+-- On success returns an array of results, one per each target thread.
+-- If the function fails on any target thread, the last error is re-thrown.
+--
+-- See thread_group:_dispatch() for the description of available options.
+--
+function threads.eval(group_name, expr, args, opts)
+    args = args or {}
+    opts = opts or {}
+    check_configured()
+    utils.check_param(group_name, 'group name', 'string', 2)
+    utils.check_param(expr, 'expression', 'string', 2)
+    utils.check_param(args, 'expression arguments', 'table', 2)
+    check_call_eval_opts(opts)
+    return find_thread_group(group_name):eval(expr, args, opts)
+end
+
+--
+-- Returns information about configured thread groups.
+--
+function threads.info()
+    check_configured()
+    local info = {
+        thread_id = this_thread_id,
+        group_name = this_group_name,
+        groups = {
+            {name = 'tx', size = 1},
+        },
+    }
+    for _, group_cfg in ipairs(threads_cfg.groups) do
+        table.insert(info.groups, {
+            name = group_cfg.name,
+            size = group_cfg.size,
+        })
+    end
+    return info
+end
+
+return threads

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -755,6 +755,35 @@ end
 
 -- }}} <replicaset>.bootstrap_leader
 
+-- {{{ threads
+
+local function set_threads(config, box_cfg, post_box_cfg_hooks)
+    local configdata = config._configdata
+    local threads_cfg = configdata:get('threads', {use_default = true})
+    local is_startup = type(box.cfg) == 'function'
+    if not is_startup then
+        if not table.equals(threads_cfg, box.internal.threads.cfg()) then
+            local warning = 'box_cfg.apply: threads configuration ' ..
+                'will not be set until the instance is restarted'
+            config._aboard:set({type = 'warn', message = warning})
+        end
+        return
+    end
+    if threads_cfg == nil then
+        return
+    end
+    if threads_cfg.groups == nil then
+        threads_cfg.groups = {}
+    end
+    box_cfg.app_threads = 0
+    for _, group_cfg in ipairs(threads_cfg.groups) do
+        box_cfg.app_threads = box_cfg.app_threads + group_cfg.size
+    end
+    post_box_cfg_hooks:add(box.internal.threads.cfg, threads_cfg)
+end
+
+-- }}} threads
+
 -- {{{ metrics
 
 local function set_metrics(configdata, box_cfg)
@@ -1391,6 +1420,7 @@ local function apply(config)
     revert_non_dynamic_options(config, box_cfg)
     set_names_in_background(config, box_cfg)
     set_bootstrap_leader(configdata, box_cfg)
+    set_threads(config, box_cfg, post_box_cfg_hooks)
     set_metrics(configdata, box_cfg)
 
     -- RO may be enforced by the isolated mode, so we call the

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -3055,6 +3055,34 @@ I['wal.retention_period'] = format_text([[
 
 -- }}} wal configuration
 
+-- {{{ threads configuration
+
+I['threads'] = format_text([[
+    The `threads` section defines configuration parameters related to
+    application threads.
+]])
+
+I['threads.groups'] = format_text([[
+    An array of thread groups.
+]])
+
+I['threads.groups.*'] = format_text([[
+    Thread group definition.
+]])
+
+I['threads.groups.*.name'] = format_text([[
+    Thread group name.
+
+    Each thread group must have a unique name. The name "tx" must not be
+    used because it is reserved for the main thread.
+]])
+
+I['threads.groups.*.size'] = format_text([[
+    Number of threads in the group.
+]])
+
+-- }}} threads configuration
+
 -- }}} Instance descriptions
 
 -- {{{ Cluster descriptions

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2339,6 +2339,19 @@ return schema.new('instance_config', schema.record({
             default = 60,
         }),
     }),
+    threads = schema.record({
+        groups = schema.array({
+            items = schema.record({
+                name = schema.scalar({
+                    type = 'string',
+                }),
+                size = schema.scalar({
+                    type = 'integer',
+                }),
+            }),
+            validate = validators['threads.groups'],
+        })
+    }),
 }), {
     methods = {
         instance_uri = instance_uri,

--- a/src/box/lua/config/validators.lua
+++ b/src/box/lua/config/validators.lua
@@ -472,4 +472,24 @@ end
 
 -- }}} sharding
 
+-- {{{ threads
+
+M['threads.groups'] = function(groups, w)
+    local group_names = {}
+    for _, group in ipairs(groups or {}) do
+        if group.name == 'tx' then
+            w.error('Thread group name "tx" is reserved')
+        end
+        if group_names[group.name] then
+            w.error('Duplicate thread group name: %q', group.name)
+        end
+        if group.size <= 0 then
+            w.error('Thread group %q has invalid size: must be > 0', group.name)
+        end
+        group_names[group.name] = true
+    end
+end
+
+-- }}} threads
+
 return M

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -112,6 +112,7 @@ extern char session_lua[],
 	console_lua[],
 	merger_lua[],
 	iproto_lua[],
+	app_threads_lua[],
 	checks_version_lua[],
 	checks_lua[],
 	metrics_api_lua[],
@@ -221,6 +222,7 @@ static const char * const lua_sources_minimal[] = {
 	"box/merger", "merger", merger_lua,
 	"box/utils", NULL, box_utils_lua,
 	"box/net_box", "net.box", net_box_lua,
+	"box/app_threads", "experimental.threads", app_threads_lua,
 	NULL
 };
 

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -189,6 +189,7 @@ local trace_check_required_modules = {
     ['builtin/error.lua'] = true,
     ['builtin/tarantool.lua']= true,
     ['builtin/version.lua']= true,
+    ['builtin/app_threads.lua'] = true,
 }
 
 --

--- a/test/box-luatest/app_threads_module_test.lua
+++ b/test/box-luatest/app_threads_module_test.lua
@@ -1,0 +1,519 @@
+local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('luatest.cluster')
+
+local g = t.group()
+
+g.test_threads_config_propagation = function()
+    --
+    -- Check that the threads configuration is propagated to box.cfg
+    -- and the threads module.
+    --
+    local config = cbuilder:new()
+        :add_instance('server', {})
+        :set_instance_option('server', 'threads.groups', {
+            {name = 'test1', size = 1},
+            {name = 'test2', size = 2},
+            {name = 'test3', size = 3},
+        })
+        :config()
+    local cluster = cluster:new(config)
+    cluster:start()
+    local expected_threads_info = {
+        thread_id = 0,
+        group_name = 'tx',
+        groups = {
+            {name = 'tx', size = 1},
+            {name = 'test1', size = 1},
+            {name = 'test2', size = 2},
+            {name = 'test3', size = 3},
+        },
+    }
+    cluster.server:exec(function(expected_threads_info)
+        t.assert_equals(box.cfg.app_threads, 6)
+        t.assert_equals(require('experimental.threads').info(),
+                        expected_threads_info)
+    end, {expected_threads_info})
+    --
+    -- Check that the threads configuration is updated only after
+    -- instance restart.
+    --
+    config = cbuilder:new()
+        :add_instance('server', {})
+        :set_instance_option('server', 'threads.groups', {
+            {name = 'test1', size = 1},
+            {name = 'test2', size = 2},
+            {name = 'test3', size = 3},
+            {name = 'test4', size = 4},
+        })
+        :config()
+    cluster:reload(config)
+    cluster.server:exec(function(expected_threads_info)
+        t.assert_covers(require('config'):info().alerts[1], {
+            message = 'box_cfg.apply: threads configuration ' ..
+                      'will not be set until the instance is restarted',
+        })
+        t.assert_equals(box.cfg.app_threads, 6)
+        t.assert_equals(require('experimental.threads').info(),
+                        expected_threads_info)
+    end, {expected_threads_info})
+    cluster.server:restart()
+    local expected_threads_info = {
+        thread_id = 0,
+        group_name = 'tx',
+        groups = {
+            {name = 'tx', size = 1},
+            {name = 'test1', size = 1},
+            {name = 'test2', size = 2},
+            {name = 'test3', size = 3},
+            {name = 'test4', size = 4},
+        },
+    }
+    cluster.server:exec(function(expected_threads_info)
+        t.assert_equals(box.cfg.app_threads, 10)
+        t.assert_equals(require('experimental.threads').info(),
+                        expected_threads_info)
+    end, {expected_threads_info})
+    --
+    -- Check configuration in other threads.
+    --
+    for i = 1, 10 do
+        local group_name
+        if i < 2 then
+            group_name = 'test1'
+        elseif i < 4 then
+            group_name = 'test2'
+        elseif i < 7 then
+            group_name = 'test3'
+        else
+            group_name = 'test4'
+        end
+        expected_threads_info.thread_id = i
+        expected_threads_info.group_name = group_name
+        cluster.server:exec(function(expected_threads_info)
+            t.assert_equals(require('experimental.threads').info(),
+                            expected_threads_info)
+        end, {expected_threads_info}, {_thread_id = i})
+    end
+end
+
+g.test_threads_not_configured = function()
+    --
+    -- Check that if the threads configuration is unset, no thread groups
+    -- are created, not even tx.
+    --
+    local config = cbuilder:new()
+        :add_instance('server', {})
+        :config()
+    local cluster = cluster:new(config)
+    cluster:start()
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        t.assert_equals(box.cfg.app_threads, 0)
+        local err = {type = 'ClientError', name = 'THREADS_NOT_CONFIGURED'}
+        t.assert_error_covers(err, threads.info)
+        t.assert_error_covers(err, threads.call)
+        t.assert_error_covers(err, threads.eval)
+    end)
+end
+
+g.test_thread_groups_not_configured = function()
+    --
+    -- Check that if the threads section is set in the config, the threads
+    -- module is configured and the tx group is created even if no thread
+    -- groups are configured.
+    --
+    local config = cbuilder:new()
+        :add_instance('server', {})
+        :set_instance_option('server', 'threads', {})
+        :config()
+    local cluster = cluster:new(config)
+    cluster:start()
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        t.assert_equals(threads.info(), {
+            thread_id = 0,
+            group_name = 'tx',
+            groups = {{name = 'tx', size = 1}},
+        })
+    end)
+end
+
+g.test_thread_function_export = function()
+    local config = cbuilder:new()
+        :add_instance('server', {})
+        :set_instance_option('server', 'threads.groups', {
+            {name = 'test1', size = 3},
+            {name = 'test2', size = 2},
+        })
+        :config()
+    local cluster = cluster:new(config)
+    cluster:start()
+    --
+    -- Argument checking.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = 'function name should be a string',
+        }, threads.export, 123)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = 'function object should be a function',
+        }, threads.export, 'test_func', 123)
+    end)
+    --
+    -- Duplicate name.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        threads.export('test_func_1', function() end)
+        threads.export('test_func_2', function() end)
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'FUNCTION_EXISTS',
+        }, threads.export, 'test_func_1', function() end)
+    end)
+end
+
+g.test_threads_call = function()
+    local config = cbuilder:new()
+        :add_instance('server', {})
+        :set_instance_option('server', 'threads.groups', {
+            {name = 'test1', size = 3},
+            {name = 'test2', size = 2},
+        })
+        :config()
+    local cluster = cluster:new(config)
+    cluster:start()
+    --
+    -- Argument checking.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = 'group name should be a string',
+        }, threads.call, 123)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = 'function name should be a string',
+        }, threads.call, 'test1', 123)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = 'function arguments should be a table',
+        }, threads.call, 'test1', 'test_func', 123)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = 'options should be a table',
+        }, threads.call, 'test1', 'test_func', {123}, 123)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "unexpected option 'foo'",
+        }, threads.call, 'test1', 'test_func', {123}, {foo = 'bar'})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options parameter 'target' should be of type string",
+        }, threads.call, 'test1', 'test_func', {123}, {target = 123})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "unexpected value for option parameter 'target': " ..
+                      "got 'foo', expected 'any' or 'all'",
+        }, threads.call, 'test1', 'test_func', {123}, {target = 'foo'})
+    end)
+    --
+    -- Unknown group.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'NO_SUCH_THREAD_GROUP',
+        }, threads.call, 'test3', 'test_func', {}, {target = 'all'})
+    end)
+    --
+    -- Unknown function.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'NO_SUCH_FUNCTION',
+        }, threads.call, 'test1', 'test_func', {}, {target = 'all'})
+    end)
+    --
+    -- Target handling.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        local group = 'test1'
+        local func = 'test_func_1'
+        threads.eval(group, [[
+            local threads = require('experimental.threads')
+            threads.export('test_func_1', function()
+                return threads.info().thread_id
+            end)
+        ]])
+        local ret_all = threads.call(group, func, {}, {target = 'all'})
+        t.assert_equals(ret_all, {{1}, {2}, {3}})
+        local ret_any = threads.call(group, func, {}, {target = 'any'})
+        t.assert_equals(#ret_any, 1)
+        t.assert_items_include(ret_all, ret_any)
+    end)
+    --
+    -- Default arguments.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        local group = 'test2'
+        local func = 'test_func_2'
+        threads.eval(group, [[
+            local threads = require('experimental.threads')
+            threads.export('test_func_2', function(...) return ... end)
+        ]])
+        t.assert_equals(threads.call(group, func), {{}, {}})
+        t.assert_equals(threads.call(group, func, {1, 2, 3}),
+                        {{1, 2, 3}, {1, 2, 3}})
+        t.assert_equals(threads.call(group, func, {1, 2, 3}, {}),
+                        {{1, 2, 3}, {1, 2, 3}})
+        t.assert_equals(threads.call(group, func, {1, 2, 3}, {target = 'all'}),
+                        {{1, 2, 3}, {1, 2, 3}})
+        t.assert_equals(threads.call(group, func, {1, 2, 3}, {target = 'any'}),
+                        {{1, 2, 3}})
+    end)
+    --
+    -- Return value and error handling.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        local group = 'test1'
+        threads.eval(group, [[
+            local threads = require('experimental.threads')
+            threads.export('test_func_3', function()
+                local thread_id = threads.info().thread_id
+                if thread_id == 1 then
+                    return 1, 2, 3
+                elseif thread_id == 3 then
+                    return {1, 2, 3}
+                end
+            end)
+        ]])
+        t.assert_equals(
+            threads.call(group, 'test_func_3', {}, {target = 'all'}),
+            {{1, 2, 3}, {}, {{1, 2, 3}}}
+        )
+        threads.eval(group, [[
+            local threads = require('experimental.threads')
+            threads.export('test_func_4', function()
+                local thread_id = threads.info().thread_id
+                if thread_id == 1 then
+                    box.error({type = 'MyErrorType', name = 'MyError1'})
+                elseif thread_id == 2 then
+                    box.error({type = 'MyErrorType', name = 'MyError2'})
+                end
+            end)
+        ]])
+        t.assert_error_covers(
+            {type = 'MyErrorType', name = 'MyError2'},
+            threads.call, group, 'test_func_4', {}, {target = 'all'}
+        )
+    end)
+    --
+    -- Calling tx thread group from tx.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        local func = 'test_func_5'
+        threads.eval('tx', [[
+            local threads = require('experimental.threads')
+            threads.export('test_func_5', threads.info)
+        ]])
+        local expected = {{threads.info()}}
+        t.assert_equals(threads.call('tx', func, {}, {target = 'any'}),
+                                     expected)
+        t.assert_equals(threads.call('tx', func, {}, {target = 'all'}),
+                                     expected)
+    end)
+    --
+    -- Usage in other a non-tx thread.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        t.assert_covers(threads.info(), {
+            thread_id = 5,
+            group_name = 'test2',
+        })
+        local func = 'test_func_6'
+        local expr = [[
+            local threads = require('experimental.threads')
+            threads.export('test_func_6', function()
+                local info = threads.info()
+                return info.group_name, info.thread_id
+            end)
+        ]]
+        threads.eval('tx', expr)
+        threads.eval('test1', expr)
+        threads.eval('test2', expr)
+        t.assert_equals(threads.call('tx', func, {}, {target = 'all'}),
+                        {{'tx', 0}})
+        t.assert_equals(threads.call('test1', func, {}, {target = 'all'}),
+                        {{'test1', 1}, {'test1', 2}, {'test1', 3}})
+        t.assert_equals(threads.call('test2', func, {}, {target = 'all'}),
+                        {{'test2', 4}, {'test2', 5}})
+    end, {}, {_thread_id = 5})
+end
+
+g.test_threads_eval = function()
+    local config = cbuilder:new()
+        :add_instance('server', {})
+        :set_instance_option('server', 'threads.groups', {
+            {name = 'test1', size = 3},
+            {name = 'test2', size = 2},
+        })
+        :config()
+    local cluster = cluster:new(config)
+    cluster:start()
+    --
+    -- Argument checking.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = 'group name should be a string',
+        }, threads.eval, 123)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = 'expression should be a string',
+        }, threads.eval, 'test1', 123)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = 'expression arguments should be a table',
+        }, threads.eval, 'test1', 'return ...', 123)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = 'options should be a table',
+        }, threads.eval, 'test1', 'return ...', {123}, 123)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "unexpected option 'foo'",
+        }, threads.eval, 'test1', 'return ...', {123}, {foo = 'bar'})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "options parameter 'target' should be of type string",
+        }, threads.eval, 'test1', 'return ...', {123}, {target = 123})
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "unexpected value for option parameter 'target': " ..
+                      "got 'foo', expected 'any' or 'all'",
+        }, threads.eval, 'test1', 'return ...', {123}, {target = 'foo'})
+    end)
+    --
+    -- Unknown group.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'NO_SUCH_THREAD_GROUP',
+        }, threads.eval, 'test3', 'return ...', {}, {target = 'all'})
+    end)
+    --
+    -- Target handling.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        local group = 'test1'
+        local expr = [[
+            local threads = require('experimental.threads')
+            return threads.info().thread_id
+        ]]
+        local ret_all = threads.eval(group, expr, {}, {target = 'all'})
+        t.assert_equals(ret_all, {{1}, {2}, {3}})
+        local ret_any = threads.eval(group, expr, {}, {target = 'any'})
+        t.assert_equals(#ret_any, 1)
+        t.assert_items_include(ret_all, ret_any)
+    end)
+    --
+    -- Default arguments.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        local group = 'test2'
+        local expr = [[return ...]]
+        t.assert_equals(threads.eval(group, expr), {{}, {}})
+        t.assert_equals(threads.eval(group, expr, {1, 2, 3}),
+                        {{1, 2, 3}, {1, 2, 3}})
+        t.assert_equals(threads.eval(group, expr, {1, 2, 3}, {}),
+                        {{1, 2, 3}, {1, 2, 3}})
+        t.assert_equals(threads.eval(group, expr, {1, 2, 3}, {target = 'all'}),
+                        {{1, 2, 3}, {1, 2, 3}})
+        t.assert_equals(threads.eval(group, expr, {1, 2, 3}, {target = 'any'}),
+                        {{1, 2, 3}})
+    end)
+    --
+    -- Return value and error handling.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        local group = 'test1'
+        local expr = [[
+            local threads = require('experimental.threads')
+            local thread_id = threads.info().thread_id
+            if thread_id == 1 then
+                return 1, 2, 3
+            elseif thread_id == 3 then
+                return {1, 2, 3}
+            end
+        ]]
+        t.assert_equals(threads.eval(group, expr, {}, {target = 'all'}),
+                        {{1, 2, 3}, {}, {{1, 2, 3}}})
+        expr = [[
+            local threads = require('experimental.threads')
+            local thread_id = threads.info().thread_id
+            if thread_id == 1 then
+                box.error({type = 'MyErrorType', name = 'MyError1'})
+            elseif thread_id == 2 then
+                box.error({type = 'MyErrorType', name = 'MyError2'})
+            end
+        ]]
+        t.assert_error_covers({type = 'MyErrorType', name = 'MyError2'},
+                              threads.eval, group, expr, {}, {target = 'all'})
+    end)
+    --
+    -- Calling tx thread group from tx.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        local expr = [[
+            return require('experimental.threads').info()
+        ]]
+        local expected = {{threads.info()}}
+        t.assert_equals(threads.eval('tx', expr, {}, {target = 'any'}),
+                                     expected)
+        t.assert_equals(threads.eval('tx', expr, {}, {target = 'all'}),
+                                     expected)
+    end)
+    --
+    -- Usage in other a non-tx thread.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        t.assert_covers(threads.info(), {
+            thread_id = 5,
+            group_name = 'test2',
+        })
+        local expr = [[
+            local threads = require('experimental.threads')
+            local info = threads.info()
+            return info.group_name, info.thread_id
+        ]]
+        t.assert_equals(threads.eval('tx', expr, {}, {target = 'all'}),
+                        {{'tx', 0}})
+        t.assert_equals(threads.eval('test1', expr, {}, {target = 'all'}),
+                        {{'test1', 1}, {'test1', 2}, {'test1', 3}})
+        t.assert_equals(threads.eval('test2', expr, {}, {target = 'all'}),
+                        {{'test2', 4}, {'test2', 5}})
+    end, {}, {_thread_id = 5})
+end

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -510,6 +510,8 @@ t;
  |   299: box.error.NO_SUCH_THREAD
  |   300: box.error.UNABLE_TO_PROCESS_IN_THREAD
  |   301: box.error.DICT_OVERFLOW
+ |   302: box.error.NO_SUCH_THREAD_GROUP
+ |   303: box.error.THREADS_NOT_CONFIGURED
  | ...
 
 test_run:cmd("setopt delimiter ''");

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -98,6 +98,7 @@ local instance_config_fields = {
     'labels',
     'isolated',
     'connpool',
+    'threads',
 }
 
 -- Verify that the fields of the given schema correspond to the

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1952,3 +1952,35 @@ g.test_isolated = function()
     instance_config:validate({isolated = true})
     t.assert_equals(instance_config:apply_default({}).isolated, false)
 end
+
+g.test_threads = function()
+    local iconfig = {threads = {}}
+    instance_config:validate(iconfig)
+
+    iconfig.threads.groups = {}
+    instance_config:validate(iconfig)
+
+    iconfig.threads.groups[1] = {name = 'test1', size = 1}
+    instance_config:validate(iconfig)
+
+    iconfig.threads.groups[2] = {name = 'test2', size = 2}
+    instance_config:validate(iconfig)
+
+    iconfig.threads.groups[3] = {name = 'tx', size = 3}
+    t.assert_error_msg_content_equals(
+        '[instance_config] threads.groups: ' ..
+        'Thread group name "tx" is reserved',
+        instance_config.validate, instance_config, iconfig)
+
+    iconfig.threads.groups[3] = {name = 'test1', size = 3}
+    t.assert_error_msg_content_equals(
+        '[instance_config] threads.groups: ' ..
+        'Duplicate thread group name: "test1"',
+        instance_config.validate, instance_config, iconfig)
+
+    iconfig.threads.groups[3] = {name = 'test3', size = 0}
+    t.assert_error_msg_content_equals(
+        '[instance_config] threads.groups: ' ..
+        'Thread group "test3" has invalid size: must be > 0',
+        instance_config.validate, instance_config, iconfig)
+end


### PR DESCRIPTION
The new module is named `experimental.threads`. It's available in all application threads and has the following public methods:

 * `threads.export(func_name, func)`: exports a local Lua function so that it can be called with `threads.call()` from other threads.
 * `threads.call(group_name, func_name, args, opts)`: calls a function on a thread group. The function must be exported.
 * `threads.eval(group_name, expr, args, opts)`: executes a Lua expression on a thread group.
 * `threads.info()`: returns information about configured thread groups and the current thread (its id and group name).

Currently, the only available call/eval option is `target`, which must be set to either `all` or `any`. It determines the set of threads on which the function will be called: if set to `all`, the function will be called on all threads (default); if set to `any`, the function will be called on a thread picked randomly.

The `threads` module API works only if the threads subsystem was configured in the config file (just setting `box.cfg.app_threads` isn't enough), otherwise all public methods throw an error. The configuration is set in the new top-level config section `threads`, which has the sub-section `groups`, which in turn stores an array of configured thread groups. Each array entry must be a map with two fields: `name` and `size`, which define the name of the thread group and the number of threads in it, respectively. All names must be unique. The name "tx" must not be used because it is reserved for the main thread group, which is created implicitly and has one thread. The threads subsystem configuration can't be updated without a restart.

Under the hood, the `threads` module uses `net.box` connections created over socket pairs with `box.session.new()`, one per each thread. The socket file descriptors are passed to application threads upon `box.cfg()` execution. The threads use `net.box.from_fd()` to establish connections.

Closes #12207