### PR TITLE
trivia: added fmt() util

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -327,6 +327,7 @@ set (common_libraries ${common_libraries} PARENT_SCOPE)
 
 add_subdirectory(lib)
 add_subdirectory(box)
+add_subdirectory(trivia)
 
 include_directories(${EXTRA_BOX_INCLUDE_DIRS})
 

--- a/src/trivia/CMakeLists.txt
+++ b/src/trivia/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(trivia STATIC util.c)
+target_link_libraries(trivia)

--- a/src/trivia/util.c
+++ b/src/trivia/util.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2010-2026, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include "trivia/util.h"
+
+/*
+ * Some of trivia primitives are depends on core facilities (log, etc.).
+ * So they are defined in core/util.c.
+ *
+ * Here is a place to define trivia primitives, which is independent
+ * from core facilities. It may be used to build libs, unit tests.
+ */
+
+#include <stdlib.h>
+
+/** Allocate space in a static buffer and vsnprintf() to it. */
+static const char *
+fmt_va(const char *fmt, va_list args)
+{
+#define ASSERT(cond) \
+	do { \
+		if (!(cond)) \
+			abort(); \
+	} while (0)
+
+	static char *buf;
+	static size_t buf_used;
+	if (buf == NULL) {
+		buf = xmalloc(FMT_BUF_SIZE);
+		LSAN_IGNORE_OBJECT(buf);
+		buf_used = 0;
+	}
+
+	va_list args_copy;
+	va_copy(args_copy, args);
+
+	int res = vsnprintf(NULL, 0, fmt, args);
+	ASSERT(res >= 0);
+	size_t size = (size_t)res + 1;
+
+	/* Recycle as in static alloc. */
+	ASSERT(size <= FMT_BUF_SIZE);
+	if (buf_used + size > FMT_BUF_SIZE)
+		buf_used = 0;
+	char *str = buf + buf_used;
+	buf_used += size;
+
+	res = vsnprintf(str, size, fmt, args_copy);
+	ASSERT((res >= 0) && (size_t)res == size - 1);
+	va_end(args_copy);
+	return str;
+#undef ASSERT
+}
+
+const char *
+fmt(const char *fmt, ...)
+{
+	va_list args;
+	const char *ret;
+	va_start(args, fmt);
+	ret = fmt_va(fmt, args);
+	va_end(args);
+	return ret;
+}

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -940,6 +940,20 @@ lsan_turn_off(void)
 
 #endif
 
+#define FMT_BUF_SIZE (1024 * 1024)
+
+/**
+ * Allocate space in a static buffer and snprintf() to it.
+ * The result string is for temporary use. It is became
+ * invalid after next N allocations, where N depends on
+ * the length of newly allocated strings.
+ *
+ * The routine aborts on any error, especially if it
+ * fails to allocate when len(output) > FMT_BUF_SIZE.
+ */
+const char *
+fmt(const char *fmt, ...) CFORMAT(printf, 1, 2);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -338,6 +338,10 @@ create_unit_test(PREFIX trivia
                  SOURCES trivia.c
                  LIBRARIES unit
 )
+create_unit_test(PREFIX trivia_util
+                 SOURCES trivia_util.c
+                 LIBRARIES trivia unit
+)
 
 if (NOT ENABLE_GCOV)
     # This test is known to be broken with GCOV

--- a/test/unit/trivia_util.c
+++ b/test/unit/trivia_util.c
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2026, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include <string.h>
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+#include "trivia/util.h"
+
+static void
+test_fmt(void)
+{
+	header();
+	plan(3);
+
+	const char *s1, *s2;
+
+	/* s1 points to buf start. */
+	s1 = fmt("%03d", 9);
+	ok(strcmp("009", s1) == 0);
+
+	s2 = fmt("12345");
+	ok(s1 < s2);
+
+	/* Make buf rewind <-> invalidate s1. */
+	size_t n = FMT_BUF_SIZE / (strlen(s1) + 1);
+	for (size_t i = 0; i < n; i++)
+		/* Same len as s1. */
+		fmt("xxx");
+	ok(strcmp("xxx", s1) == 0);
+
+	check_plan();
+	footer();
+}
+
+int
+main(void)
+{
+	plan(1);
+
+	test_fmt();
+
+	return check_plan();
+}


### PR DESCRIPTION
The `fmt()` routine is a `snprintf()` to automatically allocated/freed buffer space. The allocation works as
the static allocator.

It's a helper for debug-aware printing or to make string test samples.

```
#ifndef NDEBUG
const char *
fmt_my_type(my_type *x)
{
        return fmt("my_type(x:%u)", x->x);
}
#endif
...
say_debug("%s: arg1=%s, arg2=%s",
        __func__,
        fmt_my_type(arg1), fmt_my_type(arg2));
```

```
#define MAX_DATE_YEAR 5879611
#define MAX_DATE_MONTH 7
#define MAX_DATE_DAY 11

char *max_date = fmt("%d-%02u-%02u",
        MAX_DATE_YEAR, MAX_DATE_MONTH, MAX_DATE_DAY);
```
