### PR TITLE
box: remove tuple dictionary from space definition

### DIFF
--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -616,8 +616,6 @@ space_def_new_from_tuple(struct tuple *tuple, uint32_t errcode,
 		space_def_new(id, uid, exact_field_count, name, name_len,
 			      engine_name, engine_name_len, &opts, fields,
 			      field_count, format, format_len);
-	if (def == NULL)
-		return NULL;
 	auto def_guard = make_scoped_guard([=] { space_def_delete(def); });
 	struct engine *engine = engine_find(def->engine_name);
 	if (engine == NULL)
@@ -1255,38 +1253,19 @@ CheckSpaceFormat::prepare(struct alter_space *alter)
 /** Change non-essential properties of a space. */
 class ModifySpace: public AlterSpaceOp
 {
-	void space_swap_dictionaries(struct space_def *old_def,
-				     struct space_def *new_def,
-				     struct tuple_format *new_format);
 public:
 	ModifySpace(struct alter_space *alter, struct space_def *def)
-		: AlterSpaceOp(alter), new_def(def) {}
+		: AlterSpaceOp(alter), new_def(def),
+		  dict_with_old_names(NULL) {}
 	/* New space definition. */
 	struct space_def *new_def;
+	/* Dictionary with the old field names, referenced. */
+	struct tuple_dictionary *dict_with_old_names;
 	virtual void alter_def(struct alter_space *alter);
 	virtual void alter(struct alter_space *alter);
 	virtual void rollback(struct alter_space *alter);
 	virtual ~ModifySpace();
 };
-
-void
-ModifySpace::space_swap_dictionaries(struct space_def *old_def,
-				     struct space_def *new_def,
-				     struct tuple_format *new_format)
-{
-	/*
-	 * When new space_def is created, it allocates new dictionary.
-	 * Move new names into an old dictionary, which already is referenced
-	 * by existing tuple formats. New dictionary object is deleted later,
-	 * in alter_space_delete.
-	 */
-	tuple_dictionary_unref(new_format->dict);
-	new_format->dict = old_def->dict;
-	tuple_dictionary_ref(new_format->dict);
-
-	SWAP(old_def->dict, new_def->dict);
-	tuple_dictionary_swap(old_def->dict, new_def->dict);
-}
 
 /** Amend the definition of the new space. */
 void
@@ -1303,8 +1282,9 @@ void
 ModifySpace::alter(struct alter_space *alter)
 {
 	/*
-	 * Unless it's online space upgrade, use the old dictionary for the new
-	 * space, because it's already referenced by existing tuple formats.
+	 * Unless it's online space upgrade, use the old dictionary with the
+	 * new field names for the new space, because it's already referenced
+	 * by existing tuple formats,
 	 *
 	 * For online space upgrade, all tuples fetched from the space will be
 	 * upgraded to the new format before returning to the user so it isn't
@@ -1314,9 +1294,12 @@ ModifySpace::alter(struct alter_space *alter)
 	 * function.
 	 */
 	if (alter->space_def->opts.upgrade_def == NULL) {
-		space_swap_dictionaries(alter->old_space->def,
-					alter->new_space->def,
-					alter->new_space->format);
+		struct tuple_format *old_format = alter->old_space->format;
+		struct tuple_format *new_format = alter->new_space->format;
+		tuple_dictionary_swap(old_format->dict, new_format->dict);
+		dict_with_old_names = new_format->dict;
+		new_format->dict = old_format->dict;
+		tuple_dictionary_ref(new_format->dict);
 	}
 }
 
@@ -1324,9 +1307,8 @@ void
 ModifySpace::rollback(struct alter_space *alter)
 {
 	if (alter->space_def->opts.upgrade_def == NULL) {
-		space_swap_dictionaries(alter->new_space->def,
-					alter->old_space->def,
-					alter->new_space->format);
+		struct tuple_format *old_format = alter->old_space->format;
+		tuple_dictionary_swap(old_format->dict, dict_with_old_names);
 	}
 }
 
@@ -1334,6 +1316,8 @@ ModifySpace::~ModifySpace()
 {
 	if (new_def != NULL)
 		space_def_delete(new_def);
+	if (dict_with_old_names != NULL)
+		tuple_dictionary_unref(dict_with_old_names);
 }
 
 /** DropIndex - remove an index from space. */

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -225,10 +225,10 @@ sc_space_new(uint32_t id, const char *name,
 	     uint32_t key_part_count,
 	     struct trigger *replace_trigger)
 {
-	struct space_def *def =
-		space_def_new_xc(id, ADMIN, 0, name, strlen(name), "memtx",
-				 strlen("memtx"), &space_opts_default, NULL, 0,
-				 NULL, 0);
+	struct space_def *def = space_def_new(id, ADMIN, 0, name, strlen(name),
+					      "memtx", strlen("memtx"),
+					      &space_opts_default,
+					      NULL, 0, NULL, 0);
 	auto def_guard = make_scoped_guard([=] { space_def_delete(def); });
 	struct key_def *key_def = key_def_new(key_parts, key_part_count, 0);
 	if (key_def == NULL)
@@ -469,9 +469,9 @@ schema_init(void)
 		struct space_opts opts = space_opts_default;
 		opts.group_id = GROUP_LOCAL;
 		struct space_def *def;
-		def = space_def_new_xc(BOX_VINYL_DEFERRED_DELETE_ID, ADMIN, 0,
-				       name, strlen(name), engine,
-				       strlen(engine), &opts, NULL, 0, NULL, 0);
+		def = space_def_new(BOX_VINYL_DEFERRED_DELETE_ID, ADMIN, 0,
+				    name, strlen(name), engine,
+				    strlen(engine), &opts, NULL, 0, NULL, 0);
 		auto def_guard = make_scoped_guard([=] {
 			space_def_delete(def);
 		});

--- a/src/box/space_def.c
+++ b/src/box/space_def.c
@@ -37,6 +37,7 @@
 #include "tt_static.h"
 #include "tuple_constraint_def.h"
 #include "tuple_format.h"
+#include "tuple_dictionary.h"
 
 const struct space_opts space_opts_default = {
 	/* .group_id = */ 0,
@@ -110,14 +111,21 @@ space_tuple_format_new(struct tuple_format_vtab *vtab, void *engine,
 		       struct key_def *const *keys, uint16_t key_count,
 		       const struct space_def *def)
 {
-	return tuple_format_new(vtab, engine, keys, key_count,
+	struct tuple_dictionary *dict = tuple_dictionary_new(def->fields,
+							     def->field_count);
+	if (dict == NULL)
+		return NULL;
+	struct tuple_format *format = tuple_format_new(
+				vtab, engine, keys, key_count,
 				def->fields, def->field_count,
-				def->exact_field_count, def->dict,
+				def->exact_field_count, dict,
 				space_opts_is_data_temporary(&def->opts),
 				def->opts.is_ephemeral,
 				def->opts.constraint_def,
 				def->opts.constraint_count, def->format_data,
 				def->format_data_len);
+	tuple_dictionary_unref(dict);
+	return format;
 }
 
 /**
@@ -146,7 +154,6 @@ space_def_dup(const struct space_def *src)
 	memcpy(ret, src, size);
 	memset(&ret->opts, 0, sizeof(ret->opts));
 	ret->fields = field_def_array_dup(src->fields, src->field_count);
-	tuple_dictionary_ref(ret->dict);
 	space_def_dup_opts(ret, &src->opts);
 	if (src->format_data != NULL) {
 		ret->format_data = xmalloc(src->format_data_len);
@@ -172,11 +179,6 @@ space_def_new(uint32_t id, uint32_t uid, uint32_t exact_field_count,
 	struct space_def *def = xmalloc(size);
 	assert(name_len <= BOX_NAME_MAX);
 	assert(engine_len <= ENGINE_NAME_MAX);
-	def->dict = tuple_dictionary_new(fields, field_count);
-	if (def->dict == NULL) {
-		free(def);
-		return NULL;
-	}
 	def->id = id;
 	def->uid = uid;
 	def->exact_field_count = exact_field_count;
@@ -224,7 +226,6 @@ void
 space_def_delete(struct space_def *def)
 {
 	field_def_array_delete(def->fields, def->field_count);
-	tuple_dictionary_unref(def->dict);
 	free(def->opts.sql);
 	free(def->opts.constraint_def);
 	space_upgrade_def_delete(def->opts.upgrade_def);

--- a/src/box/space_def.h
+++ b/src/box/space_def.h
@@ -30,8 +30,8 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-#include "tuple_dictionary.h"
 #include "schema_def.h"
+#include "opt_def.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -169,11 +169,6 @@ struct space_def {
 	 */
 	uint32_t exact_field_count;
 	char engine_name[ENGINE_NAME_MAX + 1];
-	/**
-	 * Tuple field names dictionary, shared with a space's
-	 * tuple format.
-	 */
-	struct tuple_dictionary *dict;
 	/** Space fields, specified by a user. */
 	struct field_def *fields;
 	/** Length of @a fields. */
@@ -269,26 +264,6 @@ space_def_tuple_is_temporary(const char *data, uint32_t *space_id);
 
 #if defined(__cplusplus)
 } /* extern "C" */
-
-#include "diag.h"
-
-static inline struct space_def *
-space_def_new_xc(uint32_t id, uint32_t uid, uint32_t exact_field_count,
-		 const char *name, uint32_t name_len,
-		 const char *engine_name, uint32_t engine_len,
-		 const struct space_opts *opts, const struct field_def *fields,
-		 uint32_t field_count, const char *format_data,
-		 size_t format_data_len)
-{
-	struct space_def *ret = space_def_new(id, uid, exact_field_count, name,
-					      name_len, engine_name, engine_len,
-					      opts, fields, field_count,
-					      format_data, format_data_len);
-	if (ret == NULL)
-		diag_raise();
-	return ret;
-}
-
 #endif /* __cplusplus */
 
 #endif /* TARANTOOL_BOX_SPACE_DEF_H_INCLUDED */

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -390,8 +390,6 @@ sql_ephemeral_space_new(const struct sql_space_info *info)
 
 	struct space_def *space_def = space_def_new_ephemeral(field_count,
 							      fields);
-	if (space_def == NULL)
-		return NULL;
 
 	struct key_def *key_def = key_def_new(parts, part_count, 0);
 	if (key_def == NULL) {

--- a/src/box/tuple_constraint_fkey.c
+++ b/src/box/tuple_constraint_fkey.c
@@ -37,7 +37,7 @@ find_field_no_by_def(struct space *space,
 	/* A bit more complicated case - find by name. */
 	uint32_t field_no;
 	uint32_t hash = field_name_hash(field_def->name, field_def->name_len);
-	if (tuple_fieldno_by_name(space->def->dict, field_def->name,
+	if (tuple_fieldno_by_name(space->format->dict, field_def->name,
 				  field_def->name_len, hash, &field_no) != 0)
 		return -1;
 	return field_no;


### PR DESCRIPTION
When we made the tuple format registry thread-local in commit 8c3a20d74a59a ("box: make tuple format registry thread-local"), we assumed that it's safe to pass a space definition object to another thread in order to create a thread-local copy of a tuple format for a Vinyl dump/compaction task. Turns out it isn't true because a space definition stores a reference to a tuple dictionary, which is passed to `tuple_format_new()`, which increments its reference counter, which is obviously not a thread-safe operation.

Actually, we don't really need to store a tuple dictionary in a space definition because it's used only for rollback of a space format update. Instead of storing the dictionary in a space definition, we can store it in the DDL operation itself. This change makes a space definition a trivial object, as it should be, safe to be passed from one thread to another.

Note that this patch makes `space_def_new()` non-failing so it also removes the code checking its return value.

The bug was found by Andrey Saranchin (@drewdzzz) with TSAN.

Follow-up #12210