### PR TITLE
[backport 3.2] config: fix startup hang in supervised failover

### DIFF
--- a/changelogs/unreleased/gh-11318-fix-failover-hang.md
+++ b/changelogs/unreleased/gh-11318-fix-failover-hang.md
@@ -1,0 +1,4 @@
+## bugfix/failover
+
+* Fixed a bug in supervised failover when a replica could hang on startup while
+  joining an already bootstrapped replica set (gh-11318).

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -106,6 +106,29 @@ local function log_destination(log)
     end
 end
 
+local function wait_if_not_bootstrap_leader()
+    -- Wait until the instance learns its id in the replicaset to
+    -- distinguish a bootstrap leader from a regular replica.
+    --
+    -- Default value for `replication.connect_timeout` is 30 seconds.
+    local TIMEOUT = 30
+    local deadline = fiber.time() + TIMEOUT
+    while box.info.id == 0 do
+        if fiber.time() > deadline then
+            error(string.format(
+                'failed to learn instance id in the replicaset within %d ' ..
+                'seconds; cannot distinguish bootstrap leader from a ' ..
+                'regular replica.', TIMEOUT), 0)
+        end
+        fiber.sleep(0.01)
+    end
+
+    if box.info.id ~= 1 then
+        -- Not really a bootstrap leader, just a replica. Go to RO.
+        box.cfg({read_only = true})
+    end
+end
+
 --------------------------------------------------------------------------------
 --  Instance/replicaset names
 --------------------------------------------------------------------------------
@@ -349,6 +372,7 @@ end
 -- Returns nothing or {needs_retry = true}.
 local function apply(config)
     local configdata = config._configdata
+    local post_box_cfg_bootstrap_leader_hook
     local box_cfg = configdata:filter(function(w)
         return w.schema.box_cfg ~= nil
     end, {use_default = true}):map(function(w)
@@ -560,24 +584,19 @@ local function apply(config)
         -- the replicaset bootstrap is needed, before a first
         -- box.cfg().
         --
-        -- However, after leaving box.cfg() or from a background
-        -- fiber after box.ctl.wait_rw() we can check that the
-        -- instance was a bootstrap leader using the
+        -- After box.cfg() returns, we can determine whether the
+        -- instance really became the bootstrap leader using the
         -- box.info.id == 1 condition.
         --
+        -- Note that box.ctl.wait_rw() is not sufficient here:
+        -- box_cfg.read_only is set above before the instance
+        -- learns its id, so RW status does not guarantee that
+        -- box.info.id has already been assigned.
+        --
         -- If box.info.id != 1, then the replicaset was already
-        -- bootstrapped and so we should go to RO.
+        -- bootstrapped and the instance should go to RO.
         if am_i_bootstrap_leader then
-            fiber.new(function()
-                local name = 'config_set_read_only_if_not_bootstrap_leader'
-                fiber.self():name(name, {truncate = true})
-                box.ctl.wait_rw()
-                if box.info.id ~= 1 then
-                    -- Not really a bootstrap leader, just a
-                    -- replica. Go to RO.
-                    box.cfg({read_only = true})
-                end
-            end)
+            post_box_cfg_bootstrap_leader_hook = wait_if_not_bootstrap_leader
         end
     else
         assert(false)
@@ -787,6 +806,9 @@ local function apply(config)
     -- If it is reload, just apply the new configuration.
     log.debug('box_cfg.apply')
     box.cfg(box_cfg)
+    if post_box_cfg_bootstrap_leader_hook ~= nil then
+        post_box_cfg_bootstrap_leader_hook()
+    end
 end
 
 return {

--- a/test/config-luatest/supervised_bootstrap_test.lua
+++ b/test/config-luatest/supervised_bootstrap_test.lua
@@ -69,3 +69,33 @@ g.test_basic = function()
         t.assert_equals(box.info.id, 1)
     end)
 end
+
+g.test_upscale_is_not_stuck = function()
+    local config_1 = cbuilder:new()
+        :use_replicaset('r-001')
+        :set_replicaset_option('replication.failover', 'supervised')
+        :set_replicaset_option('replication.bootstrap_strategy', 'auto')
+        :add_instance('i-001', {})
+        :add_instance('i-002', {})
+        :config()
+
+    local cluster = cluster:new(config_1)
+    cluster:start()
+
+    local config_2 = cbuilder:new(config_1)
+        :use_replicaset('r-001')
+        :add_instance('i-003', {})
+        :config()
+    cluster:sync(config_2)
+    cluster:start_instance('i-003')
+
+    cluster['i-003']:exec(function()
+        local config = require('config')
+        local t = require('luatest')
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_equals(config:info().status, 'ready')
+            t.assert_equals(box.info.ro, true)
+            t.assert_not_equals(box.info.id, 1)
+        end)
+    end)
+end


### PR DESCRIPTION
*(This PR is a backport of #12157 to `release/3.2` to a future `3.2.4` release.)*

----

This patch fixes a bug where an instance could hang during startup because it tried to distinguish a bootstrap leader from a regular replica before learning its replicaset id (`box.info.id == 0`), which led to inconsistent box.info state.

Closes tarantool#11318

NO_DOC=bugfix