### PR TITLE
box: fix assertion at vclock_compare() while selecting bootstrap leader

### DIFF
--- a/changelogs/unreleased/gh-11289-assertion-vclock-compare.md
+++ b/changelogs/unreleased/gh-11289-assertion-vclock-compare.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed an assertion at `vclock_compare()` function when selecting
+  a bootstrap leader in multimaster mode (gh-11289).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -2284,8 +2284,9 @@ applier_thread_attach_applier(struct cbus_call_msg *base)
 	fiber_cond_create(&applier->thread.writer_cond);
 	applier_thread_ibuf_init(applier);
 	applier_thread_msgs_init(applier);
-	applier_thread_fiber_init(applier);
 	memset(&applier->thread.next_ack, 0, sizeof(applier->thread.next_ack));
+	applier->thread.has_acks_to_send = false;
+	applier_thread_fiber_init(applier);
 
 	return 0;
 }


### PR DESCRIPTION
This patch fixes an assertion at vclock_compare() function when selecting a bootstrap leader in multimaster mode. Due to fiber initialization before memory clearing, field applier->thread.next_ack contains a garbage value.

Closes #11289