### PR TITLE
iproto: route call requests to application threads

### DIFF
--- a/src/box/app_threads.c
+++ b/src/box/app_threads.c
@@ -29,14 +29,16 @@
 #include "lua/app_threads.h"
 
 int app_thread_count;
+__thread int app_thread_id = -1;
 
 /** Array of application threads. */
 static struct cord *app_thread_cords;
 
 static void *
-app_thread_f(void *unused)
+app_thread_f(void *arg)
 {
-	(void)unused;
+	app_thread_id = (intptr_t)arg;
+	assert(app_thread_id >= 1 && app_thread_id <= app_thread_count);
 	coio_enable();
 	tuple_init();
 	app_thread_lua_init();
@@ -62,9 +64,12 @@ app_thread_f(void *unused)
 void
 app_threads_start(int thread_count)
 {
+	assert(cord_is_main());
+	assert(app_thread_id == -1);
 	assert(app_thread_count == 0);
 	assert(app_thread_cords == NULL);
 	assert(thread_count >= 0 && thread_count <= APP_THREADS_MAX);
+	app_thread_id = 0;
 	if (thread_count == 0)
 		return;
 	app_thread_count = thread_count;
@@ -74,7 +79,8 @@ app_threads_start(int thread_count)
 		char name[16];
 		/* Sic: ids start with 1 because id 0 is reserved for tx. */
 		snprintf(name, sizeof(name), "app%d", i + 1);
-		if (cord_start(cord, name, app_thread_f, NULL) != 0)
+		if (cord_start(cord, name, app_thread_f,
+			       (void *)(intptr_t)(i + 1)) != 0)
 			panic_syserror("failed to start application thread");
 	}
 }
@@ -82,6 +88,8 @@ app_threads_start(int thread_count)
 void
 app_threads_stop(void)
 {
+	assert(cord_is_main());
+	assert(app_thread_id == 0);
 	for (int i = 0; i < app_thread_count; i++) {
 		struct cord *cord = &app_thread_cords[i];
 		cord_cancel(cord);

--- a/src/box/app_threads.h
+++ b/src/box/app_threads.h
@@ -20,6 +20,14 @@ enum {
 extern int app_thread_count;
 
 /**
+ * Identifier of the current thread:
+ * * 0 for the main thread
+ * * 1 <= id <= app_thread_count for an application thread
+ * * -1 for other threads
+ */
+extern __thread int app_thread_id;
+
+/**
  * Starts application threads.
  *
  * Each thread runs an event loop and has a cbus endpoint named 'app<id>'

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -72,6 +72,7 @@
 #include "tt_static.h"
 #include "trivia/util.h"
 #include "salad/stailq.h"
+#include "salad/grp_alloc.h"
 #include "txn.h"
 #include "on_shutdown.h"
 #include "flightrec.h"
@@ -129,6 +130,16 @@ iproto_wpos_create(struct iproto_wpos *wpos, struct obuf *out)
 	wpos->obuf = out;
 	wpos->svp = obuf_create_svp(out);
 }
+
+/** Registered function descriptor, see iproto_register_func(). */
+struct iproto_func {
+	/** Function name. */
+	char *name;
+	/** Array of serving thread ids where the function is available. */
+	int *srv_ids;
+	/** Number of entries in the srv_ids array. */
+	int srv_count;
+};
 
 struct iproto_thread {
 	/**
@@ -194,6 +205,11 @@ struct iproto_thread {
 	 * request preprocessing and use the 'override' route.
 	 */
 	mh_i32_t *req_handlers;
+	/**
+	 * Hash table of functions registered with iproto_register_func().
+	 * Keys are function names, values are iproto_func objects.
+	 */
+	mh_strnptr_t *funcs;
 	/*
 	 * Iproto thread memory pools
 	 */
@@ -473,6 +489,8 @@ struct iproto_service_msg {
 	unsigned drop_generation;
 	/** IPROTO max message count. */
 	int iproto_msg_max;
+	/** Function name passed to iproto_register_func(). */
+	char *func_name;
 };
 
 static struct iproto_service_msg *
@@ -486,6 +504,7 @@ iproto_service_msg_new(const struct cmsg_hop *route)
 	msg->stream = NULL;
 	msg->drop_generation = 0;
 	msg->iproto_msg_max = 0;
+	msg->func_name = NULL;
 	return msg;
 }
 
@@ -1921,6 +1940,29 @@ net_end_subscribe(struct cmsg *msg);
 static int
 iproto_msg_decode(struct iproto_msg *msg, struct cmsg_hop **route);
 
+/**
+ * Reroutes an IPROTO_CALL request to a random serving thread that registered
+ * the target function. Does nothing if the function isn't registered on any
+ * serving thread.
+ */
+static void
+iproto_msg_reroute(struct iproto_msg *msg, struct cmsg_hop **route)
+{
+	assert(msg->header.type == IPROTO_CALL);
+	assert(msg->header.thread_id == XROW_THREAD_UNSPEC);
+	struct iproto_thread *iproto_thread = msg->connection->iproto_thread;
+	struct mh_strnptr_t *funcs = iproto_thread->funcs;
+	const char *name = msg->call.name;
+	uint32_t name_len = mp_decode_strl(&name);
+	mh_int_t i = mh_strnptr_find_str(funcs, name, name_len);
+	if (i == mh_end(funcs))
+		return;
+	struct iproto_func *func =
+		(struct iproto_func *)mh_strnptr_node(funcs, i)->val;
+	msg->srv_id = func->srv_ids[rand() % func->srv_count];
+	*route = iproto_thread->srv[msg->srv_id].call_route;
+}
+
 static void
 iproto_msg_prepare(struct iproto_msg *msg, const char **pos, const char *reqend)
 {
@@ -2008,6 +2050,8 @@ iproto_msg_prepare(struct iproto_msg *msg, const char **pos, const char *reqend)
 
 	rc = iproto_msg_decode(msg, &route);
 	if (rc == 0) {
+		if (type == IPROTO_CALL && thread_id == XROW_THREAD_UNSPEC)
+			iproto_msg_reroute(msg, &route);
 		assert(route != NULL);
 		cmsg_init(&msg->base, route);
 		return;
@@ -4036,6 +4080,7 @@ iproto_thread_init(struct iproto_thread *iproto_thread, int srv_count)
 	iproto_thread->srv_count = srv_count;
 	iproto_thread_init_routes(iproto_thread);
 	iproto_thread->req_handlers = mh_i32_new();
+	iproto_thread->funcs = mh_strnptr_new();
 	slab_cache_create(&iproto_thread->srv[0].net_slabc, &runtime);
 	/* Init statistics counter */
 	iproto_thread->rmean = rmean_new(rmean_net_strings, RMEAN_NET_LAST);
@@ -4710,6 +4755,11 @@ void
 iproto_free(void)
 {
 	for (int i = 0; i < iproto_threads_count; i++) {
+		mh_int_t j;
+		struct mh_strnptr_t *funcs = iproto_threads[i].funcs;
+		mh_foreach(funcs, j)
+			free(mh_strnptr_node(funcs, j)->val);
+		mh_strnptr_delete(funcs);
 		mh_i32_delete(iproto_threads[i].req_handlers);
 		/*
 		 * Close socket descriptor to prevent hot standby instance
@@ -4879,4 +4929,69 @@ iproto_enable_thread_requests(void)
 	struct iproto_service_msg *msg = iproto_service_msg_new(route);
 	msg->connection = connection;
 	cpipe_push(net_pipe, &msg->base);
+}
+
+/**
+ * Register a function in an IPROTO thread.
+ */
+static void
+net_register_func(struct cmsg *m)
+{
+	const int srv_count_max = app_thread_count + 1;
+	struct iproto_service_msg *msg = (struct iproto_service_msg *)m;
+	uint32_t srv_id = msg->srv_id;
+	struct iproto_thread *iproto_thread = msg->iproto_thread;
+	const char *name = msg->func_name;
+	uint32_t name_len = strlen(name);
+	uint32_t name_hash = mh_strn_hash(name, name_len);
+	struct mh_strnptr_t *funcs = iproto_thread->funcs;
+	struct iproto_func *func;
+	struct mh_strnptr_key_t k = {name, name_len, name_hash};
+	mh_int_t i = mh_strnptr_find(funcs, &k, NULL);
+	if (i == mh_end(funcs)) {
+		struct grp_alloc all = grp_alloc_initializer();
+		grp_alloc_reserve_data(&all, sizeof(*func));
+		grp_alloc_reserve_str(&all, name_len);
+		grp_alloc_reserve_data(
+			&all, sizeof(*func->srv_ids) * srv_count_max);
+		grp_alloc_use(&all, xmalloc(grp_alloc_size(&all)));
+		func = (struct iproto_func *)grp_alloc_create_data(
+						&all, sizeof(*func));
+		func->name = grp_alloc_create_str(&all, name, name_len);
+		func->srv_ids = (int *)grp_alloc_create_data(
+			&all, sizeof(*func->srv_ids) * srv_count_max);
+		func->srv_count = 0;
+		assert(grp_alloc_size(&all) == 0);
+		struct mh_strnptr_node_t n = {
+			func->name, name_len, name_hash, func,
+		};
+		struct mh_strnptr_node_t prev;
+		struct mh_strnptr_node_t *prev_ptr = &prev;
+		mh_strnptr_put(funcs, &n, &prev_ptr, NULL);
+		assert(prev_ptr == NULL);
+	} else {
+		func = (struct iproto_func *)mh_strnptr_node(funcs, i)->val;
+	}
+	assert(func->srv_count < srv_count_max);
+	func->srv_ids[func->srv_count++] = srv_id;
+	free(msg->func_name);
+	iproto_service_msg_delete(msg);
+}
+
+void
+iproto_register_func(const char *name)
+{
+	assert(app_thread_id >= 0);
+	for (int i = 0; i < iproto_threads_count; i++) {
+		static const struct cmsg_hop route[] = {
+			{net_register_func, NULL},
+		};
+		struct iproto_service_msg *msg = iproto_service_msg_new(route);
+		struct iproto_thread *iproto_thread = &iproto_threads[i];
+		msg->srv_id = app_thread_id;
+		msg->iproto_thread = iproto_thread;
+		msg->func_name = (char *)xstrdup(name);
+		cpipe_push(&iproto_thread->srv[app_thread_id].ret_pipe,
+			   &msg->base);
+	}
 }

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -2184,6 +2184,7 @@ static void
 srv_process_cancel_inprogress(struct cmsg *m)
 {
 	struct iproto_service_msg *msg = (struct iproto_service_msg *)m;
+	assert(msg->srv_id == app_thread_id);
 	struct iproto_connection *con = msg->connection;
 	struct rlist *inprogress = &con->srv[msg->srv_id].inprogress;
 	struct iproto_msg *inprogress_msg;
@@ -2228,6 +2229,7 @@ static void
 srv_process_destroy(struct cmsg *m)
 {
 	struct iproto_service_msg *msg = (struct iproto_service_msg *)m;
+	assert(msg->srv_id == app_thread_id);
 	struct iproto_connection *con = msg->connection;
 	assert(con->state == IPROTO_CONNECTION_DESTROYED);
 	if (msg->srv_id == 0 && con->session != NULL) {
@@ -2302,13 +2304,14 @@ net_discard_input(struct cmsg *m)
 static void
 srv_discard_input(struct iproto_msg *msg)
 {
+	int srv_id = msg->srv_id;
+	assert(srv_id == app_thread_id);
 	struct iproto_thread *iproto_thread = msg->connection->iproto_thread;
 	static const struct cmsg_hop discard_input_route[] = {
 		{net_discard_input, NULL},
 	};
 	cmsg_init(&msg->discard_input, discard_input_route);
-	cpipe_push(&iproto_thread->srv[msg->srv_id].ret_pipe,
-		   &msg->discard_input);
+	cpipe_push(&iproto_thread->srv[srv_id].ret_pipe, &msg->discard_input);
 }
 
 /**
@@ -2380,6 +2383,7 @@ static inline struct iproto_msg *
 srv_accept_msg(struct cmsg *m)
 {
 	struct iproto_msg *msg = (struct iproto_msg *)m;
+	assert(msg->srv_id == app_thread_id);
 	srv_accept_wpos(msg->connection, msg->srv_id, &msg->wpos);
 	rlist_add_entry(&msg->connection->srv[msg->srv_id].inprogress,
 			msg, in_inprogress);
@@ -2445,6 +2449,7 @@ tx_check_msg(struct iproto_msg *msg)
 static inline void
 srv_end_msg(struct iproto_msg *msg)
 {
+	assert(msg->srv_id == app_thread_id);
 	rlist_del(&msg->in_inprogress);
 	msg->fiber = NULL;
 }
@@ -3700,6 +3705,7 @@ srv_process_init(struct cmsg *m)
 	struct iproto_service_msg *msg = (struct iproto_service_msg *)m;
 	struct iproto_thread *iproto_thread = msg->iproto_thread;
 	int srv_id = msg->srv_id;
+	assert(srv_id == app_thread_id);
 	slab_cache_create(&iproto_thread->srv[srv_id].net_slabc, &runtime);
 	struct cpipe *pipe = &iproto_thread->srv[srv_id].ret_pipe;
 	char endpoint_name[ENDPOINT_NAME_MAX];
@@ -3718,6 +3724,7 @@ srv_process_free(struct cmsg *m)
 	struct iproto_service_msg *msg = (struct iproto_service_msg *)m;
 	struct iproto_thread *iproto_thread = msg->iproto_thread;
 	int srv_id = msg->srv_id;
+	assert(srv_id == app_thread_id);
 	struct cpipe *pipe = &iproto_thread->srv[srv_id].ret_pipe;
 	cpipe_destroy(pipe);
 	slab_cache_destroy(&iproto_thread->srv[srv_id].net_slabc);
@@ -3732,7 +3739,9 @@ srv_process_cfg(struct cmsg *m)
 {
 	struct iproto_service_msg *msg = (struct iproto_service_msg *)m;
 	struct iproto_thread *iproto_thread = msg->iproto_thread;
-	struct cpipe *pipe = &iproto_thread->srv[msg->srv_id].ret_pipe;
+	int srv_id = msg->srv_id;
+	assert(srv_id == app_thread_id);
+	struct cpipe *pipe = &iproto_thread->srv[srv_id].ret_pipe;
 	cpipe_set_max_input(pipe, msg->iproto_msg_max / 2);
 	iproto_service_msg_delete(msg);
 }

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -142,6 +142,17 @@ iproto_override(uint32_t req_type, iproto_handler_t cb,
 void
 iproto_enable_thread_requests(void);
 
+/**
+ * Lets IPROTO threads know that there's a function with the given name
+ * in the current request-serving thread (tx or app).
+ *
+ * If a function is registered by any request-serving thread, IPROTO threads
+ * will route IPROTO_CALL requests for this function only to the threads where
+ * it was registered, evenly balancing the load among them.
+ */
+void
+iproto_register_func(const char *name);
+
 void
 iproto_init(int threads_count);
 

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -941,7 +941,7 @@ box_lua_init_minimal(struct lua_State *L)
 	box_lua_tuple_format_init(L);
 	box_lua_tuple_init(L);
 	box_lua_call_init(L);
-	box_lua_iproto_constants_init(L);
+	box_lua_iproto_init(L);
 
 	luaopen_key_def(L);
 	lua_pop(L, 1);
@@ -993,7 +993,6 @@ box_lua_init(struct lua_State *L)
 	box_lua_xlog_init(L);
 	box_lua_sql_init(L);
 	box_lua_watcher_init(L);
-	box_lua_iproto_init(L);
 	box_lua_trigger_init(L);
 	box_lua_expression_lexer_init(L);
 	box_lua_extras_init(L);

--- a/src/box/lua/iproto.c
+++ b/src/box/lua/iproto.c
@@ -251,6 +251,15 @@ lbox_iproto_enable_thread_requests(struct lua_State *L)
 	return 0;
 }
 
+/** Lua wrapper around iproto_register_func(). */
+static int
+lbox_iproto_register_func(struct lua_State *L)
+{
+	const char *name = luaL_checkstring(L, 1);
+	iproto_register_func(name);
+	return 0;
+}
+
 /**
  * Encodes a packet header/body argument to MsgPack: if the argument is a
  * string, then no encoding is needed — otherwise the argument must be a Lua
@@ -634,6 +643,7 @@ box_lua_iproto_init(struct lua_State *L)
 		{NULL, NULL}
 	};
 	static const struct luaL_Reg internal_funcs_common[] = {
+		{"register_func", lbox_iproto_register_func},
 		{NULL, NULL}
 	};
 	if (cord_is_main())

--- a/src/box/lua/iproto.c
+++ b/src/box/lua/iproto.c
@@ -607,35 +607,38 @@ truncated_input:
 }
 
 void
-box_lua_iproto_constants_init(struct lua_State *L)
+box_lua_iproto_init(struct lua_State *L)
 {
 	luaL_findtable(L, LUA_GLOBALSINDEX, "box.iproto", 0);
 	push_iproto_constants(L);
 	push_iproto_protocol_features(L);
-	lua_pop(L, 1); /* box.iproto */
-}
-
-void
-box_lua_iproto_init(struct lua_State *L)
-{
-	luaL_findtable(L, LUA_GLOBALSINDEX, "box.iproto", 0);
-	static const struct luaL_Reg funcs[] = {
+	static const struct luaL_Reg funcs_main[] = {
 		{"send", lbox_iproto_send},
+		{NULL, NULL}
+	};
+	static const struct luaL_Reg funcs_common[] = {
 		{"encode_greeting", lbox_iproto_encode_greeting},
 		{"decode_greeting", lbox_iproto_decode_greeting},
 		{"encode_packet", lbox_iproto_encode_packet},
 		{"decode_packet", lbox_iproto_decode_packet},
 		{NULL, NULL}
 	};
-	luaL_setfuncs(L, funcs, 0);
+	if (cord_is_main())
+		luaL_setfuncs(L, funcs_main, 0);
+	luaL_setfuncs(L, funcs_common, 0);
 	luaL_findtable(L, -1, "internal", 0);
-	static const struct luaL_Reg internal_funcs[] = {
+	static const struct luaL_Reg internal_funcs_main[] = {
 		{"session_new", lbox_iproto_session_new},
 		{"drop_connections", lbox_iproto_drop_connections},
 		{"enable_thread_requests", lbox_iproto_enable_thread_requests},
 		{NULL, NULL}
 	};
-	luaL_setfuncs(L, internal_funcs, 0);
+	static const struct luaL_Reg internal_funcs_common[] = {
+		{NULL, NULL}
+	};
+	if (cord_is_main())
+		luaL_setfuncs(L, internal_funcs_main, 0);
+	luaL_setfuncs(L, internal_funcs_common, 0);
 	lua_pop(L, 1); /* box.iproto.internal */
 	lua_pop(L, 1); /* box.iproto */
 }

--- a/src/box/lua/iproto.h
+++ b/src/box/lua/iproto.h
@@ -13,12 +13,6 @@ extern "C" {
 struct lua_State;
 
 /**
- * Initializes constants and feature bits in the `box.iproto` namespace.
- */
-void
-box_lua_iproto_constants_init(struct lua_State *L);
-
-/**
  * Initializes `box.iproto` submodule for working with Tarantool network
  * subsystem.
  */

--- a/src/box/lua/iproto.lua
+++ b/src/box/lua/iproto.lua
@@ -6,6 +6,8 @@ ffi.cdef[[
     cord_is_main(void);
 ]]
 
+local may_register_funcs = true
+
 -- Makes a function callable over the IPROTO protocol by the given name.
 box.iproto.export = function(func_name, func)
     utils.check_param(func_name, 'function name', 'string', 2)
@@ -14,10 +16,26 @@ box.iproto.export = function(func_name, func)
         box.error(box.error.FUNCTION_EXISTS, func_name, 2)
     end
     box.internal.func_registry[func_name] = func
+    if may_register_funcs then
+        box.iproto.internal.register_func(func_name)
+    end
 end
 
--- box.iproto.override is available in the main thread only
 if ffi.C.cord_is_main() then
+
+--
+-- box.iproto.export() may be called in the main thread before the IPROTO
+-- threads are started. In this case exported functions will be registered
+-- in IPROTO after box.cfg() is done.
+--
+may_register_funcs = false
+
+box.iproto.internal.register_funcs_after_box_cfg = function()
+    for func_name in pairs(box.internal.func_registry) do
+        box.iproto.internal.register_func(func_name)
+    end
+    may_register_funcs = true
+end
 
 -- Sets IPROTO request handler callback (second argument) for the given request
 -- type (first argument, number).

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -1277,6 +1277,8 @@ local function load_cfg(cfg)
             box.info.version)
         log.warn(msg)
     end
+
+    box.iproto.internal.register_funcs_after_box_cfg()
 end
 box.cfg = locked(load_cfg)
 

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -281,6 +281,40 @@ g.test_builtin_modules = function(cg)
         local e = box.error.new({type = 'MyError', name = 'FooBar'})
         return e:unpack()
     ]]), {type = 'MyError', name = 'FooBar'})
+    t.assert_items_equals(eval([[
+        local keys = {}
+        for k in pairs(box.iproto) do
+            table.insert(keys, k)
+        end
+        return keys
+    ]]), {
+        'GREETING_PROTOCOL_LEN_MAX',
+        'GREETING_SALT_LEN_MAX',
+        'GREETING_SIZE',
+        'ballot_key',
+        'decode_greeting',
+        'decode_packet',
+        'encode_greeting',
+        'encode_packet',
+        'export',
+        'feature',
+        'flag',
+        'internal',
+        'key',
+        'metadata_key',
+        'protocol_features',
+        'protocol_version',
+        'raft_key',
+        'type',
+    })
+    t.assert_items_equals(eval([[
+        local keys = {}
+        for k in pairs(box.iproto.internal) do
+            table.insert(keys, k)
+        end
+        return keys
+    ]]), {
+    })
 end
 
 g.test_lua_alloc = function(cg)

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -314,6 +314,7 @@ g.test_builtin_modules = function(cg)
         end
         return keys
     ]]), {
+        'register_func',
     })
 end
 

--- a/test/box-luatest/iproto_export_test.lua
+++ b/test/box-luatest/iproto_export_test.lua
@@ -1,3 +1,5 @@
+local net = require('net.box')
+
 local t = require('luatest')
 local server = require('luatest.server')
 
@@ -102,4 +104,80 @@ g2.test_iproto_export_in_app_threads = function(cg)
                           'test.func_1', {'x'}, {_thread_id = 2})
     t.assert_error_covers(err, cg.server.call, cg.server,
                           'test.func_2', {'x'}, {_thread_id = 2})
+end
+
+g2.test_iproto_call_routing = function(cg)
+    cg.server = server:new({
+        box_cfg = {
+            iproto_threads = 5,
+            app_threads = 3,
+        },
+        env = {
+            TARANTOOL_RUN_BEFORE_BOX_CFG = [[
+                box.iproto.export('test_func_1', function() return 0 end)
+            ]],
+        },
+    })
+    cg.server:start()
+    cg.server:call('box.iproto.internal.enable_thread_requests')
+    cg.server:exec(function()
+        rawset(_G, 'test_func_2', function() return 0 end)
+        box.iproto.export('test_func_3', function() return 0 end)
+        rawset(_G, 'test_func_4', function() return 0 end)
+    end, {}, {_thread_id = 0})
+    cg.server:exec(function()
+        box.iproto.export('test_func_1', function() return 1 end)
+        rawset(_G, 'test_func_2', function() return 1 end)
+        rawset(_G, 'test_func_3', function() return 1 end)
+        rawset(_G, 'test_func_4', function() return 1 end)
+    end, {}, {_thread_id = 1})
+    cg.server:exec(function()
+        box.iproto.export('test_func_1', function() return 2 end)
+        box.iproto.export('test_func_2', function() return 2 end)
+        rawset(_G, 'test_func_3', function() return 2 end)
+        rawset(_G, 'test_func_4', function() return 2 end)
+    end, {}, {_thread_id = 2})
+    cg.server:exec(function()
+        rawset(_G, 'test_func_1', function() return 3 end)
+        box.iproto.export('test_func_2', function() return 3 end)
+        box.iproto.export('test_func_3', function() return 3 end)
+        rawset(_G, 'test_func_4', function() return 3 end)
+    end, {}, {_thread_id = 3})
+    local conns = {}
+    for _ = 1, 10 do
+        table.insert(conns, net.connect(cg.server.net_box_uri))
+    end
+    local err_margin = 100
+    local total_calls = 1000
+    local thread_calls = {}
+    local function run_test(func_name)
+        for k = 0, 3 do
+            thread_calls[k] = 0
+        end
+        for _ = 1, total_calls do
+            local conn = conns[math.random(#conns)]
+            local k = conn:call(func_name)
+            thread_calls[k] = thread_calls[k] + 1
+        end
+    end
+    run_test('test_func_1')
+    t.assert_almost_equals(thread_calls[0], 333, err_margin)
+    t.assert_almost_equals(thread_calls[1], 333, err_margin)
+    t.assert_almost_equals(thread_calls[2], 333, err_margin)
+    t.assert_equals(thread_calls[3], 0)
+    run_test('test_func_2')
+    t.assert_equals(thread_calls[0], 0)
+    t.assert_equals(thread_calls[1], 0)
+    t.assert_almost_equals(thread_calls[2], 500, err_margin)
+    t.assert_almost_equals(thread_calls[3], 500, err_margin)
+    run_test('test_func_3')
+    t.assert_almost_equals(thread_calls[0], 500, err_margin)
+    t.assert_equals(thread_calls[1], 0)
+    t.assert_equals(thread_calls[2], 0)
+    t.assert_almost_equals(thread_calls[3], 500, err_margin)
+    run_test('test_func_4')
+    t.assert_equals(thread_calls[0], 1000)
+    t.assert_equals(thread_calls[1], 0)
+    t.assert_equals(thread_calls[2], 0)
+    t.assert_equals(thread_calls[3], 0)
 end


### PR DESCRIPTION
Now, if a function is exported with `box.iproto.export()` on any thread (tx or app), IPROTO threads will route `IPROTO_CALL` requests with unspecified target thread id only to those threads where this function was exported. Requests to call a function that haven't been exported on any thread are always routed to the tx thread.

The implementation is trivial: `box.iproto.export()` now sends a message to each IPROTO thread that instructs it to add the exported function name to the thread-local hash table; the IPROTO request handler checks the hash table and if it finds the function in there, it choses the target thread randomly among all serving threads where this function was exported. Note that we have to take into account the fact that `box.iproto.export()` may be called before `box.cfg()`, when IPROTO is unavailable yet. In this case we postpone function registration in IPROTO until `box.cfg()` is completed.

Closes #12312