### PR TITLE
box: log the signals handled by libev

### DIFF
--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -455,11 +455,8 @@ logrotate_cleanup_cb(struct coio_task *ptr)
 }
 
 void
-say_logrotate(struct ev_loop *loop, struct ev_signal *w, int revents)
+say_logrotate()
 {
-	(void) loop;
-	(void) w;
-	(void) revents;
 	int saved_errno = errno;
 	struct log *log;
 	rlist_foreach_entry(log, &log_rotate_list, in_log_list) {

--- a/src/lib/core/say.h
+++ b/src/lib/core/say.h
@@ -359,8 +359,9 @@ say_log_level_str(int level);
 struct ev_loop;
 struct ev_signal;
 
+/* Invoke the log rotation. */
 void
-say_logrotate(struct ev_loop *, struct ev_signal *, int /* revents */);
+say_logrotate(void);
 
 /** Init default logger. */
 void

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -47,7 +47,7 @@ ffi.cdef[[
     extern struct ev_signal;
 
     extern void
-    say_logrotate(struct ev_loop *, struct ev_signal *, int);
+    say_logrotate();
 
     enum say_level {
         S_FATAL,
@@ -265,7 +265,7 @@ local log_debug = say_closure(nil, S_DEBUG)
 -- Rotate log (basically reopen the log file and
 -- start writting into it).
 local function log_rotate()
-    ffi.C.say_logrotate(nil, nil, 0)
+    ffi.C.say_logrotate()
 end
 
 -- Returns pid of a pipe process.

--- a/src/main.cc
+++ b/src/main.cc
@@ -100,7 +100,7 @@ static char *pid_file = NULL;
 static char **main_argv;
 static int main_argc;
 /** Signals handled after start as part of the event loop. */
-static ev_signal ev_sigs[7];
+static ev_signal ev_sigs[6];
 static const int ev_sig_count = sizeof(ev_sigs)/sizeof(*ev_sigs);
 
 static double start_time;
@@ -131,9 +131,9 @@ static void
 signal_checkpoint(ev_loop *loop, struct ev_signal *w, int revents)
 {
 	(void)loop;
-	(void)w;
 	(void)revents;
-	say_info("got signal SIGUSR1, triggering checkpoint");
+	say_info("got signal #%d (%s) from PID %ld, triggering checkpoint",
+		 w->signum, strsignal(w->signum), (long)w->sender_pid);
 	box_checkpoint_async();
 }
 
@@ -202,7 +202,6 @@ static void
 signal_cb(ev_loop *loop, struct ev_signal *w, int revents)
 {
 	(void) loop;
-	(void) w;
 	(void) revents;
 
 	/**
@@ -213,7 +212,8 @@ signal_cb(ev_loop *loop, struct ev_signal *w, int revents)
 	 * explicit in the log.
 	 */
 	if (pid_file)
-		say_crit("got signal %d - %s", w->signum, strsignal(w->signum));
+		say_crit("got signal #%d (%s) from PID %ld", w->signum,
+			 strsignal(w->signum), (long)w->sender_pid);
 	start_shutdown(0);
 }
 
@@ -245,18 +245,21 @@ static void
 broadcast_sigusr2(ev_loop *loop, struct ev_signal *w, int revents)
 {
 	(void)loop;
-	(void)w;
 	(void)revents;
+	say_info("got signal #%d (%s) from PID %ld",
+		 w->signum, strsignal(w->signum), (long)w->sender_pid);
 	const char *key = "box.internal.SIGUSR2";
 	box_broadcast(key, strlen(key), NULL, 0);
 }
 
 static void
-broadcast_sighup(ev_loop *loop, struct ev_signal *w, int revents)
+signal_sighup_cb(ev_loop *loop, struct ev_signal *w, int revents)
 {
 	(void)loop;
-	(void)w;
 	(void)revents;
+	say_info("got signal #%d (%s) from PID %ld",
+		 w->signum, strsignal(w->signum), (long)w->sender_pid);
+	say_logrotate();
 	const char *key = "box.internal.SIGHUP";
 	box_broadcast(key, strlen(key), NULL, 0);
 }
@@ -322,9 +325,8 @@ signal_init(void)
 	ev_signal_init(&ev_sigs[1], signal_sigint_cb, SIGINT);
 	ev_signal_init(&ev_sigs[2], signal_cb, SIGTERM);
 	ev_signal_init(&ev_sigs[3], signal_sigwinch_cb, SIGWINCH);
-	ev_signal_init(&ev_sigs[4], say_logrotate, SIGHUP);
-	ev_signal_init(&ev_sigs[5], broadcast_sighup, SIGHUP);
-	ev_signal_init(&ev_sigs[6], broadcast_sigusr2, SIGUSR2);
+	ev_signal_init(&ev_sigs[4], signal_sighup_cb, SIGHUP);
+	ev_signal_init(&ev_sigs[5], broadcast_sigusr2, SIGUSR2);
 	for (int i = 0; i < ev_sig_count; i++)
 		ev_signal_start(loop(), &ev_sigs[i]);
 

--- a/test/app-luatest/gh_12477_signal_logging_test.lua
+++ b/test/app-luatest/gh_12477_signal_logging_test.lua
@@ -1,0 +1,51 @@
+local server = require('luatest.server')
+local popen = require('popen')
+local fio = require('fio')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.server = server:new({box_cfg = {
+        pid_file = fio.pathjoin(fio.tempdir(), 'tarantool.pid')}
+    })
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    if cg.server ~= nil then
+        cg.server:drop()
+    end
+end)
+
+-- Test all the signals handled by libev are logged.
+g.test_ev_signals = function(cg)
+    -- Send a signal with own sender PID and check if it's logged.
+    local ffi = require("ffi")
+    ffi.cdef('int kill(int pid, int signum);')
+    local function test_signal(signum)
+        -- The pattern to search for in the log.
+        local signal_log_pattern = 'got signal #' .. signum .. ' (.*) ' ..
+                                   'from PID ' .. box.info.pid
+        -- The process can be terminated by the signal - get it now.
+        local log_filename = cg.server:exec(function()
+            return rawget(_G, 'box_cfg_log_file') or box.cfg.log
+        end)
+        ffi.C.kill(cg.server.process.pid, signum)
+        t.helpers.retrying({}, function()
+            t.assert(cg.server:grep_log(signal_log_pattern, nil,
+                                        {filename = log_filename}))
+        end)
+    end
+
+    -- Test signals with no unwanted side effects.
+    test_signal(popen.signal.SIGUSR1)
+    test_signal(popen.signal.SIGUSR2)
+    test_signal(popen.signal.SIGHUP)
+
+    -- Restart after each next test.
+    test_signal(popen.signal.SIGINT)
+    cg.server:start()
+    test_signal(popen.signal.SIGTERM)
+    cg.server:start()
+end

--- a/test/app-tap/gh-2717-no-quit-sigint.test.lua
+++ b/test/app-tap/gh-2717-no-quit-sigint.test.lua
@@ -202,13 +202,13 @@ test:unlike(status.state, popen.state.ALIVE,
 
 start_time = clock.monotonic()
 local data = ''
-while data:match('got signal 2') == nil
+while data:match('got signal #2') == nil
         and clock.monotonic() - start_time < time_quota do
     data = data .. process_timeout.read_with_timeout(f,
             file_read_timeout,
             file_read_interval)
 end
-assert(data:match('got signal 2'), 'there is no one note about SIGINT')
+assert(data:match('got signal #2'), 'there is no one note about SIGINT')
 assert(clock.monotonic() - start_time < time_quota, 'time_quota is violated')
 
 f:close()

--- a/test/config-luatest/roles_test.lua
+++ b/test/config-luatest/roles_test.lua
@@ -1049,7 +1049,7 @@ g.test_role_graceful_shutdown = function(g)
     log_file:close()
 
     t.assert_str_contains(log_content,
-        '.*Terminated\n' ..
+        '.*Terminated.-\n' ..
         '.* roles.on_shutdown: stopping role two\n' ..
         '.* Role two stopped\n' ..
         '.* roles.on_shutdown: stopping role one\n' ..
@@ -1107,7 +1107,7 @@ g.test_role_graceful_shutdown_order = function(g)
     log_file:close()
 
     t.assert_str_contains(log_content,
-        '.*Terminated\n' ..
+        '.*Terminated.-\n' ..
         '.* roles.on_shutdown: stopping role one\n' ..
         '.* Role one stopped\n' ..
         '.* roles.on_shutdown: stopping role two\n' ..

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -673,6 +673,11 @@ create_unit_test(PREFIX tt_sort
                  LIBRARIES unit core
 )
 
+create_unit_test(PREFIX ev_signal_pid
+                 SOURCES ev_signal_pid.cc core_test_utils.c
+                 LIBRARIES unit core
+)
+
 create_unit_test(PREFIX iterator_position
                  SOURCES iterator_position.c box_test_utils.c
                  LIBRARIES unit box core

--- a/test/unit/ev_signal_pid.cc
+++ b/test/unit/ev_signal_pid.cc
@@ -1,0 +1,113 @@
+#include <signal.h>
+#include <tarantool_ev.h>
+
+#include "core/tt_static.h"
+#include "fiber.h"
+#include "memory.h"
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+
+static int test_result = 1;
+
+static struct ev_signal ev_sig;
+
+static bool ev_sig_handler_expect_pid_self;
+static int ev_sig_handler_call_count;
+
+static void
+ev_sig_handler(struct ev_loop *loop, struct ev_signal *w, int revents)
+{
+	(void)loop;
+	(void)revents;
+
+	note("Processing %s sent by PID %ld\n",
+	     strsignal(w->signum), (long)w->sender_pid);
+
+	fail_unless(w == &ev_sig);
+	fail_unless(w->signum == SIGUSR1);
+	fail_unless((w->sender_pid == getpid()) ==
+		    ev_sig_handler_expect_pid_self);
+	ev_sig_handler_call_count++;
+}
+
+static int
+main_f(va_list ap)
+{
+	plan(6);
+	header();
+
+	/* Set the signal handler. */
+	ev_signal_init(&ev_sig, ev_sig_handler, SIGUSR1);
+	ev_signal_start(loop(), &ev_sig);
+
+	/* Test raising a signal. */
+	raise(SIGUSR1);
+	ev_sig_handler_call_count = 0;
+	ev_sig_handler_expect_pid_self = true;
+	fiber_sleep(0);
+	is(ev_sig_handler_call_count, 1, "raise()");
+
+	/* Test killing oneself. */
+	kill(getpid(), SIGUSR1);
+	ev_sig_handler_call_count = 0;
+	ev_sig_handler_expect_pid_self = true;
+	fiber_sleep(0);
+	is(ev_sig_handler_call_count, 1, "kill() by self");
+
+	/* Test killing by child process. */
+	system(tt_sprintf("bash -c 'kill -USR1 %ld'", (long)getpid()));
+	ev_sig_handler_call_count = 0;
+	ev_sig_handler_expect_pid_self = false;
+	fiber_sleep(0);
+	is(ev_sig_handler_call_count, 1, "kill() by child");
+
+	/* Test multiple signals = one callback call. */
+	raise(SIGUSR1);
+	raise(SIGUSR1);
+	ev_sig_handler_call_count = 0;
+	ev_sig_handler_expect_pid_self = true;
+	fiber_sleep(0);
+	fiber_sleep(0);
+	is(ev_sig_handler_call_count, 1, "multiple signals one callback");
+
+	/* Test the sender_pid is PID of the last sender (oneself). */
+	system(tt_sprintf("bash -c 'kill -USR1 %ld'", (long)getpid()));
+	raise(SIGUSR1);
+	ev_sig_handler_call_count = 0;
+	ev_sig_handler_expect_pid_self = true;
+	fiber_sleep(0);
+	fiber_sleep(0);
+	is(ev_sig_handler_call_count, 1, "self is last");
+
+	/* Test the sender_pid is PID of the last sender (child). */
+	raise(SIGUSR1);
+	system(tt_sprintf("bash -c 'kill -USR1 %ld'", (long)getpid()));
+	ev_sig_handler_call_count = 0;
+	ev_sig_handler_expect_pid_self = false;
+	fiber_sleep(0);
+	fiber_sleep(0);
+	is(ev_sig_handler_call_count, 1, "child is last");
+
+	/* Unset the signal handler. */
+	ev_signal_stop(loop(), &ev_sig);
+
+	footer();
+	test_result = check_plan();
+	return 0;
+}
+
+int
+main(void)
+{
+	memory_init();
+	fiber_init(fiber_cxx_invoke);
+
+	struct fiber *main = fiber_new_xc("main", main_f);
+	fiber_wakeup(main);
+	ev_run(loop(), 0);
+
+	fiber_free();
+	memory_free();
+	return test_result;
+}

--- a/test/unit/say.c
+++ b/test/unit/say.c
@@ -130,7 +130,7 @@ test_log_rotate()
 	while (created_logs < running)
 		tt_pthread_cond_wait(&cond_sync, &mutex);
 	tt_pthread_mutex_unlock(&mutex);
-	say_logrotate(NULL, NULL, 0);
+	say_logrotate();
 
 	for (int i = 0; i < created_logs; i++) {
 		log_destroy(&loggers[i].logger);
@@ -275,7 +275,7 @@ int main()
 
 	/* Test gh-4450. */
 	log_create(&test_log, tmp_filename, false);
-	say_logrotate(NULL, NULL, 0);
+	say_logrotate();
 	coio_shutdown();
 	log_destroy(&test_log);
 

--- a/third_party/libev/ev.c
+++ b/third_party/libev/ev.c
@@ -550,8 +550,12 @@ EV_CPP (extern "C") int (signalfd) (int fd, const sigset_t *mask, int flags);
 struct signalfd_siginfo
 {
   uint32_t ssi_signo;
-  char pad[128 - sizeof (uint32_t)];
+  char unused[8];
+  uint32_t ssi_pid;
+  char pad[112];
 };
+
+static_assert(sizeof(struct signalfd_siginfo) == 128, "signalfd_siginfo size");
 #endif
 
 /* for timerfd, libev core requires TFD_TIMER_CANCEL_ON_SET &c */
@@ -2737,6 +2741,7 @@ reheap (ANHE *heap, int N)
 typedef struct
 {
   EV_ATOMIC_T pending;
+  EV_ATOMIC_T sender_pid;
 #if EV_MULTIPLICITY
   EV_P;
 #endif
@@ -2893,7 +2898,7 @@ pipecb (EV_P_ ev_io *iow, int revents)
 
       for (i = EV_NSIG - 1; i--; )
         if (ecb_expect_false (signals [i].pending))
-          ev_feed_signal_event (EV_A_ i + 1);
+          ev_feed_signal_event (EV_A_ i + 1, signals [i].sender_pid);
     }
 #endif
 
@@ -2918,7 +2923,7 @@ pipecb (EV_P_ ev_io *iow, int revents)
 /*****************************************************************************/
 
 void
-ev_feed_signal (int signum) EV_NOEXCEPT
+ev_feed_signal (int signum, pid_t sender_pid) EV_NOEXCEPT
 {
 #if EV_MULTIPLICITY
   EV_P;
@@ -2930,22 +2935,25 @@ ev_feed_signal (int signum) EV_NOEXCEPT
 #endif
 
   signals [signum - 1].pending = 1;
+  signals [signum - 1].sender_pid = sender_pid;
   evpipe_write (EV_A_ &sig_pending);
 }
 
 static void
-ev_sighandler (int signum)
+ev_sighandler (int signum, siginfo_t *info, void *unused)
 {
+  (void)unused;
+
 #ifdef _WIN32
   signal (signum, ev_sighandler);
 #endif
 
-  ev_feed_signal (signum);
+  ev_feed_signal (signum, info->si_pid);
 }
 
 ecb_noinline
 void
-ev_feed_signal_event (EV_P_ int signum) EV_NOEXCEPT
+ev_feed_signal_event (EV_P_ int signum, pid_t sender_pid) EV_NOEXCEPT
 {
   WL w;
 
@@ -2965,8 +2973,10 @@ ev_feed_signal_event (EV_P_ int signum) EV_NOEXCEPT
   signals [signum].pending = 0;
   ECB_MEMORY_FENCE_RELEASE;
 
-  for (w = signals [signum].head; w; w = w->next)
+  for (w = signals [signum].head; w; w = w->next) {
+    ((ev_signal *)w)->sender_pid = sender_pid;
     ev_feed_event (EV_A_ (W)w, EV_SIGNAL);
+  }
 }
 
 #if EV_USE_SIGNALFD
@@ -2981,7 +2991,7 @@ sigfdcb (EV_P_ ev_io *iow, int revents)
 
       /* not ISO-C, as res might be -1, but works with SuS */
       for (sip = si; (char *)sip < (char *)si + res; ++sip)
-        ev_feed_signal_event (EV_A_ sip->ssi_signo);
+        ev_feed_signal_event (EV_A_ sip->ssi_signo, sip->ssi_pid);
 
       if (res < (ssize_t)sizeof (si))
         break;
@@ -4681,9 +4691,9 @@ ev_signal_start (EV_P_ ev_signal *w) EV_NOEXCEPT
 
         evpipe_init (EV_A);
 
-        sa.sa_handler = ev_sighandler;
+        sa.sa_sigaction = ev_sighandler;
         sigfillset (&sa.sa_mask);
-        sa.sa_flags = SA_RESTART; /* if restarting works we save one iteration */
+        sa.sa_flags = SA_SIGINFO | SA_RESTART; /* if restarting works we save one iteration */
         sigaction (w->signum, &sa, 0);
 
         if (origflags & EVFLAG_NOSIGMASK)

--- a/third_party/libev/ev.h
+++ b/third_party/libev/ev.h
@@ -358,6 +358,7 @@ typedef struct ev_signal
   EV_WATCHER_LIST (ev_signal)
 
   int signum; /* ro */
+  pid_t sender_pid;  /* rw, holds the PID of the last signal sender */
 } ev_signal;
 
 /* invoked when sigchld is received and waitpid indicates the given pid */
@@ -763,8 +764,8 @@ EV_API_DECL int ev_activecnt       (EV_P) EV_NOEXCEPT;
 EV_API_DECL void ev_feed_event     (EV_P_ void *w, int revents) EV_NOEXCEPT;
 EV_API_DECL void ev_feed_fd_event  (EV_P_ int fd, int revents) EV_NOEXCEPT;
 #if EV_SIGNAL_ENABLE
-EV_API_DECL void ev_feed_signal    (int signum) EV_NOEXCEPT;
-EV_API_DECL void ev_feed_signal_event (EV_P_ int signum) EV_NOEXCEPT;
+EV_API_DECL void ev_feed_signal    (int signum, pid_t sender_pid) EV_NOEXCEPT;
+EV_API_DECL void ev_feed_signal_event (EV_P_ int signum, pid_t sender_pid) EV_NOEXCEPT;
 #endif
 EV_API_DECL void ev_invoke         (EV_P_ void *w, int revents);
 EV_API_DECL int  ev_clear_pending  (EV_P_ void *w) EV_NOEXCEPT;


### PR DESCRIPTION
Print out the PID of the last sender of a signal handled by libev. This allows to track e. g. the sourse of a `SIGTERM` signal received.

Closes #12477