### PR TITLE
box: drop `iproto_mp_ctx`

### DIFF
--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -89,8 +89,6 @@ enum {
 	ENDPOINT_NAME_MAX = 16,
 };
 
-struct mp_ctx iproto_mp_ctx;
-
 struct iproto_connection;
 struct iproto_msg;
 
@@ -3319,10 +3317,12 @@ tx_run_override_triggers(struct event *event, const char *header,
 	enum iproto_handler_status rc = IPROTO_HANDLER_FALLBACK;
 	const char *name = NULL;
 	struct func_adapter *trigger = NULL;
+	struct mp_ctx mp_ctx;
+	mp_ctx_create_default(&mp_ctx, iproto_key_translation);
 	struct port args, ret_port;
 	port_c_create(&args);
-	port_c_add_mp_object(&args, header, header_end, &iproto_mp_ctx);
-	port_c_add_mp_object(&args, body, body_end, &iproto_mp_ctx);
+	port_c_add_mp_object(&args, header, header_end, &mp_ctx);
+	port_c_add_mp_object(&args, body, body_end, &mp_ctx);
 
 	struct event_trigger_iterator it;
 	event_trigger_iterator_create(&it, event);
@@ -4196,8 +4196,6 @@ TRIGGER(trigger_on_change, trigger_on_change_iproto_notify);
 void
 iproto_init(int threads_count)
 {
-	mp_ctx_create_default(&iproto_mp_ctx, iproto_key_translation);
-
 	iproto_threads_count = 0;
 	struct session_vtab iproto_session_vtab = {
 		/* .push = */ iproto_session_push,
@@ -4726,8 +4724,6 @@ iproto_free(void)
 	 * in case it's unix sockets.
 	 */
 	evio_service_stop(&tx_binary);
-
-	mp_ctx_destroy(&iproto_mp_ctx);
 }
 
 static int

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -83,14 +83,6 @@ extern unsigned iproto_readahead;
 extern int iproto_threads_count;
 
 /**
- * An mp_ctx for `box.iproto.key` constants encoding and aliasing: used
- * in `luamp_encode_with_ctx` and `luamp_push_with_ctx`.
- *
- * NB: This struct must not be moved, only copy is allowed.
- */
-extern struct mp_ctx iproto_mp_ctx;
-
-/**
  * Return total iproto statistic.
  */
 void

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -43,7 +43,6 @@
 #include "xrow_update.h"
 #include "request.h"
 #include "xrow.h"
-#include "iproto.h"
 #include "iproto_constants.h"
 #include "schema.h"
 #include "assoc.h"
@@ -901,15 +900,17 @@ space_push_replace_trigger_arguments(struct port *args, struct txn *txn)
 	port_c_add_str0(args, iproto_type_name(stmt->type));
 	/* Pass xrow header and body to recovery triggers. */
 	if (stmt->space->run_recovery_triggers) {
+		struct mp_ctx mp_ctx;
+		mp_ctx_create_default(&mp_ctx, iproto_key_translation);
 		struct xrow_header *row = stmt->row;
 		assert(row != NULL && row->header != NULL);
 		port_c_add_mp_object(args, row->header, row->header_end,
-				     &iproto_mp_ctx);
+				     &mp_ctx);
 		assert(row->bodycnt == 1);
 		const char *body = row->body[0].iov_base;
 		const char *body_end = body + row->body[0].iov_len;
 		port_c_add_mp_object(args, body, body_end,
-				     &iproto_mp_ctx);
+				     &mp_ctx);
 	}
 }
 


### PR DESCRIPTION
Commit fe212e4b4c26 moved initialization of `iproto_mp_ctx` to `iproto_init()`, which is called on `box.cfg()`, while the flightrec reader, which may be created without calling `box.cfg()`, depends on it. As a result, the Tarantool EE test `flightrec.misc.test_time_ms_resolution` started to crash on CE submodule bump.

Actually, it looks like we don't really need `iproto_mp_ctx` at all because it's super cheap to create it where it's used. Let's simply drop it to fix Tarantool EE build.

Note, we skip calling `mp_ctx_destroy()` because `mp_ctx_create_default()` doesn't set a destructor.

**EE PR:** tarantool/tarantool-ee#1712