### PR TITLE
iproto: restrict access to application threads

### DIFF
--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -448,6 +448,7 @@ struct errcode_record {
 	_(ER_DICT_OVERFLOW, 301,		"Dictionary has no space - too many unique values are used", "max_size", UINT) \
 	_(ER_NO_SUCH_THREAD_GROUP, 302,		"Thread group does not exist", "thread_group", STRING) \
 	_(ER_THREADS_NOT_CONFIGURED, 303,	"Threads are not configured") \
+	_(ER_THREAD_REQUESTS_DISABLED, 304,	"Requests to application threads are disabled for this session") \
 	TEST_ERROR_CODES(_) /** This one should be last. */
 
 /*

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -967,6 +967,8 @@ struct iproto_connection
 	bool is_established;
 	/** Number of iproto requests in flight. */
 	size_t request_count;
+	/** Whether requests to application threads are allowed. */
+	bool may_set_thread_id;
 };
 
 /** Returns a string suitable for logging. */
@@ -1801,6 +1803,7 @@ iproto_connection_new(struct iproto_thread *iproto_thread)
 	con->is_in_replication = false;
 	con->is_drop_pending = false;
 	con->is_established = false;
+	con->may_set_thread_id = false;
 	rlist_create(&con->in_stop_list);
 	rlist_add_entry(&iproto_thread->connections, con, in_connections);
 	iproto_thread->connection_count++;
@@ -1940,6 +1943,10 @@ iproto_msg_prepare(struct iproto_msg *msg, const char **pos, const char *reqend)
 
 	type = msg->header.type;
 	thread_id = msg->header.thread_id;
+	if (thread_id != XROW_THREAD_UNSPEC && !con->may_set_thread_id) {
+		diag_set(ClientError, ER_THREAD_REQUESTS_DISABLED);
+		goto error;
+	}
 	if (thread_id != XROW_THREAD_UNSPEC &&
 	    thread_id >= (uint32_t)iproto_thread->srv_count) {
 		diag_set(ClientError, ER_NO_SUCH_THREAD, thread_id);
@@ -4834,4 +4841,33 @@ iproto_override(uint32_t req_type, iproto_handler_t cb,
 
 	iproto_override_finish(handlers, req_type, is_set);
 	return 0;
+}
+
+/**
+ * Enable requests to application threads over the given connection.
+ */
+static void
+net_enable_thread_requests(struct cmsg *m)
+{
+	struct iproto_service_msg *msg = (struct iproto_service_msg *)m;
+	msg->connection->may_set_thread_id = true;
+	iproto_service_msg_delete(msg);
+}
+
+void
+iproto_enable_thread_requests(void)
+{
+	assert(cord_is_main());
+	struct session *session = fiber_get_session(fiber());
+	if (session == NULL || session->type != SESSION_TYPE_BINARY)
+		return;
+	struct iproto_connection *connection =
+		(struct iproto_connection *)session->meta.connection;
+	struct cpipe *net_pipe = &connection->iproto_thread->srv[0].ret_pipe;
+	static const struct cmsg_hop route[] = {
+		{net_enable_thread_requests, NULL},
+	};
+	struct iproto_service_msg *msg = iproto_service_msg_new(route);
+	msg->connection = connection;
+	cpipe_push(net_pipe, &msg->base);
 }

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -135,6 +135,13 @@ int
 iproto_override(uint32_t req_type, iproto_handler_t cb,
 		iproto_handler_destroy_t destroy, void *ctx);
 
+/**
+ * Allows clients of the current session direct requests to application threads.
+ * Makes sense only if the current session type is "binary" (IPROTO).
+ */
+void
+iproto_enable_thread_requests(void);
+
 void
 iproto_init(int threads_count);
 

--- a/src/box/lua/app_threads.lua
+++ b/src/box/lua/app_threads.lua
@@ -202,6 +202,7 @@ function box.internal.threads.init(cfg, group_name, thread_id, conn_fd)
     this_group_name = group_name
     this_thread_id = thread_id
     threads_conn = net.from_fd(conn_fd, {fetch_schema = false})
+    threads_conn:call('box.iproto.internal.enable_thread_requests')
     init_thread_groups(cfg)
 end
 

--- a/src/box/lua/iproto.c
+++ b/src/box/lua/iproto.c
@@ -242,6 +242,15 @@ lbox_iproto_drop_connections(struct lua_State *L)
 	return 0;
 }
 
+/** Lua wrapper around iproto_enable_thread_requests(). */
+static int
+lbox_iproto_enable_thread_requests(struct lua_State *L)
+{
+	(void)L;
+	iproto_enable_thread_requests();
+	return 0;
+}
+
 /**
  * Encodes a packet header/body argument to MsgPack: if the argument is a
  * string, then no encoding is needed — otherwise the argument must be a Lua
@@ -623,6 +632,7 @@ box_lua_iproto_init(struct lua_State *L)
 	static const struct luaL_Reg internal_funcs[] = {
 		{"session_new", lbox_iproto_session_new},
 		{"drop_connections", lbox_iproto_drop_connections},
+		{"enable_thread_requests", lbox_iproto_enable_thread_requests},
 		{NULL, NULL}
 	};
 	luaL_setfuncs(L, internal_funcs, 0);

--- a/test/box-luatest/app_threads_module_test.lua
+++ b/test/box-luatest/app_threads_module_test.lua
@@ -77,6 +77,7 @@ g.test_threads_config_propagation = function()
     --
     -- Check configuration in other threads.
     --
+    cluster.server:call('box.iproto.internal.enable_thread_requests')
     for i = 1, 10 do
         local group_name
         if i < 2 then
@@ -338,6 +339,7 @@ g.test_threads_call = function()
     --
     -- Usage in other a non-tx thread.
     --
+    cluster.server:call('box.iproto.internal.enable_thread_requests')
     cluster.server:exec(function()
         local threads = require('experimental.threads')
         t.assert_covers(threads.info(), {
@@ -498,6 +500,7 @@ g.test_threads_eval = function()
     --
     -- Usage in other a non-tx thread.
     --
+    cluster.server:call('box.iproto.internal.enable_thread_requests')
     cluster.server:exec(function()
         local threads = require('experimental.threads')
         t.assert_covers(threads.info(), {

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -19,14 +19,31 @@ g.before_all(function(cg)
         },
     })
     cg.server:start()
+    cg.server:call('box.iproto.internal.enable_thread_requests')
 end)
 
 g.after_all(function(cg)
     cg.server:drop()
 end)
 
+g.test_thread_requests_disabled = function(cg)
+    local conn = net.connect(cg.server.net_box_uri)
+    local err = {type = 'ClientError', name = 'THREAD_REQUESTS_DISABLED'}
+    t.assert_error_covers(err, conn.call, conn, 'tonumber', {'123'},
+                          {_thread_id = 1})
+    t.assert_error_covers(err, conn.eval, conn, 'return tonumber(...)', {'123'},
+                          {_thread_id = 1})
+    conn:call('box.iproto.internal.enable_thread_requests')
+    t.assert_equals(conn:call('tonumber', {'123'},
+                              {_thread_id = 1}), 123)
+    t.assert_equals(conn:eval('return tonumber(...)', {'123'},
+                              {_thread_id = 1}), 123)
+    conn:close()
+end
+
 g.test_no_such_thread = function(cg)
     local conn = net.connect(cg.server.net_box_uri)
+    conn:call('box.iproto.internal.enable_thread_requests')
     t.assert_error_covers({
         type = 'ClientError',
         name = 'NO_SUCH_THREAD',
@@ -62,6 +79,7 @@ g.test_unable_to_process_in_thread = function(cg)
         end)
     end
     local conn = net.connect(cg.server.net_box_uri)
+    conn:call('box.iproto.internal.enable_thread_requests')
     t.assert(conn:ping())
     t.assert(conn:ping({_thread_id = 0}))
     t.assert_not(conn:ping({_thread_id = 1}))
@@ -84,6 +102,7 @@ end
 
 g.test_call_eval = function(cg)
     local conn = net.connect(cg.server.net_box_uri)
+    conn:call('box.iproto.internal.enable_thread_requests')
     -- Call a box function in the main thread.
     t.assert_covers(conn:call('box.info', {}, {_thread_id = 0}),
                     {status = 'running'})
@@ -115,6 +134,7 @@ end
 
 g.test_builtin_types_serialization = function(cg)
     local conn = net.connect(cg.server.net_box_uri)
+    conn:call('box.iproto.internal.enable_thread_requests')
     -- Check basic types.
     local function check(obj)
         local ret_obj = conn:eval([[return ...]], {obj}, {_thread_id = 1})
@@ -167,6 +187,7 @@ g.test_call_ret_tuple_extension_unset = function(cg)
     box.error.injection.set('ERRINJ_NETBOX_FLIP_FEATURE',
                             box.iproto.feature.call_ret_tuple_extension)
     local conn = net.connect(cg.server.net_box_uri)
+    conn:call('box.iproto.internal.enable_thread_requests')
     local tuple = conn:eval([[
         local format = box.tuple.format.new({
             {'a', 'unsigned'}, {'b', 'unsigned'},

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -512,6 +512,7 @@ t;
  |   301: box.error.DICT_OVERFLOW
  |   302: box.error.NO_SUCH_THREAD_GROUP
  |   303: box.error.THREADS_NOT_CONFIGURED
+ |   304: box.error.THREAD_REQUESTS_DISABLED
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
Application threads don't implement any access checks so letting clients call them is unsafe. This commit disables this functionality by default for all IPROTO connections so that an attempt to direct a request to an application thread by setting the thread id in the request header now raises an error. To enable this functionality for the current session, a client should call `box.iproto.internal.enable_thread_requests()`.

Closes #12304