### PR TITLE
main: broadcast SIGHUP for log rotation

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -100,7 +100,7 @@ static char *pid_file = NULL;
 static char **main_argv;
 static int main_argc;
 /** Signals handled after start as part of the event loop. */
-static ev_signal ev_sigs[6];
+static ev_signal ev_sigs[7];
 static const int ev_sig_count = sizeof(ev_sigs)/sizeof(*ev_sigs);
 
 static double start_time;
@@ -252,6 +252,16 @@ broadcast_sigusr2(ev_loop *loop, struct ev_signal *w, int revents)
 }
 
 static void
+broadcast_sighup(ev_loop *loop, struct ev_signal *w, int revents)
+{
+	(void)loop;
+	(void)w;
+	(void)revents;
+	const char *key = "box.internal.SIGHUP";
+	box_broadcast(key, strlen(key), NULL, 0);
+}
+
+static void
 signal_free(void)
 {
 	int i;
@@ -313,7 +323,8 @@ signal_init(void)
 	ev_signal_init(&ev_sigs[2], signal_cb, SIGTERM);
 	ev_signal_init(&ev_sigs[3], signal_sigwinch_cb, SIGWINCH);
 	ev_signal_init(&ev_sigs[4], say_logrotate, SIGHUP);
-	ev_signal_init(&ev_sigs[5], broadcast_sigusr2, SIGUSR2);
+	ev_signal_init(&ev_sigs[5], broadcast_sighup, SIGHUP);
+	ev_signal_init(&ev_sigs[6], broadcast_sigusr2, SIGUSR2);
 	for (int i = 0; i < ev_sig_count; i++)
 		ev_signal_start(loop(), &ev_sigs[i]);
 


### PR DESCRIPTION
Add a SIGHUP signal watcher that broadcasts `box.internal.SIGHUP` event. This allows Lua code (e.g., failover coordinator) to react to log rotation by reopening log files.

Required by tarantool/tarantool-ee#1725

NO_CHANGELOG=will be added in EE
NO_DOC=will be added in EE
NO_TEST=will be added in EE