### PR TITLE
gitignore: add config test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,8 @@ test/enterprise-luatest
 test/enterprise-tap
 test/enterprise-unit
 test/etcd-client
+test/failover.lua
+test/network_fault_injection.lua
 test/lib/
 test/unit/*.test
 test/unit/fiob


### PR DESCRIPTION
When building Tarantool EE, we started symlinking the config test files in the `tarantool/test` directory to simplify test bundle creation in GitLab CI. We should add them to .gitignore so that they do not appear as untracked files and are not committed accidentally.