### PR TITLE
[backport: release/2.11] ci: bump CMake to 3.26 in install-deps-debian

### DIFF
--- a/.github/actions/install-deps-debian/action.yml
+++ b/.github/actions/install-deps-debian/action.yml
@@ -21,6 +21,14 @@ runs:
           automake \
           libtool
 
+        apt-get purge --auto-remove cmake -y
+        # Old Ubuntu and Debian repos do not contain cmake 3.26.0.
+        # Thus, we use an alternative way of installing this
+        # version.
+        curl -O -L https://github.com/Kitware/CMake/releases/download/v3.26.0/cmake-3.26.0-linux-$(uname -i).tar.gz \
+        && tar -xvf cmake-3.26.0-linux-$(uname -i).tar.gz -C /usr/local --strip-components=1 \
+        && rm cmake-3.26.0-linux-$(uname -i).tar.gz
+
         luarocks install luacheck 0.26.1
         gem install coveralls-lcov
       shell: bash


### PR DESCRIPTION
(cherry picked from 2a13aaeb9873dd2e6f036b79fd2076c4c0961e4a)

It is, in general, a cherry-pick of the aforementioned commit with comments and commit message rephrasing. It is just convenient to use the same versions of CMake across all tested systems to avoid inconsistencies during the backporting of patches.

NO_TEST=ci
NO_DOC=ci
NO_CHANGELOG=ci

---

**NB**: I can't mention the commit in the other way due to the malformed commit header (checkpatch goes crazy due to the missed empty line, which should be second).