### PR TITLE
[backport 3.3] config: fix startup hang in supervised failover

### DIFF
--- a/changelogs/unreleased/gh-11318-fix-failover-hang.md
+++ b/changelogs/unreleased/gh-11318-fix-failover-hang.md
@@ -1,0 +1,4 @@
+## bugfix/failover
+
+* Fixed a bug in supervised failover when a replica could hang on startup while
+  joining an already bootstrapped replica set (gh-11318).

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -260,6 +260,29 @@ local function switch_isolated_mode_after_box_cfg(config)
     end)
 end
 
+local function wait_if_not_bootstrap_leader()
+    -- Wait until the instance learns its id in the replicaset to
+    -- distinguish a bootstrap leader from a regular replica.
+    --
+    -- Default value for `replication.connect_timeout` is 30 seconds.
+    local TIMEOUT = 30
+    local deadline = fiber.time() + TIMEOUT
+    while box.info.id == 0 do
+        if fiber.time() > deadline then
+            error(string.format(
+                'failed to learn instance id in the replicaset within %d ' ..
+                'seconds; cannot distinguish bootstrap leader from a ' ..
+                'regular replica.', TIMEOUT), 0)
+        end
+        fiber.sleep(0.01)
+    end
+
+    if box.info.id ~= 1 then
+        -- Not really a bootstrap leader, just a replica. Go to RO.
+        box.cfg({read_only = true})
+    end
+end
+
 local function log_destination(log)
     if log.to == 'stderr' or log.to == 'devnull' then
         return box.NULL
@@ -787,24 +810,19 @@ local function apply(config)
         -- the replicaset bootstrap is needed, before a first
         -- box.cfg().
         --
-        -- However, after leaving box.cfg() or from a background
-        -- fiber after box.ctl.wait_rw() we can check that the
-        -- instance was a bootstrap leader using the
+        -- After box.cfg() returns, we can determine whether the
+        -- instance really became the bootstrap leader using the
         -- box.info.id == 1 condition.
         --
+        -- Note that box.ctl.wait_rw() is not sufficient here:
+        -- box_cfg.read_only is set above before the instance
+        -- learns its id, so RW status does not guarantee that
+        -- box.info.id has already been assigned.
+        --
         -- If box.info.id != 1, then the replicaset was already
-        -- bootstrapped and so we should go to RO.
+        -- bootstrapped and the instance should go to RO.
         if am_i_bootstrap_leader then
-            fiber.new(function()
-                local name = 'config_set_read_only_if_not_bootstrap_leader'
-                fiber.self():name(name, {truncate = true})
-                box.ctl.wait_rw()
-                if box.info.id ~= 1 then
-                    -- Not really a bootstrap leader, just a
-                    -- replica. Go to RO.
-                    box.cfg({read_only = true})
-                end
-            end)
+            post_box_cfg_hooks:add(wait_if_not_bootstrap_leader)
         end
     else
         assert(false)


### PR DESCRIPTION
*(This PR is a backport of #12157 to `release/3.3` to a future `3.3.5` release.)*

----

This patch fixes a bug where an instance could hang during startup because it tried to distinguish a bootstrap leader from a regular replica before learning its replicaset id (`box.info.id == 0`), which led to inconsistent box.info state.

Closes #11318

NO_DOC=bugfix