### PR TITLE
[backport 2.11] ci: fix integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -131,11 +131,12 @@ jobs:
   #   with:
   #     artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
-  php-client:
-    needs: tarantool
-    uses: tarantool-php/client/.github/workflows/reusable_qa.yml@master
-    with:
-      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
+  # FIXME: Disabled due to tarantool-php/client#100
+  # php-client:
+  #   needs: tarantool
+  #   uses: tarantool-php/client/.github/workflows/reusable_qa.yml@master
+  #   with:
+  #     artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   php-queue:
     needs: tarantool


### PR DESCRIPTION
*(This PR is a backport of #12547 to `release/2.11`.)*

----

The tarantool-php/client integration test fails appeared. The test is temporary disabled.

The tarantool-php/client#100 issue should be fixed first before enabling test back.

Related to tarantool-php/client#100

NO_CHANGELOG=ci
NO_DOC=ci
NO_TEST=ci