### PR TITLE
test: extend fiber slice in mvcc_func_index_test

### DIFF
--- a/test/box-luatest/mvcc_func_index_test.lua
+++ b/test/box-luatest/mvcc_func_index_test.lua
@@ -433,6 +433,7 @@ g.test_no_function_call_on_non_func_read = function(cg)
         mvcc_check_has_tuple_stories()
 
         rawset(_G, 'counter', 0)
+        require('fiber').set_slice(60)
         -- Many iterations to be more sure about covering the problem.
         for i = 1, 100 do
             -- Cover all methods with FFI implementation in the following way:


### PR DESCRIPTION
The test fails way too often on aarch64 runners:

```
[064] not ok 11	box-luatest.mvcc_func_index.test_no_function_call_on_non_func_read
[064] #   fiber slice is exceeded
[064] #   stack traceback:
[064] #   	builtin/box/schema.lua:2439: in function 'select'
[064] #   	...tool/tarantool/test/box-luatest/mvcc_func_index_test.lua:446: in function <...tool/tarantool/test/box-luatest/mvcc_func_index_test.lua:405>
[064] #   	...tool/tarantool/test/box-luatest/mvcc_func_index_test.lua:405: in function 'box-luatest.mvcc_func_index.test_no_function_call_on_non_func_read'
```

Fix it by extending the fiber slice before the long loop.

Closes #12444