### PR TITLE
test: skip app threads tests on macOS

### DIFF
--- a/test/box-luatest/app_threads_module_test.lua
+++ b/test/box-luatest/app_threads_module_test.lua
@@ -3,8 +3,13 @@ local net = require('net.box')
 local t = require('luatest')
 local cbuilder = require('luatest.cbuilder')
 local cluster = require('luatest.cluster')
+local is_macos = jit.os == 'OSX'
 
 local g = t.group()
+
+g.before_all(function()
+    t.skip_if(is_macos)
+end)
 
 --
 -- FIXME(gh-12546): For server.exec to be able to find the luatest module,

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -10,6 +10,7 @@ local cbuilder = require('luatest.cbuilder')
 local cluster = require('luatest.cluster')
 local server = require('luatest.server')
 local t = require('luatest')
+local is_macos = jit.os == 'OSX'
 
 local g = t.group()
 
@@ -31,6 +32,7 @@ local function setsearchroot(server)
 end
 
 g.before_all(function(cg)
+    t.skip_if(is_macos)
     cg.server = server:new({
         box_cfg = {
             iproto_threads = 2,

--- a/test/box-luatest/iproto_export_test.lua
+++ b/test/box-luatest/iproto_export_test.lua
@@ -2,6 +2,7 @@ local net = require('net.box')
 
 local t = require('luatest')
 local server = require('luatest.server')
+local is_macos = jit.os == 'OSX'
 
 local g1 = t.group('iproto_export', t.helpers.matrix({
     before_box_cfg = {false, true},
@@ -70,6 +71,7 @@ g2.test_invalid_arguments = function(cg)
 end
 
 g2.test_iproto_export_in_app_threads = function(cg)
+    t.skip_if(is_macos)
     cg.server = server:new({box_cfg = {app_threads = 2}})
     cg.server:start()
     cg.server:call('box.iproto.internal.enable_thread_requests')
@@ -114,6 +116,7 @@ g2.test_iproto_export_in_app_threads = function(cg)
 end
 
 g2.test_iproto_call_routing = function(cg)
+    t.skip_if(is_macos)
     cg.server = server:new({
         box_cfg = {
             iproto_threads = 5,


### PR DESCRIPTION
Let's temporarily disable app_threads-related tests on macOS.

Part of #12559

NO_DOC=test
NO_CHANGELOG=test