### PR TITLE
test: isolate interactive console workdir

### DIFF
--- a/test/interactive_tarantool.lua
+++ b/test/interactive_tarantool.lua
@@ -314,6 +314,10 @@ end
 function mt.close(self)
     self:_stop_stderr_logger()
     self.ph:close()
+    if self._workdir ~= nil then
+        fio.rmtree(self._workdir)
+        self._workdir = nil
+    end
 end
 
 -- Run a command and return its response.
@@ -378,6 +382,7 @@ function M._new_internal(opts)
         ph = ph,
         _readahead_buffer = '',
         _prompt = prompt or 'tarantool> ',
+        _workdir = fio.tempdir(),
     }, mt)
 
     return res
@@ -415,6 +420,13 @@ function M.new(opts)
 
     -- Disable stdout line buffering in the child.
     res:execute_command("io.stdout:setvbuf('no')")
+    assert(res:read_response(), true)
+
+    -- Isolate box.cfg() from the inherited cwd. Some tests create an
+    -- interactive child while another Tarantool instance is already running
+    -- in the current workdir. If the child later calls box.cfg({}), it may
+    -- try to lock the same WAL directory and exit with ALREADY_RUNNING.
+    res:execute_command(("require('fio').chdir(%q)"):format(res._workdir))
     assert(res:read_response(), true)
 
     -- Log child's stderr.


### PR DESCRIPTION
This patch makes `box-luatest/session_test.lua` stable under parallel runs.

Before the patch, running with `--repeat` reliably triggered failures
(`Unexpected EOF` from `interactive_tarantool.lua`):

```sh
$ ./test-run.py --builddir ../build --repeat 10 -r 0 box-luatest/session_test.lua
<..snipped..>
[002] box-luatest/session_test.lua                                                                                                                                             [ fail ]
[002] Test failed! Output from reject file /tmp/t/rejects/box-luatest/session.reject:
[008] box-luatest/session_test.lua                                                                                                                                             [ pass ]
[002] Tarantool version is 3.7.0-entrypoint-219-ga26d68d1e7
[002] TAP version 13
[002] 1..9
[002] # Started on Mon Apr 20 09:59:31 2026
[002] # Starting group: box-luatest.session
[002] ok     1	box-luatest.session.test_sanity_check_session
[002] ok     2	box-luatest.session.test_check_session_id
[002] ok     3	box-luatest.session.test_check_session_triggers
[002] not ok 4	box-luatest.session.test_session_triggers
[002] #   ...rs/m.tiushev/vk/tarantool/test/interactive_tarantool.lua:103: Unexpected EOF
[002] #   stack traceback:
[002] #   	...rs/m.tiushev/vk/tarantool/test/interactive_tarantool.lua:103: in function 'read_chunk'
[002] #   	...rs/m.tiushev/vk/tarantool/test/interactive_tarantool.lua:117: in function 'read_line'
[002] #   	...rs/m.tiushev/vk/tarantool/test/interactive_tarantool.lua:132: in function 'read_until_line'
[002] #   	...rs/m.tiushev/vk/tarantool/test/interactive_tarantool.lua:269: in function 'read_response'
[002] #   	...m.tiushev/vk/tarantool/test/box-luatest/session_test.lua:182: in function 'box-luatest.session.test_session_triggers'
[002] #   artifacts:
[002] #   	session -> /private/tmp/t/002_box-luatest/artifacts/session-afTS1jHLtAuK
[002] ok     5	box-luatest.session.test_type_session_triggers
[002] ok     6	box-luatest.session.test_session_priveleges
[002] ok     7	box-luatest.session.test_session_gh_2994
[002] not ok 8	box-luatest.session.test_session_gh_2994_session_uid_euid
[002] #   ...rs/m.tiushev/vk/tarantool/test/interactive_tarantool.lua:103: Unexpected EOF
[002] #   stack traceback:
[002] #   	...rs/m.tiushev/vk/tarantool/test/interactive_tarantool.lua:103: in function 'read_chunk'
[002] #   	...rs/m.tiushev/vk/tarantool/test/interactive_tarantool.lua:117: in function 'read_line'
[002] #   	...rs/m.tiushev/vk/tarantool/test/interactive_tarantool.lua:132: in function 'read_until_line'
[002] #   	...rs/m.tiushev/vk/tarantool/test/interactive_tarantool.lua:269: in function 'read_response'
[002] #   	...m.tiushev/vk/tarantool/test/box-luatest/session_test.lua:279: in function 'box-luatest.session.test_session_gh_2994_session_uid_euid'
[002] #   artifacts:
[002] #   	session -> /private/tmp/t/002_box-luatest/artifacts/session-v2tyuxgV3GLa
[002] ok     9	box-luatest.session.test_gh_3450
[002] # Ran 9 tests in 4.502 seconds, 7 succeeded, 2 errored
<..snipped..>
```

After the patch, the test passes:

```sh
$ ./test-run.py --builddir ../build --repeat 100 -r 0 box-luatest/session_test.lua
<..snipped..>
[005] box-luatest/session_test.lua                                                                                                                                             [ pass ]
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Top 10 longest tests (seconds):
*   4.74 box-luatest/session_test.lua
---------------------------------------------------------------------------------
Statistics:
* pass: 100
```

Part of #12559
