### PR TITLE
error: added new injection for replication testing

### DIFF
--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -60,6 +60,7 @@
 #include "sio.h"
 #include "tt_strerror.h"
 #include "tweaks.h"
+#include "errinj.h"
 
 /**
  * In 3.0.0 the meaning of box.info.cluster changed to something not related. In
@@ -121,8 +122,13 @@ lbox_pushapplier(lua_State *L, struct applier *applier)
 			       applier->last_row_time);
 		lua_settable(L, -3);
 
+		bool write_sensitive = false;
+		ERROR_INJECT(ERRINJ_BOX_INFO_REPL_WRITE_SECRET, {
+			write_sensitive = true;
+		});
 		char name[APPLIER_SOURCE_MAXLEN];
-		int total = uri_format(name, sizeof(name), &applier->uri, false);
+		int total = uri_format(name, sizeof(name),
+				       &applier->uri, write_sensitive);
 		/*
 		 * total can be greater than sizeof(name) if
 		 * name has insufficient length. Terminating

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -86,6 +86,7 @@ struct errinj {
 	_(ERRINJ_APPLIER_SLOW_ACK, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_APPLIER_STOP_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_APPLIER_SUBSCRIBE_DELAY, ERRINJ_BOOL, {.bparam = false}) \
+	_(ERRINJ_BOX_INFO_REPL_WRITE_SECRET, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_BUILD_INDEX, ERRINJ_INT, {.iparam = -1}) \
 	_(ERRINJ_BUILD_INDEX_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_BUILD_INDEX_DISABLE_YIELD, ERRINJ_BOOL, {.bparam = false}) \


### PR DESCRIPTION
Turning it on makes `box.info.replication` to format `upstream.peer` URI with all parameters.

The feature is required for test purposes to examine actual replication peer parameters and compare them with configured ones.

Part of tarantool/tarantool-ee#1680

NO_DOC=internal
NO_CHANGELOG=internal
NO_TEST=internal