### PR TITLE
lua: export internal.net.replicaset to application threads

### DIFF
--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -223,6 +223,7 @@ static const char * const lua_sources_minimal[] = {
 	"box/utils", NULL, box_utils_lua,
 	"box/iproto", "iproto", iproto_lua,
 	"box/net_box", "net.box", net_box_lua,
+	"box/net_replicaset", "internal.net.replicaset", net_replicaset_lua,
 	"box/app_threads", "experimental.threads", app_threads_lua,
 	/*
 	 * To support tarantool-only types with checks, the module
@@ -339,7 +340,6 @@ static const char * const lua_sources_main[] = {
 	"box/xlog", "xlog", xlog_lua,
 	"box/version", NULL, internal_version_lua,
 	"box/upgrade", NULL, upgrade_lua,
-	"box/net_replicaset", "internal.net.replicaset", net_replicaset_lua,
 	"box/console", "console", console_lua,
 
 	/* {{{ config */

--- a/src/box/lua/net_replicaset.lua
+++ b/src/box/lua/net_replicaset.lua
@@ -1,5 +1,11 @@
+local ffi = require('ffi')
 local fiber = require('fiber')
 local net_box = require('net.box')
+
+ffi.cdef[[
+    bool
+    cord_is_main(void);
+]]
 
 -- The constant is copy-paste from tarantool/src/lua/socket.lua.
 local TIMEOUT_INFINITY = 500 * 365 * 86400
@@ -315,22 +321,27 @@ local function connect_by_cfg(cfg)
 end
 
 -- Allowed options and their types in cfg.instances.x of connect by name.
-local connect_by_name_cfg_template = {
+local connect_opts_template = {
     reconnect_timeout = 'number or nil',
 }
 
--- Connect by replicaset name.
--- Optional config is passed to every net.box.connect function.
+-- Given a replicaset name and connection options, return a configuration
+-- table suitable for passing to connect().
 -- REPLICASET_NOT_FOUND error may be thrown.
-local function connect_by_rs_name(replicaset_name, cfg)
-    cfg = cfg or {}
-    check_options(cfg, connect_by_name_cfg_template, 'connect cfg')
+local function get_connect_cfg(replicaset_name, opts)
+    opts = opts or {}
+    check_options(opts, connect_opts_template, 'opts')
+
+    if not ffi.C.cord_is_main() then
+        error('config is available only in main thread', 0)
+    end
+
     local config = require('config')
 
     local connect_cfg = {
         name = replicaset_name,
         instances = {},
-        reconnect_timeout = cfg.reconnect_timeout,
+        reconnect_timeout = opts.reconnect_timeout,
     }
     for _, instance_info in pairs(config:instances()) do
         if instance_info.replicaset_name == replicaset_name then
@@ -343,7 +354,15 @@ local function connect_by_rs_name(replicaset_name, cfg)
     if not next(connect_cfg.instances) then
         rs_error(box.error.REPLICASET_NOT_FOUND, replicaset_name)
     end
-   return connect_by_cfg(connect_cfg)
+    return connect_cfg
+end
+
+-- Connect by replicaset name.
+-- Options are passed to every net.box.connect function.
+-- REPLICASET_NOT_FOUND error may be thrown.
+local function connect_by_rs_name(replicaset_name, opts)
+    local connect_cfg = get_connect_cfg(replicaset_name, opts)
+    return connect_by_cfg(connect_cfg)
 end
 
 -- Connect by given config or replicaset name an config.
@@ -360,5 +379,6 @@ local function connect_common(cfg_or_name, ...)
 end
 
 return {
+    get_connect_cfg = get_connect_cfg,
     connect = connect_common,
 }

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -6,6 +6,8 @@ local socket = require('socket')
 local uuid = require('uuid')
 local varbinary = require('varbinary')
 
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('luatest.cluster')
 local server = require('luatest.server')
 local t = require('luatest')
 
@@ -661,6 +663,43 @@ g.after_test('test_net_box', function(cg)
         end
     end)
 end)
+
+g.test_net_replicaset = function()
+    local config = cbuilder:new()
+        :set_global_option('credentials.users.storage.roles', {'super'})
+        :set_global_option('credentials.users.storage.password', 'secret')
+        :set_global_option('iproto.advertise.sharding.login', 'storage')
+        :use_replicaset('storage')
+        :set_replicaset_option('replication.failover', 'manual')
+        :set_replicaset_option('leader', 'storage_a')
+        :add_instance('storage_a', {})
+        :add_instance('storage_b', {})
+        :use_replicaset('router')
+        :add_instance('router', {})
+        :set_instance_option('router', 'threads.groups', {
+            {name = 'test', size = 1},
+        })
+        :config()
+    local cluster = cluster:new(config)
+    cluster:start()
+    cluster.router:call('box.iproto.internal.enable_thread_requests')
+    local connect_cfg = cluster.router:exec(function()
+        local net_replicaset = require('internal.net.replicaset')
+        return net_replicaset.get_connect_cfg('storage')
+    end)
+    cluster.router:exec(function(connect_cfg)
+        local net_replicaset = require('internal.net.replicaset')
+        local err = 'config is available only in main thread'
+        t.assert_error_msg_equals(err, net_replicaset.get_connect_cfg,
+                                  'storage')
+        t.assert_error_msg_equals(err, net_replicaset.connect,
+                                  'storage')
+        local conn = net_replicaset.connect(connect_cfg)
+        local info = conn:call_leader('box.info')
+        t.assert_covers(info, {ro = false, name = 'storage_a'})
+        conn:close()
+    end, {connect_cfg}, {_thread_id = 1})
+end
 
 g.test_luatest_exec = function(cg)
     cg.server:exec(function()

--- a/test/box-luatest/gh_9823_net_replicaset_test.lua
+++ b/test/box-luatest/gh_9823_net_replicaset_test.lua
@@ -160,6 +160,17 @@ g.test_net_replicaset_basics = function()
         return info.name
     end)
 
+    -- Get config by replicaset name.
+    cluster.router:exec(function(leader_name)
+        local net_replicaset = require('internal.net.replicaset')
+        local connect_cfg = net_replicaset.get_connect_cfg('storage')
+        local rs = net_replicaset.connect(connect_cfg)
+        local info = rs:call_leader('box.info')
+        t.assert_equals(info.ro, false)
+        t.assert_equals(info.name, leader_name)
+        rs:close()
+    end, {leader_name})
+
     -- Connect using config.
     local rs = net_replicaset.connect(connect_cfg)
     local info = rs:call_leader('box.info')


### PR DESCRIPTION
The module can connect to a replicaset by a configuration or a name. In the latter case the connection configuration is retrieved from the global config. Since the global config is unavailable in application threads, we disable this functionality there. Instead we add the new function `get_connect_cfg` that can be used in the main thread for passing a replicaset connection configuration to application threads.

Closes #12452