### PR TITLE
audit: allow to enable `extract_key` option for particular spaces

### DIFF
--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -138,6 +138,32 @@ local function log_destination(log)
     end
 end
 
+local function audit_spaces_value(audit_log)
+    local spaces = audit_log.spaces
+
+    if spaces == nil then
+        return box.NULL
+    end
+
+    local first_key = next(spaces)
+    if first_key == nil then
+        return {}
+    end
+
+    if type(first_key) == 'number' then
+        return spaces
+    end
+
+    local res = {}
+    for space_name, opts in pairs(spaces) do
+        table.insert(res, {
+            name = space_name,
+            extract_key = opts.extract_key,
+        })
+    end
+    return res
+end
+
 -- }}} log/audit_log helpers
 
 -- {{{ log
@@ -162,6 +188,9 @@ local function set_audit_log(configdata, box_cfg)
     --
     -- `audit_log.nonblock` and 'audit_log.filter' options are marked with the
     -- `box_cfg` annotations and so they're already added to `box_cfg`.
+    --
+    -- Record form of `audit_log.spaces` must be transformed to table form
+    -- of `box.cfg.audit_spaces`.
     local audit_log = configdata:get('audit_log', {use_default = true})
     if audit_log ~= nil and next(audit_log) ~= nil then
         box_cfg.audit_log = log_destination(audit_log)
@@ -171,6 +200,7 @@ local function set_audit_log(configdata, box_cfg)
         else
             box_cfg.audit_filter = 'compatibility'
         end
+        box_cfg.audit_spaces = audit_spaces_value(audit_log)
     end
 end
 

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -180,21 +180,58 @@ I['audit_log.pipe'] = format_text([[
 ]])
 
 I['audit_log.spaces'] = format_text([[
-    The array of space names for which data operation events (`space_select`,
-    `space_insert`, `space_replace`, `space_delete`) should be logged. The array
-    accepts string values. If set to box.NULL, the data operation events are
-    logged for all spaces.
+    Specifies spaces for which data operation events (`space_select`,
+    `space_insert`, `space_replace`, `space_delete`) should be logged.
+
+    This option accepts one of the following forms:
+
+    - an array of space names;
+    - a map where keys are space names and values are audit options.
+
+    If set to box.NULL, the data operation events are logged for all spaces.
 ]])
 
 I['audit_log.spaces.*'] = format_text([[
-    A specific space name in the array for which data operation events are
-    logged. Each entry must be a string representing the name of the space
-    to monitor.
+    Specifies a space for which data operation events are logged. Accepts one
+    of the following forms:
 
-    Example:
+    - a string representing a space name;
+    - a map where the key is a space name and the value is a map with
+      per-space options.
+
+    The following option is supported:
+    - `extract_key` - optional boolean field, having the same semantics as
+      `audit_log.extract_key`, but only for the given space.
+
+    Also, space name can be a wildcard (`*`). If met, data operation events
+    are logged for all spaces. Also, its `extract_key` option, if specified, is
+    a default option for all spaces without explicitly specified `extract_key`.
+
+    Examples:
 
     `spaces: [bands, singers]`, only the events of `bands` and `singers` spaces
     are logged.
+
+    ```
+    spaces:
+        bands: {}
+        singers: {}
+    ```
+    The same semantics as above.
+
+    ```
+    spaces:
+        bands:
+            extract_key: true
+        singers:
+            extract_key: true
+        '*':
+            extract_key: false
+    ```
+    Since there is a wildcard, data operation events are logged for all spaces.
+    But events of spaces `bands` and `singers` use primary keys instead of full
+    tuples when logged. All other spaces' events still use full tuples because
+    it's explicitly specified in the wildcard entry.
 ]])
 
 I['audit_log.to'] = 'Enable audit logging and define the log location.'

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1966,13 +1966,12 @@ return schema.new('instance_config', schema.record({
             "data_operations",
             "compatibility",
         }),
-        spaces = enterprise_edition(schema.array({
-            items = schema.scalar({
-                type = 'string',
-            }),
-            box_cfg = 'audit_spaces',
+        spaces = enterprise_edition(schema.scalar({
+            -- TODO: replace with union (gh-12539).
+            type = 'any',
             box_cfg_nondynamic = true,
             default = box.NULL,
+            validate = validators['audit_log.spaces'],
         })),
         extract_key = enterprise_edition(schema.scalar({
             type = 'boolean',

--- a/src/box/lua/config/validators.lua
+++ b/src/box/lua/config/validators.lua
@@ -107,6 +107,59 @@ end
 
 -- }}} app
 
+-- {{{ audit_log
+
+local function validate_audit_log_space_opts(space, data, w)
+    if type(data) ~= 'table' then
+        w.error('audit_log.spaces.%s must be a record', space)
+    end
+    for option, value in pairs(data) do
+        if option == 'extract_key' then
+            if type(value) ~= 'boolean' then
+                w.error('audit_log.spaces.%s.extract_key must be boolean',
+                        space)
+            end
+        else
+            w.error('Unexpected field audit_log.spaces.%s.%s', space, option)
+        end
+    end
+end
+
+M['audit_log.spaces'] = function(data, w)
+    local errmsg = 'audit_log.spaces must be a map or an array of strings'
+    if type(data) ~= 'table' then
+        w.error(errmsg)
+    end
+    local first_key = next(data)
+    if first_key == nil then
+        return
+    end
+    local key_type = type(first_key)
+    if key_type == 'number' then
+        for key, value in pairs(data) do
+            if type(key) ~= 'number' then
+                w.error(errmsg)
+            end
+            if type(value) ~= 'string' then
+                w.error(errmsg)
+            end
+        end
+        return
+    end
+    if key_type == 'string' then
+        for space, opts in pairs(data) do
+            if type(space) ~= 'string' then
+                w.error(errmsg)
+            end
+            validate_audit_log_space_opts(space, opts, w)
+        end
+        return
+    end
+    w.error(errmsg)
+end
+
+-- }}} audit_log
+
 -- {{{ config
 
 M['config.context.*'] = function(var, w)

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -139,6 +139,23 @@ cfg_getd_default(const char *param, double default_val)
 	return ok ? val : default_val;
 }
 
+bool
+cfg_isnil(const char *name)
+{
+	cfg_get(name);
+	bool is_nil = lua_isnil(tarantool_L, -1);
+	lua_pop(tarantool_L, 1);
+	return is_nil;
+}
+
+bool
+cfg_istable(const char *name)
+{
+	cfg_get(name);
+	bool is_table = lua_istable(tarantool_L, -1);
+	lua_pop(tarantool_L, 1);
+	return is_table;
+}
 
 int
 cfg_getarr_size(const char *name)

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -77,6 +77,14 @@ cfg_getd(const char *param);
 double
 cfg_getd_default(const char *param, double default_val);
 
+/** Whether the parameter is absent. */
+bool
+cfg_isnil(const char *name);
+
+/** Whether the parameter is table. */
+bool
+cfg_istable(const char *name);
+
 int
 cfg_getarr_size(const char *name);
 

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -1000,15 +1000,16 @@ g.test_audit_options = function()
         'data_operations', 'compatibility'
     }
 
-    local verify = function(events)
+    local verify = function(events, audit_spaces)
         t.assert_equals(box.cfg.audit_log, nil)
         t.assert_equals(box.cfg.audit_nonblock, true)
         t.assert_equals(box.cfg.audit_format, 'csv')
         t.assert_equals(box.cfg.audit_filter, table.concat(events, ","))
-        t.assert_equals(box.cfg.audit_spaces, {'space1', 'space2', 'space3'})
+        t.assert_items_equals(box.cfg.audit_spaces, audit_spaces)
         t.assert_equals(box.cfg.audit_extract_key, true)
     end
 
+    local audit_spaces = {'space1', 'space2', 'space3'}
     helpers.success_case(g, {
         dir = dir,
         options = {
@@ -1020,7 +1021,29 @@ g.test_audit_options = function()
             ['audit_log.extract_key'] = true,
         },
         verify = verify,
-        verify_args = {events}
+        verify_args = {events, audit_spaces}
+    })
+
+    dir = treegen.prepare_directory({}, {})
+    audit_spaces = {
+        {name = '*', extract_key = true},
+        {name = 'space1'},
+        {name = 'space2', extract_key = false}}
+    helpers.success_case(g, {
+        dir = dir,
+        options = {
+            ['audit_log.to'] = 'devnull',
+            ['audit_log.nonblock'] = true,
+            ['audit_log.format'] = 'csv',
+            ['audit_log.filter'] = events,
+            ['audit_log.spaces'] = {
+                space1 = {},
+                space2 = {extract_key = false},
+                ['*'] = {extract_key = true}},
+            ['audit_log.extract_key'] = true,
+        },
+        verify = verify,
+        verify_args = {events, audit_spaces}
     })
 end
 

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1456,6 +1456,7 @@ g.test_box_cfg_coverage = function()
         metrics = true,
         audit_log = true,
         audit_filter = true,
+        audit_spaces = true,
         listen = true,
         app_threads = true,
 
@@ -1852,6 +1853,64 @@ g.test_audit_available = function()
     }
     local res = instance_config:apply_default({}).audit_log
     t.assert_equals(res, exp)
+end
+
+g.test_audit_spaces = function()
+    t.tarantool.skip_if_not_enterprise()
+    local iconfig = {audit_log = {}}
+    instance_config:validate(iconfig)
+
+    iconfig.audit_log.spaces = box.NULL
+    instance_config:validate(iconfig)
+
+    iconfig.audit_log.spaces = {}
+    instance_config:validate(iconfig)
+
+    -- Array of strings interface.
+    iconfig.audit_log.spaces = {'space1'}
+    instance_config:validate(iconfig)
+
+    iconfig.audit_log.spaces = {'space1', 'space2'}
+    instance_config:validate(iconfig)
+
+    iconfig.audit_log.spaces = {'space1', {name = 'space2'}}
+    t.assert_error_msg_content_equals(
+        '[instance_config] audit_log.spaces: ' ..
+        'audit_log.spaces must be a map or an array of strings',
+        instance_config.validate, instance_config, iconfig)
+
+    iconfig.audit_log.spaces = {{name = 'space1'}, 'space2'}
+    t.assert_error_msg_content_equals(
+        '[instance_config] audit_log.spaces: ' ..
+        'audit_log.spaces must be a map or an array of strings',
+        instance_config.validate, instance_config, iconfig)
+
+    -- Check wildcard.
+    iconfig.audit_log.spaces = {'space1', 'space2', '*'}
+    instance_config:validate(iconfig)
+
+    -- Record interface.
+    iconfig.audit_log.spaces = {space1 = {}}
+    instance_config:validate(iconfig)
+
+    iconfig.audit_log.spaces = {space1 = {}, ['*'] = {}}
+    instance_config:validate(iconfig)
+
+    iconfig.audit_log.spaces =
+        {space1 = {}, space2 = {extract_key = true}, ['*'] = {}}
+    instance_config:validate(iconfig)
+
+    iconfig.audit_log.spaces = {space1 = {extract_key = 10}}
+    t.assert_error_msg_content_equals(
+        '[instance_config] audit_log.spaces: ' ..
+        'audit_log.spaces.space1.extract_key must be boolean',
+        instance_config.validate, instance_config, iconfig)
+
+    iconfig.audit_log.spaces = {space1 = {unexpected_option = true}}
+    t.assert_error_msg_content_equals(
+        '[instance_config] audit_log.spaces: ' ..
+        'Unexpected field audit_log.spaces.space1.unexpected_option',
+        instance_config.validate, instance_config, iconfig)
 end
 
 g.test_failover = function()


### PR DESCRIPTION
See the commit for details.

Part of https://github.com/tarantool/tarantool-ee/issues/1735

EE part: https://github.com/tarantool/tarantool-ee/pull/1736.