### PR TITLE
lua: export checks and metrics to application threads

### DIFF
--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -223,27 +223,6 @@ static const char * const lua_sources_minimal[] = {
 	"box/utils", NULL, box_utils_lua,
 	"box/net_box", "net.box", net_box_lua,
 	"box/app_threads", "experimental.threads", app_threads_lua,
-	NULL
-};
-
-/** List of modules available only in the main thread. */
-static const char * const lua_sources_main[] = {
-	"box/session", NULL, session_lua,
-	"box/schema", NULL, schema_lua,
-#if ENABLE_FEEDBACK_DAEMON
-	/*
-	 * It is important to initialize the daemon before
-	 * load_cfg, because the latter picks up some values
-	 * from the feedback daemon.
-	 */
-	"box/feedback_daemon", NULL, feedback_daemon_lua,
-#endif
-	"box/xlog", "xlog", xlog_lua,
-	"box/version", NULL, internal_version_lua,
-	"box/upgrade", NULL, upgrade_lua,
-	"box/net_replicaset", "internal.net.replicaset", net_replicaset_lua,
-	"box/console", "console", console_lua,
-	"box/iproto", "iproto", iproto_lua,
 	/*
 	 * To support tarantool-only types with checks, the module
 	 * must be loaded after decimal and datetime lua modules
@@ -341,6 +320,27 @@ static const char * const lua_sources_main[] = {
 	"metrics.plugins.prometheus", metrics_plugins_prometheus_lua,
 	"third_party/metrics/metrics/plugins/json",
 	"metrics.plugins.json", metrics_plugins_json_lua,
+	NULL
+};
+
+/** List of modules available only in the main thread. */
+static const char * const lua_sources_main[] = {
+	"box/session", NULL, session_lua,
+	"box/schema", NULL, schema_lua,
+#if ENABLE_FEEDBACK_DAEMON
+	/*
+	 * It is important to initialize the daemon before
+	 * load_cfg, because the latter picks up some values
+	 * from the feedback daemon.
+	 */
+	"box/feedback_daemon", NULL, feedback_daemon_lua,
+#endif
+	"box/xlog", "xlog", xlog_lua,
+	"box/version", NULL, internal_version_lua,
+	"box/upgrade", NULL, upgrade_lua,
+	"box/net_replicaset", "internal.net.replicaset", net_replicaset_lua,
+	"box/console", "console", console_lua,
+	"box/iproto", "iproto", iproto_lua,
 
 	/* {{{ config */
 

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -825,6 +825,15 @@ tarantool_lua_init_minimal(void)
 	lua_State *L = luaT_newstate();
 	tarantool_L = L;
 
+	/**
+	 * It doesn't make much sense to use command line arguments in
+	 * application threads but some Lua modules (for example, metrics)
+	 * may rely on _G.arg being set. Let's initialize it with an empty
+	 * table to make them happy.
+	 */
+	lua_newtable(L);
+	lua_setfield(L, LUA_GLOBALSINDEX, "arg");
+
 	tarantool_lua_init_minimal_impl(L);
 }
 

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -275,6 +275,8 @@ g.test_builtin_modules = function(cg)
     check_module('key_def')
     check_module('merger')
     check_module('http.client')
+    check_module('checks')
+    check_module('metrics')
     t.assert_covers(eval([[
         local e = box.error.new({type = 'MyError', name = 'FooBar'})
         return e:unpack()
@@ -621,5 +623,35 @@ end)
 g.test_luatest_exec = function(cg)
     cg.server:exec(function()
         t.assert(true)
+    end, {}, {_thread_id = 1})
+end
+
+g.test_checks = function(cg)
+    cg.server:exec(function()
+        local checks = require('checks')
+        local function test_func(arg1, arg2)
+            checks('string', 'tuple')
+            return {arg1, arg2}
+        end
+        t.assert_error_msg_contains(
+            'bad argument #1', test_func, 10, 20)
+        t.assert_error_msg_contains(
+            'bad argument #2', test_func, 'foo', 20)
+        t.assert_equals(test_func('foo', box.tuple.new({1, 2, 3})),
+                        {'foo', box.tuple.new({1, 2, 3})})
+    end, {}, {_thread_id = 1})
+end
+
+g.test_metrics = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        metrics.gauge('test_metric'):set(123, {test_label = 'foo'})
+        t.assert_covers(metrics.collect(), {
+            {
+                metric_name = 'test_metric',
+                label_pairs = {test_label = 'foo'},
+                value = 123,
+            },
+        })
     end, {}, {_thread_id = 1})
 end


### PR DESCRIPTION
Note that this commit just exports the metrics module. It doesn't implement any functionality for collecting or exporting modules set in application threads via configurable application roles. The latter will be done later.

The metrics module uses `_G.arg` unconditionally at the top level so we have to initialize it in application threads. We set it to an empty table, which should be fine because usage of command-line arguments doesn't make much sense in application threads. It's acceptable for the metrics module because the latter uses `arg[0]` to set a metric label[^1]. If it's nil, the label won't be set, which isn't a big deal. If it turns out to be not enough for some other module, we can always export the real command-line arguments but for now this doesn't seem to be necessary.

Closes #12213
Closes #12339

[^1]: https://github.com/tarantool/metrics/blob/921efdc18da2601fab3f90e898cff98b2f0f3c19/metrics/psutils/cpu.lua#L11