### PR TITLE
box: introduce the `type` compression table key

### DIFF
--- a/src/lib/core/tt_compression.c
+++ b/src/lib/core/tt_compression.c
@@ -28,22 +28,42 @@ compression_opts_decode(const char **data, struct compression_opts *opts,
 
 	/* Parse the string version of the "compression" field. */
 	if (mp_typeof(**data) == MP_STR)
-		goto check_compression_name;
+		goto check_compression_type;
 
-	/* Parse the map version: {[1] = "none"}. */
-	if (mp_typeof(**data) != MP_MAP ||
-	    mp_decode_map(data) != 1 ||
-	    mp_typeof(**data) != MP_UINT ||
-	    mp_decode_uint(data) != 1 ||
-	    mp_typeof(**data) != MP_STR) {
-		diag_set(IllegalParams, "{'none'} compression table expected");
+	/* Parse the map version: {type = "none"}. */
+	if (mp_typeof(**data) != MP_MAP) {
+		diag_set(IllegalParams,
+			 "compression is expected to be a MAP or STR");
+		return -1;
+	}
+	uint32_t map_size = mp_decode_map(data);
+	if (map_size == 0)
+		return 0;
+	if (map_size != 1) {
+		diag_set(IllegalParams, "CE supports no compression options");
+		return -1;
+	}
+	if (mp_typeof(**data) != MP_STR) {
+		diag_set(IllegalParams,
+			 "compression option name must be a string");
+		return -1;
+	}
+	uint32_t str_len;
+	const char *str = mp_decode_str(data, &str_len);
+	if (str_len != strlen("type") || strncmp(str, "type", str_len) != 0) {
+		diag_set(IllegalParams,
+			 "CE only supports 'type' compression table key");
+		return -1;
+	}
+	if (mp_typeof(**data) != MP_STR) {
+		diag_set(IllegalParams, "non-string compression type");
 		return -1;
 	}
 
-check_compression_name:;
-	uint32_t str_len;
-	const char *str = mp_decode_str(data, &str_len);
-	if (str_len != strlen("none") || strncmp(str, "none", str_len) != 0) {
+check_compression_type:
+	str = mp_decode_str(data, &str_len);
+	if (str_len != strlen("none") ||
+	    strncmp(str, "none", str_len) != 0) {
 		diag_set(IllegalParams, "unknown compression type");
 		return -1;
 	}

--- a/test/box-luatest/gh_12117_compression_test.lua
+++ b/test/box-luatest/gh_12117_compression_test.lua
@@ -33,20 +33,49 @@ g.test_compression_values = function(cg)
         box.schema.space.create('test', {engine = engine})
 
         -- Do the tests.
-        local msg_none_table_expected = "{'none'} compression table expected"
-        local msg_unknown_compression = 'unknown compression type'
+        check_ok(nil)
+        check_ok({})
         check_ok('none')
-        check_ok({'none'})
-        check_fail('lz4', msg_unknown_compression)
-        check_fail('zlib', msg_unknown_compression)
-        check_fail('zstd', msg_unknown_compression)
-        check_fail({}, msg_none_table_expected)
-        check_fail({'lz4'}, msg_unknown_compression)
-        check_fail({'zlib'}, msg_unknown_compression)
-        check_fail({'zstd'}, msg_unknown_compression)
-        check_fail(false, msg_none_table_expected)
-        check_fail({false}, msg_none_table_expected)
-        check_fail({'one', 'two'}, msg_none_table_expected)
-        check_fail({'none', acceleration = 1}, msg_none_table_expected)
+        check_ok({type = 'none'})
+
+        -- Non-str nor map compression value.
+        local msg_map_or_str = 'compression is expected to be a MAP or STR'
+        check_fail(1, msg_map_or_str)
+        check_fail(false, msg_map_or_str)
+
+        -- More than two compression table keys.
+        local msg_no_options = 'CE supports no compression options'
+        check_fail({type = 'none', acceleration = 1}, msg_no_options)
+        check_fail({type = 'none', option = true}, msg_no_options)
+        check_fail({'none', [true] = false}, msg_no_options)
+        check_fail({'none', 'two'}, msg_no_options)
+
+        -- A non-string compression table key.
+        local msg_string_option = 'compression option name must be a string'
+        check_fail({true}, msg_string_option)
+        check_fail({'none'}, msg_string_option)
+        check_fail({[true] = 'none'}, msg_string_option)
+
+        -- A string key other than 'type'.
+        local msg_type_only = "CE only supports 'type' compression table key"
+        check_fail({none = true}, msg_type_only)
+        check_fail({acceleration = 1000}, msg_type_only)
+
+        -- Non-string provided by the 'type' key.
+        local non_string_type = 'non-string compression type'
+        check_fail({type = 1}, non_string_type)
+        check_fail({type = true}, non_string_type)
+        check_fail({type = {table = true}}, non_string_type)
+
+        -- A compression type other than 'none'.
+        local msg_unknown_type = "unknown compression type"
+        check_fail('lz4', msg_unknown_type)
+        check_fail('zlib', msg_unknown_type)
+        check_fail('zstd', msg_unknown_type)
+        check_fail('invalid', msg_unknown_type)
+        check_fail({type = 'lz4'}, msg_unknown_type)
+        check_fail({type = 'zlib'}, msg_unknown_type)
+        check_fail({type = 'zstd'}, msg_unknown_type)
+        check_fail({type = 'invalid'}, msg_unknown_type)
     end, {cg.params.engine})
 end


### PR DESCRIPTION
And drop the option where the compression type is specified by the first element of the compression table. This makes all the table keys consistent (having string type, instead of one having a numeric type).

NO_DOC=ee
NO_CHANGELOG=ee