### PR TITLE
lua: fix error traces in threads module

### DIFF
--- a/src/box/lua/app_threads.lua
+++ b/src/box/lua/app_threads.lua
@@ -72,7 +72,7 @@ end
 local function find_thread_group(group_name)
     local group = thread_groups[group_name]
     if group == nil then
-        box.error(box.error.NO_SUCH_THREAD_GROUP, group_name)
+        box.error(box.error.NO_SUCH_THREAD_GROUP, group_name, 3)
     end
     return group
 end
@@ -133,7 +133,7 @@ function thread_group_methods:_dispatch(cb, args, opts)
         end
     end
     if last_err ~= nil then
-        error(last_err)
+        box.error(last_err, 2)
     end
     return results
 end
@@ -242,7 +242,7 @@ function threads.export(func_name, func)
     utils.check_param(func_name, 'function name', 'string', 2)
     utils.check_param(func, 'function object', 'function', 2)
     if exported_functions[func_name] ~= nil then
-        box.error(box.error.FUNCTION_EXISTS, func_name)
+        box.error(box.error.FUNCTION_EXISTS, func_name, 2)
     end
     exported_functions[func_name] = func
 end

--- a/src/lua/init.lua
+++ b/src/lua/init.lua
@@ -185,11 +185,11 @@ end
 local trace_check_required_modules = {
     ['builtin/box/schema.lua'] = true,
     ['builtin/box/session.lua'] = true,
+    ['builtin/box/app_threads.lua'] = true,
     ['builtin/digest.lua'] = true,
     ['builtin/error.lua'] = true,
     ['builtin/tarantool.lua']= true,
     ['builtin/version.lua']= true,
-    ['builtin/app_threads.lua'] = true,
 }
 
 --


### PR DESCRIPTION
The `experimental.threads` module entry in the whitelist enabling error trace checking contains a typo, as a result, traces of errors raised in this module weren't checked properly. Fix the whitelist entry and add error levels where required to pass the checks.

Fixes commit 396b00834a1f ("lua: add module for working with application threads").