### PR TITLE
Synchronous Promote - Part 3 - Encapsulate limbo acks collection logic

### DIFF
--- a/changelogs/unreleased/gh-12557-election-wal-queue-max-size-crash.md
+++ b/changelogs/unreleased/gh-12557-election-wal-queue-max-size-crash.md
@@ -1,0 +1,7 @@
+## bugfix/election
+
+* Fixed a bug where a replica could crash or exhibit undefined behavior when
+  the election leader sent this replica a synchronous replication control
+  command (promotion or demotion), but the replica received it just before
+  performing a cascading journal rollback. This could happen if the
+  `wal.queue_max_size` setting was reached (gh-12557).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -1437,9 +1437,11 @@ apply_synchro_req(uint32_t replica_id, struct xrow_header *row, struct synchro_r
 	if (txn_limbo_req_prepare(&txn_limbo, req) < 0)
 		goto err;
 	if (journal_write(&entry.base) != 0) {
-		txn_limbo_req_rollback(&txn_limbo, req);
+		if (!entry.base.is_complete)
+			txn_limbo_req_rollback(&txn_limbo, req);
 		goto err;
 	}
+	assert(entry.base.is_complete);
 	if (entry.base.res < 0) {
 		diag_set_journal_res(entry.base.res);
 		goto err;

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3246,6 +3246,39 @@ box_check_promote(void) {
 	return 0;
 }
 
+/**
+ * Wait until this instance becomes writable, as long as it remains the Raft
+ * leader.
+ */
+static int
+box_wait_for_rw_while_leader(struct raft *raft)
+{
+	assert(is_box_configured);
+	double deadline = ev_monotonic_now(loop()) +
+		replication_synchro_timeout;
+	while (box_is_ro()) {
+		if (raft->state != RAFT_STATE_LEADER) {
+			diag_set(ClientError, ER_INTERFERING_ELECTIONS);
+			return -1;
+		}
+		struct trigger on_update;
+		trigger_create(
+			&on_update,
+			[](struct trigger *t, void *) -> int {
+				fiber_wakeup((struct fiber *)t->data);
+				return 0;
+			}, fiber(), NULL);
+		raft_on_update(raft, &on_update);
+		int rc = fiber_cond_wait_deadline(&ro_cond, deadline);
+		trigger_clear(&on_update);
+		if (rc != 0)
+			return -1;
+	}
+	assert(raft->state == RAFT_STATE_LEADER);
+	assert(!box_is_ro());
+	return 0;
+}
+
 int
 box_promote(void)
 {
@@ -3293,7 +3326,7 @@ box_promote(void)
 		is_in_box_promote = false;
 		if (box_raft_try_promote() != 0)
 			return -1;
-		return box_wait_ro(false, replication_synchro_timeout);
+		return box_wait_for_rw_while_leader(raft);
 	default:
 		unreachable();
 	}

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6503,9 +6503,9 @@ box_storage_init(void)
 	gc_init(on_garbage_collection);
 	engine_init();
 	schema_init();
-	txn_limbo_init(box_raft());
 	journal_on_cascading_rollback = box_on_journal_cascading_rollback;
 	replication_init(cfg_geti_default("replication_threads", 1));
+	txn_limbo_init(box_raft());
 	iproto_init(cfg_geti("iproto_threads"));
 	sql_init();
 	audit_log_init();
@@ -6536,8 +6536,8 @@ box_storage_free(void)
 		return;
 	wal_free();
 	iproto_free();
-	replication_free();
 	txn_limbo_free();
+	replication_free();
 	gc_free();
 	engine_free();
 	flightrec_free();

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2847,45 +2847,6 @@ box_set_instance_name(void)
 	guard.is_active = false;
 }
 
-/** Trigger to catch ACKs from all nodes when need to wait for quorum. */
-struct synchro_quorum_trigger {
-	/** Inherit trigger. */
-	struct trigger base;
-	/** Target LSN to wait for. */
-	int64_t target_lsn;
-	/** Replica ID whose LSN is being waited. */
-	uint32_t replica_id;
-	/**
-	 * All versions of the given replica's LSN as seen by other nodes. The
-	 * same as in the txn limbo.
-	 */
-	struct vclock vclock;
-	/** Number of nodes who confirmed the LSN. */
-	int ack_count;
-	/** Fiber to wakeup when quorum is reached. */
-	struct fiber *waiter;
-};
-
-static int
-synchro_quorum_on_ack_f(struct trigger *trigger, void *event)
-{
-	struct replication_ack *ack = (struct replication_ack *)event;
-	struct synchro_quorum_trigger *t =
-		(struct synchro_quorum_trigger *)trigger;
-	int64_t new_lsn = vclock_get(ack->vclock, t->replica_id);
-	int64_t old_lsn = vclock_get(&t->vclock, ack->source);
-	if (new_lsn < t->target_lsn || old_lsn >= t->target_lsn)
-		return 0;
-
-	vclock_follow(&t->vclock, ack->source, new_lsn);
-	++t->ack_count;
-	if (t->ack_count >= replication_synchro_quorum) {
-		fiber_wakeup(t->waiter);
-		trigger_clear(trigger);
-	}
-	return 0;
-}
-
 static int
 box_check_waiting_for_own_rows_f(struct trigger *trigger, void *event)
 {
@@ -2915,40 +2876,6 @@ box_check_waiting_for_own_rows(void)
 	} else {
 		box_set_waiting_for_own_rows(false);
 	}
-}
-
-/**
- * A helper which count how many nodes have the needed LSN of the given node.
- */
-static int
-box_ack_count(uint32_t lead_id, int64_t target_lsn, struct vclock *vclock)
-{
-	/* Take this node into account immediately. */
-	int ack_count = vclock_get(box_vclock, lead_id) >= target_lsn;
-	replicaset_foreach(replica) {
-		if (relay_get_state(replica->relay) != RELAY_FOLLOW ||
-		    replica->anon)
-			continue;
-
-		assert(replica->id != REPLICA_ID_NIL);
-		assert(!tt_uuid_is_equal(&INSTANCE_UUID, &replica->uuid));
-
-		int64_t lsn = vclock_get(relay_vclock(replica->relay), lead_id);
-		/*
-		 * The replica might not yet received anything from the old
-		 * leader. Easily can happen with a newly added replica. Vclock
-		 * can't be followed then because would assert on lsn > old lsn
-		 * whereas they are both 0.
-		 */
-		if (lsn == 0)
-			continue;
-		vclock_follow(vclock, replica->id, lsn);
-		if (lsn >= target_lsn) {
-			ack_count++;
-			continue;
-		}
-	}
-	return ack_count;
 }
 
 /** box_wait_vclock trigger data. */
@@ -3090,14 +3017,27 @@ box_wait_limbo_acked(double timeout)
 {
 	if (txn_limbo_is_empty(&txn_limbo))
 		return txn_limbo.queue.confirmed_lsn;
-
+#ifndef NDEBUG
+	++errinj(ERRINJ_WAIT_QUORUM_COUNT, ERRINJ_INT)->iparam;
+#endif
 	uint64_t promote_term = txn_limbo.term;
-	struct txn_limbo_entry *last_entry;
-	last_entry = txn_limbo_last_synchro_entry(&txn_limbo);
-	/* Wait for the last entries WAL write. */
-	if (last_entry->lsn < 0) {
-		int64_t tid = last_entry->txn->id;
-		if (txn_persist_all_prepared(NULL) != 0)
+	int64_t tid = txn_limbo_last_synchro_entry(&txn_limbo)->txn->id;
+	double deadline = fiber_clock() + timeout;
+	while (!fiber_is_cancelled()) {
+		int64_t lsn = txn_limbo_last_synchro_entry(&txn_limbo)->lsn;
+		if (lsn > 0 && txn_limbo_has_quorum_for(&txn_limbo, lsn))
+			return lsn;
+		struct trigger on_ack;
+		trigger_create(
+			&on_ack, [](struct trigger *trigger, void *) -> int {
+			fiber_wakeup((struct fiber *)trigger->data);
+			return 0;
+		}, fiber(), NULL);
+		trigger_add(&replicaset.on_ack, &on_ack);
+		int rc = fiber_cond_wait_deadline(&txn_limbo.queue.cond,
+						  deadline);
+		trigger_clear(&on_ack);
+		if (rc != 0)
 			return -1;
 		if (box_check_promote_term_intact(promote_term) != 0)
 			return -1;
@@ -3110,68 +3050,8 @@ box_wait_limbo_acked(double timeout)
 			return -1;
 		}
 	}
-	assert(last_entry->lsn > 0);
-	int64_t wait_lsn = last_entry->lsn;
-
-#ifndef NDEBUG
-	++errinj(ERRINJ_WAIT_QUORUM_COUNT, ERRINJ_INT)->iparam;
-#endif
-	struct synchro_quorum_trigger t;
-	memset(&t, 0, sizeof(t));
-	vclock_create(&t.vclock);
-	int ack_count = box_ack_count(txn_limbo.queue.owner_id, wait_lsn,
-				      &t.vclock);
-	if (ack_count < replication_synchro_quorum) {
-		if (replicaset.registered_count < replication_synchro_quorum)
-			say_warn("replication_synchro_quorum is higher than number of "
-				 "registered replicas. The node will be in RO state "
-				 "because it can't collect acks for synchronous queue");
-		t.target_lsn = wait_lsn;
-		t.replica_id = txn_limbo.queue.owner_id;
-		t.ack_count = ack_count;
-		t.waiter = fiber();
-		trigger_create(&t.base, synchro_quorum_on_ack_f, NULL, NULL);
-		trigger_add(&replicaset.on_ack, &t.base);
-		double deadline = ev_monotonic_now(loop()) + timeout;
-		while (!fiber_is_cancelled() &&
-		       t.ack_count < replication_synchro_quorum) {
-			if (fiber_cond_wait_deadline(&txn_limbo.queue.cond,
-						     deadline) == -1)
-				break;
-		}
-		trigger_clear(&t.base);
-		ack_count = t.ack_count;
-		/*
-		 * No point to proceed after cancellation even if got the
-		 * quorum. The quorum is waited by limbo clear function.
-		 * Emptying the limbo involves a pair of blocking WAL
-		 * writes, making the fiber sleep even longer, which
-		 * isn't appropriate when it's canceled.
-		 */
-		if (fiber_is_cancelled()) {
-			diag_set(FiberIsCancelled);
-			return -1;
-		}
-		if (ack_count < replication_synchro_quorum) {
-			diag_set(TimedOut);
-			return -1;
-		}
-	}
-
-	if (box_check_promote_term_intact(promote_term) != 0)
-		return -1;
-
-	if (txn_limbo_is_empty(&txn_limbo))
-		return txn_limbo.queue.confirmed_lsn;
-
-	if (wait_lsn < txn_limbo_last_synchro_entry(&txn_limbo)->lsn) {
-		diag_set(ClientError, ER_QUORUM_WAIT,
-			 replication_synchro_quorum,
-			 "new synchronous transactions appeared");
-		return -1;
-	}
-
-	return wait_lsn;
+	diag_set(FiberIsCancelled);
+	return -1;
 }
 
 /** A guard to block multiple simultaneous promote()/demote() invocations. */

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3021,7 +3021,6 @@ box_wait_limbo_acked(double timeout)
 	++errinj(ERRINJ_WAIT_QUORUM_COUNT, ERRINJ_INT)->iparam;
 #endif
 	uint64_t promote_term = txn_limbo.term;
-	int64_t tid = txn_limbo_last_synchro_entry(&txn_limbo)->txn->id;
 	double deadline = fiber_clock() + timeout;
 	while (!fiber_is_cancelled()) {
 		int64_t lsn = txn_limbo_last_synchro_entry(&txn_limbo)->lsn;
@@ -3043,12 +3042,6 @@ box_wait_limbo_acked(double timeout)
 			return -1;
 		if (txn_limbo_is_empty(&txn_limbo))
 			return txn_limbo.queue.confirmed_lsn;
-		if (tid != txn_limbo_last_synchro_entry(&txn_limbo)->txn->id) {
-			diag_set(ClientError, ER_QUORUM_WAIT,
-				 replication_synchro_quorum,
-				 "new synchronous transactions appeared");
-			return -1;
-		}
 	}
 	diag_set(FiberIsCancelled);
 	return -1;

--- a/src/box/checkpoint.c
+++ b/src/box/checkpoint.c
@@ -74,17 +74,6 @@ txn_journal_flush(struct journal_checkpoint *out, bool do_journal_rotation)
 	return journal_sync(&out->vclock);
 }
 
-int
-txn_persist_all_prepared(struct vclock *out)
-{
-	struct journal_checkpoint journal;
-	if (txn_journal_flush(&journal, false /* do journal rotation */) != 0)
-		return -1;
-	if (out != NULL)
-		vclock_copy(out, &journal.vclock);
-	return 0;
-}
-
 /** Build a checkpoint of all the transaction-related global states. */
 static int
 txn_checkpoint_build(struct box_checkpoint *out, bool do_journal_rotation)

--- a/src/box/checkpoint.h
+++ b/src/box/checkpoint.h
@@ -62,14 +62,6 @@ int
 box_checkpoint_build_from_snapshot(struct box_checkpoint *out,
 				   const struct vclock *vclock);
 
-/**
- * Wait until all the prepared txns have been successfully written to the
- * journal. However there is not guarantee that they are going to be committed.
- * For synchronous txns just a journal write isn't enough.
- */
-int
-txn_persist_all_prepared(struct vclock *out);
-
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -54,7 +54,6 @@
 #include "xrow_io.h"
 #include "xstream.h"
 #include "wal.h"
-#include "txn_limbo.h"
 #include "raft.h"
 #include "box.h"
 
@@ -673,18 +672,8 @@ tx_status_update(struct cmsg *msg)
 	 * true proper replica must declare itself not anon, and not be expelled
 	 * by the master.
 	 */
-	if (!anon && ack.source != REPLICA_ID_NIL) {
-		/*
-		 * If the limbo has no owner, this will be ack for 0 LSN (since
-		 * acks have vclock[0] decoded as 0 on the receiving side,
-		 * regardless what was send). 0 LSN won't bump quorum and will
-		 * be just nop.
-		 */
-		int64_t lsn = vclock_get(ack.vclock, txn_limbo.queue.owner_id);
-		assert(txn_limbo.queue.owner_id != REPLICA_ID_NIL || lsn == 0);
-		txn_limbo_ack(&txn_limbo, ack.source, lsn);
+	if (!anon && ack.source != REPLICA_ID_NIL)
 		trigger_run(&replicaset.on_ack, &ack);
-	}
 
 	if (!relay->tx.is_paired) {
 		/*

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -669,14 +669,18 @@ tx_status_update(struct cmsg *msg)
 	raft_process_term(box_raft(), status->term, ack.source);
 	/*
 	 * Let pending synchronous transactions know, which of
-	 * them were successfully sent to the replica. Acks are
-	 * collected only by the transactions originator (which is
-	 * the single master in 100% so far). Other instances wait
-	 * for master's CONFIRM message instead.
+	 * them were successfully sent to the replica.
 	 */
-	if (txn_limbo.state == TXN_LIMBO_STATE_LEADER && !anon) {
-		txn_limbo_ack(&txn_limbo, ack.source,
-			      vclock_get(ack.vclock, instance_id));
+	if (!anon) {
+		/*
+		 * If the limbo has no owner, this will be ack for 0 LSN (since
+		 * acks have vclock[0] decoded as 0 on the receiving side,
+		 * regardless what was send). 0 LSN won't bump quorum and will
+		 * be just nop.
+		 */
+		int64_t lsn = vclock_get(ack.vclock, txn_limbo.queue.owner_id);
+		assert(txn_limbo.queue.owner_id != REPLICA_ID_NIL || lsn == 0);
+		txn_limbo_ack(&txn_limbo, ack.source, lsn);
 	}
 	trigger_run(&replicaset.on_ack, &ack);
 

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -654,6 +654,11 @@ tx_status_update(struct cmsg *msg)
 	ack.vclock_sync = status->vclock_sync;
 	bool anon = status->relay->replica->anon;
 	/*
+	 * Zero component must be ignored at all stages and paths of ACKs. Local
+	 * txns acking makes no logical sense.
+	 */
+	assert(vclock_get(ack.vclock, REPLICA_ID_NIL) == 0);
+	/*
 	 * It is important to process the term first and freeze the limbo before
 	 * an ACK if the term was bumped. This is because majority of the
 	 * cluster might be already living in a new term and this ACK is coming
@@ -1017,7 +1022,7 @@ relay_check_status_needs_update(struct relay *relay)
 		{tx_status_update, NULL}
 	};
 	cmsg_init(&status_msg->msg, route);
-	vclock_copy(&status_msg->vclock, send_vclock);
+	vclock_copy_ignore0(&status_msg->vclock, send_vclock);
 	status_msg->txn_lag = relay->txn_lag;
 	status_msg->relay = relay;
 	status_msg->term = last_recv_ack->term;

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -668,10 +668,12 @@ tx_status_update(struct cmsg *msg)
 	 */
 	raft_process_term(box_raft(), status->term, ack.source);
 	/*
-	 * Let pending synchronous transactions know, which of
-	 * them were successfully sent to the replica.
+	 * A replica can declare itself anon, but master might assign it an ID.
+	 * Or replica might be having an ID, but the master can remove it. A
+	 * true proper replica must declare itself not anon, and not be expelled
+	 * by the master.
 	 */
-	if (!anon) {
+	if (!anon && ack.source != REPLICA_ID_NIL) {
 		/*
 		 * If the limbo has no owner, this will be ack for 0 LSN (since
 		 * acks have vclock[0] decoded as 0 on the receiving side,
@@ -681,8 +683,8 @@ tx_status_update(struct cmsg *msg)
 		int64_t lsn = vclock_get(ack.vclock, txn_limbo.queue.owner_id);
 		assert(txn_limbo.queue.owner_id != REPLICA_ID_NIL || lsn == 0);
 		txn_limbo_ack(&txn_limbo, ack.source, lsn);
+		trigger_run(&replicaset.on_ack, &ack);
 	}
-	trigger_run(&replicaset.on_ack, &ack);
 
 	if (!relay->tx.is_paired) {
 		/*

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -1933,11 +1933,10 @@ check_vclock_sync_on_ack(struct trigger *trigger, void *event)
 		(struct sync_trigger_data *)trigger->data;
 	uint32_t id = ack->source;
 	/*
-	 * Anonymous replica acks are not counted for synchronous transactions,
-	 * so linearizable read shouldn't count them as well.
+	 * Messages from anon replicas are skipped on a lower level, as having
+	 * no weight on any decision making.
 	 */
-	if (id == 0)
-		return 0;
+	assert(id != REPLICA_ID_NIL);
 	uint64_t sync = data->vclock_syncs[id];
 	int accounted_count = bit_count_u32(data->collected_vclock_map);
 	if (!bit_test(&data->collected_vclock_map, id) && sync > 0 &&

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -935,8 +935,7 @@ txn_on_journal_write(struct journal_entry *entry)
 		if (txn->fiber != NULL)
 			fiber_wakeup(txn->fiber);
 		assert(txn->limbo_entry->lsn == lsn);
-		if (txn_has_flag(txn, TXN_WAIT_ACK))
-			txn_limbo_ack(&txn_limbo, ack_origin_id, lsn);
+		txn_limbo_ack(&txn_limbo, ack_origin_id, lsn);
 	}
 finish:
 	fiber_set_txn(fiber(), NULL);

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -901,6 +901,7 @@ txn_on_journal_write(struct journal_entry *entry)
 		txn_complete_success(txn);
 	} else {
 		int64_t lsn;
+		uint32_t ack_origin_id;
 		/*
 		 * Synchro lsn is taken from the last global row of a
 		 * transaction. When this is a remote transaction
@@ -909,28 +910,33 @@ txn_on_journal_write(struct journal_entry *entry)
 		 * global row.
 		 */
 		if (txn->n_applier_rows > 0) {
+			ack_origin_id = instance_id;
 			lsn = entry->rows[txn->n_applier_rows - 1]->lsn;
 		} else {
 			int i = entry->n_rows - 1;
 			struct xrow_header **rows = entry->rows;
-			/*
-			 * We don't care which lsn to choose for a fully local
-			 * transaction.
-			 */
 			if (!txn_is_fully_local(txn)) {
 				while (rows[i]->group_id == GROUP_LOCAL)
 					i--;
 				assert(i >= 0);
+				ack_origin_id = instance_id;
+			} else {
+				/*
+				 * Fully local transactions use vclock[0]
+				 * component and their WAL write confirms
+				 * nothing. The code here uses ID nil as
+				 * destination /dev/null for such acks.
+				 */
+				ack_origin_id = REPLICA_ID_NIL;
 			}
 			lsn = rows[i]->lsn;
 		}
 		txn_limbo_assign_lsn(&txn_limbo, txn->limbo_entry, lsn);
 		if (txn->fiber != NULL)
 			fiber_wakeup(txn->fiber);
-		if (txn_limbo.state == TXN_LIMBO_STATE_LEADER &&
-		    txn_has_flag(txn, TXN_WAIT_ACK))
-			txn_limbo_ack(&txn_limbo, txn_limbo.queue.owner_id,
-				      txn->limbo_entry->lsn);
+		assert(txn->limbo_entry->lsn == lsn);
+		if (txn_has_flag(txn, TXN_WAIT_ACK))
+			txn_limbo_ack(&txn_limbo, ack_origin_id, lsn);
 	}
 finish:
 	fiber_set_txn(fiber(), NULL);

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -931,11 +931,10 @@ txn_on_journal_write(struct journal_entry *entry)
 			}
 			lsn = rows[i]->lsn;
 		}
-		txn_limbo_assign_lsn(&txn_limbo, txn->limbo_entry, lsn);
+		txn_limbo_assign_lsn(&txn_limbo, ack_origin_id,
+				     txn->limbo_entry, lsn);
 		if (txn->fiber != NULL)
 			fiber_wakeup(txn->fiber);
-		assert(txn->limbo_entry->lsn == lsn);
-		txn_limbo_ack(&txn_limbo, ack_origin_id, lsn);
 	}
 finish:
 	fiber_set_txn(fiber(), NULL);

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -466,25 +466,9 @@ txn_limbo_req_promote(struct txn_limbo *limbo, uint16_t type, int64_t lsn,
 	return 0;
 }
 
-/**
- * Check that some synchronous transactions have gathered quorum and
- * write a confirmation entry of the last confirmed transaction.
- */
-static void
-txn_limbo_confirm(struct txn_limbo *limbo)
-{
-	assert(limbo->state == TXN_LIMBO_STATE_LEADER);
-	if (limbo->is_in_rollback)
-		return;
-	if (txn_limbo_queue_bump_volatile_confirm(&limbo->queue))
-		fiber_wakeup(limbo->worker);
-}
-
 void
 txn_limbo_ack(struct txn_limbo *limbo, uint32_t replica_id, int64_t lsn)
 {
-	assert(limbo->state == TXN_LIMBO_STATE_LEADER);
-	assert(!txn_limbo_is_ro(limbo));
 	if (txn_limbo_queue_ack(&limbo->queue, replica_id, lsn))
 		fiber_wakeup(limbo->worker);
 }
@@ -501,6 +485,14 @@ int
 txn_limbo_wait_empty(struct txn_limbo *limbo, double timeout)
 {
 	return txn_limbo_queue_wait_empty(&limbo->queue, timeout);
+}
+
+bool
+txn_limbo_has_quorum_for(struct txn_limbo *limbo, int64_t lsn)
+{
+	assert(lsn > 0);
+	return vclock_count_ge(&limbo->queue.vclock, lsn) >=
+	       replication_synchro_quorum;
 }
 
 /**
@@ -988,8 +980,10 @@ void
 txn_limbo_on_parameters_change(struct txn_limbo *limbo)
 {
 	/* The replication_synchro_quorum value may have changed. */
-	if (limbo->state == TXN_LIMBO_STATE_LEADER)
-		txn_limbo_confirm(limbo);
+	if (!limbo->is_in_rollback &&
+	    txn_limbo_is_owned_by_current_instance(limbo) &&
+	     txn_limbo_queue_bump_volatile_confirm(&limbo->queue))
+		fiber_wakeup(limbo->worker);
 	/*
 	 * Wakeup all the others - timed out will rollback. Also
 	 * there can be non-transactional waiters, such as CONFIRM

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -137,6 +137,13 @@ txn_limbo_replica_confirmed_lsn(const struct txn_limbo *limbo,
 	return vclock_get(&limbo->queue.confirmed_vclock, replica_id);
 }
 
+static void
+txn_limbo_ack(struct txn_limbo *limbo, uint32_t replica_id, int64_t lsn)
+{
+	if (txn_limbo_queue_ack(&limbo->queue, replica_id, lsn))
+		fiber_wakeup(limbo->worker);
+}
+
 /**
  * Write a confirmation entry to the WAL. After it's written all the
  * transactions waiting for confirmation may be finished.
@@ -226,6 +233,23 @@ txn_limbo_worker_f(va_list args)
 	return 0;
 }
 
+static int
+txn_limbo_on_ack_f(struct trigger *t, void *event)
+{
+	struct txn_limbo *limbo = t->data;
+	assert(t == &limbo->on_ack);
+	const struct replication_ack *ack = event;
+	/*
+	 * If the limbo has no owner, this will be ack for 0 LSN (since acks
+	 * have vclock[0] decoded as 0 on the receiving side, regardless what
+	 * was send). 0 LSN won't bump quorum and will be just nop.
+	 */
+	int64_t lsn = vclock_get(ack->vclock, limbo->queue.owner_id);
+	assert(limbo->queue.owner_id != REPLICA_ID_NIL || lsn == 0);
+	txn_limbo_ack(limbo, ack->source, lsn);
+	return 0;
+}
+
 static inline void
 txn_limbo_create(struct txn_limbo *limbo, struct raft *raft)
 {
@@ -243,6 +267,8 @@ txn_limbo_create(struct txn_limbo *limbo, struct raft *raft)
 		panic("failed to allocate synchronous queue worker fiber");
 	limbo->worker->f_arg = limbo;
 	fiber_set_joinable(limbo->worker, true);
+	trigger_create(&limbo->on_ack, txn_limbo_on_ack_f, limbo, NULL);
+	trigger_add(&replicaset.on_ack, &limbo->on_ack);
 }
 
 void
@@ -303,6 +329,7 @@ txn_limbo_set_max_size(struct txn_limbo *limbo, int64_t size)
 static inline void
 txn_limbo_destroy(struct txn_limbo *limbo)
 {
+	trigger_clear(&limbo->on_ack);
 	txn_limbo_queue_destroy(&limbo->queue);
 	TRASH(limbo);
 }
@@ -376,10 +403,11 @@ txn_limbo_abort(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 }
 
 void
-txn_limbo_assign_lsn(struct txn_limbo *limbo, struct txn_limbo_entry *entry,
-		     int64_t lsn)
+txn_limbo_assign_lsn(struct txn_limbo *limbo, uint32_t origin_id,
+		     struct txn_limbo_entry *entry, int64_t lsn)
 {
 	txn_limbo_queue_assign_lsn(&limbo->queue, entry, lsn);
+	txn_limbo_ack(limbo, origin_id, lsn);
 }
 
 enum txn_limbo_wait_entry_result
@@ -464,13 +492,6 @@ txn_limbo_req_promote(struct txn_limbo *limbo, uint16_t type, int64_t lsn,
 	synchro_request_write_or_panic(&req);
 	txn_limbo_req_commit(limbo, &req);
 	return 0;
-}
-
-void
-txn_limbo_ack(struct txn_limbo *limbo, uint32_t replica_id, int64_t lsn)
-{
-	if (txn_limbo_queue_ack(&limbo->queue, replica_id, lsn))
-		fiber_wakeup(limbo->worker);
 }
 
 int

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -342,6 +342,12 @@ int
 txn_limbo_wait_empty(struct txn_limbo *limbo, double timeout);
 
 /**
+ * True if enough ACKs are received for the given LSN to consider it confirmed.
+ */
+bool
+txn_limbo_has_quorum_for(struct txn_limbo *limbo, int64_t lsn);
+
+/**
  * Persist limbo state to a given synchro request.
  */
 void

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -171,6 +171,8 @@ struct txn_limbo {
 	 * `confirmed_lsn`.
 	 */
 	struct fiber *worker;
+	/** A trigger invoked on replica acks. */
+	struct trigger on_ack;
 };
 
 /**
@@ -259,15 +261,8 @@ txn_limbo_abort(struct txn_limbo *limbo, struct txn_limbo_entry *entry);
 
 /** Assign the LSN to the queue entry. */
 void
-txn_limbo_assign_lsn(struct txn_limbo *limbo, struct txn_limbo_entry *entry,
-		     int64_t lsn);
-
-/**
- * Ack all transactions up to the given LSN on behalf of the
- * replica with the specified ID.
- */
-void
-txn_limbo_ack(struct txn_limbo *limbo, uint32_t replica_id, int64_t lsn);
+txn_limbo_assign_lsn(struct txn_limbo *limbo, uint32_t origin_id,
+		     struct txn_limbo_entry *entry, int64_t lsn);
 
 /** Try to wait for the given entry's completion. */
 enum txn_limbo_wait_entry_result

--- a/src/box/txn_limbo_queue.c
+++ b/src/box/txn_limbo_queue.c
@@ -120,6 +120,8 @@ txn_limbo_queue_complete_fail(struct txn_limbo_queue *queue,
 	txn->limbo_entry = NULL;
 	txn_limbo_queue_abort(queue, entry);
 	txn_clear_flags(txn, TXN_WAIT_SYNC | TXN_WAIT_ACK);
+	if (entry == queue->entry_to_confirm)
+		queue->entry_to_confirm = NULL;
 	txn_limbo_queue_complete(txn, false);
 }
 
@@ -141,6 +143,8 @@ txn_limbo_queue_complete_success(struct txn_limbo_queue *queue,
 	 * affected transactions.
 	 */
 	assert(txn->signature >= 0);
+	if (entry == queue->entry_to_confirm)
+		queue->entry_to_confirm = NULL;
 	txn_limbo_queue_complete(txn, true);
 }
 
@@ -156,46 +160,6 @@ txn_limbo_queue_rollback_volatile_up_to(struct txn_limbo_queue *queue,
 			break;
 		txn_limbo_queue_complete_fail(queue, e, TXN_SIGNATURE_CASCADE);
 	}
-}
-
-/**
- * Assign a remote LSN to a limbo entry. That happens when a
- * remote transaction is added to the limbo and starts waiting for
- * a confirm.
- */
-static void
-txn_limbo_queue_assign_remote_lsn(struct txn_limbo_queue *queue,
-				  struct txn_limbo_entry *entry, int64_t lsn)
-{
-	VERIFY(queue->owner_id != REPLICA_ID_NIL);
-	assert(!txn_limbo_queue_is_owned_by_current_instance(queue));
-	assert(entry->lsn == -1);
-	assert(lsn > 0);
-	/*
-	 * Same as with local LSN assign, it is given after a WAL write. But for
-	 * remotely received transactions it doesn't matter so far. They don't
-	 * needs ACKs. They wait for explicit confirmations. That will be a
-	 * problem when need acks for anything else and when local txns will
-	 * become optionally non-blocking.
-	 */
-	entry->lsn = lsn;
-}
-
-/**
- * Assign a local LSN to a limbo entry. That happens when a local
- * transaction is written to WAL.
- */
-static void
-txn_limbo_queue_assign_local_lsn(struct txn_limbo_queue *queue,
-				 struct txn_limbo_entry *entry, int64_t lsn)
-{
-	assert(queue->owner_id != REPLICA_ID_NIL);
-	assert(txn_limbo_queue_is_owned_by_current_instance(queue));
-	assert(entry->lsn == -1);
-	assert(lsn > 0);
-	entry->lsn = lsn;
-	if (entry == queue->entry_to_confirm)
-		queue->ack_count = vclock_count_ge(&queue->vclock, entry->lsn);
 }
 
 static int
@@ -504,10 +468,12 @@ void
 txn_limbo_queue_assign_lsn(struct txn_limbo_queue *queue,
 			   struct txn_limbo_entry *entry, int64_t lsn)
 {
-	if (txn_limbo_queue_is_owned_by_current_instance(queue))
-		txn_limbo_queue_assign_local_lsn(queue, entry, lsn);
-	else
-		txn_limbo_queue_assign_remote_lsn(queue, entry, lsn);
+	assert(queue->owner_id != REPLICA_ID_NIL);
+	assert(entry->lsn == -1);
+	assert(lsn > 0);
+	entry->lsn = lsn;
+	if (entry == queue->entry_to_confirm)
+		queue->ack_count = vclock_count_ge(&queue->vclock, entry->lsn);
 }
 
 enum txn_limbo_wait_entry_result
@@ -762,6 +728,14 @@ txn_limbo_queue_transfer_ownership(struct txn_limbo_queue *queue,
 					  new_owner_id);
 	queue->volatile_confirmed_lsn = queue->confirmed_lsn;
 	queue->entry_to_confirm = NULL;
+	/*
+	 * Previous owner had the vclock filled relative to own ID. It means all
+	 * cells in the vclock were different versions of the LSN of the
+	 * previous owner. When the owner is changed, the old vclock and acks
+	 * stop making sense.
+	 */
+	vclock_clear(&queue->vclock);
+	queue->ack_count = 0;
 }
 
 bool
@@ -769,6 +743,8 @@ txn_limbo_queue_ack(struct txn_limbo_queue *queue, uint32_t replica_id,
 		    int64_t lsn)
 {
 	if (rlist_empty(&queue->entries))
+		return false;
+	if (replica_id == REPLICA_ID_NIL)
 		return false;
 	assert(queue->owner_id != REPLICA_ID_NIL);
 	int64_t prev_lsn = vclock_get(&queue->vclock, replica_id);
@@ -783,7 +759,6 @@ txn_limbo_queue_ack(struct txn_limbo_queue *queue, uint32_t replica_id,
 	if (lsn == prev_lsn)
 		return false;
 	vclock_follow(&queue->vclock, replica_id, lsn);
-
 	if (queue->entry_to_confirm == NULL ||
 	    queue->entry_to_confirm->lsn < 0)
 		return false;
@@ -797,7 +772,6 @@ txn_limbo_queue_ack(struct txn_limbo_queue *queue, uint32_t replica_id,
 bool
 txn_limbo_queue_bump_volatile_confirm(struct txn_limbo_queue *queue)
 {
-	assert(txn_limbo_queue_is_owned_by_current_instance(queue));
 	if (queue->entry_to_confirm == NULL ||
 	    queue->entry_to_confirm->lsn == -1)
 		return false;
@@ -810,6 +784,7 @@ txn_limbo_queue_bump_volatile_confirm(struct txn_limbo_queue *queue)
 	 * vclock_size(&queue->vclock) >= replication_synchro_quorum
 	 */
 	assert(k >= 0);
+	assert(!rlist_empty(&queue->entries));
 	int64_t confirm_lsn = vclock_nth_element(&queue->vclock, k);
 	assert(confirm_lsn >= queue->entry_to_confirm->lsn);
 	struct txn_limbo_entry *e = queue->entry_to_confirm;
@@ -834,7 +809,7 @@ txn_limbo_queue_bump_volatile_confirm(struct txn_limbo_queue *queue)
 		}
 	}
 	assert(max_assigned_lsn != -1);
-	assert(max_assigned_lsn > queue->volatile_confirmed_lsn);
+	assert(max_assigned_lsn >= queue->volatile_confirmed_lsn);
 	queue->volatile_confirmed_lsn = max_assigned_lsn;
 	return true;
 }

--- a/test/replication-luatest/election_new_txns_during_leader_promote_acks_test.lua
+++ b/test/replication-luatest/election_new_txns_during_leader_promote_acks_test.lua
@@ -1,0 +1,294 @@
+local t = require('luatest')
+local cluster = require('luatest.replica_set')
+local server = require('luatest.server')
+
+local g = t.group('cover-box-wait-limbo-acked')
+local wait_timeout = 120
+
+local function wait_pair_sync(server1, server2)
+    t.helpers.retrying({timeout = wait_timeout}, function()
+        server1:wait_for_vclock_of(server2)
+        server2:wait_for_vclock_of(server1)
+        server1:assert_follows_upstream(server2:get_instance_id())
+        server2:assert_follows_upstream(server1:get_instance_id())
+    end)
+end
+
+local function wait_full_sync(cg, names)
+    for _, name1 in pairs(names) do
+        for _, name2 in pairs(names) do
+            if name1 ~= name2 then
+                wait_pair_sync(cg[name1], cg[name2])
+            end
+        end
+    end
+end
+
+--
+-- The test covers the following scenario:
+-- 1. A node had a transaction from the old leader.
+-- 2. The node starts elections.
+-- 3. It receives a new transaction from the old leader, while the elections are
+--   already ongoing.
+-- 4. It receives votes and wins the elections.
+-- 5. It waits for a quorum on both txns.
+-- 6. It writes PROMOTE and becomes a true leader.
+--
+-- The expected behaviour is that the node will wait for both transactions to
+-- gain the quorum. Not like it would only collect quorum for whatever
+-- transaction was the last at the moment of elections start.
+--
+
+g.before_each(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.cluster = cluster:new({})
+    cg.test_make_uri = function(name)
+        return server.build_listen_uri(name, cg.cluster.id)
+    end
+    --
+    -- The test tries to reproduce the case in a realistic way with as few
+    -- error injections as possible, without manipulating the quorum in an
+    -- unreal way, and without using election_mode='off', which is broken
+    -- anyway.
+    --
+    -- For that the test needs many nodes, used for certain roles declared in
+    -- their names. Although technically all the nodes here are identical in
+    -- their setup.
+    --
+    local all_names = {'node1', 'node2', 'voter3', 'voter4', 'stash5'}
+    local box_cfg = {
+        replication = {},
+        replication_synchro_quorum = 3,
+        replication_synchro_timeout = 100000,
+        replication_timeout = 0.1,
+        election_fencing_mode='off',
+        election_timeout = 1000,
+        replication_reconnect_timeout = 0.1,
+    }
+    for _, name in pairs(all_names) do
+        table.insert(box_cfg.replication, cg.test_make_uri(name))
+    end
+    for _, name in pairs(all_names) do
+        if name == 'node1' then
+            box_cfg.election_mode = 'manual'
+        else
+            box_cfg.election_mode = 'voter'
+        end
+        cg[name] = cg.cluster:build_and_add_server({
+            alias = name,
+            box_cfg = box_cfg
+        })
+    end
+    cg.cluster:start()
+    --
+    -- Restart replication to apply the new timeout. Just setting the timeout
+    -- isn't enough, because some already waiting calls in relay/applier still
+    -- can be waiting on the old timeout. Need to restart all these places.
+    --
+    for _, name in pairs(all_names) do
+        cg[name]:update_box_cfg({
+            election_mode = 'manual',
+            replication_timeout = 1000,
+            replication = {},
+        })
+    end
+    for _, name in pairs(all_names) do
+        cg[name]:update_box_cfg({replication = box_cfg.replication})
+    end
+    wait_full_sync(cg, all_names)
+    cg.node1:exec(function()
+        box.ctl.promote()
+        box.schema.space.create('test', {is_sync = true})
+        box.space.test:create_index('pk')
+    end)
+    wait_full_sync(cg, all_names)
+    cg.test_fullmesh_replication = box_cfg.replication
+    cg.test_all_names = all_names
+end)
+
+g.after_each(function(cg)
+    cg.cluster:drop()
+end)
+
+g.test_new_synchronous_transactions_appeared_while_wait_quorum = function(cg)
+    --
+    -- Split the cluster:
+    --
+    -- {node1, stash5}
+    -- {node2, voter3, voter4}
+    --
+    local cfg_replication_15 = {
+        cg.test_make_uri('node1'),
+        cg.test_make_uri('stash5'),
+    }
+    cg.node1:update_box_cfg({replication = cfg_replication_15})
+    cg.stash5:update_box_cfg({replication = cfg_replication_15})
+    local cfg_replication_234 = {
+        cg.test_make_uri('node2'),
+        cg.test_make_uri('voter3'),
+        cg.test_make_uri('voter4'),
+    }
+    cg.node2:update_box_cfg({replication = cfg_replication_234})
+    cg.voter3:update_box_cfg({replication = cfg_replication_234})
+    cg.voter4:update_box_cfg({replication = cfg_replication_234})
+    --
+    -- Node1 makes a txn and stashes it on the stash5 node.
+    --
+    cg.node1:exec(function()
+        local fiber = require('fiber')
+        rawset(_G, 'f_txn1', fiber.new(function()
+            box.space.test:replace{1}
+        end))
+    end)
+    cg.stash5:exec(function(timeout)
+        t.helpers.retrying({timeout = timeout}, function()
+            t.assert_equals(box.info.synchro.queue.len, 1)
+        end)
+    end, {wait_timeout})
+    --
+    -- Node1 and stash5 are fully isolated alone.
+    --
+    cg.node1:update_box_cfg({replication = {}})
+    cg.stash5:update_box_cfg({replication = {}})
+    --
+    -- Node1 makes a second txn.
+    --
+    cg.node1:exec(function()
+        local fiber = require('fiber')
+        rawset(_G, 'f_txn2', fiber.new(function()
+            box.space.test:replace{2}
+        end))
+    end)
+    --
+    -- The state now is:
+    --
+    -- {node1:  ?txn1, ?txn2}
+    -- {node2, voter3, voter4}
+    -- {stash5: ?txn1}
+    --
+    -- Node2 must start new elections. But the test must not allow it to win
+    -- yet. It must only let it broadcast the vote request. Then node2 would be
+    -- controllably stuck in ongoing elections.
+    --
+    -- For that make the voters stop WAL writes when they receive a vote
+    -- request.
+    --
+    local block_on_vote_f = function(timeout)
+        local fiber = require('fiber')
+        rawset(_G, 'f_block_until_vote', fiber.new(function()
+            fiber.self():set_joinable(true)
+            repeat
+                fiber.testcancel()
+                box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+                box.error.injection.set('ERRINJ_WAL_DELAY', false)
+                t.helpers.retrying({timeout = timeout}, function()
+                    if pcall(fiber.testcancel) then
+                        t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+                    end
+                end)
+            until box.info.election.vote ~= 0
+        end))
+    end
+    cg.voter3:exec(block_on_vote_f, {wait_timeout})
+    cg.voter4:exec(block_on_vote_f, {wait_timeout})
+    --
+    -- Node2 starts promotion.
+    --
+    cg.node2:exec(function()
+        local fiber = require('fiber')
+        rawset(_G, 'f_promote', fiber.new(function()
+            fiber.self():set_joinable(true)
+            box.ctl.promote()
+        end))
+    end)
+    --
+    -- The voters receive the vote request.
+    --
+    local finish_vote_f = function(timeout)
+        t.assert((_G.f_block_until_vote:join(timeout)))
+        t.assert_not_equals(box.info.election.vote, 0)
+        -- And must not download whatever will be happening with node2.
+        box.cfg{replication = {}}
+    end
+    cg.voter3:exec(finish_vote_f, {wait_timeout})
+    cg.voter4:exec(finish_vote_f, {wait_timeout})
+    --
+    -- The state now:
+    --
+    -- {node1: ?txn1, ?txn2}
+    -- {node2: candidate}
+    -- {voter3, voter4: prepared to vote for node2}
+    -- {stash5: ?txn1}
+    --
+    -- While the voters are "thinking", the candidate node2 receives txn1 made
+    -- by the old leader. Stash5 node (which only has txn1) will provide it.
+    --
+    local cfg_replication_25 = {
+        cg.test_make_uri('node2'),
+        cg.test_make_uri('stash5'),
+    }
+    cg.node2:update_box_cfg({replication = cfg_replication_25})
+    --
+    -- The voters finish their votes. Not responding to node2 yet. There is no
+    -- replication between them.
+    --
+    local finish_wal_work_f = function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end
+    cg.voter3:exec(finish_wal_work_f)
+    cg.voter4:exec(finish_wal_work_f)
+    --
+    -- Node2, still candidate, receives txn1 from stash5. It is received after
+    -- node2 has already started elections, but before the elections are won.
+    --
+    cg.stash5:update_box_cfg({replication = cfg_replication_25})
+    cg.node2:exec(function(timeout)
+        t.helpers.retrying({timeout = timeout}, function()
+            t.assert_equals(box.info.synchro.queue.len, 1)
+        end)
+    end, {wait_timeout})
+    --
+    -- The voters send their votes to node2, which in turn wins the elections.
+    -- But it can't be promoted yet, because it needs to gain a quorum on the
+    -- txn1. This won't happen, because the voter nodes download nothing from
+    -- node2 and won't ack txn1. Only node1 downloads from the voters, not vice
+    -- versa.
+    --
+    cg.node2:update_box_cfg({replication = cfg_replication_234})
+    cg.node2:exec(function(timeout)
+        t.helpers.retrying({timeout = timeout}, function()
+            t.assert_equals(box.info.election.state, 'leader')
+        end)
+        -- Promotion isn't done yet, although the elections are won.
+        t.assert_lt(box.info.synchro.queue.term, box.info.election.term)
+    end, {wait_timeout})
+    --
+    -- While waiting, node2 receives the txn2 from node1. This txn was received
+    -- after winning the elections, but before writing PROMOTE.
+    --
+    cg.node2:update_box_cfg({replication = cg.test_fullmesh_replication})
+    cg.node2:exec(function(timeout)
+        t.helpers.retrying({timeout = timeout}, function()
+            t.assert_equals(box.info.synchro.queue.len, 2)
+        end)
+        t.assert_equals(box.info.election.state, 'leader')
+        t.assert_lt(box.info.synchro.queue.term, box.info.election.term)
+    end, {wait_timeout})
+    --
+    -- All replication is restored.
+    --
+    for _, name in pairs(cg.test_all_names) do
+        cg[name]:update_box_cfg({replication = cg.test_fullmesh_replication})
+    end
+    --
+    -- The node2 must wait for the last txn (txn2) to gain the quorum and write
+    -- PROMOTE including this txn. Even though it was received after winning the
+    -- elections.
+    --
+    cg.node2:exec(function(timeout)
+        t.assert((_G.f_promote:join(timeout)))
+        t.assert_equals(box.info.election.state, 'leader')
+        t.assert_equals(box.info.synchro.queue.term, box.info.election.term)
+        t.assert_equals(box.space.test:select(), {{1}, {2}})
+    end, {wait_timeout})
+end

--- a/test/replication-luatest/gh_10040_promote_wait_limbo_test.lua
+++ b/test/replication-luatest/gh_10040_promote_wait_limbo_test.lua
@@ -10,7 +10,7 @@ g.before_all(function(cg)
     local config = {
         election_mode = 'manual',
         replication = {master_uri, replica_uri},
-        replication_synchro_timeout = 30
+        replication_synchro_timeout = 1000
     }
     cg.master = cg.replica_set:build_and_add_server({
         alias = 'master',
@@ -43,14 +43,14 @@ g.test_promote_waits_for_quorum = function(cg)
     cg.replica:exec(function()
         local fiber = require('fiber')
         box.cfg{replication_synchro_quorum = 3}
-        t.helpers.retrying({timeout = 5}, function()
+        t.helpers.retrying({timeout = 60}, function()
             t.assert_gt(box.info.synchro.queue.len, 0)
         end)
         local prom_fiber = fiber.new(function()
             return pcall(box.ctl.promote)
         end)
         prom_fiber:set_joinable(true)
-        t.helpers.retrying({timeout = 5}, function()
+        t.helpers.retrying({timeout = 60}, function()
             t.assert_equals(box.info.election.state, 'leader')
         end)
         local is_finished, _ = prom_fiber:join(0.01)
@@ -60,4 +60,52 @@ g.test_promote_waits_for_quorum = function(cg)
         t.assert_not(err)
         t.assert_not(box.info.ro)
     end)
+    --
+    -- Cleanup.
+    --
+    cg.master:wait_for_vclock_of(cg.replica)
+    cg.master:exec(function()
+        box.cfg{replication_synchro_quorum = box.NULL}
+        box.ctl.promote()
+    end)
+    cg.replica:exec(function()
+        box.cfg{replication_synchro_quorum = box.NULL}
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+end
+
+g.test_promote_aborts_wait_when_not_leader = function(cg)
+    cg.master:exec(function()
+        local fiber = require('fiber')
+        box.ctl.demote()
+        t.assert_equals(box.info.election.leader, 0)
+        box.cfg{read_only = true}
+        local is_promote_finished = false
+        local f = fiber.new(function()
+            local ok, err = pcall(box.ctl.promote)
+            is_promote_finished = true
+            return {ok, err}
+        end)
+        f:set_joinable(true)
+        t.helpers.retrying({timeout = 60}, function()
+            local info = box.info
+            t.assert_equals(info.election.leader, info.id)
+            t.assert_equals(info.election.term, info.synchro.queue.term)
+            t.assert_equals(info.synchro.queue.owner, info.id)
+        end)
+        t.assert(box.info.ro)
+        t.assert_not(is_promote_finished)
+        box.ctl.demote()
+        local ok, err = f:join(60)
+        t.assert(ok)
+        ok, err = unpack(err)
+        t.assert(err)
+        t.assert_not(ok)
+        --
+        -- Cleanup.
+        --
+        box.cfg{read_only = false}
+        box.ctl.promote()
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
 end

--- a/test/replication-luatest/gh_10727_no_local_rows_test.lua
+++ b/test/replication-luatest/gh_10727_no_local_rows_test.lua
@@ -54,12 +54,13 @@ end
 local function write_subscribe(s, version_id, instance_uuid, rs_uuid, vclock)
     local header = {
         [key.REQUEST_TYPE] = box.iproto.type.SUBSCRIBE,
-        [key.SYNC] = version_id,
+        [key.SYNC] = 1,
     }
     local body = {
         [key.REPLICASET_UUID] = rs_uuid,
         [key.INSTANCE_UUID] = instance_uuid,
         [key.VCLOCK] = encode_map(vclock),
+        [key.SERVER_VERSION] = version_id,
     }
     return socket_write(s, header, body)
 end

--- a/test/replication-luatest/gh_11574_hang_in_box_wait_quorum_test.lua
+++ b/test/replication-luatest/gh_11574_hang_in_box_wait_quorum_test.lua
@@ -67,7 +67,7 @@ local function capture_synchro_queue_and_push_sync_transaction(server)
         box.atomic({wait = "submit"}, function() box.space.s:replace{0} end)
         t.assert_equals(box.info.synchro.queue.len, 1)
         -- So that we have the opportunity to perform some actions during
-        -- hang in box_wait_quorum, we wrap the last box.ctl.promote into
+        -- hang in quorum waiting code, we wrap the last box.ctl.promote into
         -- fiber and join it after some actions. In our case this action
         -- is reconfiguring of replication_synchro_quorum.
         box.cfg{election_mode = "manual"}
@@ -81,7 +81,7 @@ end
 
 local function wait_until_synchro_queue_is_empty(server)
     -- In some rare cases the limbo may not be cleared in time after
-    -- successful completion of box_wait_quorum. We should wrap it
+    -- successful completion of quorum wait. We should wrap it
     -- into retrying block.
     server:exec(function()
         t.helpers.retrying({}, function()
@@ -96,8 +96,8 @@ g.test_box_wait_quorum_while_changing_replication_synchro_quorum = function(g)
     g.server1:exec(function()
         -- It is necessary to wait until the g.server1 enters the leader state,
         -- because otherwise the reconfiguration may appear earlier than
-        -- the invocation of the box_wait_quorum with higher quorum - 4.
-        -- The reconfiguration must be performed strctly after box_wait_quorum
+        -- the quorum wait starts with higher quorum - 4.
+        -- The reconfiguration must be performed strctly after the quorum wait
         -- starts and hangs.
         t.helpers.retrying({}, function()
             t.assert_equals(box.info.election.state, "leader")

--- a/test/replication-luatest/gh_12557_election_applier_wal_queue_fail_test.lua
+++ b/test/replication-luatest/gh_12557_election_applier_wal_queue_fail_test.lua
@@ -1,0 +1,109 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local cluster = require('luatest.replica_set')
+
+local wait_timeout = 120
+local g = t.group()
+
+g.before_all(function(g)
+    t.tarantool.skip_if_not_debug()
+    g.cluster = cluster:new({})
+    local box_cfg = {
+        replication_timeout = 0.1,
+        replication_synchro_quorum = 1,
+        replication_synchro_timeout = 1000,
+        election_mode = 'manual',
+        replication = {
+            server.build_listen_uri('server1', g.cluster.id),
+            server.build_listen_uri('server2', g.cluster.id),
+        },
+    }
+    g.server1 = g.cluster:build_and_add_server({
+        alias = 'server1', box_cfg = box_cfg
+    })
+    box_cfg.election_mode = 'voter'
+    box_cfg.wal_queue_max_size = 1
+    g.server2 = g.cluster:build_and_add_server({
+        alias = 'server2', box_cfg = box_cfg
+    })
+    g.cluster:start()
+    g.server1:exec(function()
+        local s = box.schema.create_space('test_local', {is_local = true})
+        s:create_index('pk')
+    end)
+    g.server2:wait_for_vclock_of(g.server1)
+end)
+g.after_all(function(g)
+    g.cluster:drop()
+end)
+
+--
+-- gh-12557: there was a bug that if a synchronous request in applier was rolled
+-- back while waiting in the journal's volatile queue, then it would try to be
+-- rolled back second time and in case of PROMOTE/DEMOTE it would crash in
+-- debug + have undefined behaviour in release.
+--
+-- But ideally it must just break the replication in a recoverable way.
+--
+g.test_case = function(g)
+    --
+    -- The next incoming PROMOTE will get blocked before starting a WAL write.
+    --
+    g.server2:exec(function()
+        box.error.injection.set('ERRINJ_TXN_LIMBO_BEGIN_DELAY_COUNTDOWN', 0)
+    end)
+    --
+    -- Server 1 sends a PROMOTE.
+    --
+    local term = g.server1:exec(function()
+        box.ctl.demote()
+        box.ctl.promote()
+        return box.info.synchro.queue.term
+    end)
+    g.server2:exec(function(timeout, term)
+        local fiber = require('fiber')
+        --
+        -- The PROMOTE is received.
+        --
+        t.helpers.retrying({timeout = timeout}, function()
+            t.assert(box.error.injection.get('ERRINJ_TXN_LIMBO_BEGIN_DELAY'))
+        end)
+        --
+        -- But before it a transaction manages to squeeze in and it takes the
+        -- whole WAL queue, forcing the PROMOTE journal entry to wait in the
+        -- volatile state.
+        --
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+        local f = fiber.create(function()
+            fiber.self():set_joinable(true)
+            box.space.test_local:replace{1}
+        end)
+        box.error.injection.set('ERRINJ_TXN_LIMBO_BEGIN_DELAY', false)
+        t.helpers.retrying({timeout = timeout}, function()
+            t.assert(box.info.synchro.queue.busy)
+        end)
+        --
+        -- And the transaction fails to be written to WAL. Which causes
+        -- cascading rollback of the PROMOTE entry.
+        --
+        box.error.injection.set('ERRINJ_WAL_ROTATE', true)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        local ok, err = f:join(timeout)
+        t.assert(err)
+        t.assert_not(ok)
+        t.helpers.retrying({timeout = timeout}, function()
+            t.assert_not(box.info.synchro.queue.busy)
+        end)
+        box.error.injection.set('ERRINJ_WAL_ROTATE', false)
+        t.assert_lt(box.info.synchro.queue.term, term)
+        --
+        -- Replication can be restarted and fixed easy.
+        --
+        local repl = box.cfg.replication
+        box.cfg{replication = {}}
+        box.cfg{replication = repl}
+        t.helpers.retrying({timeout = timeout}, function()
+            t.assert_equals(box.info.synchro.queue.term, term)
+        end)
+    end, {wait_timeout, term})
+end

--- a/test/replication-luatest/gh_7318_box_wait_limbo_acked_test.lua
+++ b/test/replication-luatest/gh_7318_box_wait_limbo_acked_test.lua
@@ -2,11 +2,12 @@ local t = require('luatest')
 local cluster = require('luatest.replica_set')
 local proxy = require('luatest.replica_proxy')
 local server = require('luatest.server')
+local assertions = require('luatest.assertions')
 
 local g = t.group('cover-box-wait-limbo-acked')
 --
 -- gh-7318:
--- Cover box_wait_limbo_acked with tests.
+-- Cover promotion's synchro queue quorum wait with tests.
 --
 local wait_timeout = 10
 
@@ -71,22 +72,6 @@ local function server_wait_wait_quorum_count_ge_than(server, threshold)
     end, {threshold, wait_timeout})
 end
 
-local function server_wait_synchro_queue_is_busy(server)
-    server:exec(function(wait_timeout)
-        t.helpers.retrying({timeout = wait_timeout}, function()
-            t.assert_equals(box.info.synchro.queue.busy, true)
-        end, {wait_timeout})
-    end)
-end
-
-local function server_wait_promote_greatest_term_ge_than(server, threshold)
-    server:exec(function(threshold, wait_timeout)
-        t.helpers.retrying({timeout = wait_timeout}, function(threshold)
-            t.assert_ge(box.info.synchro.queue.term, threshold)
-        end, threshold)
-    end, {threshold, wait_timeout})
-end
-
 g.before_each(function(cg)
     t.tarantool.skip_if_not_debug()
 
@@ -146,254 +131,60 @@ g.after_each(function(cg)
     cg.replica_proxy:stop()
 end)
 
-g.test_wal_sync_fails = function(cg)
-    -- The purpose of the test is to cover 'if (wal_sync(NULL) != 0)' in
-    -- 'box_wait_limbo_acked()'. For this we use a special injection -
-    -- 'ERRINJ_WAL_SYNC'.
-    local f = cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
-        local f = require('fiber').create(function()
-            return pcall(box.ctl.promote)
-        end)
-        f:set_joinable(true)
-        return f:id()
-    end)
-    -- We want the new term to be written strictly before insert.
-    server_wait_wal_is_blocked(cg.replica)
-    cg.master:exec(function()
-        require('fiber').create(function() box.space.test:insert{1} end)
-    end)
-    -- We need to make sure that one entry is in limbo so that
-    -- we don't exit 'box_wait_limbo_acked()' immediately after
-    -- 'if (txn_limbo_is_empty(&txn_limbo))'.
-    server_wait_synchro_queue_len_is_equal(cg.replica, 1)
-    -- We allow one entry to be written to exit
-    -- 'box_raft_wait_term_persisted()'. But we don't allow insert to be
-    -- written to ensure it hits 'if (last_entry->lsn < 0)' and then enters
-    -- 'wal_sync()' call.
-    cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_SYNC', true)
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
-        box.error.injection.set('ERRINJ_WAL_DELAY', false)
-    end)
-    -- We need to be sure we entered the wal_sync call
-    -- before allowing the rest of the entries to be written.
-    server_wait_wal_is_blocked(cg.replica)
-    cg.replica:exec(function(f)
-        t.assert_equals(box.info.synchro.queue.len, 1)
-        box.error.injection.set('ERRINJ_WAL_SYNC', false)
-        box.error.injection.set('ERRINJ_WAL_DELAY', false)
-        local _, ok, err = require('fiber').find(f):join()
-        t.assert(not ok)
-        t.assert_equals(err.type, 'ClientError')
-        t.assert_equals(err.message, 'Error injection \'wal sync\'')
-    end, {f})
-    server_becomes_the_leader_again(cg.master)
-    server_wait_synchro_queue_len_is_equal(cg.replica, 0)
-end
-
-g.test_update_greatest_term_while_wal_sync = function(cg)
-    -- The purpose of the test is to cover
-    -- 'if (box_check_promote_term_intact(promote_term) != 0)' in
-    -- 'box_wait_limbo_acked()' located immediately after 'wal_sync()' call.
-    -- For this we use a special injection - 'ERRINJ_WAL_SYNC_DELAY'.
-    local term = cg.replica:get_election_term()
-    local f = cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_SYNC_DELAY', true)
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
-        local f = require('fiber').create(function()
-            return pcall(box.ctl.promote)
-        end)
-        f:set_joinable(true)
-        return f:id()
-    end)
-    cg.replica:wait_for_election_term(term + 1)
-    server_wait_wal_is_blocked(cg.replica)
-    cg.master:exec(function()
-        require('fiber').create(function() box.space.test:insert{1} end)
-        require('fiber').create(function() box.ctl.demote() end)
-    end)
-    server_wait_synchro_queue_len_is_equal(cg.replica, 1)
-    cg.replica:wait_for_election_term(term + 2)
-    cg.master:exec(function()
-        box.cfg{replication_synchro_quorum=1}
-    end)
-    cg.master:wait_until_election_leader_found()
-    cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
-        box.error.injection.set('ERRINJ_WAL_DELAY', false)
-    end)
-    server_wait_wal_is_blocked(cg.replica)
-    cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_DELAY', false)
-    end)
-    -- Before leaving wal_sync we need to make sure that
-    -- 'promote_greatest_term' is updated.
-    server_wait_promote_greatest_term_ge_than(cg.replica, 3)
-    cg.replica:exec(function(f)
-        box.error.injection.set('ERRINJ_WAL_SYNC_DELAY', false)
-        local _, ok, err = require('fiber').find(f):join()
-        t.assert(not ok)
-        t.assert_equals(err.type, 'ClientError')
-        t.assert_equals(err.message, 'Instance with replica id 1 '
-            .. 'was promoted first')
-    end, {f})
-    server_wait_synchro_queue_len_is_equal(cg.replica, 0)
-end
-
-g.test_txn_limbo_is_empty_while_wal_sync = function(cg)
-    -- The purpose of the test is to cover
-    -- 'if (txn_limbo_is_empty(&txn_limbo))' in
-    -- 'box_wait_limbo_acked()' located immediately after 'wal_sync()' call.
-    -- For this we use a special injection - 'ERRINJ_WAL_SYNC_DELAY'.
-
-    -- If the master becomes a leader again, we will cover the condition
-    -- from the previous test, and not what we want.
-    cg.master:exec(function()
-        box.cfg{
-            election_mode='off',
-            replication_synchro_quorum=1
-        }
-    end)
-    local f = cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_SYNC_DELAY', true)
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
-        local f = require('fiber').create(function()
-            return pcall(box.ctl.promote)
-        end)
-        f:set_joinable(true)
-        return f:id()
-    end)
-    server_wait_wal_is_blocked(cg.replica)
-    cg.master:exec(function()
-        box.space.test:insert{1}
-    end)
-    server_wait_synchro_queue_len_is_equal(cg.replica, 1)
-    server_wait_synchro_queue_is_busy(cg.replica)
-    cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
-        box.error.injection.set('ERRINJ_WAL_DELAY', false)
-    end)
-    server_wait_wal_is_blocked(cg.replica)
-    cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_DELAY', false)
-    end)
-    server_wait_synchro_queue_len_is_equal(cg.replica, 0)
-    cg.replica:exec(function(f)
-        box.error.injection.set('ERRINJ_WAL_SYNC_DELAY', false)
-        local _, ok, err = require('fiber').find(f):join()
-        t.assert(ok)
-        t.assert(not err)
-    end, {f})
-    server_becomes_the_leader_again(cg.master)
-    server_wait_synchro_queue_len_is_equal(cg.replica, 0)
-end
-
-g.test_new_synchronous_transactions_appeared_while_wal_sync = function(cg)
-    -- The purpose of the test is to cover
-    -- 'if (tid != txn_limbo_last_synchro_entry(&txn_limbo)->txn->id)' in
-    -- 'box_wait_limbo_acked()' located immediately after 'wal_sync()' call.
-    local f = cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
-        local f = require('fiber').create(function()
-            return pcall(box.ctl.promote)
-        end)
-        f:set_joinable(true)
-        return f:id()
-    end)
-    server_wait_wal_is_blocked(cg.replica)
-    cg.master:exec(function()
-        require('fiber').create(function() box.space.test:insert{1} end)
-    end)
-    server_wait_synchro_queue_len_is_equal(cg.replica, 1)
-    cg.master:exec(function()
-        -- We don’t let the second insert immediately get to the follower.
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
-        require('fiber').create(function() box.space.test:insert{2} end)
-    end)
-    cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
-        box.error.injection.set('ERRINJ_WAL_DELAY', false)
-    end)
-    server_wait_wal_is_blocked(cg.replica)
-    cg.master:exec(function()
-        -- Follower is now in 'wal_sync' so we can write the second insert.
-        box.error.injection.set('ERRINJ_WAL_DELAY', false)
-    end)
-    server_wait_synchro_queue_len_is_equal(cg.replica, 2)
-    cg.replica:exec(function(f)
-        box.error.injection.set('ERRINJ_WAL_DELAY', false)
-        local _, ok, err = require('fiber').find(f):join()
-        t.assert(not ok)
-        t.assert_equals(err.type, 'ClientError')
-        t.assert_equals(err.message, 'Couldn\'t wait for quorum 2: '
-            .. 'new synchronous transactions appeared')
-    end, {f})
-    server_becomes_the_leader_again(cg.master)
-    server_wait_synchro_queue_len_is_equal(cg.replica, 0)
-end
-
 g.test_update_greatest_term_while_wait_quorum = function(cg)
-    -- The purpose of the test is to cover
-    -- 'if (box_check_promote_term_intact(promote_term) != 0)' in
-    -- 'box_wait_limbo_acked()' located immediately after 'box_wait_quorum()'.
-    local f = cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
-        local f = require('fiber').create(function()
-            return pcall(box.ctl.promote)
-        end)
-        f:set_joinable(true)
-        return f:id()
-    end)
-    server_wait_wal_is_blocked(cg.replica)
-    -- In some tests we want to stop fiber 'f' at 'box_wait_quorum'.
-    -- Therefore, we pause replica_proxy.
-    cg.replica_proxy:pause()
-    -- We wait until the connection is suspended.
-    t.helpers.retrying({timeout = wait_timeout}, function()
-        cg.master:exec(function()
-            local status = box.info.replication[2].upstream.status
-            t.assert(status ~= 'follow')
-        end)
-    end)
-    cg.master:exec(function()
-        require('fiber').create(function() box.space.test:insert{1} end)
-    end)
-    server_wait_synchro_queue_len_is_equal(cg.replica, 1)
+    -- The purpose of the test is to cover synchro queue term bump right after
+    -- the quorum for pending transactions was gathered.
     cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
-        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        box.cfg{election_mode = 'manual'}
     end)
-    server_wait_wal_is_blocked(cg.replica)
-    local wait_quorum_count = get_wait_quorum_count(cg.replica)
-    local ff = require('fiber').create(function()
-        cg.replica:exec(function(f)
-            box.error.injection.set('ERRINJ_WAL_DELAY', false)
-            local _, ok, err = require('fiber').find(f):join()
-            t.assert(not ok)
-            t.assert_equals(err.type, 'ClientError')
-            local master_id = box.info.replication[1].id
-            t.assert_equals(err.message, 'Instance with replica id '
-                .. master_id .. ' was promoted first')
-        end, {f})
+    local term = cg.master:exec(function()
+        local fiber = require('fiber')
+        box.cfg{
+            election_mode = 'manual',
+            election_timeout = 1000,
+            replication_synchro_quorum = 3,
+        }
+        t.assert_equals(box.info.election.state, 'leader')
+        rawset(_G, 'f_txn', fiber.create(function()
+            fiber.self():set_joinable(true)
+            box.space.test:replace{1}
+        end))
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        t.assert_equals(box.info.synchro.queue.owner, box.info.id)
+        t.assert_equals(box.info.election.state, 'leader')
+        box.ctl.demote()
+        t.assert_equals(box.info.election.state, 'follower')
+        rawset(_G, 'f_promote', fiber.create(function()
+            fiber.self():set_joinable(true)
+            box.ctl.promote()
+        end))
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.election.state, 'leader')
+        end)
+        t.assert_equals(box.info.synchro.queue.owner, box.info.id)
+        t.assert_lt(box.info.synchro.queue.term, box.info.election.term)
+        return box.info.election.term
     end)
-    ff:set_joinable(true)
-    -- We need to be sure we entered the 'box_wait_quorum' call.
-    server_wait_wait_quorum_count_ge_than(cg.replica, wait_quorum_count + 1)
-    server_becomes_the_leader_again(cg.master)
-    server_wait_promote_greatest_term_ge_than(cg.replica, 3)
-    -- Replica collects quorum.
-    cg.replica_proxy:resume()
-    local ok, err = ff:join()
-    t.assert_equals(err, nil)
-    t.assert(ok)
-    server_wait_synchro_queue_len_is_equal(cg.replica, 0)
+    cg.replica:exec(function(term)
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.election.term, term)
+        end)
+        box.cfg{
+            replication_synchro_quorum = 1,
+            election_timeout = 1000,
+        }
+        box.ctl.promote()
+    end, {term})
+    cg.master:wait_for_vclock_of(cg.replica)
+    cg.master:exec(function()
+        t.assert_not((_G.f_promote:join(120)))
+        t.assert((_G.f_txn:join(120)))
+    end)
 end
 
 g.test_txn_limbo_is_empty_while_wait_quorum = function(cg)
-    -- The purpose of the test is to cover
-    -- 'if (txn_limbo_is_empty(&txn_limbo))' in
-    -- 'box_wait_limbo_acked()' located immediately after 'box_wait_quorum()'.
+    -- The purpose of the test is to see what happens when the synchro queue
+    -- gets empty during quorum wait.
     local f = cg.replica:exec(function()
         box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
         local f = require('fiber').create(function()
@@ -415,7 +206,7 @@ g.test_txn_limbo_is_empty_while_wait_quorum = function(cg)
     end)
     server_wait_synchro_queue_len_is_equal(cg.replica, 1)
     -- The master must not send 'CONFIRM' before fiber 'f'
-    -- reaches 'box_wait_quorum'. However, we must collect
+    -- reaches the quorum waiting code. However, we must collect
     -- quorum now, because then limbo on the master will be
     -- frozen after we write a new term on the replica.
     cg.master_proxy:pause()
@@ -453,9 +244,8 @@ g.test_txn_limbo_is_empty_while_wait_quorum = function(cg)
 end
 
 g.test_quorum_less_replication_synchro_quorum = function(cg)
-    -- The purpose of the test is to cover
-    -- 'if (quorum < replication_synchro_quorum)' in
-    -- 'box_wait_limbo_acked()' located immediately after 'box_wait_quorum()'.
+    -- The purpose of the test is to cover what happens when the quorum is
+    -- changing during synchro queue quorum waiting.
     local f = cg.replica:exec(function()
         box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
         local f = require('fiber').create(function()
@@ -493,9 +283,10 @@ g.test_quorum_less_replication_synchro_quorum = function(cg)
 end
 
 g.test_new_synchronous_transactions_appeared_while_wait_quorum = function(cg)
-    -- The purpose of the test is to cover
-    -- 'if (wait_lsn < txn_limbo_last_synchro_entry(&txn_limbo)->lsn)' in
-    -- 'box_wait_limbo_acked()' located immediately after 'box_wait_quorum()'.
+    assertions.skip("not testable without crutches anymore")
+    -- The purpose of the test is to cover what happens when new transactions
+    -- are coming into the synchro queue while the instance is trying to gather
+    -- the quorum for promotion.
     cg.master:exec(function()
         box.cfg{
             election_fencing_mode='off',

--- a/test/replication-luatest/gh_7318_box_wait_limbo_acked_test.lua
+++ b/test/replication-luatest/gh_7318_box_wait_limbo_acked_test.lua
@@ -2,7 +2,6 @@ local t = require('luatest')
 local cluster = require('luatest.replica_set')
 local proxy = require('luatest.replica_proxy')
 local server = require('luatest.server')
-local assertions = require('luatest.assertions')
 
 local g = t.group('cover-box-wait-limbo-acked')
 --
@@ -280,77 +279,4 @@ g.test_quorum_less_replication_synchro_quorum = function(cg)
     end, {f})
     server_becomes_the_leader_again(cg.master)
     server_wait_synchro_queue_len_is_equal(cg.replica, 0)
-end
-
-g.test_new_synchronous_transactions_appeared_while_wait_quorum = function(cg)
-    assertions.skip("not testable without crutches anymore")
-    -- The purpose of the test is to cover what happens when new transactions
-    -- are coming into the synchro queue while the instance is trying to gather
-    -- the quorum for promotion.
-    cg.master:exec(function()
-        box.cfg{
-            election_fencing_mode='off',
-            replication_synchro_quorum=3
-        }
-    end)
-    cg.replica_proxy:pause()
-    t.helpers.retrying({timeout = wait_timeout}, function()
-        cg.master:exec(function()
-            local status = box.info.replication[2].upstream.status
-            t.assert(status ~= 'follow')
-        end)
-    end)
-    local f = cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
-        local f = require('fiber').create(function()
-            return pcall(box.ctl.promote)
-        end)
-        f:set_joinable(true)
-        return f:id()
-    end)
-    server_wait_wal_is_blocked(cg.replica)
-    cg.master:exec(function()
-        require('fiber').create(function() box.space.test:insert{1} end)
-    end)
-    server_wait_synchro_queue_len_is_equal(cg.master, 1)
-    server_wait_synchro_queue_len_is_equal(cg.replica, 1)
-    -- The second transaction should not arrive before at the replica
-    -- before fiber 'f' reaches 'box_wait_quorum'.
-    cg.master_proxy:pause()
-    t.helpers.retrying({timeout = wait_timeout}, function()
-        cg.replica:exec(function()
-            local status = box.info.replication[1].upstream.status
-            t.assert(status ~= 'follow')
-        end)
-    end)
-    cg.master:exec(function()
-        require('fiber').create(function() box.space.test:insert{2} end)
-    end)
-    server_wait_synchro_queue_len_is_equal(cg.master, 2)
-    cg.replica:exec(function()
-        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
-        box.error.injection.set('ERRINJ_WAL_DELAY', false)
-    end)
-    server_wait_wal_is_blocked(cg.replica)
-    local wait_quorum_count = get_wait_quorum_count(cg.replica)
-    local ff = require('fiber').create(function()
-        cg.replica:exec(function(f)
-            box.error.injection.set('ERRINJ_WAL_DELAY', false)
-            local _, ok, err = require('fiber').find(f):join()
-            t.assert(not ok)
-            t.assert_equals(err.type, 'ClientError')
-            t.assert_equals(err.message, 'Couldn\'t wait for quorum 2: '
-                .. 'new synchronous transactions appeared')
-        end, {f})
-    end)
-    ff:set_joinable(true)
-    server_wait_wait_quorum_count_ge_than(cg.replica, wait_quorum_count + 1)
-    -- Now the master will send the second insert transaction.
-    cg.master_proxy:resume()
-    server_wait_synchro_queue_len_is_equal(cg.replica, 2)
-    cg.replica_proxy:resume()
-    local ok, err = ff:join()
-    t.assert(ok)
-    t.assert(not err)
-    server_becomes_the_leader_again(cg.master)
 end


### PR DESCRIPTION
The main goal of the PR is in the subject - hide the details of limbo ack collection inside the limbo itself. It was already quite overcomplicated and would have gotten much worse in scope of #8095 unless some action is taken now.

For Synchronous Promotion the limbo will have to learn to collect acks even when it is not in the leader state, not caught up with Raft. It will be possible, that the instance is Raft leader, owns the limbo in a previous term, and still has to collect ACKs to finish the promotion.

Having such deep details of limbo internals outside of the limbo's code would be quite inconvenient to maintain. The present patchset takes care so the limbo has all its ACK logic in one place, not sticking out anywhere.

Additional proofs of this patchset being in the right direction are the following bonus things:
- Relay module is untied from the limbo. Less cognitive load for devs to think why these modules were related.
- The code of acks collection became immensely simpler and shorter, having less corner cases, and being easier to understand.