### PR TITLE
test: make SO_REUSEPORT socket test portable

### DIFF
--- a/test/app/socket.result
+++ b/test/app/socket.result
@@ -440,17 +440,17 @@ s:setsockopt('SOL_SOCKET', 'SO_REUSEPORT', true)
 ---
 - true
 ...
-s:getsockopt('SOL_SOCKET', 'SO_REUSEPORT')
+s:getsockopt('SOL_SOCKET', 'SO_REUSEPORT') > 0
 ---
-- 1
+- true
 ...
 s:setsockopt('SOL_SOCKET', 'SO_REUSEPORT', false)
 ---
 - true
 ...
-s:getsockopt('SOL_SOCKET', 'SO_REUSEPORT')
+s:getsockopt('SOL_SOCKET', 'SO_REUSEPORT') == 0
 ---
-- 0
+- true
 ...
 s:bind('127.0.0.1', 0)
 ---

--- a/test/app/socket.test.lua
+++ b/test/app/socket.test.lua
@@ -135,9 +135,9 @@ s:close()
 s = socket('PF_INET', 'SOCK_STREAM', 'tcp')
 s:setsockopt('SOL_SOCKET', 'SO_REUSEADDR', true)
 s:setsockopt('SOL_SOCKET', 'SO_REUSEPORT', true)
-s:getsockopt('SOL_SOCKET', 'SO_REUSEPORT')
+s:getsockopt('SOL_SOCKET', 'SO_REUSEPORT') > 0
 s:setsockopt('SOL_SOCKET', 'SO_REUSEPORT', false)
-s:getsockopt('SOL_SOCKET', 'SO_REUSEPORT')
+s:getsockopt('SOL_SOCKET', 'SO_REUSEPORT') == 0
 s:bind('127.0.0.1', 0)
 s:listen(128)
 


### PR DESCRIPTION
This patch makes the `SO_REUSEPORT` check in `app/socket.test.lua` portable across platforms.

On macOS `getsockopt(SOL_SOCKET, SO_REUSEPORT)` returns the raw `SO_REUSEPORT` flag value, `0x0200`, when the option is enabled, instead of 1.

On my machine:
```c
#define SO_REUSEPORT    0x0200          /* allow local address & port reuse */
```

Part of #12559