### PR TITLE
config: disown via origin switch without drop

### DIFF
--- a/test/box-luatest/gh_12267_broken_privs_after_disown_test.lua
+++ b/test/box-luatest/gh_12267_broken_privs_after_disown_test.lua
@@ -162,5 +162,27 @@ g.test_disown = function()
 
         local info_after_disown = get_users_info()
         t.assert_equals(info_before_disown, info_after_disown)
+
+        local config = require('config')
+        config:reload()
+        t.helpers.retrying({timeout = 2, delay = 0.4}, function()
+            t.assert_equals(config:info().status, 'check_warnings')
+        end)
+
+        local info_after_disown_and_cfg_reload = get_users_info()
+        t.assert_equals(info_before_disown, info_after_disown_and_cfg_reload)
+
+        local function assert_config_origin(kind, name)
+            local exists = box.schema[kind].exists
+            t.assert(exists(name, {_origin = 'config'}))
+            t.assert_not(exists(name, {_origin = ''}))
+        end
+
+        assert_config_origin('role', 'sharding')
+        assert_config_origin('role', 'reader')
+        assert_config_origin('user', 'storage')
+        assert_config_origin('user', 'replicator')
+        assert_config_origin('user', 'test')
+        assert_config_origin('user', 'client')
     end, {find_orphan_users_script})
 end

--- a/tools/find-orphan-users.lua
+++ b/tools/find-orphan-users.lua
@@ -35,12 +35,9 @@
 --
 -- dofile('/path/to/this/file.lua')
 
-local bit = require('bit')
-
 local DEFAULT_ORIGIN = ''
 local CONFIG_ORIGIN = 'config'
 local USER_OPTS_FIELD = 8
-local PRIV_OPTS_FIELD = 6
 
 -- Return origins for user/role from the given tuple.
 local function user_origins_from_tuple(tuple)
@@ -96,27 +93,6 @@ local function gen_disown_f(user_or_role)
         error(('%s: %s'):format(func_name, fmt:format(...)), 0)
     end
 
-    local function migrate_privileges_to_config(uid)
-        for _, tuple in ipairs(box.space._priv.index.primary:select({uid})) do
-            local opts = tuple[PRIV_OPTS_FIELD]
-            local origins
-            if opts ~= nil and opts.origins ~= nil then
-                origins = table.deepcopy(opts.origins)
-            else
-                origins = {[DEFAULT_ORIGIN] = tuple.privilege}
-            end
-            if origins[DEFAULT_ORIGIN] ~= nil
-               and origins[DEFAULT_ORIGIN] ~= 0 then
-                origins[CONFIG_ORIGIN] = bit.bor(origins[CONFIG_ORIGIN] or 0,
-                    origins[DEFAULT_ORIGIN])
-                opts = opts or {}
-                opts.origins = origins
-                box.space._priv:update({tuple.grantee, tuple.object_type,
-                    tuple.object_id}, {{'=', PRIV_OPTS_FIELD, opts}})
-            end
-        end
-    end
-
     return function(name)
         if type(name) ~= 'string' then
             e('expected string, got %s', type(name))
@@ -140,13 +116,26 @@ local function gen_disown_f(user_or_role)
             e('the %s %q is not owned by the Lua code', user_or_role, name)
         end
 
-        -- Temporary compatibility step: migrate previously granted privileges
-        -- to CONFIG origin before drop. We don't have centralized privilege
-        -- management from YAML yet, so for now we just migrate existing grants.
-        -- This prevents privilege loss when upgrading from older Tarantool
-        -- versions where earlier grants could otherwise be overwritten.
-        migrate_privileges_to_config(t.id)
-        box.schema[user_or_role].drop(name, {_origin = DEFAULT_ORIGIN})
+        -- Temporary compatibility behavior:
+        --   * Do not drop DEFAULT origin for now.
+        --   * Just switch user/role ownership from DEFAULT to CONFIG in _user.
+        --
+        -- We currently don't have a way to properly synchronize privileges with
+        -- the configuration:
+        --
+        --   1) We don't yet have a complete mechanism to manage default
+        --      privileges from YAML (gh-12306).
+        --   2) We also can't declaratively describe which non-default grants
+        --      should be migrated into YAML (gx-12534).
+        -- So dropping DEFAULT origin here may lead to privilege loss during
+        -- synchronization. We keep existing grants intact and only update
+        -- ownership metadata.
+        local opts = t[USER_OPTS_FIELD] or {}
+        origins = table.deepcopy(origins)
+        origins[DEFAULT_ORIGIN] = nil
+        origins[CONFIG_ORIGIN] = true
+        opts.origins = origins
+        box.space._user:update({t.id}, {{'=', USER_OPTS_FIELD, opts}})
 
         return ('The %s %q is now considered to be managed by the ' ..
                 'configuration.\nNote that it may still retain implicit ' ..


### PR DESCRIPTION
This patch fixes a bug in the disown operation by switching from dropping the DEFAULT origin to directly updating the ownership metadata in `_user.opts.origins`. The DEFAULT origin is removed and the CONFIG origin is set, preserving existing privileges while transferring user/role ownership to the YAML configuration.

Follows up #12267

NO_DOC=bugfix
NO_CHANGELOG=bugfix