### PR TITLE
test/fuzz: enable building

### DIFF
--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -281,6 +281,9 @@ if(ENABLE_SECURITY)
 endif()
 
 add_library(box STATIC ${box_sources})
+if(OSS_FUZZ)
+  target_link_options(box PUBLIC "-stdlib=libstdc++")
+endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_definitions(-DSQL_DEBUG=1)


### PR DESCRIPTION
The backported patch fixes a linking problem with libicu.

---------

The patch enables additional fuzzing tests in build.

The patch add a compiler flag `-stdlib=libstdc++` required for successful libicu compilation. Otherwise linkage of `tarantool` binary is failed with errors below:

NO_WRAP
box/libnode_name.a -lpthread -lrt -lm -ldl -lresolv -lgcc -lgcc_s -lc -lgcc -lgcc_s /usr/bin/ld: ../build/icu-prefix/lib/libicuuc.a(umutex.ao): in function `icu::UMutex::getMutex()': umutex.cpp:(.text._ZN3icu6UMutex8getMutexEv+0x1f): undefined reference to `std::__once_callable' /usr/bin/ld: umutex.cpp:(.text._ZN3icu6UMutex8getMutexEv+0x2d): undefined reference to `std::__once_call' /usr/bin/ld: umutex.cpp:(.text._ZN3icu6UMutex8getMutexEv+0x57): undefined reference to `__once_proxy' /usr/bin/ld: umutex.cpp:(.text._ZN3icu6UMutex8getMutexEv+0xf3): undefined reference to `std::__throw_system_error(int)' /usr/bin/ld: ../build/icu-prefix/lib/libicuuc.a(umutex.ao): in function `icu::umtx_init()': umutex.cpp:(.text._ZN3icuL9umtx_initEv+0x36): undefined reference to `std::condition_variable::condition_variable()' /usr/bin/ld: ../build/icu-prefix/lib/libicuuc.a(umutex.ao): in function `umtx_lock': umutex.cpp:(.text.umtx_lock+0x47): undefined reference to `std::__throw_system_error(int)' NO_WRAP

NO_CHANGELOG=testing
NO_DOC=testing
NO_TEST=testing

(cherry picked from commit 43aa0bf45ef18f76b312fabf3d3842d81a970bae)