### PR TITLE
test: make http client version test stable

### DIFF
--- a/test/app-luatest/http_client_http_version_test.lua
+++ b/test/app-luatest/http_client_http_version_test.lua
@@ -47,6 +47,11 @@ local expected = {
 
 http_version_group.before_each(function(g)
     g.server = socket.tcp_server('127.0.0.1', 0, function(_s) end)
+    t.helpers.retrying({timeout = 5}, function()
+        local conn = socket.tcp_connect('127.0.0.1', g.server:name().port)
+        t.assert_not_equals(conn, nil)
+        conn:close()
+    end)
 end)
 
 http_version_group.after_each(function(g)
@@ -72,23 +77,28 @@ local http_request_script = string.dump(function()
 end)
 
 http_version_group.test_http_version = function(g)
-    local dir = treegen.prepare_directory({}, {})
-    local script_name = 'http_request.lua'
-    treegen.write_file(dir, script_name, http_request_script)
-    local args = {script_name}
-    local opts = {nojson = true, stderr = true}
-    local env = {HTTP_SERVER_PORT = g.server:name().port}
-    env.PROTO = g.params.proto
-    env.HTTP_VERSION = g.params.version
-    justrun.tarantool(dir, env, args, opts)
-
-    local log_path = fio.pathjoin(dir, 'tarantool.log')
-    local log_file = fio.open(log_path)
-    t.assert_not_equals(log_file, nil)
-    local log_data = log_file:read()
-    log_file:close()
     local exp = expected[tostring(g.params.version)][g.params.proto]
-    t.assert_str_contains(log_data, exp)
+    -- Test runs a throwaway server and external process in parallel.
+    -- Under load, the child may fail to connect before reaching the
+    -- HTTP/ALPN path, so retry for a short time.
+    t.helpers.retrying({timeout = 5}, function()
+        local dir = treegen.prepare_directory({}, {})
+        local script_name = 'http_request.lua'
+        treegen.write_file(dir, script_name, http_request_script)
+        local args = {script_name}
+        local opts = {nojson = true, stderr = true}
+        local env = {HTTP_SERVER_PORT = g.server:name().port}
+        env.PROTO = g.params.proto
+        env.HTTP_VERSION = g.params.version
+        justrun.tarantool(dir, env, args, opts)
+
+        local log_path = fio.pathjoin(dir, 'tarantool.log')
+        local log_file = fio.open(log_path)
+        t.assert_not_equals(log_file, nil)
+        local log_data = log_file:read()
+        log_file:close()
+        t.assert_str_contains(log_data, exp)
+    end)
 end
 
 wrong_version_group.test_request_wrong_http_version = function()


### PR DESCRIPTION
This patch makes `app-luatest/http_client_http_version_test.lua` stable under load.

Before patch:

<details>
<summary><b>test log</b></summary>

```
===============================================================================================================================================================
WORKR TEST                                            PARAMS                                                                                       RESULT
---------------------------------------------------------------------------------------------------------------------------------------------------------------
[003] app-luatest/http_client_http_version_test.lua                                                                                                [ fail ]
[003] Test failed! Output from reject file /tmp/t/rejects/app-luatest/http_client_http_version.reject:
[005] app-luatest/http_client_http_version_test.lua                                                                                                [ pass ]
[003] Tarantool version is 3.7.0-entrypoint-224-g7998ef33c3
[003] TAP version 13
[003] 1..11
[003] # Started on Mon Apr 20 17:17:06 2026
[003] # Starting group: app-luatest.http_client_http_version
[003] ok     1  app-luatest.http_client_http_version.test_request_wrong_http_version
[003] # Starting group: versions.proto:"http"
[003] ok     2  versions.proto:"http".test_http_version
[003] # Starting group: versions.proto:"http".version:"1.1"
[003] ok     3  versions.proto:"http".version:"1.1".test_http_version
[003] # Starting group: versions.proto:"http".version:"2"
[003] ok     4  versions.proto:"http".version:"2".test_http_version
[003] # Starting group: versions.proto:"http".version:"2-prior-knowledge"
[003] ok     5  versions.proto:"http".version:"2-prior-knowledge".test_http_version
[003] # Starting group: versions.proto:"http".version:"2-tls"
[003] ok     6  versions.proto:"http".version:"2-tls".test_http_version
[003] # Starting group: versions.proto:"https"
[003] ok     7  versions.proto:"https".test_http_version
[003] # Starting group: versions.proto:"https".version:"1.1"
[003] ok     8  versions.proto:"https".version:"1.1".test_http_version
[003] # Starting group: versions.proto:"https".version:"2"
[003] ok     9  versions.proto:"https".version:"2".test_http_version
[003] # Starting group: versions.proto:"https".version:"2-prior-knowledge"
[003] ok     10 versions.proto:"https".version:"2-prior-knowledge".test_http_version
[003] # Starting group: versions.proto:"https".version:"2-tls"
[003] not ok 11 versions.proto:"https".version:"2-tls".test_http_version
[003] #   ...ntool/test/app-luatest/http_client_http_version_test.lua:96: Could not find substring 
[003] #   "ALPN: curl offers h2,http/1.1"
[003] #    in string 
[003] #   "2026-04-20 17:17:08.316 [95278] main/104/http_request.lua I> libcurl: * !!! WARNING !!!\
[003] #   2026-04-20 17:17:08.317 [95278] main/104/http_request.lua I> libcurl: * This is a debug build of libcurl, do not use in production.\
[003] #   2026-04-20 17:17:08.317 [95278] main I> libcurl: * STATE: INIT => SETUP handle 0x10a809208; line 1884\
[003] #   2026-04-20 17:17:08.317 [95278] main I> libcurl: * STATE: SETUP => CONNECT handle 0x10a809208; line 1900\
[003] #   2026-04-20 17:17:08.317 [95278] main I> libcurl: * Added connection 0. The cache now contains 1 members\
[003] #   2026-04-20 17:17:08.317 [95278] main I> libcurl: * STATE: CONNECT => CONNECTING handle 0x10a809208; line 1941\
[003] #   2026-04-20 17:17:08.317 [95278] main I> libcurl: *   Trying 127.0.0.1:53087...\
[003] #   2026-04-20 17:17:08.318 [95278] main I> libcurl: * Curl_multi_closed, fd=13 multi is 0x11c6869c8\
[003] #   2026-04-20 17:17:08.318 [95278] main I> libcurl: * Curl_multi_closed, fd=13 entry is 0x1045040c8\
[003] #   2026-04-20 17:17:08.318 [95278] main I> libcurl: * Failed to connect to 127.0.0.1 port 53087 after 0 ms: Could not connect to server\
[003] #   2026-04-20 17:17:08.318 [95278] main I> libcurl: * multi_done[CONNECTING]: status: 7 prem: 1 done: 0\
[003] #   2026-04-20 17:17:08.318 [95278] main I> libcurl: * multi_done, not reusing connection=0, forbid=0, close=0, premature=1, conn_multiplex=0\
[003] #   2026-04-20 17:17:08.318 [95278] main I> libcurl: * Curl_disconnect(conn #0, aborted=1)\
[003] #   2026-04-20 17:17:08.318 [95278] main I> libcurl: * closing connection #0\
[003] #   2026-04-20 17:17:08.318 [95278] main I> libcurl: * [CCACHE] closing #0\
[003] #   2026-04-20 17:17:08.318 [95278] main utils.c:703 E> ...ntool/test/app-luatest/http_client_http_version_test.lua:76: assertion failed! {\"type\":\"LuajitError\",\"trace\":[{\"file\":\"src/lua/utils.c\",\"line\":703}]}\
[003] #   2026-04-20 17:17:08.318 [95278] main say.c:88 F> fatal error, exiting the event loop\
[003] #   "
[003] #   stack traceback:
[003] #         ...ntool/test/app-luatest/http_client_http_version_test.lua:96: in function 'versions.proto:"https".version:"2-tls".test_http_version'
[003] # Ran 11 tests in 1.769 seconds, 10 succeeded, 1 failed
[003] 
[003] [test-run server "luatest_server"] Last 15 lines of the log file /private/tmp/t/003_app-luatest/http_client_http_version_test.log:
[003] started logging into a pipe, SIGHUP log rotation disabled
[Main process] Got failed test; gently terminate all workers...
[003] Worker "003_app-luatest" got failed test; stopping the server...
[001] app-luatest/http_client_http_version_test.lua                                                                                                [ pass ]
[001] Worker "001_app-luatest" got signal to terminate; stopping the server...
[006] app-luatest/http_client_http_version_test.lua                                                                                                [ pass ]
[009] app-luatest/http_client_http_version_test.lua                                                                                                [ pass ]
[009] Worker "009_app-luatest" got signal to terminate; stopping the server...
[006] Worker "006_app-luatest" got signal to terminate; stopping the server...
[008] app-luatest/http_client_http_version_test.lua                                                                                                [ pass ]
[008] Worker "008_app-luatest" got signal to terminate; stopping the server...
[010] app-luatest/http_client_http_version_test.lua                                                                                                [ pass ]
[010] Worker "010_app-luatest" got signal to terminate; stopping the server...
[007] app-luatest/http_client_http_version_test.lua                                                                                                [ pass ]
[007] Worker "007_app-luatest" got signal to terminate; stopping the server...
[002] app-luatest/http_client_http_version_test.lua                                                                                                [ pass ]
[002] Worker "002_app-luatest" got signal to terminate; stopping the server...
[004] app-luatest/http_client_http_version_test.lua                                                                                                [ pass ]
[004] Worker "004_app-luatest" got signal to terminate; stopping the server...
---------------------------------------------------------------------------------------------------------------------------------------------------------------
Duration of failed tests (seconds):
*   2.08 app-luatest/http_client_http_version_test.lua                

Top 10 longest tests (seconds):
*   2.08 app-luatest/http_client_http_version_test.lua                
---------------------------------------------------------------------------------
Statistics:
* pass: 9
* fail: 1
Failed tasks:
- [app-luatest/http_client_http_version_test.lua, null]
# logfile:        /private/tmp/t/log/003_app-luatest.log
# luatest logfile: /private/tmp/t/003_app-luatest/run.log
# reproduce file: /private/tmp/t/reproduce/003_app-luatest.list.yaml
```

</details>


Part of #12559

NO_DOC=test
NO_CHANGELOG=test