### PR TITLE
box: enable runtime privileges for application threads

### DIFF
--- a/src/box/app_threads.c
+++ b/src/box/app_threads.c
@@ -14,6 +14,7 @@
 
 #include "coio_task.h"
 #include "cord_buf.h"
+#include "call.h"
 #include "diag.h"
 #include "fiber.h"
 #include "fiber_pool.h"
@@ -21,9 +22,12 @@
 #include "msgpuck.h"
 #include "port.h"
 #include "say.h"
+#include "schema_def.h"
 #include "tarantool_ev.h"
 #include "trivia/util.h"
+#include "tt_static.h"
 #include "tuple.h"
+#include "user_def.h"
 #include "xrow.h"
 
 #include "lua/app_threads.h"
@@ -56,6 +60,7 @@ app_thread_f(void *arg)
 	while (!rlist_empty(&fiber_pool.idle))
 		rlist_shift(&fiber_pool.idle);
 	app_thread_lua_free();
+	box_lua_call_runtime_priv_reset();
 	tuple_free();
 	cord_buf_free();
 	return NULL;
@@ -106,6 +111,19 @@ app_thread_process_call(struct call_request *request, struct port *port)
 {
 	const char *name = request->name;
 	uint32_t name_len = mp_decode_strl(&name);
+	struct runtime_credentials *runtime_cr =
+			fiber()->storage.runtime_credentials;
+	const char *uname = runtime_cr->user_name != NULL ?
+			    runtime_cr->user_name : "guest";
+	uint32_t uname_len = strlen(uname);
+	if (strcmp(uname, "admin") != 0 &&
+	    !box_lua_call_runtime_priv_is_granted(uname, uname_len,
+						  name, name_len)) {
+		diag_set(AccessDeniedError, priv_name(PRIV_X),
+			 schema_object_name(SC_FUNCTION),
+			 tt_cstr(name, name_len), uname);
+		return -1;
+	}
 	struct mp_box_ctx ctx;
 	if (mp_box_ctx_create(&ctx, NULL, request->tuple_formats) != 0)
 		return -1;

--- a/src/box/call.c
+++ b/src/box/call.c
@@ -52,7 +52,7 @@ struct rlist box_on_call = RLIST_HEAD_INITIALIZER(box_on_call);
 
 static const struct port_vtab port_msgpack_vtab;
 
-static struct mh_strnstrnptr_t *user_rt_access = NULL;
+static __thread struct mh_strnstrnptr_t *user_rt_access = NULL;
 
 void
 port_msgpack_create_with_ctx(struct port *base, const char *data,
@@ -163,10 +163,6 @@ box_run_on_call(enum iproto_type type, const char *expr, int expr_len,
 	};
 	trigger_run(&box_on_call, &ctx);
 }
-
-static bool
-box_lua_call_runtime_priv_is_granted(const char *uname, uint32_t uname_len,
-				     const char *fname, uint32_t fname_len);
 
 int
 access_check_lua_call(const char *name, uint32_t name_len)
@@ -356,7 +352,7 @@ box_lua_call_runtime_priv_grant(const char *uname, uint32_t uname_len,
 	mh_strnstrnptr_put(user_rt_access, &access_node, NULL, NULL);
 }
 
-static bool
+bool
 box_lua_call_runtime_priv_is_granted(const char *uname, uint32_t uname_len,
 				     const char *fname, uint32_t fname_len)
 {

--- a/src/box/call.c
+++ b/src/box/call.c
@@ -34,6 +34,7 @@
 #include "../lua/init.h" /* tarantool_lua_is_builtin_global */
 #include "schema.h"
 #include "session.h"
+#include "fiber.h"
 #include "func.h"
 #include "port.h"
 #include "box.h"
@@ -187,13 +188,18 @@ access_check_lua_call(const char *name, uint32_t name_len)
 		    (object[cr->auth_token].effective & PRIV_X) != 0)
 			return 0;
 	}
-	struct user *user = user_find(cr->uid);
-	if (user != NULL) {
-		const char *uname = user->def->name;
+	struct runtime_credentials *runtime_cr =
+			fiber()->storage.runtime_credentials;
+	if (runtime_cr != NULL) {
+		const char *uname = runtime_cr->user_name != NULL ?
+				    runtime_cr->user_name : "guest";
 		uint32_t uname_len = strlen(uname);
 		if (box_lua_call_runtime_priv_is_granted(uname, uname_len, name,
 							 name_len))
 			return 0;
+	}
+	struct user *user = user_find(cr->uid);
+	if (user != NULL) {
 		diag_set(AccessDeniedError, priv_name(PRIV_X),
 			 schema_object_name(SC_FUNCTION),
 			 tt_cstr(name, name_len), user->def->name);

--- a/src/box/call.h
+++ b/src/box/call.h
@@ -103,6 +103,13 @@ void
 box_lua_call_runtime_priv_grant(const char *uname, uint32_t uname_len,
 				const char *fname, uint32_t fname_len);
 
+/**
+ * Return true if a user has access to a lua_call function.
+ */
+bool
+box_lua_call_runtime_priv_is_granted(const char *uname, uint32_t uname_len,
+				     const char *fname, uint32_t fname_len);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/call.h
+++ b/src/box/call.h
@@ -42,6 +42,12 @@ extern "C" {
 struct port;
 struct call_request;
 
+/** Credentials used for runtime privilege checking. */
+struct runtime_credentials {
+	/** Name of the authenticated user. */
+	char *user_name;
+};
+
 /** Context passed to box_on_call trigger callback. */
 struct box_on_call_ctx {
 	/** True for EVAL, false for CALL. */

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -189,6 +189,7 @@ struct iproto_thread {
 	struct cmsg_hop rollback_route[2];
 	struct cmsg_hop rollback_on_disconnect_route[2];
 	struct cmsg_hop disconnect_route[2];
+	struct cmsg_hop auth_route[2];
 	struct cmsg_hop misc_route[2];
 	struct cmsg_hop select_route[2];
 	struct cmsg_hop process1_route[2];
@@ -435,6 +436,8 @@ struct iproto_cfg_msg: public cbus_call_msg
 			struct iostream io;
 			/** New connection session. */
 			struct session *session;
+			/** Authenticated user name. */
+			char *user_name;
 		} session_new;
 		struct {
 			/** Overridden request type. */
@@ -491,6 +494,8 @@ struct iproto_service_msg {
 	int iproto_msg_max;
 	/** Function name passed to iproto_register_func(). */
 	char *func_name;
+	/** Authenticated user name. */
+	char *user_name;
 };
 
 static struct iproto_service_msg *
@@ -505,6 +510,7 @@ iproto_service_msg_new(const struct cmsg_hop *route)
 	msg->drop_generation = 0;
 	msg->iproto_msg_max = 0;
 	msg->func_name = NULL;
+	msg->user_name = NULL;
 	return msg;
 }
 
@@ -602,8 +608,12 @@ struct iproto_msg
 		struct call_request call;
 		/** Watch request. */
 		struct watch_request watch;
-		/** Authentication request. */
-		struct auth_request auth;
+		struct {
+			/** Authentication request. */
+			struct auth_request auth;
+			/** Set if the request was successfully processed. */
+			bool auth_successful;
+		};
 		/** Features request. */
 		struct id_request id;
 		/** SQL request, if this is the EXECUTE/PREPARE request. */
@@ -853,6 +863,10 @@ struct iproto_connection
 		 * List of inprogress messages (see iproto_msg::in_inprogress).
 		 */
 		struct rlist inprogress;
+		/**
+		 * Credentials used for checking runtime privileges.
+		 */
+		struct runtime_credentials runtime_credentials;
 	} *srv;
 	/**
 	 * When we flush output, we cycle through all serving threads' output
@@ -1812,6 +1826,7 @@ iproto_connection_new(struct iproto_thread *iproto_thread)
 		iproto_wpos_create(&con->srv[i].wpos, con->srv[i].p_obuf);
 		iproto_wpos_create(&con->srv[i].wend, con->srv[i].p_obuf);
 		rlist_create(&con->srv[i].inprogress);
+		con->srv[i].runtime_credentials.user_name = NULL;
 	}
 	con->flush.srv_id = 0;
 	con->flush.wend = con->srv[0].wend;
@@ -1876,6 +1891,7 @@ iproto_connection_delete(struct iproto_connection *con)
 	for (int i = 0; i < iproto_thread->srv_count; i++) {
 		assert(!obuf_is_initialized(&con->srv[i].obuf[0]));
 		assert(!obuf_is_initialized(&con->srv[i].obuf[1]));
+		free(con->srv[i].runtime_credentials.user_name);
 	}
 	assert(mh_size(con->streams) == 0);
 	mh_i64ptr_delete(con->streams);
@@ -2160,9 +2176,10 @@ iproto_msg_decode(struct iproto_msg *msg, struct cmsg_hop **route)
 		*route = iproto_thread->misc_route;
 		return 0;
 	case IPROTO_AUTH:
-		*route = iproto_thread->misc_route;
+		*route = iproto_thread->auth_route;
 		if (xrow_decode_auth(&msg->header, &msg->auth))
 			return -1;
+		msg->auth_successful = false;
 		return 0;
 	default:
 		*route = NULL;
@@ -2433,6 +2450,9 @@ srv_accept_msg(struct cmsg *m)
 			msg, in_inprogress);
 	assert(msg->fiber == NULL);
 	msg->fiber = fiber();
+	assert(msg->fiber->storage.runtime_credentials == NULL);
+	msg->fiber->storage.runtime_credentials =
+		&msg->connection->srv[msg->srv_id].runtime_credentials;
 	return msg;
 }
 
@@ -2495,6 +2515,7 @@ srv_end_msg(struct iproto_msg *msg)
 {
 	assert(msg->srv_id == app_thread_id);
 	rlist_del(&msg->in_inprogress);
+	msg->fiber->storage.runtime_credentials = NULL;
 	msg->fiber = NULL;
 }
 
@@ -3043,6 +3064,76 @@ iproto_session_notify(struct session *session, uint64_t sync,
 		      const char *key, size_t key_len,
 		      const char *data, const char *data_end);
 
+/** Process a user authentication request in the tx thread. */
+static void
+tx_process_auth(struct cmsg *m)
+{
+	struct iproto_msg *msg = tx_accept_msg(m);
+	struct iproto_connection *con = msg->connection;
+	struct obuf *out = iproto_msg_obuf(msg);
+	struct obuf_svp svp = obuf_create_svp(out);
+	assert(!in_txn());
+	if (tx_check_msg(msg) != 0)
+		goto error;
+	if (box_process_auth(&msg->auth, con->salt, IPROTO_SALT_SIZE) != 0)
+		goto error;
+	msg->auth_successful = true;
+	iproto_reply_ok(out, msg->header.sync, ::schema_version);
+	iproto_wpos_create(&msg->wpos, out);
+	tx_end_msg(msg, &svp);
+	return;
+error:
+	svp = obuf_create_svp(out);
+	tx_reply_error(msg);
+	tx_end_msg(msg, &svp);
+}
+
+/** Finish a user authentication request in a serving thread. */
+static void
+srv_finish_auth(struct cmsg *m)
+{
+	struct iproto_service_msg *msg = (struct iproto_service_msg *)m;
+	struct iproto_connection *con = msg->connection;
+	int srv_id = msg->srv_id;
+	assert(srv_id == app_thread_id);
+	struct runtime_credentials *cr = &con->srv[srv_id].runtime_credentials;
+	free(cr->user_name);
+	cr->user_name = msg->user_name;
+	iproto_service_msg_delete(msg);
+}
+
+/**
+ * Finish a user authentication request in the IPROTO thread.
+ *
+ * The function sends a message to each serving threads that makes it update
+ * credentials used for runtime privilege checking.
+ */
+static void
+net_finish_auth(struct cmsg *m)
+{
+	struct iproto_msg *msg = (struct iproto_msg *)m;
+	if (msg->auth_successful) {
+		struct iproto_connection *con = msg->connection;
+		struct iproto_thread *iproto_thread = con->iproto_thread;
+		static const struct cmsg_hop finish_auth_route[] = {
+			{srv_finish_auth, NULL},
+		};
+		const char *user_name = msg->auth.user_name;
+		uint32_t user_name_len = mp_decode_strl(&user_name);
+		for (int i = 0; i < iproto_thread->srv_count; i++) {
+			struct iproto_service_msg *finish_auth_msg =
+				iproto_service_msg_new(finish_auth_route);
+			finish_auth_msg->srv_id = i;
+			finish_auth_msg->connection = con;
+			finish_auth_msg->user_name =
+				(char *)xstrndup(user_name, user_name_len);
+			cpipe_push(&iproto_thread->srv[i].pipe,
+				   &finish_auth_msg->base);
+		}
+	}
+	net_send_msg(m);
+}
+
 static void
 tx_process_misc(struct cmsg *m)
 {
@@ -3057,12 +3148,6 @@ tx_process_misc(struct cmsg *m)
 	struct ballot ballot;
 	header = obuf_create_svp(out);
 	switch (msg->header.type) {
-	case IPROTO_AUTH:
-		if (box_process_auth(&msg->auth, con->salt,
-				     IPROTO_SALT_SIZE) != 0)
-			goto error;
-		iproto_reply_ok(out, msg->header.sync, ::schema_version);
-		break;
 	case IPROTO_PING:
 		iproto_reply_ok(out, msg->header.sync, ::schema_version);
 		break;
@@ -3714,7 +3799,7 @@ net_send_greeting(struct cmsg *m)
 static void
 iproto_thread_accept(struct iproto_thread *iproto_thread, struct iostream *io,
 		     struct sockaddr *addr, socklen_t addrlen,
-		     struct session *session)
+		     struct session *session, char *user_name)
 {
 	struct iproto_connection *con = iproto_connection_new(iproto_thread);
 	struct cpipe *tx_pipe = &iproto_thread->srv[0].pipe;
@@ -3723,6 +3808,8 @@ iproto_thread_accept(struct iproto_thread *iproto_thread, struct iostream *io,
 	memcpy(&msg->connect.addrstorage, addr, addrlen);
 	msg->connect.addrlen = addrlen;
 	msg->connect.session = session;
+	for (int i = 0; i < iproto_thread->srv_count; i++)
+		con->srv[i].runtime_credentials.user_name = user_name;
 	iostream_move(&con->io, io);
 	cmsg_init(&msg->base, iproto_thread->connect_route);
 	msg->p_ibuf = con->p_ibuf;
@@ -3737,7 +3824,7 @@ iproto_on_accept_cb(struct evio_service *service, struct iostream *io,
 	struct iproto_thread *iproto_thread =
 		(struct iproto_thread *)service->on_accept_param;
 	iproto_thread_accept(iproto_thread, io, addr, addrlen,
-			     /*session=*/NULL);
+			     /*session=*/NULL, /*user_name=*/NULL);
 }
 
 /**
@@ -4025,6 +4112,8 @@ iproto_thread_init_routes(struct iproto_thread *iproto_thread)
 		{net_finish_rollback_on_disconnect, NULL};
 	iproto_thread->disconnect_route[0] = {tx_process_disconnect, net_pipe};
 	iproto_thread->disconnect_route[1] = {net_finish_disconnect, NULL};
+	iproto_thread->auth_route[0] = {tx_process_auth, net_pipe};
+	iproto_thread->auth_route[1] = {net_finish_auth, NULL};
 	iproto_thread->misc_route[0] = {tx_process_misc, net_pipe};
 	iproto_thread->misc_route[1] = {net_send_msg, NULL};
 	iproto_thread->select_route[0] = {tx_process_select, net_pipe};
@@ -4411,12 +4500,14 @@ iproto_do_cfg_f(struct cbus_call_msg *m)
 	case IPROTO_CFG_SESSION_NEW: {
 		struct iostream *io = &cfg_msg->session_new.io;
 		struct session *session = cfg_msg->session_new.session;
+		char *user_name = cfg_msg->session_new.user_name;
 		struct sockaddr_storage addrstorage;
 		struct sockaddr *addr = (struct sockaddr *)&addrstorage;
 		socklen_t addrlen = sizeof(addrstorage);
 		if (sio_getpeername(io->fd, addr, &addrlen) != 0)
 			addrlen = 0;
-		iproto_thread_accept(iproto_thread, io, addr, addrlen, session);
+		iproto_thread_accept(iproto_thread, io, addr, addrlen,
+				     session, user_name);
 		break;
 	}
 	case IPROTO_CFG_DROP_CONNECTIONS: {
@@ -4676,14 +4767,18 @@ iproto_session_new(struct iostream *io, struct user *user, uint64_t *sid)
 		diag_set(ClientError, ER_SHUTDOWN);
 		return -1;
 	}
+	char *user_name = NULL;
 	struct session *session = session_new(SESSION_TYPE_BACKGROUND);
-	if (user != NULL)
+	if (user != NULL) {
 		credentials_reset(&session->credentials, user);
+		user_name = (char *)xstrdup(user->def->name);
+	}
 	struct iproto_cfg_msg *cfg_msg =
 		(struct iproto_cfg_msg *)xmalloc(sizeof(*cfg_msg));
 	iproto_cfg_msg_create(cfg_msg, IPROTO_CFG_SESSION_NEW);
 	iostream_move(&cfg_msg->session_new.io, io);
 	cfg_msg->session_new.session = session;
+	cfg_msg->session_new.user_name = user_name;
 	static int thread = 0;
 	thread = (thread + 1) % iproto_threads_count;
 	iproto_do_cfg_async(&iproto_threads[thread], cfg_msg);

--- a/src/box/lua/app_threads.lua
+++ b/src/box/lua/app_threads.lua
@@ -158,6 +158,23 @@ function thread_group_methods:init(cfg, group_name)
 end
 
 --
+-- Callback for thread_group:reload_priv().
+--
+local function thread_reload_priv_cb(args, thread_id)
+    assert(threads_conn ~= nil)
+    return threads_conn:call('box.internal.threads.reload_priv', args,
+                             {_thread_id = thread_id, is_async = true})
+end
+
+--
+-- Reloads privileges in all threads of this group.
+--
+function thread_group_methods:reload_priv(priv)
+    assert(threads_conn ~= nil)
+    return self:_dispatch(thread_reload_priv_cb, {priv}, {target = 'all'})
+end
+
+--
 -- Callback for thread_group:call().
 --
 local function thread_call_cb(args, thread_id)
@@ -207,6 +224,18 @@ function box.internal.threads.init(cfg, group_name, thread_id, conn_fd)
 end
 
 --
+-- Reloads privileges in the current thread.
+--
+function box.internal.threads.reload_priv(priv)
+    box.internal.lua_call_runtime_priv_reset()
+    for user_name, funcs in pairs(priv) do
+        for func_name, _ in pairs(funcs) do
+            box.internal.lua_call_runtime_priv_grant(user_name, func_name)
+        end
+    end
+end
+
+--
 -- Configures the threads subsystem. Called once from the main thread.
 -- If called without arguments, returns the current configuration.
 --
@@ -220,6 +249,18 @@ function box.internal.threads.cfg(cfg)
     for group_name, group in pairs(thread_groups) do
         if group_name ~= this_group_name then
             group:init(cfg, group_name)
+        end
+    end
+end
+
+--
+-- Configures runtime privileges in application threads. Note that the main
+-- thread is excluded (it's supposed to be configured before box.cfg).
+--
+function box.internal.threads.cfg_priv(priv)
+    for group_name, group in pairs(thread_groups) do
+        if group_name ~= 'tx' then
+            group:reload_priv(priv)
         end
     end
 end

--- a/src/box/lua/call.c
+++ b/src/box/lua/call.c
@@ -1337,10 +1337,14 @@ on_msgpack_serializer_update(struct trigger *trigger, void *event)
 
 static TRIGGER(on_alter_func_in_lua, lbox_func_new_or_delete);
 
-static const struct luaL_Reg boxlib_internal[] = {
+static const struct luaL_Reg boxlib_internal_main[] = {
 	{"call_loadproc",  lbox_call_loadproc},
 	{"module_reload", lbox_module_reload},
 	{"func_call", lbox_func_call},
+	{NULL, NULL}
+};
+
+static const struct luaL_Reg boxlib_internal_common[] = {
 	{"lua_call_runtime_priv_grant", lbox_box_lua_call_runtime_priv_grant},
 	{"lua_call_runtime_priv_reset", lbox_box_lua_call_runtime_priv_reset},
 	{NULL, NULL}
@@ -1355,10 +1359,13 @@ box_lua_call_init(struct lua_State *L)
 	trigger_add(&luaL_msgpack_default->on_update,
 		    &call_serializer_no_error_ext.update_trigger);
 
+	luaL_findtable(L, LUA_GLOBALSINDEX, "box.internal", 0);
+	if (cord_is_main())
+		luaL_setfuncs(L, boxlib_internal_main, 0);
+	luaL_setfuncs(L, boxlib_internal_common, 0);
+	lua_pop(L, 1);
+
 	if (cord_is_main()) {
-		luaL_findtable(L, LUA_GLOBALSINDEX, "box.internal", 0);
-		luaL_setfuncs(L, boxlib_internal, 0);
-		lua_pop(L, 1);
 		/*
 		 * Register the trigger that will push persistent
 		 * Lua functions objects to Lua.

--- a/src/box/lua/config/applier/runtime_priv.lua
+++ b/src/box/lua/config/applier/runtime_priv.lua
@@ -16,6 +16,9 @@ local function add_funcs(res, user_or_role_def)
         end
         if has_execute and privilege.lua_call ~= nil then
             for _, func_name in ipairs(privilege.lua_call) do
+                if func_name == 'all' then
+                    func_name = ''
+                end
                 res[func_name] = true
             end
         end
@@ -99,10 +102,9 @@ local function grant_implicit_privileges(configdata)
     end
 end
 
-local function apply(config_module)
+local function extract_priv(configdata)
     -- Prepare a context with the configuration information to
     -- transform.
-    local configdata = config_module._configdata
     local ctx = {
         roles = configdata:get('credentials.roles') or {},
         users = configdata:get('credentials.users') or {},
@@ -124,24 +126,33 @@ local function apply(config_module)
             res[user_name] = funcs
         end
     end
+    return res
+end
+
+local function apply(config_module)
+    local configdata = config_module._configdata
+    local priv = extract_priv(configdata)
 
     -- Reset the runtime privileges and grant all the configured
     -- ones.
     box.internal.lua_call_runtime_priv_reset()
-    for user_name, funcs in pairs(res) do
+    for user_name, funcs in pairs(priv) do
         for func_name, _ in pairs(funcs) do
-            if func_name == 'all' then
-                box.internal.lua_call_runtime_priv_grant(user_name, '')
-            else
-                box.internal.lua_call_runtime_priv_grant(user_name, func_name)
-            end
+            box.internal.lua_call_runtime_priv_grant(user_name, func_name)
         end
     end
 
     grant_implicit_privileges(configdata)
 end
 
+local function post_apply(config_module)
+    local configdata = config_module._configdata
+    local priv = extract_priv(configdata)
+    box.internal.threads.cfg_priv(priv)
+end
+
 return {
     name = 'runtime_priv',
     apply = apply,
+    post_apply = post_apply,
 }

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -601,6 +601,7 @@ fiber_attr_create(struct fiber_attr *fiber_attr);
 struct session;
 struct txn;
 struct credentials;
+struct runtime_credentials;
 struct lua_State;
 struct ipc_wait_pad;
 
@@ -727,6 +728,8 @@ struct fiber {
 		struct session *session;
 		struct credentials *credentials;
 		struct txn *txn;
+		/** Credentials used for checking runtime privileges. */
+		struct runtime_credentials *runtime_credentials;
 		/** Fields related to Lua code execution. */
 		struct {
 			/**

--- a/test/box-luatest/app_threads_module_test.lua
+++ b/test/box-luatest/app_threads_module_test.lua
@@ -1,3 +1,5 @@
+local net = require('net.box')
+
 local t = require('luatest')
 local cbuilder = require('luatest.cbuilder')
 local cluster = require('luatest.cluster')
@@ -519,4 +521,121 @@ g.test_threads_eval = function()
         t.assert_equals(threads.eval('test2', expr, {}, {target = 'all'}),
                         {{'test2', 4}, {'test2', 5}})
     end, {}, {_thread_id = 5})
+end
+
+g.test_threads_priv = function()
+    local config = cbuilder:new()
+        :set_global_option('credentials.users.guest.privileges', {
+            {
+                permissions = {'execute'},
+                lua_call = {'test_func_1', 'test_func_2'},
+            },
+        })
+        :set_global_option('credentials.users.admin.password', 'secret')
+        :set_global_option('credentials.users.alice.password', 'ALICE')
+        :set_global_option('credentials.users.alice.privileges', {
+            {
+                permissions = {'execute'},
+                lua_call = {'test_func_1'},
+            },
+        })
+        :set_global_option('credentials.users.bob.password', 'BOB')
+        :set_global_option('credentials.users.bob.privileges', {
+            {
+                permissions = {'execute'},
+                lua_call = {'all'},
+            },
+        })
+        :add_instance('server', {})
+        :set_instance_option('server', 'threads.groups', {
+            {name = 'test1', size = 1},
+            {name = 'test2', size = 2},
+            {name = 'test3', size = 3},
+        })
+        :config()
+    local cluster = cluster:new(config)
+    cluster.server:start()
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        for _, group in ipairs(threads.info().groups) do
+            threads.eval(group.name, [[
+                for _, f in ipairs({
+                    'test_func_1', 'test_func_2', 'test_func_3',
+                }) do
+                    box.iproto.export(f, function() return f end)
+                end
+            ]])
+        end
+    end)
+    local conn_guest = net.connect(cluster.server.net_box_uri)
+    local conn_admin = net.connect(cluster.server.net_box_uri,
+                                   {user = 'admin', password = 'secret'})
+    local conn_alice = net.connect(cluster.server.net_box_uri,
+                                   {user = 'alice', password = 'ALICE'})
+    local conn_bob = net.connect(cluster.server.net_box_uri,
+                                 {user = 'bob', password = 'BOB'})
+    local function check_ok(conn, func_name)
+        t.assert_equals(conn:call(func_name), func_name)
+    end
+    local function check_err(conn, func_name)
+        t.assert_error_covers({
+            type = 'AccessDeniedError',
+            access_type = 'Execute',
+            object_type = 'function',
+            object_name = func_name,
+            user = conn.opts and conn.opts.user or 'guest',
+        }, conn.call, conn, func_name)
+    end
+    -- Run the checks a few times so that function call requests land in
+    -- different application threads.
+    for _ = 1, 10 do
+        check_ok(conn_admin, 'test_func_1')
+        check_ok(conn_admin, 'test_func_2')
+        check_ok(conn_admin, 'test_func_3')
+        check_ok(conn_guest, 'test_func_1')
+        check_ok(conn_guest, 'test_func_2')
+        check_err(conn_guest, 'test_func_3')
+        check_ok(conn_alice, 'test_func_1')
+        check_err(conn_alice, 'test_func_2')
+        check_err(conn_alice, 'test_func_3')
+        check_ok(conn_bob, 'test_func_1')
+        check_ok(conn_bob, 'test_func_2')
+        check_ok(conn_bob, 'test_func_3')
+    end
+    -- Reload config and check again.
+    config = cbuilder:new(config)
+        :set_global_option('credentials.users.guest.privileges', {
+            {
+                permissions = {'execute'},
+                lua_call = {'test_func_3'},
+            },
+        })
+        :set_global_option('credentials.users.alice.privileges', {
+            {
+                permissions = {'execute'},
+                lua_call = {'all'},
+            },
+        })
+        :set_global_option('credentials.users.bob.privileges', {
+            {
+                permissions = {'execute'},
+                lua_call = {'test_func_2'},
+            },
+        })
+        :config()
+    cluster:reload(config)
+    for _ = 1, 10 do
+        check_ok(conn_admin, 'test_func_1')
+        check_ok(conn_admin, 'test_func_2')
+        check_ok(conn_admin, 'test_func_3')
+        check_err(conn_guest, 'test_func_1')
+        check_err(conn_guest, 'test_func_2')
+        check_ok(conn_guest, 'test_func_3')
+        check_ok(conn_alice, 'test_func_1')
+        check_ok(conn_alice, 'test_func_2')
+        check_ok(conn_alice, 'test_func_3')
+        check_err(conn_bob, 'test_func_1')
+        check_ok(conn_bob, 'test_func_2')
+        check_err(conn_bob, 'test_func_3')
+    end
 end

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -20,6 +20,9 @@ g.before_all(function(cg)
     })
     cg.server:start()
     cg.server:call('box.iproto.internal.enable_thread_requests')
+    cg.server:exec(function()
+        box.schema.user.passwd('admin', 'secret')
+    end)
 end)
 
 g.after_all(function(cg)
@@ -27,7 +30,9 @@ g.after_all(function(cg)
 end)
 
 g.test_thread_requests_disabled = function(cg)
-    local conn = net.connect(cg.server.net_box_uri)
+    local conn = net.connect(cg.server.net_box_uri, {
+        user = 'admin', password = 'secret',
+    })
     local err = {type = 'ClientError', name = 'THREAD_REQUESTS_DISABLED'}
     t.assert_error_covers(err, conn.call, conn, 'tonumber', {'123'},
                           {_thread_id = 1})
@@ -101,7 +106,9 @@ g.test_unable_to_process_in_thread = function(cg)
 end
 
 g.test_call_eval = function(cg)
-    local conn = net.connect(cg.server.net_box_uri)
+    local conn = net.connect(cg.server.net_box_uri, {
+        user = 'admin', password = 'secret',
+    })
     conn:call('box.iproto.internal.enable_thread_requests')
     -- Call a box function in the main thread.
     t.assert_covers(conn:call('box.info', {}, {_thread_id = 0}),

--- a/test/box-luatest/iproto_export_test.lua
+++ b/test/box-luatest/iproto_export_test.lua
@@ -74,6 +74,9 @@ g2.test_iproto_export_in_app_threads = function(cg)
     cg.server:start()
     cg.server:call('box.iproto.internal.enable_thread_requests')
     cg.server:exec(function()
+        box.schema.user.passwd('admin', 'secret')
+    end)
+    cg.server:exec(function()
         box.iproto.export('test.func_1', function(v) return {1, v} end)
     end, {}, {_thread_id = 0})
     cg.server:exec(function()
@@ -85,24 +88,28 @@ g2.test_iproto_export_in_app_threads = function(cg)
         rawset(_G, 'test', {})
         _G.test.func_3 = function(v) return {3, v} end
     end, {}, {_thread_id = 2})
+    local conn = net.connect(cg.server.net_box_uri, {
+        user = 'admin', password = 'secret',
+    })
+    conn:call('box.iproto.internal.enable_thread_requests')
     local err = {type = 'ClientError', name = 'NO_SUCH_PROC'}
-    t.assert_equals(cg.server:call('test.func_1', {'x'}, {_thread_id = 0}),
+    t.assert_equals(conn:call('test.func_1', {'x'}, {_thread_id = 0}),
                     {1, 'x'})
-    t.assert_error_covers(err, cg.server.call, cg.server,
+    t.assert_error_covers(err, conn.call, conn,
                           'test.func_2', {'x'}, {_thread_id = 0})
-    t.assert_error_covers(err, cg.server.call, cg.server,
+    t.assert_error_covers(err, conn.call, conn,
                           'test.func_3', {'x'}, {_thread_id = 0})
-    t.assert_equals(cg.server:call('test.func_2', {'x'}, {_thread_id = 1}),
+    t.assert_equals(conn:call('test.func_2', {'x'}, {_thread_id = 1}),
                     {2, 'x'})
-    t.assert_error_covers(err, cg.server.call, cg.server,
+    t.assert_error_covers(err, conn.call, conn,
                           'test.func_1', {'x'}, {_thread_id = 1})
-    t.assert_error_covers(err, cg.server.call, cg.server,
+    t.assert_error_covers(err, conn.call, conn,
                           'test.func_3', {'x'}, {_thread_id = 1})
-    t.assert_equals(cg.server:call('test.func_3', {'x'}, {_thread_id = 2}),
+    t.assert_equals(conn:call('test.func_3', {'x'}, {_thread_id = 2}),
                     {3, 'x'})
-    t.assert_error_covers(err, cg.server.call, cg.server,
+    t.assert_error_covers(err, conn.call, conn,
                           'test.func_1', {'x'}, {_thread_id = 2})
-    t.assert_error_covers(err, cg.server.call, cg.server,
+    t.assert_error_covers(err, conn.call, conn,
                           'test.func_2', {'x'}, {_thread_id = 2})
 end
 
@@ -120,6 +127,9 @@ g2.test_iproto_call_routing = function(cg)
     })
     cg.server:start()
     cg.server:call('box.iproto.internal.enable_thread_requests')
+    cg.server:exec(function()
+        box.schema.user.passwd('admin', 'secret')
+    end)
     cg.server:exec(function()
         rawset(_G, 'test_func_2', function() return 0 end)
         box.iproto.export('test_func_3', function() return 0 end)
@@ -145,7 +155,10 @@ g2.test_iproto_call_routing = function(cg)
     end, {}, {_thread_id = 3})
     local conns = {}
     for _ = 1, 10 do
-        table.insert(conns, net.connect(cg.server.net_box_uri))
+        local conn = net.connect(cg.server.net_box_uri, {
+            user = 'admin', password = 'secret',
+        })
+        table.insert(conns, conn)
     end
     local err_margin = 100
     local total_calls = 1000


### PR DESCRIPTION
Runtime privileges are now propagated from the config to application threads and checked before processing IPROTO CALL requests. Note that the admin is still allowed to execute any IPROTO CALL request. This is required for the threads Lua module to work.

Closes #12475