### PR TITLE
config: support human-readable size and duration units

### DIFF
--- a/changelogs/unreleased/gh-5786-human-readable-size-options.md
+++ b/changelogs/unreleased/gh-5786-human-readable-size-options.md
@@ -1,0 +1,5 @@
+## feature/config
+
+* Memory-related configuration options now support human-readable size units.
+  Values can be specified using B, KiB, MiB, GiB, TiB, and PiB in both
+  configuration files and via `box.cfg{...}` (gh-5786).

--- a/changelogs/unreleased/gh-5786-human-readable-timeout-options.md
+++ b/changelogs/unreleased/gh-5786-human-readable-timeout-options.md
@@ -1,0 +1,5 @@
+## feature/config
+
+* Duration-related configuration options now support human-readable time units.
+  Values can be specified using ms, s, m, h, d, w, M, and y in both
+  configuration files and via `box.cfg{...}` (gh-5786).

--- a/changelogs/unreleased/gh-5786-schema-normalize.md
+++ b/changelogs/unreleased/gh-5786-schema-normalize.md
@@ -1,0 +1,6 @@
+## feature/config
+
+* The `experimental.config.utils.schema` module now provides the
+  `:normalize()` method. It converts human-readable byte sizes and duration
+  strings, such as `256MiB` or `30s`, to numeric values according to the
+  schema annotations (gh-5786).

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -54,6 +54,7 @@ lua_source(lua_sources lua/config/utils/aboard.lua         config_utils_aboard_l
 lua_source(lua_sources lua/config/utils/expression.lua     config_utils_expression_lua)
 lua_source(lua_sources lua/config/utils/file.lua           config_utils_file_lua)
 lua_source(lua_sources lua/config/utils/log.lua            config_utils_log_lua)
+lua_source(lua_sources lua/config/utils/size.lua           config_utils_size_lua)
 lua_source(lua_sources lua/config/utils/odict.lua          config_utils_odict_lua)
 lua_source(lua_sources lua/config/utils/schema.lua         config_utils_schema_lua)
 lua_source(lua_sources lua/config/utils/snapshot.lua       config_utils_snapshot_lua)

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -62,6 +62,7 @@ lua_source(lua_sources lua/config/utils/tabulate.lua       config_utils_tabulate
 lua_source(lua_sources lua/config/utils/textutils.lua      config_utils_textutils_lua)
 lua_source(lua_sources lua/config/utils/funcutils.lua      config_utils_funcutils_lua)
 lua_source(lua_sources lua/config/utils/network.lua        config_utils_network_lua)
+lua_source(lua_sources lua/config/utils/units.lua          config_utils_units_lua)
 # }}} config
 
 lua_source(lua_sources lua/connpool.lua connpool_lua)

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -309,8 +309,10 @@ local function build_iconfig(instance_def)
         replicaset_name = instance_def.replicaset_name,
         group_name = instance_def.group_name,
     }
-    instance_def.iconfig = instance_config:apply_vars(iconfig, vars)
-    instance_def.iconfig_def = instance_config:apply_vars(iconfig_def, vars)
+    instance_def.iconfig = instance_config:apply_byte_sizes(
+        instance_config:apply_vars(iconfig, vars))
+    instance_def.iconfig_def = instance_config:apply_byte_sizes(
+        instance_config:apply_vars(iconfig_def, vars))
 end
 
 -- Instance object metatable.
@@ -1053,8 +1055,10 @@ local function new(iconfig, cconfig, instance_name)
         replicaset_name = found.replicaset_name,
         group_name = found.group_name,
     }
-    iconfig = instance_config:apply_vars(iconfig, vars)
-    iconfig_def = instance_config:apply_vars(iconfig_def, vars)
+    iconfig = instance_config:apply_byte_sizes(
+        instance_config:apply_vars(iconfig, vars))
+    iconfig_def = instance_config:apply_byte_sizes(
+        instance_config:apply_vars(iconfig_def, vars))
 
     local replicaset_uuid = instance_config:get(iconfig_def,
         'database.replicaset_uuid')

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -320,8 +320,10 @@ local function build_iconfig(instance_def)
         replicaset_name = instance_def.replicaset_name,
         group_name = instance_def.group_name,
     }
-    instance_def.iconfig = instance_config:apply_vars(iconfig, vars)
-    instance_def.iconfig_def = instance_config:apply_vars(iconfig_def, vars)
+    instance_def.iconfig = instance_config:normalize(
+        instance_config:apply_vars(iconfig, vars))
+    instance_def.iconfig_def = instance_config:normalize(
+        instance_config:apply_vars(iconfig_def, vars))
 end
 
 -- Instance object metatable.
@@ -1064,8 +1066,10 @@ local function new(iconfig, cconfig, instance_name)
         replicaset_name = found.replicaset_name,
         group_name = found.group_name,
     }
-    iconfig = instance_config:apply_vars(iconfig, vars)
-    iconfig_def = instance_config:apply_vars(iconfig_def, vars)
+    iconfig = instance_config:normalize(
+        instance_config:apply_vars(iconfig, vars))
+    iconfig_def = instance_config:normalize(
+        instance_config:apply_vars(iconfig_def, vars))
 
     local replicaset_uuid = instance_config:get(iconfig_def,
         'database.replicaset_uuid')

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -24,6 +24,15 @@ local function format_text(s)
     end)
 end
 
+local function format_bytes_text(s)
+    return format_text(s .. [[
+
+        You can specify the value either as a number of bytes or as a
+        human-readable string with binary units (for example, `1GiB`,
+        `256MiB`, `4KiB`).
+    ]])
+end
+
 -- {{{ Instance descriptions
 
 local I = {}
@@ -1426,7 +1435,7 @@ I['feedback.metrics_collect_interval'] = format_text([[
     The interval (in seconds) for collecting metrics.
 ]])
 
-I['feedback.metrics_limit'] = format_text([[
+I['feedback.metrics_limit'] = format_bytes_text([[
     The maximum size of memory (in bytes) used to store metrics before
     sending them to the feedback server. If the size of collected metrics
     exceeds this value, earlier metrics are dropped.
@@ -1531,12 +1540,12 @@ I['flightrec.logs_log_level'] = format_text([[
     differ from `log_level`.
 ]])
 
-I['flightrec.logs_max_msg_size'] = format_text([[
+I['flightrec.logs_max_msg_size'] = format_bytes_text([[
     Specify the maximum size (in bytes) of the log message. The log message
     is truncated if its size exceeds this limit.
 ]])
 
-I['flightrec.logs_size'] = format_text([[
+I['flightrec.logs_size'] = format_bytes_text([[
     Specify the size (in bytes) of the log storage. You can set this option
     to 0 to disable the log storage.
 ]])
@@ -1553,17 +1562,17 @@ I['flightrec.metrics_period'] = format_text([[
     frequency of metric dumps is defined by `flightrec.metrics_interval`.
 ]])
 
-I['flightrec.requests_max_req_size'] = format_text([[
+I['flightrec.requests_max_req_size'] = format_bytes_text([[
     Specify the maximum size (in bytes) of a request entry.
     A request entry is truncated if this size is exceeded.
 ]])
 
-I['flightrec.requests_max_res_size'] = format_text([[
+I['flightrec.requests_max_res_size'] = format_bytes_text([[
     Specify the maximum size (in bytes) of a response entry.
     A response entry is truncated if this size is exceeded.
 ]])
 
-I['flightrec.requests_size'] = format_text([[
+I['flightrec.requests_size'] = format_bytes_text([[
     Specify the size (in bytes) of storage for the request and
     response data. You can set this parameter to 0 to disable
     a storage of requests and responses.
@@ -1750,7 +1759,7 @@ I['iproto.net_msg_max'] = format_text([[
     network messages.
 ]])
 
-I['iproto.readahead'] = format_text([[
+I['iproto.readahead'] = format_bytes_text([[
     The size of the read-ahead buffer associated with a client connection. The
     larger the buffer, the more memory an active connection consumes, and the
     more requests can be read from the operating system buffer in a single
@@ -2016,7 +2025,7 @@ I['lua'] = format_text([[
     to Lua within Tarantool.
 ]])
 
-I['lua.memory'] = format_text([[
+I['lua.memory'] = format_bytes_text([[
     Define amount of memory available to Lua in bytes.
     Default is 2GB, with a minimum of 256MB.
 
@@ -2044,12 +2053,12 @@ I['memtx.allocator'] = format_text([[
       switch to `system` in such cases.
 ]])
 
-I['memtx.max_tuple_size'] = format_text([[
+I['memtx.max_tuple_size'] = format_bytes_text([[
     Size of the largest allocation unit for the memtx storage engine in bytes.
     It can be increased if it is necessary to store large tuples.
 ]])
 
-I['memtx.memory'] = format_text([[
+I['memtx.memory'] = format_bytes_text([[
     The amount of memory in bytes that Tarantool allocates to store tuples.
     When the limit is reached, `INSERT` and `UPDATE` requests fail with the
     `ER_MEMORY_ISSUE` error. The server does not go beyond the `memtx.memory`
@@ -2057,7 +2066,7 @@ I['memtx.memory'] = format_text([[
     indexes and connection information.
 ]])
 
-I['memtx.min_tuple_size'] = format_text([[
+I['memtx.min_tuple_size'] = format_bytes_text([[
     Size of the smallest allocation unit in bytes. It can be decreased if
     most of the tuples are very small.
 ]])
@@ -2068,7 +2077,7 @@ I['memtx.slab_alloc_factor'] = format_text([[
     on the total amount of memory available and the distribution of item sizes.
 ]])
 
-I['memtx.slab_alloc_granularity'] = format_text([[
+I['memtx.slab_alloc_granularity'] = format_bytes_text([[
     Specify the granularity in bytes of memory allocation in the small
     allocator. The `memtx.slab_alloc_granularity` value should meet the
     following conditions:
@@ -2818,7 +2827,7 @@ I['snapshot.by.interval'] = format_text([[
     daemon is disabled.
 ]])
 
-I['snapshot.by.wal_size'] = format_text([[
+I['snapshot.by.wal_size'] = format_bytes_text([[
     The threshold for the total size in bytes for all WAL files created
     since the last snapshot taken. Once the configured threshold is exceeded,
     the WAL thread notifies the checkpoint daemon that it must make a new
@@ -2857,7 +2866,7 @@ I['snapshot.snap_io_rate_limit'] = format_text([[
 
 I['sql'] = 'This section defines configuration parameters related to SQL.'
 
-I['sql.cache_size'] = format_text([[
+I['sql.cache_size'] = format_bytes_text([[
     The maximum cache size (in bytes) for all SQL prepared statements.
     To see the actual cache size, use `box.info.sql().cache.size`.
 ]])
@@ -2932,22 +2941,22 @@ I['vinyl.dir'] = format_text([[
     relative to `process.work_dir`.
 ]])
 
-I['vinyl.max_tuple_size'] = format_text([[
+I['vinyl.max_tuple_size'] = format_bytes_text([[
     The size of the largest allocation unit, for the vinyl storage engine.
     It can be increased if it is necessary to store large tuples.
 ]])
 
-I['vinyl.memory'] = format_text([[
+I['vinyl.memory'] = format_bytes_text([[
     The maximum number of in-memory bytes that vinyl uses.
 ]])
 
-I['vinyl.page_size'] = format_text([[
+I['vinyl.page_size'] = format_bytes_text([[
     The page size. A page is a read/write unit for vinyl disk operations.
     The `vinyl.page_size` setting is a default value for the page_size option
     passed to `space_object:create_index()`.
 ]])
 
-I['vinyl.range_size'] = format_text([[
+I['vinyl.range_size'] = format_bytes_text([[
     The default maximum range size for a vinyl index, in bytes. The maximum
     range size affects the decision of whether to split a range.
 
@@ -3009,13 +3018,13 @@ I['quiver.dir'] = format_text([[
     relative to `process.work_dir`.
 ]])
 
-I['quiver.memory'] = format_text([[
+I['quiver.memory'] = format_bytes_text([[
     The maximum size of in-memory buffers used for accumulating write requests.
     The quiver engine decides when it should start dumping in-memory buffers to
     disk depending on this parameter.
 ]])
 
-I['quiver.run_size'] = format_text([[
+I['quiver.run_size'] = format_bytes_text([[
     The maximum size of a run file, in bytes. When the quiver engine dumps
     in-memory buffers to disk, it splits the output stream into files depending
     on this parameter.
@@ -3091,7 +3100,7 @@ I['wal.ext.spaces.*.new'] = I['wal.ext.new']
 
 I['wal.ext.spaces.*.old'] = I['wal.ext.old']
 
-I['wal.max_size'] = format_text([[
+I['wal.max_size'] = format_bytes_text([[
     The maximum number of bytes in a single write-ahead log file. When a
     request would cause an `.xlog` file to become larger than `wal.max_size`,
     Tarantool creates a new WAL file.
@@ -3107,7 +3116,7 @@ I['wal.mode'] = format_text([[
     - `fsync`: fibers wait for their data, `fsync(2)` follows each `write(2)`.
 ]])
 
-I['wal.queue_max_size'] = format_text([[
+I['wal.queue_max_size'] = format_bytes_text([[
     The size of the queue in bytes used by a replica to submit new transactions
     to a write-ahead log (WAL). This option helps limit the rate at which a
     replica submits transactions to the WAL. Limiting the queue size might be

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -33,6 +33,15 @@ local function format_bytes_text(s)
     ]])
 end
 
+local function format_duration_text(s)
+    return format_text(s .. [[
+
+        You can specify the value either as a number of seconds or as a
+        human-readable string with time units (for example, `30s`, `5m`,
+        `1h`).
+    ]])
+end
+
 -- {{{ Instance descriptions
 
 local I = {}
@@ -598,7 +607,7 @@ I['config.etcd.http.request.interface'] = format_text([[
 
     See https://curl.se/libcurl/c/CURLOPT_INTERFACE.html for details.
 ]])
-I['config.etcd.http.request.timeout'] = format_text([[
+I['config.etcd.http.request.timeout'] = format_duration_text([[
     A time period required to process an HTTP request to an etcd server:
     from sending a request to receiving a response.
 ]])
@@ -657,7 +666,7 @@ I['config.etcd.watchers.reconnect_max_attempts'] = format_text([[
     of connection failure.
 ]])
 
-I['config.etcd.watchers.reconnect_timeout'] = format_text([[
+I['config.etcd.watchers.reconnect_timeout'] = format_duration_text([[
     The timeout (in seconds) between attempts to reconnect to an etcd
     server in case of connection failure.
 ]])
@@ -738,11 +747,11 @@ I['config.storage.prefix'] = format_text([[
     Note that `<prefix>` should start with a slash (`/`).
 ]])
 
-I['config.storage.reconnect_after'] = format_text([[
+I['config.storage.reconnect_after'] = format_duration_text([[
     A number of seconds to wait before reconnecting to a configuration storage.
 ]])
 
-I['config.storage.timeout'] = format_text([[
+I['config.storage.timeout'] = format_duration_text([[
     The interval (in seconds) to perform the status check of a configuration
     storage.
 ]])
@@ -759,7 +768,7 @@ I['connpool'] = format_text([[
     instances within the cluster.
 ]])
 
-I['connpool.idle_timeout'] = format_text([[
+I['connpool.idle_timeout'] = format_duration_text([[
     Tarantool connection pool automatically manages connections to the
     instances and automatically closes the ones that are not needed for a
     while.
@@ -1035,11 +1044,11 @@ I['database.replicaset_uuid'] = format_text([[
 
 I['database.txn_isolation'] = 'A transaction isolation level.'
 
-I['database.txn_timeout'] = format_text([[
+I['database.txn_timeout'] = format_duration_text([[
     A timeout (in seconds) after which the transaction is rolled back.
 ]])
 
-I['database.txn_synchro_timeout'] = format_text([[
+I['database.txn_synchro_timeout'] = format_duration_text([[
     A timeout (in seconds) after which the fiber is detached from synchronous
     transaction that is currently collecting quorum. After the timeout expires,
     the transaction is not rolled back but continues to wait for a quorum in
@@ -1056,17 +1065,17 @@ I['failover'] = format_text([[
     The `failover` section defines parameters related to a supervised failover.
 ]])
 
-I['failover.call_timeout'] = format_text([[
+I['failover.call_timeout'] = format_duration_text([[
     A call timeout (in seconds) for connections
     used by monitoring and autofailover components.
 ]])
 
-I['failover.connect_timeout'] = format_text([[
+I['failover.connect_timeout'] = format_duration_text([[
     A connection timeout (in seconds) for connections
     used by monitoring and autofailover components.
 ]])
 
-I['failover.lease_interval'] = format_text([[
+I['failover.lease_interval'] = format_duration_text([[
     A time interval (in seconds) that specifies how long an instance should
     be a leader without renew requests from a coordinator. When this interval
     expires, the leader switches to read-only mode. This action is performed
@@ -1180,17 +1189,17 @@ I['failover.metrics.exporters.*.format'] = format_text([[
     the specified format.
 ]])
 
-I['failover.probe_interval'] = format_text([[
+I['failover.probe_interval'] = format_duration_text([[
     A time interval (in seconds) that specifies how often a monitoring service
     of the failover coordinator polls an instance for its status.
 ]])
 
-I['failover.renew_interval'] = format_text([[
+I['failover.renew_interval'] = format_duration_text([[
     A time interval (in seconds) that specifies how often a failover coordinator
     sends read-write deadline renewals.
 ]])
 
-I['failover.replication_lag_threshold'] = format_text([[
+I['failover.replication_lag_threshold'] = format_duration_text([[
     A replication lag threshold (in seconds). If an instance's replication lag
     exceeds this threshold, the supervised failover coordinator ignores the
     instance when selecting a new leader if `synchro_mode` is `true` for this
@@ -1417,7 +1426,7 @@ I['failover.stateboard.enabled'] = format_text([[
     Enable or disable the failover coordinator stateboard.
 ]])
 
-I['failover.stateboard.keepalive_interval'] = format_text([[
+I['failover.stateboard.keepalive_interval'] = format_duration_text([[
     A time interval (in seconds) that specifies how long a transient state
     information is stored and how quickly a lock expires.
 
@@ -1426,7 +1435,7 @@ I['failover.stateboard.keepalive_interval'] = format_text([[
     a replica set leader to go to read-only mode for some time.
 ]])
 
-I['failover.stateboard.renew_interval'] = format_text([[
+I['failover.stateboard.renew_interval'] = format_duration_text([[
     A time interval (in seconds) that specifies how often a failover
     coordinator writes its state information to etcd. This option also
     determines the frequency at which an active coordinator reads new
@@ -1462,9 +1471,11 @@ I['feedback.enabled'] = format_text([[
 
 I['feedback.host'] = 'The address to which information is sent.'
 
-I['feedback.interval'] = 'The interval (in seconds) of sending information.'
+I['feedback.interval'] = format_duration_text([[
+    The interval (in seconds) of sending information.
+]])
 
-I['feedback.metrics_collect_interval'] = format_text([[
+I['feedback.metrics_collect_interval'] = format_duration_text([[
     The interval (in seconds) for collecting metrics.
 ]])
 
@@ -1488,7 +1499,7 @@ I['fiber'] = format_text([[
     and cooperative multitasking.
 ]])
 
-I['fiber.io_collect_interval'] = format_text([[
+I['fiber.io_collect_interval'] = format_duration_text([[
     The time period (in seconds) a fiber sleeps between iterations of the
     event loop.
 
@@ -1503,15 +1514,15 @@ I['fiber.slice'] = format_text([[
     for fiber slices. See `fiber.set_max_slice` for details and examples.
 ]])
 
-I['fiber.slice.err'] = format_text([[
-    Set a time period (in seconds) that specifies the warning slice.
-]])
-
-I['fiber.slice.warn'] = format_text([[
+I['fiber.slice.err'] = format_duration_text([[
     Set a time period (in seconds) that specifies the error slice.
 ]])
 
-I['fiber.too_long_threshold'] = format_text([[
+I['fiber.slice.warn'] = format_duration_text([[
+    Set a time period (in seconds) that specifies the warning slice.
+]])
+
+I['fiber.too_long_threshold'] = format_duration_text([[
     If processing a request takes longer than the given period (in seconds),
     the fiber warns about it in the log.
 
@@ -1583,12 +1594,12 @@ I['flightrec.logs_size'] = format_bytes_text([[
     to 0 to disable the log storage.
 ]])
 
-I['flightrec.metrics_interval'] = format_text([[
+I['flightrec.metrics_interval'] = format_duration_text([[
     Specify the time interval (in seconds) that defines the frequency
     of dumping metrics. This value shouldn't exceed `flightrec.metrics_period`.
 ]])
 
-I['flightrec.metrics_period'] = format_text([[
+I['flightrec.metrics_period'] = format_duration_text([[
     Specify the time period (in seconds) that defines how long metrics
     are stored from the moment of dump. So, this value defines how much
     historical metrics data is collected up to the moment of crash. The
@@ -2272,7 +2283,7 @@ I['replication.anon'] = format_text([[
       or replica set leader.
 ]])
 
-I['replication.anon_ttl'] = format_text([[
+I['replication.anon_ttl'] = format_duration_text([[
     Time-to-live (in seconds) of disconnected anonymous replicas (see
     `replication.anon` for the definition of anonymous replica). If an anonymous
     replica hasn't been in touch for longer than `replication.anon_ttl`, it is
@@ -2375,7 +2386,7 @@ I['replication.bootstrap_strategy'] = format_text([[
     bootstrap.
 ]])
 
-I['replication.connect_timeout'] = format_text([[
+I['replication.connect_timeout'] = format_duration_text([[
     A timeout (in seconds) a replica waits when trying to connect to a master
     in a cluster.
 
@@ -2421,7 +2432,7 @@ I['replication.election_mode'] = format_text([[
       elections, it becomes a leader but won't participate in any new elections.
 ]])
 
-I['replication.election_timeout'] = format_text([[
+I['replication.election_timeout'] = format_duration_text([[
     Specifies the timeout (in seconds) between election rounds in the leader
     election process if the previous round ended up with a split vote.
 
@@ -2486,7 +2497,7 @@ I['replication.skip_conflict'] = format_text([[
     `replication.skip_conflict` is set to `true`, such errors are ignored.
 ]])
 
-I['replication.sync_lag'] = format_text([[
+I['replication.sync_lag'] = format_duration_text([[
     The maximum delay (in seconds) between the time when data is written to
     the master and the time when it is written to a replica.
 
@@ -2494,7 +2505,7 @@ I['replication.sync_lag'] = format_text([[
     network delay, set this option to a large value.
 ]])
 
-I['replication.sync_timeout'] = format_text([[
+I['replication.sync_timeout'] = format_duration_text([[
     The timeout (in seconds) that a node waits when trying to sync with other
     nodes in a replica set after connecting or during a configuration update.
     This could fail indefinitely if `replication.sync_lag` is smaller than
@@ -2561,7 +2572,7 @@ I['replication.linearizable_quorum'] = format_text([[
       perform requests to synchronous, local or temporary spaces.
 ]])
 
-I['replication.synchro_timeout'] = format_text([[
+I['replication.synchro_timeout'] = format_duration_text([[
     For synchronous replication only. Specify how many seconds to wait for a
     synchronous transaction quorum replication until it is declared failed and
     is rolled back.
@@ -2579,7 +2590,7 @@ I['replication.threads'] = format_text([[
     to serve are distributed evenly between the threads.
 ]])
 
-I['replication.timeout'] = format_text([[
+I['replication.timeout'] = format_duration_text([[
     A time interval (in seconds) used by a master to send heartbeat requests to
     a replica when there are no updates to send to this replica. For each
     request, a replica should return a heartbeat acknowledgment.
@@ -2590,7 +2601,7 @@ I['replication.timeout'] = format_text([[
 ]])
 
 
-I['replication.reconnect_timeout'] = format_text([[
+I['replication.reconnect_timeout'] = format_duration_text([[
     The timeout (in seconds) between attempts to reconnect to a master
     in case of connection failure. Default is box.NULL. If the option is
     set to box.NULL, then it equals to replication_timeout.
@@ -2631,7 +2642,7 @@ I['security'] = format_text([[
     security settings.
 ]])
 
-I['security.auth_delay'] = format_text([[
+I['security.auth_delay'] = format_duration_text([[
     Specify a period of time (in seconds) that a specific user should wait for
     the next attempt after failed authentication.
 
@@ -2724,7 +2735,7 @@ I['sharding.bucket_count'] = format_text([[
     The total number of buckets in a cluster.
 ]])
 
-I['sharding.connection_outdate_delay'] = format_text([[
+I['sharding.connection_outdate_delay'] = format_duration_text([[
     Time to outdate old objects on reload.
 ]])
 
@@ -2732,7 +2743,7 @@ I['sharding.discovery_mode'] = format_text([[
     A mode of the background discovery fiber used by the router to find buckets.
 ]])
 
-I['sharding.failover_ping_timeout'] = format_text([[
+I['sharding.failover_ping_timeout'] = format_duration_text([[
     The timeout (in seconds) after which a node is considered unavailable if
     there are no responses during this period. The failover fiber is used to
     detect if a node is down.
@@ -2821,7 +2832,7 @@ I['sharding.shard_index'] = format_text([[
     the index, other parts are optional.
 ]])
 
-I['sharding.sync_timeout'] = format_text([[
+I['sharding.sync_timeout'] = format_duration_text([[
     The timeout to wait for synchronization of the old master with replicas
     before demotion. Used when switching a master or when manually calling
     the `sync()` function.
@@ -2854,7 +2865,7 @@ I['snapshot.by'] = format_text([[
     exceeds a certain threshold.
 ]])
 
-I['snapshot.by.interval'] = format_text([[
+I['snapshot.by.interval'] = format_duration_text([[
     The interval in seconds between actions by the checkpoint daemon. If
     the option is set to a value greater than zero, and there is activity
     that causes change to a database, then the checkpoint daemon calls
@@ -2934,12 +2945,12 @@ I['stateboard.enabled'] = format_text([[
     Enable or disable the stateboard service.
 ]])
 
-I['stateboard.keepalive_interval'] = format_text([[
+I['stateboard.keepalive_interval'] = format_duration_text([[
     A time interval (in seconds) that specifies how long a transient state
     information is stored.
 ]])
 
-I['stateboard.renew_interval'] = format_text([[
+I['stateboard.renew_interval'] = format_duration_text([[
     A time interval (in seconds) that specifies how often a Tarantool instance
     writes its state information to the stateboard.
 ]])
@@ -3024,7 +3035,7 @@ I['vinyl.run_size_ratio'] = format_text([[
     run_size_ratio option passed to `space_object:create_index()`.
 ]])
 
-I['vinyl.timeout'] = format_text([[
+I['vinyl.timeout'] = format_duration_text([[
     The vinyl storage engine has a scheduler that performs compaction.
     When vinyl is low on available memory, the compaction scheduler may
     be unable to keep up with incoming update requests. In that situation,
@@ -3074,7 +3085,7 @@ I['wal'] = format_text([[
     This section defines configuration parameters related to write-ahead log.
 ]])
 
-I['wal.cleanup_delay'] = format_text([[
+I['wal.cleanup_delay'] = format_duration_text([[
     The delay in seconds used to prevent the Tarantool garbage collector from
     immediately removing write-ahead log files after a node restart. This
     delay eliminates possible erroneous situations when the master deletes
@@ -3094,7 +3105,7 @@ I['wal.dir'] = format_text([[
     options to store them on different physical disks for performance matters.
 ]])
 
-I['wal.dir_rescan_delay'] = format_text([[
+I['wal.dir_rescan_delay'] = format_duration_text([[
     The time interval in seconds between periodic scans of the write-ahead-log
     file directory, when checking for changes to write-ahead-log files for the
     sake of replication or hot standby.
@@ -3160,7 +3171,7 @@ I['wal.queue_max_size'] = format_bytes_text([[
     transactions faster than writing them to the WAL.
 ]])
 
-I['wal.retention_period'] = format_text([[
+I['wal.retention_period'] = format_duration_text([[
     The delay in seconds used to prevent the Tarantool garbage collector from
     removing a write-ahead log file after it has been closed. If a node is
     restarted, `wal.retention_period` counts down from the last modification

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -24,6 +24,15 @@ local function format_text(s)
     end)
 end
 
+local function format_bytes_text(s)
+    return format_text(s .. [[
+
+        You can specify the value either as a number of bytes or as a
+        human-readable string with binary units (for example, `1GiB`,
+        `256MiB`, `4KiB`).
+    ]])
+end
+
 -- {{{ Instance descriptions
 
 local I = {}
@@ -1459,7 +1468,7 @@ I['feedback.metrics_collect_interval'] = format_text([[
     The interval (in seconds) for collecting metrics.
 ]])
 
-I['feedback.metrics_limit'] = format_text([[
+I['feedback.metrics_limit'] = format_bytes_text([[
     The maximum size of memory (in bytes) used to store metrics before
     sending them to the feedback server. If the size of collected metrics
     exceeds this value, earlier metrics are dropped.
@@ -1564,12 +1573,12 @@ I['flightrec.logs_log_level'] = format_text([[
     differ from `log_level`.
 ]])
 
-I['flightrec.logs_max_msg_size'] = format_text([[
+I['flightrec.logs_max_msg_size'] = format_bytes_text([[
     Specify the maximum size (in bytes) of the log message. The log message
     is truncated if its size exceeds this limit.
 ]])
 
-I['flightrec.logs_size'] = format_text([[
+I['flightrec.logs_size'] = format_bytes_text([[
     Specify the size (in bytes) of the log storage. You can set this option
     to 0 to disable the log storage.
 ]])
@@ -1586,17 +1595,17 @@ I['flightrec.metrics_period'] = format_text([[
     frequency of metric dumps is defined by `flightrec.metrics_interval`.
 ]])
 
-I['flightrec.requests_max_req_size'] = format_text([[
+I['flightrec.requests_max_req_size'] = format_bytes_text([[
     Specify the maximum size (in bytes) of a request entry.
     A request entry is truncated if this size is exceeded.
 ]])
 
-I['flightrec.requests_max_res_size'] = format_text([[
+I['flightrec.requests_max_res_size'] = format_bytes_text([[
     Specify the maximum size (in bytes) of a response entry.
     A response entry is truncated if this size is exceeded.
 ]])
 
-I['flightrec.requests_size'] = format_text([[
+I['flightrec.requests_size'] = format_bytes_text([[
     Specify the size (in bytes) of storage for the request and
     response data. You can set this parameter to 0 to disable
     a storage of requests and responses.
@@ -1783,7 +1792,7 @@ I['iproto.net_msg_max'] = format_text([[
     network messages.
 ]])
 
-I['iproto.readahead'] = format_text([[
+I['iproto.readahead'] = format_bytes_text([[
     The size of the read-ahead buffer associated with a client connection. The
     larger the buffer, the more memory an active connection consumes, and the
     more requests can be read from the operating system buffer in a single
@@ -2049,7 +2058,7 @@ I['lua'] = format_text([[
     to Lua within Tarantool.
 ]])
 
-I['lua.memory'] = format_text([[
+I['lua.memory'] = format_bytes_text([[
     Define amount of memory available to Lua in bytes.
     Default is 2GB, with a minimum of 256MB.
 
@@ -2077,12 +2086,12 @@ I['memtx.allocator'] = format_text([[
       switch to `system` in such cases.
 ]])
 
-I['memtx.max_tuple_size'] = format_text([[
+I['memtx.max_tuple_size'] = format_bytes_text([[
     Size of the largest allocation unit for the memtx storage engine in bytes.
     It can be increased if it is necessary to store large tuples.
 ]])
 
-I['memtx.memory'] = format_text([[
+I['memtx.memory'] = format_bytes_text([[
     The amount of memory in bytes that Tarantool allocates to store tuples.
     When the limit is reached, `INSERT` and `UPDATE` requests fail with the
     `ER_MEMORY_ISSUE` error. The server does not go beyond the `memtx.memory`
@@ -2090,7 +2099,7 @@ I['memtx.memory'] = format_text([[
     indexes and connection information.
 ]])
 
-I['memtx.min_tuple_size'] = format_text([[
+I['memtx.min_tuple_size'] = format_bytes_text([[
     Size of the smallest allocation unit in bytes. It can be decreased if
     most of the tuples are very small.
 ]])
@@ -2101,7 +2110,7 @@ I['memtx.slab_alloc_factor'] = format_text([[
     on the total amount of memory available and the distribution of item sizes.
 ]])
 
-I['memtx.slab_alloc_granularity'] = format_text([[
+I['memtx.slab_alloc_granularity'] = format_bytes_text([[
     Specify the granularity in bytes of memory allocation in the small
     allocator. The `memtx.slab_alloc_granularity` value should meet the
     following conditions:
@@ -2493,7 +2502,7 @@ I['replication.sync_timeout'] = format_text([[
     If `replication.sync_timeout` expires, the replica enters `orphan` status.
 ]])
 
-I['replication.synchro_queue_max_size'] = format_text([[
+I['replication.synchro_queue_max_size'] = format_bytes_text([[
     Puts a limit on the number of transactions in the master synchronous queue.
 
     `replication.synchro_queue_max_size` is measured in number of bytes to
@@ -2854,7 +2863,7 @@ I['snapshot.by.interval'] = format_text([[
     daemon is disabled.
 ]])
 
-I['snapshot.by.wal_size'] = format_text([[
+I['snapshot.by.wal_size'] = format_bytes_text([[
     The threshold for the total size in bytes for all WAL files created
     since the last snapshot taken. Once the configured threshold is exceeded,
     the WAL thread notifies the checkpoint daemon that it must make a new
@@ -2893,7 +2902,7 @@ I['snapshot.snap_io_rate_limit'] = format_text([[
 
 I['sql'] = 'This section defines configuration parameters related to SQL.'
 
-I['sql.cache_size'] = format_text([[
+I['sql.cache_size'] = format_bytes_text([[
     The maximum cache size (in bytes) for all SQL prepared statements.
     To see the actual cache size, use `box.info.sql().cache.size`.
 ]])
@@ -2951,7 +2960,7 @@ I['vinyl.bloom_fpr'] = format_text([[
     `space_object:create_index()`.
 ]])
 
-I['vinyl.cache'] = format_text([[
+I['vinyl.cache'] = format_bytes_text([[
     The cache size for the vinyl storage engine. The cache can
     be resized dynamically.
 ]])
@@ -2968,22 +2977,22 @@ I['vinyl.dir'] = format_text([[
     relative to `process.work_dir`.
 ]])
 
-I['vinyl.max_tuple_size'] = format_text([[
+I['vinyl.max_tuple_size'] = format_bytes_text([[
     The size of the largest allocation unit, for the vinyl storage engine.
     It can be increased if it is necessary to store large tuples.
 ]])
 
-I['vinyl.memory'] = format_text([[
+I['vinyl.memory'] = format_bytes_text([[
     The maximum number of in-memory bytes that vinyl uses.
 ]])
 
-I['vinyl.page_size'] = format_text([[
+I['vinyl.page_size'] = format_bytes_text([[
     The page size. A page is a read/write unit for vinyl disk operations.
     The `vinyl.page_size` setting is a default value for the page_size option
     passed to `space_object:create_index()`.
 ]])
 
-I['vinyl.range_size'] = format_text([[
+I['vinyl.range_size'] = format_bytes_text([[
     The default maximum range size for a vinyl index, in bytes. The maximum
     range size affects the decision of whether to split a range.
 
@@ -3045,13 +3054,13 @@ I['quiver.dir'] = format_text([[
     relative to `process.work_dir`.
 ]])
 
-I['quiver.memory'] = format_text([[
+I['quiver.memory'] = format_bytes_text([[
     The maximum size of in-memory buffers used for accumulating write requests.
     The quiver engine decides when it should start dumping in-memory buffers to
     disk depending on this parameter.
 ]])
 
-I['quiver.run_size'] = format_text([[
+I['quiver.run_size'] = format_bytes_text([[
     The maximum size of a run file, in bytes. When the quiver engine dumps
     in-memory buffers to disk, it splits the output stream into files depending
     on this parameter.
@@ -3127,7 +3136,7 @@ I['wal.ext.spaces.*.new'] = I['wal.ext.new']
 
 I['wal.ext.spaces.*.old'] = I['wal.ext.old']
 
-I['wal.max_size'] = format_text([[
+I['wal.max_size'] = format_bytes_text([[
     The maximum number of bytes in a single write-ahead log file. When a
     request would cause an `.xlog` file to become larger than `wal.max_size`,
     Tarantool creates a new WAL file.
@@ -3143,7 +3152,7 @@ I['wal.mode'] = format_text([[
     - `fsync`: fibers wait for their data, `fsync(2)` follows each `write(2)`.
 ]])
 
-I['wal.queue_max_size'] = format_text([[
+I['wal.queue_max_size'] = format_bytes_text([[
     The size of the queue in bytes used by a replica to submit new transactions
     to a write-ahead log (WAL). This option helps limit the rate at which a
     replica submits transactions to the WAL. Limiting the queue size might be

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -4,6 +4,7 @@ local tarantool = require('tarantool')
 local urilib = require('uri')
 local file = require('internal.config.utils.file')
 local log = require('internal.config.utils.log')
+local size = require('internal.config.utils.size')
 local validators = require('internal.config.validators')
 local funcutils = require('internal.config.utils.funcutils')
 local network = require('internal.config.utils.network')
@@ -89,6 +90,12 @@ local function enterprise_edition(schema_node)
         schema_node.apply_default_if,
         enterprise_edition_apply_default_if)
 
+    return schema_node
+end
+
+-- Mark a schema node as representing a byte size value.
+local function byte_size(schema_node)
+    schema_node.byte_size = true
     return schema_node
 end
 
@@ -299,6 +306,22 @@ end
 
 local function feedback_apply_default_if(_data, _w)
     return box.internal.feedback_daemon ~= nil
+end
+
+local function apply_byte_sizes_f(data, w)
+    if w.schema == nil or w.schema.byte_size ~= true or data == nil then
+        return data
+    end
+
+    local parsed, err = size.parse(data)
+    if parsed == nil then
+        w.error('Unable to parse a byte size: %s', err)
+    end
+    return parsed
+end
+
+local function apply_byte_sizes(self, iconfig)
+    return self:map(iconfig, apply_byte_sizes_f)
 end
 
 return schema.new('instance_config', schema.record({
@@ -517,12 +540,12 @@ return schema.new('instance_config', schema.record({
         -- Maximum allowed memory allocated by Lua.
         -- The value can't be less than 256MB and can't be
         -- changed without restarting the Tarantool instance.
-        memory = schema.scalar({
-            type = 'integer',
+        memory = byte_size(schema.scalar({
+            type = 'integer, string',
             -- Default value: 2GB.
             default = 2 * 1024 * 1024 * 1024,
             validate = validators['lua.memory'],
-        }),
+        })),
     }),
     console = schema.record({
         enabled = schema.scalar({
@@ -859,11 +882,11 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'net_msg_max',
             default = 768,
         }),
-        readahead = schema.scalar({
-            type = 'integer',
+        readahead = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'readahead',
             default = 16320,
-        }),
+        })),
         ssl = enterprise_edition(schema.record({
             ca_file = schema.scalar({
                 type = 'string',
@@ -946,18 +969,18 @@ return schema.new('instance_config', schema.record({
         }),
     }),
     sql = schema.record({
-        cache_size = schema.scalar({
-            type = 'integer',
+        cache_size = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'sql_cache_size',
             default = 5 * 1024 * 1024,
-        }),
+        })),
     }),
     memtx = schema.record({
-        memory = schema.scalar({
-            type = 'integer',
+        memory = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'memtx_memory',
             default = 256 * 1024 * 1024,
-        }),
+        })),
         allocator = schema.enum({
             'small',
             'system',
@@ -966,29 +989,29 @@ return schema.new('instance_config', schema.record({
             box_cfg_nondynamic = true,
             default = 'small',
         }),
-        slab_alloc_granularity = schema.scalar({
-            type = 'integer',
+        slab_alloc_granularity = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'slab_alloc_granularity',
             box_cfg_nondynamic = true,
             default = 8,
-        }),
+        })),
         slab_alloc_factor = schema.scalar({
             type = 'number',
             box_cfg = 'slab_alloc_factor',
             box_cfg_nondynamic = true,
             default = 1.05,
         }),
-        min_tuple_size = schema.scalar({
-            type = 'integer',
+        min_tuple_size = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'memtx_min_tuple_size',
             box_cfg_nondynamic = true,
             default = 16,
-        }),
-        max_tuple_size = schema.scalar({
-            type = 'integer',
+        })),
+        max_tuple_size = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'memtx_max_tuple_size',
             default = 1024 * 1024,
-        }),
+        })),
         sort_threads = schema.scalar({
             type = 'integer',
             box_cfg = 'memtx_sort_threads',
@@ -1008,11 +1031,11 @@ return schema.new('instance_config', schema.record({
             box_cfg_nondynamic = true,
             default = 0.05,
         }),
-        cache = schema.scalar({
-            type = 'integer',
+        cache = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'vinyl_cache',
             default = 128 * 1024 * 1024,
-        }),
+        })),
         defer_deletes = schema.scalar({
             type = 'boolean',
             box_cfg = 'vinyl_defer_deletes',
@@ -1025,28 +1048,28 @@ return schema.new('instance_config', schema.record({
             mkdir = true,
             default = 'var/lib/{{ instance_name }}',
         }),
-        max_tuple_size = schema.scalar({
-            type = 'integer',
+        max_tuple_size = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'vinyl_max_tuple_size',
             default = 1024 * 1024,
-        }),
-        memory = schema.scalar({
-            type = 'integer',
+        })),
+        memory = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'vinyl_memory',
             default = 128 * 1024 * 1024,
-        }),
-        page_size = schema.scalar({
-            type = 'integer',
+        })),
+        page_size = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'vinyl_page_size',
             box_cfg_nondynamic = true,
             default = 8 * 1024,
-        }),
-        range_size = schema.scalar({
-            type = 'integer',
+        })),
+        range_size = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'vinyl_range_size',
             box_cfg_nondynamic = true,
             default = box.NULL,
-        }),
+        })),
         read_threads = schema.scalar({
             type = 'integer',
             box_cfg = 'vinyl_read_threads',
@@ -1085,16 +1108,16 @@ return schema.new('instance_config', schema.record({
             mkdir = true,
             default = 'var/lib/{{ instance_name }}',
         })),
-        memory = enterprise_edition(schema.scalar({
-            type = 'integer',
+        memory = enterprise_edition(byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'quiver_memory',
             default = 128 * 1024 * 1024,
-        })),
-        run_size = enterprise_edition(schema.scalar({
-            type = 'integer',
+        }))),
+        run_size = enterprise_edition(byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'quiver_run_size',
             default = 16 * 1024 * 1024,
-        })),
+        }))),
     })),
     wal = schema.record({
         dir = schema.scalar({
@@ -1113,22 +1136,22 @@ return schema.new('instance_config', schema.record({
             box_cfg_nondynamic = true,
             default = 'write',
         }),
-        max_size = schema.scalar({
-            type = 'integer',
+        max_size = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'wal_max_size',
             box_cfg_nondynamic = true,
             default = 256 * 1024 * 1024,
-        }),
+        })),
         dir_rescan_delay = schema.scalar({
             type = 'number',
             box_cfg = 'wal_dir_rescan_delay',
             default = 2,
         }),
-        queue_max_size = schema.scalar({
-            type = 'integer',
+        queue_max_size = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'wal_queue_max_size',
             default = 16 * 1024 * 1024,
-        }),
+        })),
         cleanup_delay = schema.scalar({
             type = 'number',
             box_cfg = 'wal_cleanup_delay',
@@ -1194,11 +1217,11 @@ return schema.new('instance_config', schema.record({
                 box_cfg = 'checkpoint_interval',
                 default = 3600,
             }),
-            wal_size = schema.scalar({
-                type = 'integer',
+            wal_size = byte_size(schema.scalar({
+                type = 'integer, string',
                 box_cfg = 'checkpoint_wal_threshold',
                 default = 1e18,
-            }),
+            })),
         }),
         count = schema.scalar({
             type = 'integer',
@@ -1303,11 +1326,11 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'replication_synchro_timeout',
             default = 5,
         }),
-        synchro_queue_max_size = schema.scalar({
-            type = 'integer',
+        synchro_queue_max_size = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'replication_synchro_queue_max_size',
             default = 16 * 1024 * 1024,
-        }),
+        })),
         connect_timeout = schema.scalar({
             type = 'number',
             box_cfg = 'replication_connect_timeout',
@@ -1602,13 +1625,13 @@ return schema.new('instance_config', schema.record({
             apply_default_if = feedback_apply_default_if,
             validate = validators['feedback.interval'],
         }),
-        metrics_limit = schema.scalar({
-            type = 'integer',
+        metrics_limit = byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'feedback_metrics_limit',
             default = 1024 * 1024,
             apply_default_if = feedback_apply_default_if,
             validate = validators['feedback.metrics_limit'],
-        }),
+        })),
     }),
     flightrec = schema.record({
         enabled = enterprise_edition(schema.scalar({
@@ -1616,16 +1639,16 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'flightrec_enabled',
             default = false,
         })),
-        logs_size = enterprise_edition(schema.scalar({
-            type = 'integer',
+        logs_size = enterprise_edition(byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'flightrec_logs_size',
             default = 10485760,
-        })),
-        logs_max_msg_size = enterprise_edition(schema.scalar({
-            type = 'integer',
+        }))),
+        logs_max_msg_size = enterprise_edition(byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'flightrec_logs_max_msg_size',
             default = 4096,
-        })),
+        }))),
         logs_log_level = enterprise_edition(schema.scalar({
             type = 'integer',
             box_cfg = 'flightrec_logs_log_level',
@@ -1642,21 +1665,21 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'flightrec_metrics_period',
             default = 60 * 3,
         })),
-        requests_size = enterprise_edition(schema.scalar({
-            type = 'integer',
+        requests_size = enterprise_edition(byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'flightrec_requests_size',
             default = 10485760,
-        })),
-        requests_max_req_size = enterprise_edition(schema.scalar({
-            type = 'integer',
+        }))),
+        requests_max_req_size = enterprise_edition(byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'flightrec_requests_max_req_size',
             default = 16384,
-        })),
-        requests_max_res_size = enterprise_edition(schema.scalar({
-            type = 'integer',
+        }))),
+        requests_max_res_size = enterprise_edition(byte_size(schema.scalar({
+            type = 'integer, string',
             box_cfg = 'flightrec_requests_max_res_size',
             default = 16384,
-        })),
+        }))),
     }),
     security = schema.record({
         auth_type = schema.enum({
@@ -2377,6 +2400,7 @@ return schema.new('instance_config', schema.record({
     methods = {
         instance_uri = instance_uri,
         apply_vars = apply_vars,
+        apply_byte_sizes = apply_byte_sizes,
         base_dir = base_dir,
         prepare_file_path = prepare_file_path,
         enhance_uri_ssl_params = enhance_uri_ssl_params,

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -161,6 +161,12 @@ local function vshard_since(version, schema_node)
     return schema_node
 end
 
+-- Mark a schema node as representing a byte size value.
+local function byte_size(schema_node)
+    schema_node.byte_size = true
+    return schema_node
+end
+
 -- Accept a value of 'iproto.listen' option and return the first URI
 -- that is suitable to create a client socket (not just to listen
 -- on the server as, say, 0.0.0.0:3301 or localhost:0).
@@ -599,12 +605,12 @@ return schema.new('instance_config', schema.record({
         -- Maximum allowed memory allocated by Lua.
         -- The value can't be less than 256MB and can't be
         -- changed without restarting the Tarantool instance.
-        memory = schema.scalar({
+        memory = byte_size(schema.scalar({
             type = 'integer',
             -- Default value: 2GB.
             default = 2 * 1024 * 1024 * 1024,
             validate = validators['lua.memory'],
-        }),
+        })),
     }),
     console = schema.record({
         enabled = schema.scalar({
@@ -947,11 +953,11 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'net_msg_max',
             default = 768,
         }),
-        readahead = schema.scalar({
+        readahead = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'readahead',
             default = 16320,
-        }),
+        })),
         ssl = enterprise_edition(schema.record({
             ca_file = schema.scalar({
                 type = 'string',
@@ -1034,18 +1040,18 @@ return schema.new('instance_config', schema.record({
         }),
     }),
     sql = schema.record({
-        cache_size = schema.scalar({
+        cache_size = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'sql_cache_size',
             default = 5 * 1024 * 1024,
-        }),
+        })),
     }),
     memtx = schema.record({
-        memory = schema.scalar({
+        memory = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'memtx_memory',
             default = 256 * 1024 * 1024,
-        }),
+        })),
         allocator = schema.enum({
             'small',
             'system',
@@ -1054,29 +1060,29 @@ return schema.new('instance_config', schema.record({
             box_cfg_nondynamic = true,
             default = 'small',
         }),
-        slab_alloc_granularity = schema.scalar({
+        slab_alloc_granularity = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'slab_alloc_granularity',
             box_cfg_nondynamic = true,
             default = 8,
-        }),
+        })),
         slab_alloc_factor = schema.scalar({
             type = 'number',
             box_cfg = 'slab_alloc_factor',
             box_cfg_nondynamic = true,
             default = 1.05,
         }),
-        min_tuple_size = schema.scalar({
+        min_tuple_size = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'memtx_min_tuple_size',
             box_cfg_nondynamic = true,
             default = 16,
-        }),
-        max_tuple_size = schema.scalar({
+        })),
+        max_tuple_size = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'memtx_max_tuple_size',
             default = 1024 * 1024,
-        }),
+        })),
         sort_threads = schema.scalar({
             type = 'integer',
             box_cfg = 'memtx_sort_threads',
@@ -1096,11 +1102,11 @@ return schema.new('instance_config', schema.record({
             box_cfg_nondynamic = true,
             default = 0.05,
         }),
-        cache = schema.scalar({
+        cache = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'vinyl_cache',
             default = 128 * 1024 * 1024,
-        }),
+        })),
         defer_deletes = schema.scalar({
             type = 'boolean',
             box_cfg = 'vinyl_defer_deletes',
@@ -1113,28 +1119,28 @@ return schema.new('instance_config', schema.record({
             mkdir = true,
             default = 'var/lib/{{ instance_name }}',
         }),
-        max_tuple_size = schema.scalar({
+        max_tuple_size = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'vinyl_max_tuple_size',
             default = 1024 * 1024,
-        }),
-        memory = schema.scalar({
+        })),
+        memory = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'vinyl_memory',
             default = 128 * 1024 * 1024,
-        }),
-        page_size = schema.scalar({
+        })),
+        page_size = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'vinyl_page_size',
             box_cfg_nondynamic = true,
             default = 8 * 1024,
-        }),
-        range_size = schema.scalar({
+        })),
+        range_size = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'vinyl_range_size',
             box_cfg_nondynamic = true,
             default = box.NULL,
-        }),
+        })),
         read_threads = schema.scalar({
             type = 'integer',
             box_cfg = 'vinyl_read_threads',
@@ -1173,16 +1179,16 @@ return schema.new('instance_config', schema.record({
             mkdir = true,
             default = 'var/lib/{{ instance_name }}',
         })),
-        memory = enterprise_edition(schema.scalar({
+        memory = enterprise_edition(byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'quiver_memory',
             default = 128 * 1024 * 1024,
-        })),
-        run_size = enterprise_edition(schema.scalar({
+        }))),
+        run_size = enterprise_edition(byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'quiver_run_size',
             default = 16 * 1024 * 1024,
-        })),
+        }))),
     })),
     wal = schema.record({
         dir = schema.scalar({
@@ -1201,22 +1207,22 @@ return schema.new('instance_config', schema.record({
             box_cfg_nondynamic = true,
             default = 'write',
         }),
-        max_size = schema.scalar({
+        max_size = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'wal_max_size',
             box_cfg_nondynamic = true,
             default = 256 * 1024 * 1024,
-        }),
+        })),
         dir_rescan_delay = schema.scalar({
             type = 'number',
             box_cfg = 'wal_dir_rescan_delay',
             default = 2,
         }),
-        queue_max_size = schema.scalar({
+        queue_max_size = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'wal_queue_max_size',
             default = 16 * 1024 * 1024,
-        }),
+        })),
         cleanup_delay = schema.scalar({
             type = 'number',
             box_cfg = 'wal_cleanup_delay',
@@ -1282,11 +1288,11 @@ return schema.new('instance_config', schema.record({
                 box_cfg = 'checkpoint_interval',
                 default = 3600,
             }),
-            wal_size = schema.scalar({
+            wal_size = byte_size(schema.scalar({
                 type = 'integer',
                 box_cfg = 'checkpoint_wal_threshold',
                 default = 1e18,
-            }),
+            })),
         }),
         count = schema.scalar({
             type = 'integer',
@@ -1391,11 +1397,11 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'replication_synchro_timeout',
             default = 5,
         }),
-        synchro_queue_max_size = schema.scalar({
+        synchro_queue_max_size = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'replication_synchro_queue_max_size',
             default = 16 * 1024 * 1024,
-        }),
+        })),
         connect_timeout = schema.scalar({
             type = 'number',
             box_cfg = 'replication_connect_timeout',
@@ -1696,13 +1702,13 @@ return schema.new('instance_config', schema.record({
             apply_default_if = feedback_apply_default_if,
             validate = validators['feedback.interval'],
         }),
-        metrics_limit = schema.scalar({
+        metrics_limit = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'feedback_metrics_limit',
             default = 1024 * 1024,
             apply_default_if = feedback_apply_default_if,
             validate = validators['feedback.metrics_limit'],
-        }),
+        })),
     }),
     flightrec = schema.record({
         enabled = enterprise_edition(schema.scalar({
@@ -1710,16 +1716,16 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'flightrec_enabled',
             default = false,
         })),
-        logs_size = enterprise_edition(schema.scalar({
+        logs_size = enterprise_edition(byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'flightrec_logs_size',
             default = 10485760,
-        })),
-        logs_max_msg_size = enterprise_edition(schema.scalar({
+        }))),
+        logs_max_msg_size = enterprise_edition(byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'flightrec_logs_max_msg_size',
             default = 4096,
-        })),
+        }))),
         logs_log_level = enterprise_edition(schema.scalar({
             type = 'integer',
             box_cfg = 'flightrec_logs_log_level',
@@ -1736,21 +1742,21 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'flightrec_metrics_period',
             default = 60 * 3,
         })),
-        requests_size = enterprise_edition(schema.scalar({
+        requests_size = enterprise_edition(byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'flightrec_requests_size',
             default = 10485760,
-        })),
-        requests_max_req_size = enterprise_edition(schema.scalar({
+        }))),
+        requests_max_req_size = enterprise_edition(byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'flightrec_requests_max_req_size',
             default = 16384,
-        })),
-        requests_max_res_size = enterprise_edition(schema.scalar({
+        }))),
+        requests_max_res_size = enterprise_edition(byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'flightrec_requests_max_res_size',
             default = 16384,
-        })),
+        }))),
     }),
     security = schema.record({
         auth_type = schema.enum({

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -167,6 +167,12 @@ local function byte_size(schema_node)
     return schema_node
 end
 
+-- Mark a schema node as representing a duration value.
+local function duration(schema_node)
+    schema_node.duration = true
+    return schema_node
+end
+
 -- Accept a value of 'iproto.listen' option and return the first URI
 -- that is suitable to create a client socket (not just to listen
 -- on the server as, say, 0.0.0.0:3301 or localhost:0).
@@ -419,12 +425,12 @@ return schema.new('instance_config', schema.record({
             })),
             http = schema.record({
                 request = schema.record({
-                    timeout = schema.scalar({
+                    timeout = duration(schema.scalar({
                         type = 'number',
                         -- default = 0.3 is applied right in the
                         -- etcd source. See a comment above
                         -- regarding defaults in config.etcd.
-                    }),
+                    })),
                     unix_socket = schema.scalar({
                         type = 'string',
                     }),
@@ -437,12 +443,12 @@ return schema.new('instance_config', schema.record({
                 }),
             }),
             watchers = schema.record({
-                reconnect_timeout = schema.scalar({
+                reconnect_timeout = duration(schema.scalar({
                     type = 'number',
                     -- default = 1.0 is applied right in the
                     -- etcd source. See a comment above
                     -- regarding defaults in config.etcd.
-                }),
+                })),
                 reconnect_max_attempts = schema.scalar({
                     type = 'integer',
                     -- default = 10 is applied right in the
@@ -516,14 +522,14 @@ return schema.new('instance_config', schema.record({
                 }),
                 validate = validators['config.storage.endpoints'],
             }),
-            timeout = schema.scalar({
+            timeout = duration(schema.scalar({
                 type = 'number',
                 default = 3,
-            }),
-            reconnect_after = schema.scalar({
+            })),
+            reconnect_after = duration(schema.scalar({
                 type = 'number',
                 default = 3,
-            })
+            }))
         }, {
             validate = validators['config.storage'],
         })),
@@ -627,16 +633,16 @@ return schema.new('instance_config', schema.record({
         }),
     }),
     fiber = schema.record({
-        io_collect_interval = schema.scalar({
+        io_collect_interval = duration(schema.scalar({
             type = 'number',
             box_cfg = 'io_collect_interval',
             default = box.NULL,
-        }),
-        too_long_threshold = schema.scalar({
+        })),
+        too_long_threshold = duration(schema.scalar({
             type = 'number',
             box_cfg = 'too_long_threshold',
             default = 0.5,
-        }),
+        })),
         worker_pool_threads = schema.scalar({
             type = 'number',
             box_cfg = 'worker_pool_threads',
@@ -647,14 +653,14 @@ return schema.new('instance_config', schema.record({
             default = 768,
         }),
         slice = schema.record({
-            warn = schema.scalar({
+            warn = duration(schema.scalar({
                 type = 'number',
                 default = 0.5,
-            }),
-            err = schema.scalar({
+            })),
+            err = duration(schema.scalar({
                 type = 'number',
                 default = 1,
-            }),
+            })),
         }),
         top = schema.record({
             enabled = schema.scalar({
@@ -1014,16 +1020,16 @@ return schema.new('instance_config', schema.record({
         }, {
             default = box.NULL,
         }),
-        txn_timeout = schema.scalar({
+        txn_timeout = duration(schema.scalar({
             type = 'number',
             box_cfg = 'txn_timeout',
             default = 365 * 100 * 86400,
-        }),
-        txn_synchro_timeout = schema.scalar({
+        })),
+        txn_synchro_timeout = duration(schema.scalar({
             type = 'number',
             box_cfg = 'txn_synchro_timeout',
             default = 5,
-        }),
+        })),
         txn_isolation = schema.enum({
             'read-committed',
             'read-confirmed',
@@ -1159,11 +1165,11 @@ return schema.new('instance_config', schema.record({
             box_cfg_nondynamic = true,
             default = 3.5,
         }),
-        timeout = schema.scalar({
+        timeout = duration(schema.scalar({
             type = 'number',
             box_cfg = 'vinyl_timeout',
             default = 60,
-        }),
+        })),
         write_threads = schema.scalar({
             type = 'integer',
             box_cfg = 'vinyl_write_threads',
@@ -1213,27 +1219,27 @@ return schema.new('instance_config', schema.record({
             box_cfg_nondynamic = true,
             default = 256 * 1024 * 1024,
         })),
-        dir_rescan_delay = schema.scalar({
+        dir_rescan_delay = duration(schema.scalar({
             type = 'number',
             box_cfg = 'wal_dir_rescan_delay',
             default = 2,
-        }),
+        })),
         queue_max_size = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'wal_queue_max_size',
             default = 16 * 1024 * 1024,
         })),
-        cleanup_delay = schema.scalar({
+        cleanup_delay = duration(schema.scalar({
             type = 'number',
             box_cfg = 'wal_cleanup_delay',
             -- No default value here - the option is deprecated
             -- and shouldn't be used by default.
-        }),
-        retention_period = enterprise_edition(schema.scalar({
+        })),
+        retention_period = enterprise_edition(duration(schema.scalar({
             type = 'number',
             box_cfg = 'wal_retention_period',
             default = 0,
-        })),
+        }))),
         -- box.cfg({wal_ext = <...>}) replaces the previous
         -- value without any merging. See explanation why it is
         -- important in the log.modules description.
@@ -1283,11 +1289,11 @@ return schema.new('instance_config', schema.record({
             default = 'var/lib/{{ instance_name }}',
         }),
         by = schema.record({
-            interval = schema.scalar({
+            interval = duration(schema.scalar({
                 type = 'number',
                 box_cfg = 'checkpoint_interval',
                 default = 3600,
-            }),
+            })),
             wal_size = byte_size(schema.scalar({
                 type = 'integer',
                 box_cfg = 'checkpoint_wal_threshold',
@@ -1370,55 +1376,55 @@ return schema.new('instance_config', schema.record({
             box_cfg = 'replication_anon',
             default = false,
         }),
-        anon_ttl = schema.scalar({
+        anon_ttl = duration(schema.scalar({
             type = 'number',
             box_cfg = 'replication_anon_ttl',
             default = 60 * 60,
-        }),
+        })),
         threads = schema.scalar({
             type = 'integer',
             box_cfg = 'replication_threads',
             box_cfg_nondynamic = true,
             default = 1,
         }),
-        timeout = schema.scalar({
+        timeout = duration(schema.scalar({
             type = 'number',
             box_cfg = 'replication_timeout',
             default = 1,
-        }),
-        reconnect_timeout = schema.scalar({
+        })),
+        reconnect_timeout = duration(schema.scalar({
             type = 'number',
             box_cfg = 'replication_reconnect_timeout',
             -- The effective default is replication_timeout.
             default = box.NULL,
-        }),
-        synchro_timeout = schema.scalar({
+        })),
+        synchro_timeout = duration(schema.scalar({
             type = 'number',
             box_cfg = 'replication_synchro_timeout',
             default = 5,
-        }),
+        })),
         synchro_queue_max_size = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'replication_synchro_queue_max_size',
             default = 16 * 1024 * 1024,
         })),
-        connect_timeout = schema.scalar({
+        connect_timeout = duration(schema.scalar({
             type = 'number',
             box_cfg = 'replication_connect_timeout',
             default = 30,
-        }),
-        sync_timeout = schema.scalar({
+        })),
+        sync_timeout = duration(schema.scalar({
             type = 'number',
             box_cfg = 'replication_sync_timeout',
             -- The effective default is determined depending on
             -- the compat.box_cfg_replication_sync_timeout option.
             default = box.NULL,
-        }),
-        sync_lag = schema.scalar({
+        })),
+        sync_lag = duration(schema.scalar({
             type = 'number',
             box_cfg = 'replication_sync_lag',
             default = 10,
-        }),
+        })),
         synchro_quorum = schema.union({
             variants = {
                 schema.scalar({type = 'string'}),
@@ -1451,11 +1457,11 @@ return schema.new('instance_config', schema.record({
             -- the replication.failover option.
             default = box.NULL,
         }),
-        election_timeout = schema.scalar({
+        election_timeout = duration(schema.scalar({
             type = 'number',
             box_cfg = 'election_timeout',
             default = 5,
-        }),
+        })),
         election_fencing_mode = schema.enum({
             'off',
             'soft',
@@ -1681,13 +1687,13 @@ return schema.new('instance_config', schema.record({
             apply_default_if = feedback_apply_default_if,
             validate = validators['feedback.host'],
         }),
-        metrics_collect_interval = schema.scalar({
+        metrics_collect_interval = duration(schema.scalar({
             type = 'number',
             box_cfg = 'feedback_metrics_collect_interval',
             default = 60,
             apply_default_if = feedback_apply_default_if,
             validate = validators['feedback.metrics_collect_interval'],
-        }),
+        })),
         send_metrics = schema.scalar({
             type = 'boolean',
             box_cfg = 'feedback_send_metrics',
@@ -1695,13 +1701,13 @@ return schema.new('instance_config', schema.record({
             apply_default_if = feedback_apply_default_if,
             validate = validators['feedback.send_metrics'],
         }),
-        interval = schema.scalar({
+        interval = duration(schema.scalar({
             type = 'number',
             box_cfg = 'feedback_interval',
             default = 3600,
             apply_default_if = feedback_apply_default_if,
             validate = validators['feedback.interval'],
-        }),
+        })),
         metrics_limit = byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'feedback_metrics_limit',
@@ -1732,16 +1738,16 @@ return schema.new('instance_config', schema.record({
             default = 6,
             allowed_values = {0, 1, 2, 3, 4, 5, 6, 7},
         })),
-        metrics_interval = enterprise_edition(schema.scalar({
+        metrics_interval = enterprise_edition(duration(schema.scalar({
             type = 'number',
             box_cfg = 'flightrec_metrics_interval',
             default = 1.0,
-        })),
-        metrics_period = enterprise_edition(schema.scalar({
+        }))),
+        metrics_period = enterprise_edition(duration(schema.scalar({
             type = 'number',
             box_cfg = 'flightrec_metrics_period',
             default = 60 * 3,
-        })),
+        }))),
         requests_size = enterprise_edition(byte_size(schema.scalar({
             type = 'integer',
             box_cfg = 'flightrec_requests_size',
@@ -1767,11 +1773,11 @@ return schema.new('instance_config', schema.record({
             default = 'chap-sha1',
             validate = validators['security.auth_type'],
         }),
-        auth_delay = enterprise_edition(schema.scalar({
+        auth_delay = enterprise_edition(duration(schema.scalar({
             type = 'number',
             default = 0,
             box_cfg = 'auth_delay',
-        })),
+        }))),
         auth_retries = enterprise_edition(schema.scalar({
             type = 'integer',
             default = 0,
@@ -1949,20 +1955,20 @@ return schema.new('instance_config', schema.record({
             default = 1,
             validate = validators['sharding.rebalancer_max_sending'],
         }),
-        sync_timeout = schema.scalar({
+        sync_timeout = duration(schema.scalar({
             type = 'number',
             default = 1,
             validate = validators['sharding.sync_timeout'],
-        }),
-        connection_outdate_delay = schema.scalar({
+        })),
+        connection_outdate_delay = duration(schema.scalar({
             type = 'number',
             validate = validators['sharding.connection_outdate_delay'],
-        }),
-        failover_ping_timeout = schema.scalar({
+        })),
+        failover_ping_timeout = duration(schema.scalar({
             type = 'number',
             default = 5,
             validate = validators['sharding.failover_ping_timeout'],
-        }),
+        })),
         discovery_mode = schema.enum({
             'on',
             'off',
@@ -2130,30 +2136,30 @@ return schema.new('instance_config', schema.record({
     }),
     -- Options of the failover coordinator service.
     failover = schema.record({
-        probe_interval = schema.scalar({
+        probe_interval = duration(schema.scalar({
             type = 'number',
             default = 10,
-        }),
-        connect_timeout = schema.scalar({
+        })),
+        connect_timeout = duration(schema.scalar({
             type = 'number',
             default = 1,
-        }),
-        call_timeout = schema.scalar({
+        })),
+        call_timeout = duration(schema.scalar({
             type = 'number',
             default = 1,
-        }),
-        lease_interval = schema.scalar({
+        })),
+        lease_interval = duration(schema.scalar({
             type = 'number',
             default = 30,
-        }),
-        renew_interval = schema.scalar({
+        })),
+        renew_interval = duration(schema.scalar({
             type = 'number',
             default = 10,
-        }),
-        replication_lag_threshold = schema.scalar({
+        })),
+        replication_lag_threshold = duration(schema.scalar({
             type = 'number',
             default = 1,
-        }),
+        })),
         -- Configure how to work with a remote storage, where
         -- failover coordinators leave its state information.
         --
@@ -2179,10 +2185,10 @@ return schema.new('instance_config', schema.record({
                 default = true,
             }),
             -- How often information in the stateboard is updated.
-            renew_interval = schema.scalar({
+            renew_interval = duration(schema.scalar({
                 type = 'number',
                 default = 2,
-            }),
+            })),
             -- How long a transient state information is stored.
             --
             -- Beware: it affects how fast a coordinator assumes
@@ -2192,10 +2198,10 @@ return schema.new('instance_config', schema.record({
             -- failover.lease_interval. Otherwise the coordinator
             -- switching causes replicaset leaders to go to the
             -- read-only mode for some time interval.
-            keepalive_interval = schema.scalar({
+            keepalive_interval = duration(schema.scalar({
                 type = 'number',
                 default = 10,
-            }),
+            })),
         }),
         replicasets = schema.map({
             -- Name of the replica.
@@ -2494,20 +2500,20 @@ return schema.new('instance_config', schema.record({
             type = 'boolean',
             default = false,
         }),
-        renew_interval = schema.scalar({
+        renew_interval = duration(schema.scalar({
             type = 'number',
             default = 2,
-        }),
-        keepalive_interval = schema.scalar({
+        })),
+        keepalive_interval = duration(schema.scalar({
             type = 'number',
             default = 10,
-        }),
+        })),
     })),
     connpool = schema.record({
-        idle_timeout = schema.scalar({
+        idle_timeout = duration(schema.scalar({
             type = 'number',
             default = 60,
-        }),
+        })),
     }),
     threads = schema.record({
         groups = schema.array({

--- a/src/box/lua/config/utils/schema.lua
+++ b/src/box/lua/config/utils/schema.lua
@@ -264,6 +264,43 @@ scalars.integer = {
     jsonschema = {type = 'integer'},
 }
 
+scalars['integer, string'] = {
+    type = 'integer, string',
+    validate_noexc = function(data)
+        if type(data) == 'string' then
+            return true
+        end
+        return scalars.integer.validate_noexc(data)
+    end,
+    fromenv = function(_env_var_name, raw_value)
+        local n = tonumber64(raw_value)
+        if n ~= nil and n - math.floor(n) == 0 then
+            return n
+        end
+        return raw_value
+    end,
+    never_accept_number = false,
+    jsonschema = {type = {'string', 'integer'}},
+}
+scalars['string, integer'] = {
+    type = 'string, integer',
+    validate_noexc = function(data)
+        if type(data) == 'string' then
+            return true
+        end
+        return scalars.integer.validate_noexc(data)
+    end,
+    fromenv = function(_env_var_name, raw_value)
+        local n = tonumber(raw_value)
+        if n ~= nil and n - math.floor(n) == 0 then
+            return n
+        end
+        return raw_value
+    end,
+    never_accept_number = false,
+    jsonschema = {type = {'string', 'integer'}},
+}
+
 scalars.boolean = {
     type = 'boolean',
     validate_noexc = function(data)

--- a/src/box/lua/config/utils/schema.lua
+++ b/src/box/lua/config/utils/schema.lua
@@ -11,6 +11,7 @@
 -- * discriminator
 -- * description
 -- * byte_size
+-- * duration
 --
 -- Others are just stored.
 
@@ -38,6 +39,10 @@ local byte_size_jsonschema_pattern =
     '^(?:\\d+(?:\\.\\d*)?|\\.\\d+)\\s*' ..
     '(?:[Bb]|[Kk][Ii][Bb]|[Mm][Ii][Bb]|[Gg][Ii][Bb]|' ..
     '[Tt][Ii][Bb]|[Pp][Ii][Bb])?$'
+
+local duration_jsonschema_pattern =
+    '^(?:\\d+(?:\\.\\d*)?|\\.\\d+)\\s*' ..
+    '(?:ms|s|m|h|d|w|M|y)?$'
 
 -- {{{ Walkthrough helpers
 
@@ -219,20 +224,48 @@ scalars.string = {
 
 scalars.number = {
     type = 'number',
-    validate_noexc = function(data)
+    validate_noexc = function(data, schema)
+        if is_annotated(schema, 'duration') then
+            local _, err = units.parse_duration(data)
+            if err ~= nil then
+                return false, err
+            end
+            return true
+        end
+
         -- TODO: Should we accept cdata<int64_t> and
         -- cdata<uint64_t> here?
         return validate_type_noexc(data, 'number')
     end,
-    fromenv = function(env_var_name, raw_value)
+    fromenv = function(env_var_name, raw_value, schema)
         -- TODO: Accept large integers and return cdata<int64_t>
         -- or cdata<uint64_t>?
-        local res = tonumber(raw_value)
-        if res == nil then
-            error(('Unable to decode a number value from environment ' ..
-                'variable %q, got %q'):format(env_var_name, raw_value), 0)
+        local parser = is_annotated(schema, 'duration') and
+            units.parse_duration or tonumber
+        local res, err = parser(raw_value)
+        if res ~= nil then
+            return res
         end
-        return res
+
+        local msg = ('Unable to decode a number value from environment ' ..
+                     'variable %q, got %q'):format(env_var_name, raw_value)
+
+        -- tonumber() returns nil on parse failure without treating it as an
+        -- internal parser error, so err can be nil here.
+        if err ~= nil then
+            msg = ('%s: %s'):format(msg, err)
+        end
+
+        error(msg, 0)
+    end,
+    normalize = function(data, schema)
+        if type(data) ~= 'string' then
+            return data
+        end
+        if not is_annotated(schema, 'duration') then
+            return data
+        end
+        return units.parse_duration(data)
     end,
     never_accept_number = false,
     jsonschema = {type = 'number'},
@@ -241,9 +274,17 @@ scalars.number = {
 scalars.integer = {
     type = 'integer',
     validate_noexc = function(data, schema)
-        if is_annotated(schema, 'byte_size') then
-            local _, err = units.parse_byte_size(data)
+        if is_annotated(schema, 'byte_size') or
+           is_annotated(schema, 'duration') then
+            local parser = is_annotated(schema, 'byte_size') and
+                units.parse_byte_size or units.parse_duration
+            local parsed, err = parser(data)
             if err ~= nil then
+                return false, err
+            end
+            if parsed - math.floor(parsed) ~= 0 then
+                local err = ('Expected number without a fractional part, ' ..
+                    'got %s'):format(parsed)
                 return false, err
             end
             return true
@@ -265,12 +306,22 @@ scalars.integer = {
         return true
     end,
     fromenv = function(env_var_name, raw_value, schema)
-        local parser = is_annotated(schema, 'byte_size') and
-            units.parse_byte_size or tonumber64
+        local parser = tonumber64
+        if is_annotated(schema, 'byte_size') then
+            parser = units.parse_byte_size
+        elseif is_annotated(schema, 'duration') then
+            parser = units.parse_duration
+        end
         local res, err = parser(raw_value)
 
         if res ~= nil then
-            return res
+            if is_annotated(schema, 'duration') and
+                    res - math.floor(res) ~= 0 then
+                err = ('Expected number without a fractional part, got %s')
+                    :format(res)
+            else
+                return res
+            end
         end
 
         local msg = ('Unable to decode an integer value from environment ' ..
@@ -288,10 +339,13 @@ scalars.integer = {
         if type(data) ~= 'string' then
             return data
         end
-        if not is_annotated(schema, 'byte_size') then
+        if is_annotated(schema, 'byte_size') then
+            return units.parse_byte_size(data)
+        elseif is_annotated(schema, 'duration') then
+            return units.parse_duration(data)
+        else
             return data
         end
-        return units.parse_byte_size(data)
     end,
     never_accept_number = false,
     jsonschema = {type = 'integer'},
@@ -2227,6 +2281,9 @@ local function jsonschema_impl(schema, ctx)
         if is_annotated(schema, 'byte_size') then
             scalar_copy.type = {'integer', 'string'}
             scalar_copy.pattern = byte_size_jsonschema_pattern
+        elseif is_annotated(schema, 'duration') then
+            scalar_copy.type = {schema.type, 'string'}
+            scalar_copy.pattern = duration_jsonschema_pattern
         end
         return set_common_jsonschema_fields(scalar_copy, schema)
     elseif schema.type == 'union' then
@@ -2509,6 +2566,17 @@ local function validate_schema_node_unit_annotations(schema, ctx)
     if schema.byte_size and schema.type ~= 'integer' then
         walkthrough_error(ctx, '"byte_size" requires an integer scalar, ' ..
             'got %s', schema.type)
+    end
+
+    if schema.byte_size and schema.duration then
+        walkthrough_error(ctx, '"byte_size" and "duration" annotations are ' ..
+            'mutually exclusive')
+    end
+
+    if schema.duration and schema.type ~= 'number' and
+            schema.type ~= 'integer' then
+        walkthrough_error(ctx, '"duration" requires a numeric scalar, got %s',
+            schema.type)
     end
 end
 

--- a/src/box/lua/config/utils/schema.lua
+++ b/src/box/lua/config/utils/schema.lua
@@ -10,11 +10,13 @@
 -- * apply_default_if
 -- * discriminator
 -- * description
+-- * byte_size
 --
 -- Others are just stored.
 
 local fun = require('fun')
 local json = require('json')
+local units = require('internal.config.utils.units')
 
 local json_noexc = json.new()
 json_noexc.cfg({encode_use_tostring = true})
@@ -25,6 +27,17 @@ local schema_mt = {}
 local scalars = {}
 
 local table_is_array
+local map_impl
+local normalize_f
+
+local function is_annotated(schema, name)
+    return schema ~= nil and schema[name] == true
+end
+
+local byte_size_jsonschema_pattern =
+    '^(?:\\d+(?:\\.\\d*)?|\\.\\d+)\\s*' ..
+    '(?:[Bb]|[Kk][Ii][Bb]|[Mm][Ii][Bb]|[Gg][Ii][Bb]|' ..
+    '[Tt][Ii][Bb]|[Pp][Ii][Bb])?$'
 
 -- {{{ Walkthrough helpers
 
@@ -227,7 +240,15 @@ scalars.number = {
 
 scalars.integer = {
     type = 'integer',
-    validate_noexc = function(data)
+    validate_noexc = function(data, schema)
+        if is_annotated(schema, 'byte_size') then
+            local _, err = units.parse_byte_size(data)
+            if err ~= nil then
+                return false, err
+            end
+            return true
+        end
+
         -- TODO: Accept cdata<int64_t> and cdata<uint64_t>.
         local ok, err = validate_type_noexc(data, 'number')
         if not ok then
@@ -243,13 +264,34 @@ scalars.integer = {
         end
         return true
     end,
-    fromenv = function(env_var_name, raw_value)
-        local res = tonumber64(raw_value)
-        if res == nil then
-            error(('Unable to decode an integer value from environment ' ..
-                'variable %q, got %q'):format(env_var_name, raw_value), 0)
+    fromenv = function(env_var_name, raw_value, schema)
+        local parser = is_annotated(schema, 'byte_size') and
+            units.parse_byte_size or tonumber64
+        local res, err = parser(raw_value)
+
+        if res ~= nil then
+            return res
         end
-        return res
+
+        local msg = ('Unable to decode an integer value from environment ' ..
+                     'variable %q, got %q'):format(env_var_name, raw_value)
+
+        -- tonumber64() returns nil on parse failure without treating it as an
+        -- internal parser error, so err can be nil here.
+        if err ~= nil then
+            msg = ('%s: %s'):format(msg, err)
+        end
+
+        error(msg, 0)
+    end,
+    normalize = function(data, schema)
+        if type(data) ~= 'string' then
+            return data
+        end
+        if not is_annotated(schema, 'byte_size') then
+            return data
+        end
+        return units.parse_byte_size(data)
     end,
     never_accept_number = false,
     jsonschema = {type = 'integer'},
@@ -795,10 +837,19 @@ local function validate_impl(schema, data, ctx)
         local scalar_def = scalars[schema.type]
         assert(scalar_def ~= nil)
 
-        local ok, err = scalar_def.validate_noexc(data)
+        local ok, err = scalar_def.validate_noexc(data, schema)
         if not ok then
             walkthrough_error(ctx, 'Unexpected data for scalar %q: %s',
                 schema.type, err)
+        end
+        if scalar_def.normalize ~= nil and data ~= nil then
+            -- Node-specific validators below expect canonical scalar values.
+            local normalized, err = scalar_def.normalize(data, schema)
+            if err ~= nil then
+                walkthrough_error(ctx, 'Unexpected data for scalar %q: %s',
+                    schema.type, err)
+            end
+            data = normalized
         end
     elseif schema.type == 'record' then
         walkthrough_assert_table(ctx, schema, data)
@@ -1030,7 +1081,10 @@ end
 local function get_impl(schema, data, ctx)
     -- The journey is finished. Return what is under the feet.
     if #ctx.journey == 0 then
-        return data
+        if data == nil then
+            return data
+        end
+        return map_impl(schema, data, normalize_f, ctx)
     end
 
     -- There are more steps in the journey (at least one).
@@ -1147,7 +1201,8 @@ function methods.get(self, data, path)
     end
 
     if path == nil or next(path) == nil then
-        return data
+        local ctx = walkthrough_start(self)
+        return map_impl(schema, data, normalize_f, ctx)
     end
 
     local ctx = walkthrough_start(self, {
@@ -1614,7 +1669,7 @@ local function map_schemaless(old, f, ctx)
     return res
 end
 
-local function map_impl(schema, data, f, ctx)
+function map_impl(schema, data, f, ctx)
     if schema.type == 'any' then
         return map_schemaless(data, f, ctx)
     end
@@ -1789,6 +1844,36 @@ function methods.map(self, data, f, f_ctx)
 end
 
 -- }}} <schema object>:map()
+
+-- {{{ <schema object>:normalize()
+
+function normalize_f(data, w)
+    if data == nil or w.schema == nil or not is_scalar(w.schema) then
+        return data
+    end
+
+    local normalize = scalars[w.schema.type].normalize
+    if normalize == nil then
+        return data
+    end
+
+    local res, err = normalize(data, w.schema)
+    if err ~= nil then
+        w.error('%s', err)
+    end
+    return res
+end
+
+-- Normalize scalar values according to the schema.
+--
+-- Important: the data is assumed as already validated against
+-- the given schema. (A fast type check is performed on composite
+-- types, but it is not recommended to lean on it.)
+function methods.normalize(self, data)
+    return self:map(data, normalize_f)
+end
+
+-- }}} <schema object>:normalize()
 
 -- {{{ <schema object>:apply_default()
 
@@ -2139,6 +2224,10 @@ local function jsonschema_impl(schema, ctx)
         -- If the schema is a scalar type (string, number, etc.)
         -- copy the corresponding JSON schema.
         local scalar_copy = table.copy(scalars[schema.type].jsonschema)
+        if is_annotated(schema, 'byte_size') then
+            scalar_copy.type = {'integer', 'string'}
+            scalar_copy.pattern = byte_size_jsonschema_pattern
+        end
         return set_common_jsonschema_fields(scalar_copy, schema)
     elseif schema.type == 'union' then
         local any_of = {}
@@ -2416,9 +2505,17 @@ local function validate_schema_node_union(schema, ctx)
     end
 end
 
+local function validate_schema_node_unit_annotations(schema, ctx)
+    if schema.byte_size and schema.type ~= 'integer' then
+        walkthrough_error(ctx, '"byte_size" requires an integer scalar, ' ..
+            'got %s', schema.type)
+    end
+end
+
 local function validate_schema_impl(schema, ctx)
     validate_schema_node_unique_items(schema, ctx)
     validate_schema_node_union(schema, ctx)
+    validate_schema_node_unit_annotations(schema, ctx)
 
     -- luacheck: ignore 542 empty if branch
     if is_scalar(schema) then
@@ -2766,7 +2863,7 @@ fromenv = function(env_var_name, raw_value, schema)
     if is_scalar(schema) then
         local scalar_def = scalars[schema.type]
         assert(scalar_def ~= nil)
-        return scalar_def.fromenv(env_var_name, raw_value)
+        return scalar_def.fromenv(env_var_name, raw_value, schema)
     elseif schema.type == 'union' then
         return union_from_env(env_var_name, raw_value, schema)
     elseif schema.type == 'record' then

--- a/src/box/lua/config/utils/size.lua
+++ b/src/box/lua/config/utils/size.lua
@@ -1,0 +1,59 @@
+local M = {}
+
+local units = {
+    B = 1,
+    KIB = 1024,
+    MIB = 1024 * 1024,
+    GIB = 1024 * 1024 * 1024,
+    TIB = 1024 * 1024 * 1024 * 1024,
+    PIB = 1024 * 1024 * 1024 * 1024 * 1024,
+}
+
+local function normalize_number(value)
+    local number = tonumber(value)
+    if number == nil then
+        return nil, ('Unable to parse a number from %q'):format(value)
+    end
+    if number < 0 then
+        return nil, ('Expected a non-negative number, got %s'):format(number)
+    end
+    if number - math.floor(number) ~= 0 then
+        return nil, ('Expected a number without a fractional part, got %s')
+            :format(number)
+    end
+    return number
+end
+
+function M.parse(value)
+    if type(value) == 'number' then
+        return normalize_number(value)
+    end
+    if type(value) ~= 'string' then
+        return nil, ('Expected a number or a string, got %q')
+            :format(type(value))
+    end
+
+    local number, unit = value:match('^%s*([%d%.]+)%s*([%a]*)%s*$')
+    if number == nil then
+        return nil, ('Unable to parse a byte size from %q'):format(value)
+    end
+
+    local parsed, err = normalize_number(number)
+    if parsed == nil then
+        return nil, err
+    end
+
+    if unit == nil or unit == '' then
+        return parsed
+    end
+
+    unit = unit:upper()
+    local multiplier = units[unit]
+    if multiplier == nil then
+        return nil, ('Unknown size suffix %q (use B, KiB, MiB, GiB, TiB, ' ..
+            'PiB, or no suffix for bytes)'):format(unit)
+    end
+    return parsed * multiplier
+end
+
+return M

--- a/src/box/lua/config/utils/units.lua
+++ b/src/box/lua/config/utils/units.lua
@@ -24,6 +24,19 @@ local byte_size_unit_defs = {
 local byte_size_units, byte_size_unit_names_str =
     make_units(byte_size_unit_defs, string.upper)
 
+local duration_unit_defs = {
+    {'ms', 0.001},
+    {'s', 1},
+    {'m', 60},
+    {'h', 60 * 60},
+    {'d', 24 * 60 * 60},
+    {'w', 7 * 24 * 60 * 60},
+    {'M', 30 * 24 * 60 * 60},
+    {'y', 365 * 24 * 60 * 60},
+}
+
+local duration_units, duration_unit_names_str = make_units(duration_unit_defs)
+
 function units.parse_byte_size(value)
     if type(value) ~= 'number' and type(value) ~= 'string' then
         return nil, ('Expected byte size as number or string with optional ' ..
@@ -69,6 +82,44 @@ function units.parse_byte_size(value)
             :format(parsed)
     end
     return math.floor(parsed * multiplier)
+end
+
+function units.parse_duration(value)
+    if type(value) ~= 'number' and type(value) ~= 'string' then
+        return nil, ('Expected duration as number or string with optional ' ..
+                     'duration suffix, got %s'):format(type(value))
+    end
+
+    local number, unit = value, nil
+    if type(value) ~= 'number' then
+        number, unit = value:match('^([%-]?[%d%.]+)%s*([%a]*)$')
+    end
+
+    if number == nil then
+        return nil, ('Unable to parse a number from %q'):format(value)
+    end
+
+    local parsed = tonumber(number)
+    if parsed == nil then
+        return nil, ('Unable to parse a number from %q'):format(number)
+    end
+
+    if parsed < 0 then
+        return nil, ('Expected a non-negative duration, got %s')
+            :format(parsed)
+    end
+
+    if unit == nil or unit == '' then
+        return parsed
+    end
+
+    local multiplier = duration_units[unit]
+    if multiplier == nil then
+        return nil, ('Unknown duration suffix %q (use %s)')
+            :format(unit, duration_unit_names_str)
+    end
+
+    return parsed * multiplier
 end
 
 return units

--- a/src/box/lua/config/utils/units.lua
+++ b/src/box/lua/config/utils/units.lua
@@ -1,0 +1,74 @@
+local units = {}
+
+local function make_units(defs, normalize)
+    local res = {}
+    local names = {}
+    for _, def in ipairs(defs) do
+        local name, multiplier = unpack(def)
+        local key = normalize ~= nil and normalize(name) or name
+        res[key] = multiplier
+        table.insert(names, name)
+    end
+    return res, table.concat(names, ', ')
+end
+
+local byte_size_unit_defs = {
+    {'B', 1},
+    {'KiB', 1024},
+    {'MiB', 1024 * 1024},
+    {'GiB', 1024 * 1024 * 1024},
+    {'TiB', 1024 * 1024 * 1024 * 1024},
+    {'PiB', 1024 * 1024 * 1024 * 1024 * 1024},
+}
+
+local byte_size_units, byte_size_unit_names_str =
+    make_units(byte_size_unit_defs, string.upper)
+
+function units.parse_byte_size(value)
+    if type(value) ~= 'number' and type(value) ~= 'string' then
+        return nil, ('Expected byte size as number or string with optional ' ..
+                     'byte size suffix, got %s'):format(type(value))
+    end
+
+    local number, unit = value, nil
+    if type(value) ~= 'number' then
+        number, unit = value:match('^([%-]?[%d%.]+)%s*([%a]*)$')
+    end
+
+    if number == nil then
+        return nil, ('Unable to parse a number from %q'):format(value)
+    end
+
+    local parser = tonumber64
+    if type(number) == 'string' and number:find('.', 1, true) ~= nil then
+        parser = tonumber
+    end
+    local parsed = parser(number)
+    if parsed == nil then
+        return nil, ('Unable to parse a number from %q'):format(number)
+    end
+    if parsed < 0 then
+        return nil, ('Expected a non-negative byte size, got %s')
+            :format(parsed)
+    end
+
+    local multiplier
+    if unit == nil or unit == '' then
+        multiplier = 1
+    else
+        unit = unit:upper()
+        multiplier = byte_size_units[unit]
+        if multiplier == nil then
+            return nil, ('Unknown byte size suffix %q (use %s)')
+                :format(unit, byte_size_unit_names_str)
+        end
+    end
+
+    if multiplier == 1 and parsed - math.floor(parsed) ~= 0 then
+        return nil, ('Expected byte size without a fractional part, got %s')
+            :format(parsed)
+    end
+    return math.floor(parsed * multiplier)
+end
+
+return units

--- a/src/box/lua/config/validators.lua
+++ b/src/box/lua/config/validators.lua
@@ -2,6 +2,7 @@ local tarantool = require('tarantool')
 local urilib = require('uri')
 local uuid = require('uuid')
 local network = require('internal.config.utils.network')
+local size = require('internal.config.utils.size')
 
 
 -- Store validation functions. Each key in this table corresponds
@@ -378,7 +379,11 @@ end
 -- {{{ lua
 
 M['lua.memory'] = function(data, w)
-    if data < 256 * 1024 * 1024 then
+    local parsed, err = size.parse(data)
+    if parsed == nil then
+        w.error('Unable to parse a byte size: %s', err)
+    end
+    if parsed < 256 * 1024 * 1024 then
         w.error('Memory limit should be >= 256MB')
     end
 end

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -184,6 +184,7 @@ extern char session_lua[],
 	config_utils_expression_lua[],
 	config_utils_file_lua[],
 	config_utils_log_lua[],
+	config_utils_size_lua[],
 	config_utils_odict_lua[],
 	config_utils_schema_lua[],
 	config_utils_snapshot_lua[],
@@ -370,6 +371,10 @@ static const char * const lua_sources_main[] = {
 	"config/utils/log",
 	"internal.config.utils.log",
 	config_utils_log_lua,
+
+	"config/utils/size",
+	"internal.config.utils.size",
+	config_utils_size_lua,
 
 	"config/utils/odict",
 	"internal.config.utils.odict",

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -192,6 +192,7 @@ extern char session_lua[],
 	config_utils_textutils_lua[],
 	config_utils_funcutils_lua[],
 	config_utils_network_lua[],
+	config_utils_units_lua[],
 	/* }}} config */
 
 	connpool_lua[];
@@ -383,6 +384,10 @@ static const char * const lua_sources_main[] = {
 	"config/utils/funcutils",
 	"internal.config.utils.funcutils",
 	config_utils_funcutils_lua,
+
+	"config/utils/units",
+	"internal.config.utils.units",
+	config_utils_units_lua,
 
 	"config/utils/schema",
 	"experimental.config.utils.schema",

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -8,6 +8,7 @@ local math = require('math')
 local fiber = require('fiber')
 local fio = require('fio')
 local compat = require('compat')
+local size = require('internal.config.utils.size')
 
 local function nop() end
 
@@ -453,6 +454,53 @@ local function normalize_node_name(name)
     -- possible to use normal comparison functions and display also always
     -- lowercase.
     return string.lower(name)
+end
+
+-- box.cfg options that accept a human-readable byte size string.
+--
+-- Keep legacy behavior for plain numeric strings: they should be
+-- rejected as a wrong type ("should be of type number").
+local byte_size_cfg = {
+    memtx_memory = true,
+    memtx_min_tuple_size = true,
+    memtx_max_tuple_size = true,
+    slab_alloc_granularity = true,
+    vinyl_memory = true,
+    vinyl_cache = true,
+    vinyl_max_tuple_size = true,
+    vinyl_range_size = true,
+    vinyl_page_size = true,
+    quiver_memory = true,
+    quiver_run_size = true,
+    flightrec_logs_size = true,
+    flightrec_logs_max_msg_size = true,
+    flightrec_requests_size = true,
+    flightrec_requests_max_req_size = true,
+    flightrec_requests_max_res_size = true,
+    readahead = true,
+    wal_max_size = true,
+    checkpoint_wal_threshold = true,
+    wal_queue_max_size = true,
+    replication_synchro_queue_max_size = true,
+    feedback_metrics_limit = true,
+    sql_cache_size = true,
+}
+
+local function normalize_byte_size_option(option_name, value)
+    if type(value) ~= 'string' then
+        return value
+    end
+    -- Keep legacy box.cfg() behavior: a plain numeric string
+    -- should still be rejected by a type check (`number` is
+    -- expected). Parse only strings with an explicit suffix.
+    if value:match('^%s*[%d%.]+%s*$') ~= nil then
+        return value
+    end
+    local parsed, err = size.parse(value)
+    if parsed == nil then
+        box.error(box.error.CFG, option_name, err)
+    end
+    return parsed
 end
 
 -- options that require special handling
@@ -923,6 +971,9 @@ local function prepare_cfg(cfg, old_cfg, default_cfg, template_cfg, modify_cfg)
             -- "" and NULL = ffi.cast('void *', 0) set option to default value
             v = default_cfg[k]
         else
+            if byte_size_cfg[k] then
+                v = normalize_byte_size_option(k, v)
+            end
             check_cfg_option_type(template_cfg[k], k, v)
         end
         if modify_cfg ~= nil and type(modify_cfg[k]) == 'function' then

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -486,6 +486,35 @@ local byte_size_cfg = {
     sql_cache_size = true,
 }
 
+-- box.cfg options that accept a human-readable duration string.
+--
+-- Keep legacy behavior for plain numeric strings: they should be
+-- rejected as a wrong type ("should be of type number").
+local duration_cfg = {
+    io_collect_interval = true,
+    too_long_threshold = true,
+    txn_timeout = true,
+    txn_synchro_timeout = true,
+    vinyl_timeout = true,
+    wal_dir_rescan_delay = true,
+    wal_cleanup_delay = true,
+    wal_retention_period = true,
+    checkpoint_interval = true,
+    replication_anon_ttl = true,
+    replication_timeout = true,
+    replication_reconnect_timeout = true,
+    replication_synchro_timeout = true,
+    replication_connect_timeout = true,
+    replication_sync_timeout = true,
+    replication_sync_lag = true,
+    election_timeout = true,
+    feedback_metrics_collect_interval = true,
+    feedback_interval = true,
+    flightrec_metrics_interval = true,
+    flightrec_metrics_period = true,
+    auth_delay = true,
+}
+
 local function normalize_byte_size_option(option_name, value)
     if type(value) ~= 'string' then
         return value
@@ -494,6 +523,20 @@ local function normalize_byte_size_option(option_name, value)
         return value
     end
     local parsed, err = units.parse_byte_size(value)
+    if parsed == nil then
+        box.error(box.error.CFG, option_name, err)
+    end
+    return parsed
+end
+
+local function normalize_duration_option(option_name, value)
+    if type(value) ~= 'string' then
+        return value
+    end
+    if value:match('^%s*[%+%-]?[%d%.]+%s*$') ~= nil then
+        return value
+    end
+    local parsed, err = units.parse_duration(value)
     if parsed == nil then
         box.error(box.error.CFG, option_name, err)
     end
@@ -970,6 +1013,8 @@ local function prepare_cfg(cfg, old_cfg, default_cfg, template_cfg, modify_cfg)
         else
             if byte_size_cfg[k] then
                 v = normalize_byte_size_option(k, v)
+            elseif duration_cfg[k] then
+                v = normalize_duration_option(k, v)
             end
             check_cfg_option_type(template_cfg[k], k, v)
         end

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -8,6 +8,7 @@ local math = require('math')
 local fiber = require('fiber')
 local fio = require('fio')
 local compat = require('compat')
+local units = require('internal.config.utils.units')
 
 local function nop() end
 
@@ -453,6 +454,50 @@ local function normalize_node_name(name)
     -- possible to use normal comparison functions and display also always
     -- lowercase.
     return string.lower(name)
+end
+
+-- box.cfg options that accept a human-readable byte size string.
+--
+-- Keep legacy behavior for plain numeric strings: they should be
+-- rejected as a wrong type ("should be of type number").
+local byte_size_cfg = {
+    memtx_memory = true,
+    memtx_min_tuple_size = true,
+    memtx_max_tuple_size = true,
+    slab_alloc_granularity = true,
+    vinyl_memory = true,
+    vinyl_cache = true,
+    vinyl_max_tuple_size = true,
+    vinyl_range_size = true,
+    vinyl_page_size = true,
+    quiver_memory = true,
+    quiver_run_size = true,
+    flightrec_logs_size = true,
+    flightrec_logs_max_msg_size = true,
+    flightrec_requests_size = true,
+    flightrec_requests_max_req_size = true,
+    flightrec_requests_max_res_size = true,
+    readahead = true,
+    wal_max_size = true,
+    checkpoint_wal_threshold = true,
+    wal_queue_max_size = true,
+    replication_synchro_queue_max_size = true,
+    feedback_metrics_limit = true,
+    sql_cache_size = true,
+}
+
+local function normalize_byte_size_option(option_name, value)
+    if type(value) ~= 'string' then
+        return value
+    end
+    if value:match('^%s*[%+%-]?[%d%.]+%s*$') ~= nil then
+        return value
+    end
+    local parsed, err = units.parse_byte_size(value)
+    if parsed == nil then
+        box.error(box.error.CFG, option_name, err)
+    end
+    return parsed
 end
 
 -- options that require special handling
@@ -923,6 +968,9 @@ local function prepare_cfg(cfg, old_cfg, default_cfg, template_cfg, modify_cfg)
             -- "" and NULL = ffi.cast('void *', 0) set option to default value
             v = default_cfg[k]
         else
+            if byte_size_cfg[k] then
+                v = normalize_byte_size_option(k, v)
+            end
             check_cfg_option_type(template_cfg[k], k, v)
         end
         if modify_cfg ~= nil and type(modify_cfg[k]) == 'function' then

--- a/test/box-luatest/box_byte_size_test.lua
+++ b/test/box-luatest/box_byte_size_test.lua
@@ -1,0 +1,26 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.after_all(function(g)
+    if g.server ~= nil then
+        g.server:drop()
+        g.server = nil
+    end
+end)
+
+g.test_box_cfg_human_readable_values = function(g)
+    g.server = server:new({
+        box_cfg = {
+            memtx_memory = '8GiB',
+            vinyl_memory = '32 MiB',
+        }
+    })
+    g.server:start()
+
+    g.server:exec(function()
+        t.assert_equals(box.cfg.memtx_memory, 8 * 1024 * 1024 * 1024)
+        t.assert_equals(box.cfg.vinyl_memory, 32 * 1024 * 1024)
+    end)
+end

--- a/test/box-luatest/box_byte_size_test.lua
+++ b/test/box-luatest/box_byte_size_test.lua
@@ -1,0 +1,27 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.after_all(function(g)
+    if g.server ~= nil then
+        g.server:drop()
+        g.server = nil
+    end
+end)
+
+g.test_box_cfg_human_readable_values = function(g)
+    g.server = server:new({
+        box_cfg = {
+            memtx_memory = '8GiB',
+            vinyl_memory = '0.1GiB',
+        }
+    })
+    g.server:start()
+
+    g.server:exec(function()
+        t.assert_equals(box.cfg.memtx_memory, 8 * 1024 * 1024 * 1024)
+        t.assert_equals(box.cfg.vinyl_memory,
+                        math.floor(0.1 * 1024 * 1024 * 1024))
+    end)
+end

--- a/test/box-luatest/box_duration_test.lua
+++ b/test/box-luatest/box_duration_test.lua
@@ -1,0 +1,30 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.after_all(function(g)
+    if g.server ~= nil then
+        g.server:drop()
+        g.server = nil
+    end
+end)
+
+g.test_box_cfg_human_readable_values = function(g)
+    g.server = server:new({
+        box_cfg = {
+            too_long_threshold = '1.5s',
+            replication_timeout = '2m',
+            replication_connect_timeout = '30s',
+            election_timeout = '300ms',
+        }
+    })
+    g.server:start()
+
+    g.server:exec(function()
+        t.assert_equals(box.cfg.too_long_threshold, 1.5)
+        t.assert_equals(box.cfg.replication_timeout, 120)
+        t.assert_equals(box.cfg.replication_connect_timeout, 30)
+        t.assert_equals(box.cfg.election_timeout, 0.3)
+    end)
+end

--- a/test/config-luatest/config_byte_size_test.lua
+++ b/test/config-luatest/config_byte_size_test.lua
@@ -1,0 +1,57 @@
+local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('luatest.cluster')
+
+local g = t.group()
+
+g.test_human_readable_value = function()
+    local config = cbuilder:new()
+        :set_global_option('lua.memory', '256 MiB')
+        :add_instance('i-001', {})
+        :config()
+
+    local cluster = cluster:new(config)
+    cluster:start()
+
+    cluster['i-001']:exec(function()
+        local alloc = require('internal.alloc')
+        local config = require('config')
+
+        t.assert_equals(config:get('lua.memory'), 256 * 1024 * 1024)
+        t.assert_equals(alloc.getlimit(), 256 * 1024 * 1024)
+    end)
+end
+
+g.test_size_parse = function()
+    local size = require('internal.config.utils.size')
+
+    local cases = {
+        {value = 0, expected = 0},
+        {value = 42, expected = 42},
+        {value = '42', expected = 42},
+        {value = '42B', expected = 42},
+        {value = ' 32 MiB ', expected = 32 * 1024 * 1024},
+        {value = '8GiB', expected = 8 * 1024 * 1024 * 1024},
+    }
+
+    for _, case in ipairs(cases) do
+        t.assert_equals(size.parse(case.value), case.expected)
+    end
+end
+
+g.test_size_parse_errors = function()
+    local size = require('internal.config.utils.size')
+
+    local _, err
+    _, err = size.parse(-1)
+    t.assert_str_contains(err, 'Expected a non-negative number')
+
+    _, err = size.parse('2.5MiB')
+    t.assert_str_contains(err, 'without a fractional part')
+
+    _, err = size.parse('10MB')
+    t.assert_str_contains(err, 'Unknown size suffix')
+
+    _, err = size.parse({})
+    t.assert_str_contains(err, 'Expected a number or a string')
+end

--- a/test/config-luatest/config_byte_size_test.lua
+++ b/test/config-luatest/config_byte_size_test.lua
@@ -1,0 +1,31 @@
+local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('luatest.cluster')
+local schema = require('experimental.config.utils.schema')
+
+local g = t.group()
+
+g.test_human_readable_value = function()
+    local config = cbuilder:new()
+        :set_global_option('lua.memory', '256 MiB')
+        :add_instance('i-001', {})
+        :config()
+
+    local cluster = cluster:new(config)
+    cluster:start()
+
+    cluster['i-001']:exec(function()
+        local config = require('config')
+
+        t.assert_equals(config:get('lua.memory'), 256 * 1024 * 1024)
+    end)
+end
+
+g.test_fromenv = function()
+    local s = schema.scalar({
+        type = 'integer',
+        byte_size = true,
+    })
+
+    t.assert_equals(schema.fromenv('TT_READAHEAD', '32 KiB', s), 32 * 1024)
+end

--- a/test/config-luatest/config_duration_test.lua
+++ b/test/config-luatest/config_duration_test.lua
@@ -1,0 +1,55 @@
+local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('luatest.cluster')
+local schema = require('experimental.config.utils.schema')
+
+local g = t.group()
+
+g.test_human_readable_timeout = function()
+    local config = cbuilder:new()
+        :set_global_option('replication.timeout', '2m')
+        :set_global_option('replication.election_timeout', '300ms')
+        :add_instance('i-001', {})
+        :config()
+
+    local cluster = cluster:new(config)
+    cluster:start()
+
+    cluster['i-001']:exec(function()
+        local config = require('config')
+
+        t.assert_equals(config:get('replication.timeout'), 2 * 60)
+        t.assert_equals(config:get('replication.election_timeout'), 0.3)
+        t.assert_equals(box.cfg.replication_timeout, 2 * 60)
+        t.assert_equals(box.cfg.election_timeout, 0.3)
+    end)
+end
+
+g.test_human_readable_fiber_durations = function()
+    local config = cbuilder:new()
+        :set_global_option('fiber.too_long_threshold', '1.5s')
+        :set_global_option('fiber.slice.warn', '2s')
+        :set_global_option('fiber.slice.err', '3s')
+        :add_instance('i-001', {})
+        :config()
+
+    local cluster = cluster:new(config)
+    cluster:start()
+
+    cluster['i-001']:exec(function()
+        local config = require('config')
+
+        t.assert_equals(config:get('fiber.too_long_threshold'), 1.5)
+        t.assert_equals(config:get('fiber.slice.warn'), 2)
+        t.assert_equals(config:get('fiber.slice.err'), 3)
+    end)
+end
+
+g.test_fromenv = function()
+    local s = schema.scalar({
+        type = 'number',
+        duration = true,
+    })
+
+    t.assert_equals(schema.fromenv('TT_REPLICATION_TIMEOUT', '2m', s), 2 * 60)
+end

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -97,7 +97,7 @@ local function verify_configdata()
 
     t.assert_equals(data:get('iproto'), expected.iproto)
 
-    local f = function(w) return w.schema.type == 'integer' end
+    local f = function(w) return w.schema.byte_size == true end
     local function remove_descriptions(tbl)
         if type(tbl) ~= 'table' then
             return
@@ -121,10 +121,12 @@ local function verify_configdata()
             schema = {
                 box_cfg = "sql_cache_size",
                 default = 5242880,
-                type = "integer",
+                type = "integer, string",
+                byte_size = true,
                 computed = {
                     annotations = {
                         box_cfg = "sql_cache_size",
+                        byte_size = true,
                     },
                 },
             },
@@ -135,10 +137,12 @@ local function verify_configdata()
             schema = {
                 box_cfg = "memtx_memory",
                 default = 268435456,
-                type = "integer",
+                type = "integer, string",
+                byte_size = true,
                 computed = {
                     annotations = {
                         box_cfg = "memtx_memory",
+                        byte_size = true,
                     },
                 },
             },

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -120,11 +120,13 @@ local function verify_configdata()
             path = {"sql", "cache_size"},
             schema = {
                 box_cfg = "sql_cache_size",
+                byte_size = true,
                 default = 5242880,
                 type = "integer",
                 computed = {
                     annotations = {
                         box_cfg = "sql_cache_size",
+                        byte_size = true,
                     },
                 },
             },
@@ -134,11 +136,13 @@ local function verify_configdata()
             path = {"memtx", "memory"},
             schema = {
                 box_cfg = "memtx_memory",
+                byte_size = true,
                 default = 268435456,
                 type = "integer",
                 computed = {
                     annotations = {
                         box_cfg = "memtx_memory",
+                        byte_size = true,
                     },
                 },
             },

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1987,11 +1987,11 @@ g.test_failover = function()
             call_timeout = 2,
             lease_interval = 10,
             renew_interval = 1,
-            replication_lag_threshold = 10,
+            replication_lag_threshold = '10s',
             stateboard = {
                 enabled = true,
-                renew_interval = 1,
-                keepalive_interval = 5,
+                renew_interval = '1s',
+                keepalive_interval = '5s',
             },
             replicasets = {
                 replicaset001 = {

--- a/test/config-luatest/jsonschema_config_test.lua
+++ b/test/config-luatest/jsonschema_config_test.lua
@@ -93,13 +93,16 @@ g.test_json_schema_section_from_config = function()
                 },
                 type = 'object',
             },
-            max_size = {default = 268435456, type = 'integer'},
+            max_size = {default = 268435456, type = {'string', 'integer'}},
             mode = {
                 default = 'write',
                 enum = {'none', 'write', 'fsync'},
                 type = 'string'
             },
-            queue_max_size = {default = 16777216, type = 'integer'},
+            queue_max_size = {
+                default = 16777216,
+                type = {'string', 'integer'},
+            },
             retention_period = {default = 0, type = 'number'},
         },
         type = 'object',

--- a/test/config-luatest/jsonschema_config_test.lua
+++ b/test/config-luatest/jsonschema_config_test.lua
@@ -7,6 +7,8 @@ local g = t.group()
 local byte_size_pattern = '^(?:\\d+(?:\\.\\d*)?|\\.\\d+)\\s*' ..
     '(?:[Bb]|[Kk][Ii][Bb]|[Mm][Ii][Bb]|[Gg][Ii][Bb]|' ..
     '[Tt][Ii][Bb]|[Pp][Ii][Bb])?$'
+local duration_pattern = '^(?:\\d+(?:\\.\\d*)?|\\.\\d+)\\s*' ..
+    '(?:ms|s|m|h|d|w|M|y)?$'
 
 local function remove_descriptions(tbl)
     if type(tbl) ~= 'table' then
@@ -67,16 +69,26 @@ g.test_json_schema_section_from_config = function()
                     'The time interval in seconds between periodic scans of ' ..
                     'the write-ahead-log file directory, when checking for ' ..
                     'changes to write-ahead-log files for the sake of ' ..
-                    'replication or hot standby.')
+                    'replication or hot standby.\n\nYou can specify the ' ..
+                    'value either as a number of seconds or as a ' ..
+                    'human-readable string with time units (for example, ' ..
+                    '`30s`, `5m`, `1h`).')
 
     remove_descriptions(wal_section)
 
     local expected = {
         additionalProperties = false,
         properties = {
-            cleanup_delay = {type = 'number'},
+            cleanup_delay = {
+                pattern = duration_pattern,
+                type = {'number', 'string'},
+            },
             dir = {default = 'var/lib/{{ instance_name }}', type = 'string'},
-            dir_rescan_delay = {default = 2, type = 'number'},
+            dir_rescan_delay = {
+                default = 2,
+                pattern = duration_pattern,
+                type = {'number', 'string'},
+            },
             ext = {
                 additionalProperties = false,
                 default = box.NULL,
@@ -112,7 +124,11 @@ g.test_json_schema_section_from_config = function()
                 pattern = byte_size_pattern,
                 type = {'integer', 'string'},
             },
-            retention_period = {default = 0, type = 'number'},
+            retention_period = {
+                default = 0,
+                pattern = duration_pattern,
+                type = {'number', 'string'},
+            },
         },
         type = 'object',
     }

--- a/test/config-luatest/jsonschema_config_test.lua
+++ b/test/config-luatest/jsonschema_config_test.lua
@@ -4,6 +4,10 @@ local fiber = require('fiber')
 
 local g = t.group()
 
+local byte_size_pattern = '^(?:\\d+(?:\\.\\d*)?|\\.\\d+)\\s*' ..
+    '(?:[Bb]|[Kk][Ii][Bb]|[Mm][Ii][Bb]|[Gg][Ii][Bb]|' ..
+    '[Tt][Ii][Bb]|[Pp][Ii][Bb])?$'
+
 local function remove_descriptions(tbl)
     if type(tbl) ~= 'table' then
         return
@@ -93,13 +97,21 @@ g.test_json_schema_section_from_config = function()
                 },
                 type = 'object',
             },
-            max_size = {default = 268435456, type = 'integer'},
+            max_size = {
+                default = 268435456,
+                pattern = byte_size_pattern,
+                type = {'integer', 'string'},
+            },
             mode = {
                 default = 'write',
                 enum = {'none', 'write', 'fsync'},
                 type = 'string'
             },
-            queue_max_size = {default = 16777216, type = 'integer'},
+            queue_max_size = {
+                default = 16777216,
+                pattern = byte_size_pattern,
+                type = {'integer', 'string'},
+            },
             retention_period = {default = 0, type = 'number'},
         },
         type = 'object',

--- a/test/config-luatest/jsonschema_schema_test.lua
+++ b/test/config-luatest/jsonschema_schema_test.lua
@@ -3,6 +3,10 @@ local schema = require('experimental.config.utils.schema')
 
 local g = t.group()
 
+local byte_size_pattern = '^(?:\\d+(?:\\.\\d*)?|\\.\\d+)\\s*' ..
+    '(?:[Bb]|[Kk][Ii][Bb]|[Mm][Ii][Bb]|[Gg][Ii][Bb]|' ..
+    '[Tt][Ii][Bb]|[Pp][Ii][Bb])?$'
+
 local function variant_by_type(schema, schema_type)
     for _, variant in ipairs(schema.variants) do
         if variant.type == schema_type then
@@ -72,6 +76,10 @@ g.test_json_schema = function()
             },
             discriminator = string_or_union_discriminator,
         }),
+        saz = schema.scalar({
+            type = 'integer',
+            byte_size = true,
+        }),
     }))
 
     local expected = {
@@ -119,6 +127,10 @@ g.test_json_schema = function()
                         },
                     },
                 },
+            },
+            saz = {
+                pattern = byte_size_pattern,
+                type = {'integer', 'string'},
             },
         },
         type = 'object',

--- a/test/config-luatest/jsonschema_schema_test.lua
+++ b/test/config-luatest/jsonschema_schema_test.lua
@@ -6,6 +6,8 @@ local g = t.group()
 local byte_size_pattern = '^(?:\\d+(?:\\.\\d*)?|\\.\\d+)\\s*' ..
     '(?:[Bb]|[Kk][Ii][Bb]|[Mm][Ii][Bb]|[Gg][Ii][Bb]|' ..
     '[Tt][Ii][Bb]|[Pp][Ii][Bb])?$'
+local duration_pattern = '^(?:\\d+(?:\\.\\d*)?|\\.\\d+)\\s*' ..
+    '(?:ms|s|m|h|d|w|M|y)?$'
 
 local function variant_by_type(schema, schema_type)
     for _, variant in ipairs(schema.variants) do
@@ -80,6 +82,14 @@ g.test_json_schema = function()
             type = 'integer',
             byte_size = true,
         }),
+        taz = schema.scalar({
+            type = 'number',
+            duration = true,
+        }),
+        uaz = schema.scalar({
+            type = 'integer',
+            duration = true,
+        }),
     }))
 
     local expected = {
@@ -130,6 +140,14 @@ g.test_json_schema = function()
             },
             saz = {
                 pattern = byte_size_pattern,
+                type = {'integer', 'string'},
+            },
+            taz = {
+                pattern = duration_pattern,
+                type = {'number', 'string'},
+            },
+            uaz = {
+                pattern = duration_pattern,
                 type = {'integer', 'string'},
             },
         },

--- a/test/config-luatest/schema_test.lua
+++ b/test/config-luatest/schema_test.lua
@@ -711,6 +711,38 @@ g.test_validate_schema = function()
             }),
         }))
     end)
+
+    exp_err_msg = '[myschema] foo: "byte_size" requires an integer scalar, ' ..
+        'got record'
+    t.assert_error_msg_equals(exp_err_msg, function()
+        schema.new('myschema', schema.record({
+            foo = schema.record({}, {
+                byte_size = true,
+            }),
+        }))
+    end)
+
+    exp_err_msg = '[myschema] foo: "byte_size" requires an integer scalar, ' ..
+        'got number'
+    t.assert_error_msg_equals(exp_err_msg, function()
+        schema.new('myschema', schema.record({
+            foo = schema.scalar({
+                type = 'number',
+                byte_size = true,
+            }),
+        }))
+    end)
+
+    exp_err_msg = '[myschema] foo: "byte_size" requires an integer scalar, ' ..
+        'got string'
+    t.assert_error_msg_equals(exp_err_msg, function()
+        schema.new('myschema', schema.record({
+            foo = schema.scalar({
+                type = 'string',
+                byte_size = true,
+            }),
+        }))
+    end)
 end
 
 g.test_validate_schema_union_discriminator = function()
@@ -1074,10 +1106,55 @@ g.test_validate_integer = function()
 
     -- Bad cases.
     assert_validate_scalar_expects_only_given_type(s, 'number')
+    assert_validate_scalar_error(s, '5 KiB',
+        'Expected "number", got "string"')
     assert_validate_scalar_error(s, 5.5,
         'Expected number without a fractional part, got 5.5')
 
     -- TODO: +inf, -inf, NaN.
+end
+
+g.test_validate_byte_size = function()
+    local s = schema.new('myschema', schema.scalar({
+        type = 'integer',
+        byte_size = true,
+    }))
+
+    -- Good cases.
+    s:validate(0)
+    s:validate(5)
+    s:validate('5B')
+    s:validate('5 KiB')
+    s:validate('1.5 GiB')
+
+    -- Bad cases.
+    local exp_err_msg_tmpl = ('Expected byte size as number or string with ' ..
+        'optional byte size suffix, got %s')
+    for i = 1, table.maxn(samples) do
+        local data = samples[i]
+        if type(data) ~= 'number' and type(data) ~= 'string' then
+            t.assert_error_msg_contains(exp_err_msg_tmpl:format(type(data)),
+                                        s.validate, s, data)
+        end
+    end
+    assert_validate_scalar_error(s, 5.5,
+        'Expected byte size without a fractional part, got 5.5')
+    assert_validate_scalar_error(s, '5.5',
+        'Expected byte size without a fractional part, got 5.5')
+    assert_validate_scalar_error(s, '5.5B',
+        'Expected byte size without a fractional part, got 5.5')
+    assert_validate_scalar_error(s, -5,
+        'Expected a non-negative byte size, got -5')
+    assert_validate_scalar_error(s, '-5KiB',
+        'Expected a non-negative byte size, got -5')
+    assert_validate_scalar_error(s, '5 MB',
+        'Unknown byte size suffix "MB" (use B, KiB, MiB, GiB, TiB, PiB)')
+    assert_validate_scalar_error(s, '+5KiB',
+        'Unable to parse a number from "+5KiB"')
+    assert_validate_scalar_error(s, ' 5KiB',
+        'Unable to parse a number from " 5KiB"')
+    assert_validate_scalar_error(s, '5KiB ',
+        'Unable to parse a number from "5KiB "')
 end
 
 g.test_validate_boolean = function()
@@ -1599,6 +1676,17 @@ g.test_get_nested_in_record = function()
     local data = {}
     t.assert_equals(s:get(data, 'foo'), nil)
     t.assert_equals(s:get(data, 'foo.bar'), nil)
+end
+
+g.test_get_normalizes_integer = function()
+    local s = schema.new('myschema', schema.record({
+        size = schema.scalar({type = 'integer', byte_size = true}),
+    }))
+
+    t.assert_equals(s:get({size = '5 KiB'}, 'size'), 5 * 1024)
+    t.assert_equals(s:get({size = '1.3 GiB'}, 'size'),
+                    math.floor(1.3 * 1024 * 1024 * 1024))
+    t.assert_equals(s:get({size = '5 KiB'}), {size = 5 * 1024})
 end
 
 -- Verify that there are no problems with composite data in a
@@ -3264,6 +3352,20 @@ g.test_map_any_traverses_tables = function()
     end)
 end
 
+g.test_normalize_any_traverses_tables = function()
+    local s = schema.new('myschema', schema.scalar({type = 'any'}))
+
+    local data = {
+        plain = '1 KiB',
+        nested = {
+            timeout = '1 h',
+            list = {'2 KiB', 42, box.NULL},
+        },
+    }
+
+    t.assert_equals(s:normalize(data), data)
+end
+
 g.test_cycle_under_any_tables = function()
     local config_yaml = [[
 app:
@@ -4274,6 +4376,18 @@ local fromenv_cases = {
         schema = schema.scalar({type = 'integer'}),
         raw_value = '-5',
         exp_value = -5,
+    },
+    integer_byte_size = {
+        schema = schema.scalar({type = 'integer', byte_size = true}),
+        raw_value = '5KiB',
+        exp_value = 5 * 1024,
+    },
+    integer_byte_size_error = {
+        schema = schema.scalar({type = 'integer', byte_size = true}),
+        raw_value = '5MB',
+        exp_err_msg = 'Unable to decode an integer value from environment ' ..
+            'variable "MYVAR", got "5MB": Unknown byte size suffix "MB" ' ..
+            '(use B, KiB, MiB, GiB, TiB, PiB)',
     },
     integer_error = {
         schema = schema.scalar({type = 'integer'}),

--- a/test/config-luatest/schema_test.lua
+++ b/test/config-luatest/schema_test.lua
@@ -743,6 +743,46 @@ g.test_validate_schema = function()
             }),
         }))
     end)
+
+    schema.new('myschema', schema.record({
+        foo = schema.scalar({
+            type = 'integer',
+            duration = true,
+        }),
+    }))
+
+    exp_err_msg = '[myschema] foo: "duration" requires a numeric scalar, ' ..
+        'got string'
+    t.assert_error_msg_equals(exp_err_msg, function()
+        schema.new('myschema', schema.record({
+            foo = schema.scalar({
+                type = 'string',
+                duration = true,
+            }),
+        }))
+    end)
+
+    exp_err_msg = '[myschema] foo: "duration" requires a numeric scalar, ' ..
+        'got record'
+    t.assert_error_msg_equals(exp_err_msg, function()
+        schema.new('myschema', schema.record({
+            foo = schema.record({}, {
+                duration = true,
+            }),
+        }))
+    end)
+
+    exp_err_msg = '[myschema] foo: "byte_size" and "duration" annotations ' ..
+        'are mutually exclusive'
+    t.assert_error_msg_equals(exp_err_msg, function()
+        schema.new('myschema', schema.record({
+            foo = schema.scalar({
+                type = 'integer',
+                byte_size = true,
+                duration = true,
+            }),
+        }))
+    end)
 end
 
 g.test_validate_schema_union_discriminator = function()
@@ -884,8 +924,74 @@ g.test_validate_number = function()
 
     -- Bad cases.
     assert_validate_scalar_expects_only_given_type(s, 'number')
+    assert_validate_scalar_error(s, '5s', 'Expected "number", got "string"')
 
     -- TODO: +inf, -inf, NaN.
+end
+
+g.test_validate_duration = function()
+    local s = schema.new('myschema', schema.scalar({
+        type = 'number',
+        duration = true,
+    }))
+
+    -- Good cases.
+    s:validate(0)
+    s:validate(5)
+    s:validate(5.3)
+    s:validate('1.5h')
+    s:validate('5ms')
+    s:validate('5s')
+    s:validate('5 m')
+    s:validate('5h')
+    s:validate('5d')
+    s:validate('5w')
+    s:validate('5M')
+    s:validate('5y')
+
+    -- Bad cases.
+    local exp_err_msg_tmpl = 'Expected duration as number or string with ' ..
+        'optional duration suffix, got %s'
+    for i = 1, table.maxn(samples) do
+        local data = samples[i]
+        if type(data) ~= 'number' and type(data) ~= 'string' then
+            t.assert_error_msg_contains(exp_err_msg_tmpl:format(type(data)),
+                                        s.validate, s, data)
+        end
+    end
+    assert_validate_scalar_error(s, -5,
+        'Expected a non-negative duration, got -5')
+    assert_validate_scalar_error(s, '-5m',
+        'Expected a non-negative duration, got -5')
+    assert_validate_scalar_error(s, 'foo',
+        'Unable to parse a number from "foo"')
+    assert_validate_scalar_error(s, '+5m',
+        'Unable to parse a number from "+5m"')
+    assert_validate_scalar_error(s, ' 5m',
+        'Unable to parse a number from " 5m"')
+    assert_validate_scalar_error(s, '5m ',
+        'Unable to parse a number from "5m "')
+end
+
+g.test_validate_integer_duration = function()
+    local s = schema.new('myschema', schema.scalar({
+        type = 'integer',
+        duration = true,
+    }))
+
+    -- Good cases.
+    s:validate(0)
+    s:validate(5)
+    s:validate('2m')
+    s:validate('1000ms')
+
+    -- Bad cases.
+    assert_validate_scalar_error(s, 5.5,
+        'Expected number without a fractional part, got 5.5')
+    assert_validate_scalar_error(s, '1.5s',
+        'Expected number without a fractional part, got 1.5')
+    assert_validate_scalar_error(s, '1500ms',
+        'Expected number without a fractional part, got 1.5')
 end
 
 g.test_validate_union = function()
@@ -1687,6 +1793,25 @@ g.test_get_normalizes_integer = function()
     t.assert_equals(s:get({size = '1.3 GiB'}, 'size'),
                     math.floor(1.3 * 1024 * 1024 * 1024))
     t.assert_equals(s:get({size = '5 KiB'}), {size = 5 * 1024})
+end
+
+g.test_get_normalizes_number = function()
+    local s = schema.new('myschema', schema.record({
+        timeout = schema.scalar({type = 'number', duration = true}),
+    }))
+
+    t.assert_equals(s:get({timeout = '1.5 h'}, 'timeout'), 1.5 * 60 * 60)
+    t.assert_equals(s:get({timeout = '1.5 h'}),
+                    {timeout = 1.5 * 60 * 60})
+end
+
+g.test_get_normalizes_integer_duration = function()
+    local s = schema.new('myschema', schema.record({
+        timeout = schema.scalar({type = 'integer', duration = true}),
+    }))
+
+    t.assert_equals(s:get({timeout = '2m'}, 'timeout'), 2 * 60)
+    t.assert_equals(s:get({timeout = '2m'}), {timeout = 2 * 60})
 end
 
 -- Verify that there are no problems with composite data in a
@@ -4360,6 +4485,30 @@ local fromenv_cases = {
         schema = schema.scalar({type = 'number'}),
         raw_value = '-5.5',
         exp_value = -5.5,
+    },
+    number_duration = {
+        schema = schema.scalar({type = 'number', duration = true}),
+        raw_value = '300ms',
+        exp_value = 0.3,
+    },
+    number_duration_error = {
+        schema = schema.scalar({type = 'number', duration = true}),
+        raw_value = '5q',
+        exp_err_msg = 'Unable to decode a number value from environment ' ..
+            'variable "MYVAR", got "5q": Unknown duration suffix "q" ' ..
+            '(use ms, s, m, h, d, w, M, y)',
+    },
+    integer_duration = {
+        schema = schema.scalar({type = 'integer', duration = true}),
+        raw_value = '2m',
+        exp_value = 120,
+    },
+    integer_duration_error = {
+        schema = schema.scalar({type = 'integer', duration = true}),
+        raw_value = '1500ms',
+        exp_err_msg = 'Unable to decode an integer value from environment ' ..
+            'variable "MYVAR", got "1500ms": Expected number without a ' ..
+            'fractional part, got 1.5',
     },
     number_error = {
         schema = schema.scalar({type = 'number'}),


### PR DESCRIPTION
This patch adds support for specifying byte-size and duration configuration options in a human-readable format.

Byte-size options support the following units: B, KiB, MiB, GiB, TiB, and PiB. Duration options support the following units: ms, s, m, h, d, w, M and y.

The new format is accepted both in declarative configuration and in `box.cfg{}`.

Closes #5786

NO_DOC=will be added in a separate PR