### PR TITLE
test: set searchroot in application threads

### DIFF
--- a/test/box-luatest/app_threads_module_test.lua
+++ b/test/box-luatest/app_threads_module_test.lua
@@ -6,6 +6,23 @@ local cluster = require('luatest.cluster')
 
 local g = t.group()
 
+--
+-- FIXME(gh-12546): For server.exec to be able to find the luatest module,
+-- searchroot must be set in the test server. For the main thread, this is
+-- done automatically by luatest itself, but due to the bug in Tarantool,
+-- searchroot isn't propagated to application threads so we have to set it
+-- manually. Remove this when the bug is fixed.
+--
+local function setsearchroot(server)
+    local searchroot, app_threads = server:exec(function()
+        return package.searchroot(), box.cfg.app_threads
+    end)
+    for i = 1, app_threads do
+        server:eval('package.setsearchroot(...)', {searchroot},
+                    {_thread_id = i})
+    end
+end
+
 g.test_threads_config_propagation = function()
     --
     -- Check that the threads configuration is propagated to box.cfg
@@ -80,6 +97,7 @@ g.test_threads_config_propagation = function()
     -- Check configuration in other threads.
     --
     cluster.server:call('box.iproto.internal.enable_thread_requests')
+    setsearchroot(cluster.server)
     for i = 1, 10 do
         local group_name
         if i < 2 then
@@ -342,6 +360,7 @@ g.test_threads_call = function()
     -- Usage in other a non-tx thread.
     --
     cluster.server:call('box.iproto.internal.enable_thread_requests')
+    setsearchroot(cluster.server)
     cluster.server:exec(function()
         local threads = require('experimental.threads')
         t.assert_covers(threads.info(), {
@@ -503,6 +522,7 @@ g.test_threads_eval = function()
     -- Usage in other a non-tx thread.
     --
     cluster.server:call('box.iproto.internal.enable_thread_requests')
+    setsearchroot(cluster.server)
     cluster.server:exec(function()
         local threads = require('experimental.threads')
         t.assert_covers(threads.info(), {

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -13,6 +13,23 @@ local t = require('luatest')
 
 local g = t.group()
 
+--
+-- FIXME(gh-12546): For server.exec to be able to find the luatest module,
+-- searchroot must be set in the test server. For the main thread, this is
+-- done automatically by luatest itself, but due to the bug in Tarantool,
+-- searchroot isn't propagated to application threads so we have to set it
+-- manually. Remove this when the bug is fixed.
+--
+local function setsearchroot(server)
+    local searchroot, app_threads = server:exec(function()
+        return package.searchroot(), box.cfg.app_threads
+    end)
+    for i = 1, app_threads do
+        server:eval('package.setsearchroot(...)', {searchroot},
+                    {_thread_id = i})
+    end
+end
+
 g.before_all(function(cg)
     cg.server = server:new({
         box_cfg = {
@@ -22,6 +39,7 @@ g.before_all(function(cg)
     })
     cg.server:start()
     cg.server:call('box.iproto.internal.enable_thread_requests')
+    setsearchroot(cg.server)
     cg.server:exec(function()
         box.schema.user.passwd('admin', 'secret')
     end)
@@ -683,6 +701,7 @@ g.test_net_replicaset = function()
     local cluster = cluster:new(config)
     cluster:start()
     cluster.router:call('box.iproto.internal.enable_thread_requests')
+    setsearchroot(cluster.router)
     local connect_cfg = cluster.router:exec(function()
         local net_replicaset = require('internal.net.replicaset')
         return net_replicaset.get_connect_cfg('storage')


### PR DESCRIPTION
Luatest sets searchroot in test servers with `package.setsearchroot` so that `server.exec` can find the luatest module (tarantool/luatest#450). The problem is that searchroot isn't propagated to application threads (#12546). Let's propagate it manually as a workaround until the bug is fixed so that we can update luatest.