### PR TITLE
[backport 3.2] config: add `skip_replication_names` compat option

### DIFF
--- a/changelogs/unreleased/gh-10426-t3-inst-to-t2-rs.md
+++ b/changelogs/unreleased/gh-10426-t3-inst-to-t2-rs.md
@@ -1,0 +1,5 @@
+## bugfix/config
+
+* Fixed a startup failure when a Tarantool 3.x instance configured via
+  the declarative config joined a 2.x replica set, where the master had
+  no instance or replica set names stored in its snapshot (gh-10426).

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -420,6 +420,8 @@ local function apply(config)
     local failover = configdata:get('replication.failover',
         {use_default = true})
     local is_anon = configdata:get('replication.anon', {use_default = true})
+    local skip_names_on_startup = is_startup and configdata:get(
+        'compat.skip_replication_names', {use_default = true}) == 'old'
 
     -- Read-only or read-write?
     if failover == 'off' then
@@ -627,11 +629,13 @@ local function apply(config)
     -- system space, so it can't have a persistent instance name.
     -- It is never returned by :missing_names().
     local missing_names = configdata:missing_names()
-    if not is_anon and not missing_names._peers[names.instance_name] then
-        box_cfg.instance_name = names.instance_name
-    end
-    if not missing_names[names.replicaset_name] then
-        box_cfg.replicaset_name = names.replicaset_name
+    if not skip_names_on_startup then
+        if not is_anon and not missing_names._peers[names.instance_name] then
+            box_cfg.instance_name = names.instance_name
+        end
+        if not missing_names[names.replicaset_name] then
+            box_cfg.replicaset_name = names.replicaset_name
+        end
     end
     if not missing_names_is_empty(missing_names, names.replicaset_name) then
         if is_startup then

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -472,7 +472,8 @@ local mt = {
 
 -- Validate UUIDs and names passed to config against the data,
 -- saved inside snapshot. Fail early if mismatch is found.
-local function validate_names(saved_names, config_names, iconfig)
+local function validate_names(saved_names, config_names, iconfig, opts)
+    local skip_names = opts ~= nil and opts.skip_names or false
     -- Snapshot always has replicaset uuid and
     -- at least one peer in _cluster space.
     if saved_names.replicaset_uuid == nil then
@@ -498,11 +499,13 @@ local function validate_names(saved_names, config_names, iconfig)
                             config_names.replicaset_uuid), 0)
     end
 
-    if saved_names.replicaset_name ~= nil and
-       saved_names.replicaset_name ~= config_names.replicaset_name then
-        error(string.format('Replicaset name mismatch. Snapshot: %s, ' ..
-                            'config: %s.', saved_names.replicaset_name,
-                            config_names.replicaset_name), 0)
+    if not skip_names then
+        if saved_names.replicaset_name ~= nil and
+           saved_names.replicaset_name ~= config_names.replicaset_name then
+            error(string.format('Replicaset name mismatch. Snapshot: %s, ' ..
+                                'config: %s.', saved_names.replicaset_name,
+                                config_names.replicaset_name), 0)
+        end
     end
 
     if config_names.instance_uuid ~= nil and
@@ -512,17 +515,20 @@ local function validate_names(saved_names, config_names, iconfig)
                             config_names.instance_uuid), 0)
     end
 
-    if saved_names.instance_name ~= nil and
-       saved_names.instance_name ~= config_names.instance_name then
-        error(string.format('Instance name mismatch. Snapshot: %s, ' ..
-                            'config: %s.', saved_names.instance_name,
-                            config_names.instance_name), 0)
+    if not skip_names then
+        if saved_names.instance_name ~= nil and
+           saved_names.instance_name ~= config_names.instance_name then
+            error(string.format('Instance name mismatch. Snapshot: %s, ' ..
+                                'config: %s.', saved_names.instance_name,
+                                config_names.instance_name), 0)
+        end
     end
 
     -- Fail early, if current UUID is not set, but no name is found
     -- inside the snapshot file. Ignore this failure, if replica is
     -- configured as anonymous, anon replicas cannot have names.
-    if not instance_config:get(iconfig, 'replication.anon') then
+    if not instance_config:get(iconfig, 'replication.anon') and
+       not skip_names then
         if saved_names.instance_name == nil and
            config_names.instance_uuid == nil then
             error(string.format('Instance name for %s is not set in snapshot' ..
@@ -984,13 +990,17 @@ local function new(iconfig, cconfig, instance_name)
     -- and during config reload.
     local saved_names = find_saved_names(iconfig_def)
     if saved_names ~= nil then
+        local skip_replication_names = instance_config:get(iconfig_def,
+            'compat.skip_replication_names') == 'old'
         validate_names(saved_names, {
             replicaset_name = found.replicaset_name,
             instance_name = instance_name,
             -- UUIDs from config, generated one should not be used here.
             replicaset_uuid = replicaset_uuid,
             instance_uuid = instance_uuid,
-        }, iconfig_def)
+        }, iconfig_def, {
+            skip_names = skip_replication_names,
+        })
     end
 
     return setmetatable({

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2467,6 +2467,12 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'new',
         }),
+        skip_replication_names = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'new',
+        }),
         box_error_unpack_type_and_code = schema.enum({
             'old',
             'new',

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -156,6 +156,15 @@ back to the user-provided 'is_sync' space option.
 https://tarantool.io/compat/box_consider_system_spaces_synchronous
 ]]
 
+local SKIP_REPLICATION_NAMES_BRIEF = [[
+Skip applying and validating instance and replicaset names during replication
+startup. The old behavior allows a Tarantool 3.x instance configured via the
+declarative config to join a Tarantool 2.11 replicaset whose snapshot may not
+contain names yet.
+
+https://tarantool.io/compat/skip_replication_names
+]]
+
 -- Returns an action callback that toggles a tweak.
 local function tweak_action(tweak_name, old_tweak_value, new_tweak_value)
     return function(is_new)
@@ -286,6 +295,12 @@ local options = {
             box_consider_system_spaces_synchronous_tweak_action(is_new)
             ffi.C.system_spaces_update_is_sync_state_from_compat()
       end
+    },
+    skip_replication_names = {
+        default = 'new',
+        obsolete = nil,
+        brief = SKIP_REPLICATION_NAMES_BRIEF,
+        action = function() end,
     },
 }
 

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -352,6 +352,7 @@ g.test_defaults = function()
             box_error_unpack_type_and_code = 'old',
             console_session_scope_vars = 'old',
             datetime_setfn_timestamp_type_check = 'old',
+            skip_replication_names = 'new',
         },
     }
     local res = cluster_config:apply_default({})

--- a/test/replication-luatest/gh_10426_inst_t3_to_rs_t2_test.lua
+++ b/test/replication-luatest/gh_10426_inst_t3_to_rs_t2_test.lua
@@ -1,0 +1,177 @@
+local t = require('luatest')
+local fio = require('fio')
+local yaml = require('yaml')
+local fun = require('fun')
+local treegen = require('luatest.treegen')
+local justrun = require('luatest.justrun')
+local server = require('luatest.server')
+
+local g = t.group()
+
+local function read_log_uuids(log_path)
+    local fh = fio.open(log_path, {'O_RDONLY'})
+    if fh == nil then
+        return nil, nil
+    end
+    local log = fh:read()
+    fh:close()
+
+    local instance_uuid = log:match('instance uuid ([0-9a-f%-]+)')
+    local replicaset_uuid = log:match('replicaset uuid ([0-9a-f%-]+)')
+
+    return instance_uuid, replicaset_uuid
+end
+
+local function start_source_instance(dir)
+    local workdir = fio.pathjoin(dir, 'i-001')
+    local log_rel = 'var/lib/i-001/instance.log'
+    local log_path = fio.pathjoin(workdir, log_rel)
+
+    local socket_path = fio.pathjoin(workdir, 'i-001.iproto')
+    local opts = {
+        alias = 'i-001',
+        workdir = workdir,
+        chdir = workdir,
+        net_box_uri = 'unix/:' .. socket_path,
+        box_cfg = {
+            listen = 'unix/:' .. socket_path,
+            memtx_dir = 'var/lib/i-001',
+            wal_dir = 'var/lib/i-001',
+            log = log_rel,
+        },
+        env = {
+            TARANTOOL_RUN_BEFORE_BOX_CFG =
+                "require('fio').mktree('var/lib/i-001')",
+        },
+    }
+    local instance = server:new(opts)
+    instance:start()
+
+    local instance_uuid
+    local replicaset_uuid
+    t.helpers.retrying({timeout = 20}, function()
+        instance_uuid, replicaset_uuid = read_log_uuids(log_path)
+        t.assert_not_equals(instance_uuid, nil)
+        t.assert_not_equals(replicaset_uuid, nil)
+    end)
+
+    return instance, instance_uuid, replicaset_uuid, socket_path
+end
+
+local function build_config(dir, uuids, source_socket_path,
+                            skip_replication_names)
+    local data_dir_2 = fio.abspath(fio.pathjoin(dir, 'i-002/var/lib/i-002'))
+    fio.mktree(data_dir_2)
+
+    return {
+        replication = {
+            failover = 'manual',
+        },
+        compat = {
+            skip_replication_names = skip_replication_names and 'old' or 'new'
+        },
+        groups = {
+            ['g-001'] = {
+                replicasets = {
+                    ['r-001'] = {
+                        database = {
+                            replicaset_uuid = uuids.replicaset_uuid,
+                        },
+                        leader = 'i-001',
+                        instances = {
+                            ['i-001'] = {
+                                database = {
+                                    instance_uuid = uuids.instance_uuid,
+                                },
+                                iproto = {
+                                    listen = {
+                                        {uri = 'unix/:' .. source_socket_path},
+                                    },
+                                },
+                            },
+                            ['i-002'] = {
+                                iproto = {
+                                    listen = {
+                                        {uri = 'unix/:./i-002.iproto'},
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+end
+
+local function write_config(dir, config)
+    return treegen.write_file(dir, 'config.yaml', yaml.encode(config))
+end
+
+local function start_replica(dir, config)
+    local config_file = write_config(dir, config)
+    local opts = {config_file = config_file, chdir = dir}
+    local instance = server:new(fun.chain(opts, {alias = 'i-002'}):tomap())
+    instance:start({wait_until_ready = false})
+    instance:wait_until_ready()
+
+    return instance
+end
+
+g.after_each(function(g)
+    if g.instance_1 ~= nil then
+        g.instance_1:drop()
+        g.instance_1 = nil
+    end
+    if g.instance_2 ~= nil then
+        g.instance_2:drop()
+        g.instance_2 = nil
+    end
+end)
+
+g.test_new_skip_replication_names_compat = function(g)
+    local dir = treegen.prepare_directory({}, {})
+    g.instance_1, g.instance_uuid, g.replicaset_uuid, g.source_socket_path =
+        start_source_instance(dir)
+
+    local config = build_config(dir, {
+        instance_uuid = g.instance_uuid,
+        replicaset_uuid = g.replicaset_uuid,
+    }, g.source_socket_path)
+    local config_file = write_config(dir, config)
+
+    local args = {'--name', 'i-002', '--config', config_file}
+    local res =
+        justrun.tarantool(dir, {}, args, {nojson = true, stderr = true})
+    t.assert_equals(res.exit_code, 1)
+    t.assert_str_contains(res.stderr,
+        "Replicaset name mismatch: name 'r-001' provided in config")
+end
+
+g.test_old_skip_replication_names_compat = function(g)
+    local dir = treegen.prepare_directory({}, {})
+    g.instance_1, g.instance_uuid, g.replicaset_uuid, g.source_socket_path =
+        start_source_instance(dir)
+
+    local config = build_config(dir, {
+        instance_uuid = g.instance_uuid,
+        replicaset_uuid = g.replicaset_uuid,
+    }, g.source_socket_path, true)
+
+    g.instance_2 = start_replica(dir, config)
+
+    g.instance_1:exec(function()
+        t.helpers.retrying({timeout = 20}, function()
+            t.assert(box.info.replication[2])
+            t.assert_equals(box.info.replication[2].downstream.status,
+                            'follow')
+        end)
+    end)
+    g.instance_2:exec(function()
+        t.helpers.retrying({timeout = 20}, function()
+            t.assert(box.info.replication[1])
+            t.assert_equals(box.info.replication[1].upstream.status,
+                            'follow')
+        end)
+    end)
+end


### PR DESCRIPTION
*(This PR is a backport of #12196 to `release/3.2` to a future `3.2.4` release.)*

----

This patch fixes a bug when a Tarantool 3 instance configured via the declarative config could not join a Tarantool 2 replica set if the master snapshot did not contain instance and replica set names yet.

To address this, introduce a new compat option, `skip_replication_names`, which controls instance and replica set name handling during replication startup. In the `old` mode, Tarantool skips applying `instance_name` and `replicaset_name` on startup and does not validate them against snapshot data. In the `new` mode, Tarantool preserves the previous behavior and applies and validates names on startup.

Closes #10426

NO_DOC=will added in separate PR

(cherry picked from commit 4e6123983f67e26387a1808218e979c0bbdf222d)