### PR TITLE
test: make fio tempdir test stable

### DIFF
--- a/test/app/fio.result
+++ b/test/app/fio.result
@@ -1474,7 +1474,7 @@ cwd = fio.cwd()
 old_tmpdir = os.getenv('TMPDIR')
 ---
 ...
-tmpdir = cwd..'/tmp-.dot.-'
+tmpdir = cwd..'/tmp-.dot.-'..tostring(fiber.time64())
 ---
 ...
 fio.mkdir(tmpdir)

--- a/test/app/fio.test.lua
+++ b/test/app/fio.test.lua
@@ -477,7 +477,7 @@ fio.mktree('/dev/null/dir')
 cwd = fio.cwd()
 old_tmpdir = os.getenv('TMPDIR')
 
-tmpdir = cwd..'/tmp-.dot.-'
+tmpdir = cwd..'/tmp-.dot.-'..tostring(fiber.time64())
 fio.mkdir(tmpdir)
 os.setenv('TMPDIR', tmpdir)
 dir = fio.tempdir()


### PR DESCRIPTION
This patch makes `app/fio.test.lua` stable under parallel runs.

Before patch
```
===========================================================================================================================================================================================
WORKR TEST                                            PARAMS                                                                                                                   RESULT
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
[006] app/fio.test.lua                                                                                                                                                         [ pass ]
[016] app/fio.test.lua                                                                                                                                                         [ pass ]
<..snipped..>
[013] app/fio.test.lua                                                                                                                                                         [ pass ]
[012] app/fio.test.lua                                                                                                                                                         [ pass ]
[003] app/fio.test.lua                                                                                                                                                         [ pass ]
[006] app/fio.test.lua                                                                                                                                                         [ fail ]
[006]
[006] Test failed! Result content mismatch:
[006] --- app/fio.result	Sun Apr 19 22:44:39 2026
[006] +++ /tmp/t/rejects/app/fio.reject	Tue Apr 21 10:26:53 2026
[006] @@ -1479,7 +1479,8 @@
[006]  ...
[006]  fio.mkdir(tmpdir)
[006]  ---
[006] -- true
[006] +- false
[006] +- 'fio: File exists'
[006]  ...
[006]  os.setenv('TMPDIR', tmpdir)
[006]  ---
[006]
[006] [test-run server "app"] Last 15 lines of the log file /private/tmp/t/006_app/app.log:
[006] 2026-04-21 10:26:52.557 [73513] main/106/gc gc.c:320 I> wal/engine cleanup is resumed
[006] 2026-04-21 10:26:52.557 [73513] main/104/app/box.load_cfg load_cfg.lua:1001 I> set 'memtx_memory' configuration option to 107374182
[006] 2026-04-21 10:26:52.557 [73513] main/104/app/box.load_cfg load_cfg.lua:1001 I> set 'log' configuration option to "/private/tmp/t/006_app/app.log"
[006] 2026-04-21 10:26:52.557 [73513] main/104/app/box.load_cfg load_cfg.lua:1001 I> set 'listen' configuration option to "unix/:/private/tmp/t/006_app/app.i"
[006] 2026-04-21 10:26:52.557 [73513] main/104/app/box.load_cfg load_cfg.lua:1001 I> set 'replication_sync_timeout' configuration option to 100
[006] 2026-04-21 10:26:52.557 [73513] main/107/checkpoint_daemon gc.c:614 I> scheduled next checkpoint for Tue Apr 21 12:03:47 2026
[006] 2026-04-21 10:26:52.557 [73513] main/104/app box.cc:450 I> box switched to rw
[006] 2026-04-21 10:26:52.558 [73513] main/118/console/unix/:/private/tmp/t/006_app/app.c/socket socket.lua:1142 I> started
[006] 2026-04-21 10:26:52.558 [73513] main main.cc:1114 I> entering the event loop
[006] 2026-04-21 10:26:53.114 [73513] main/120/console/unix/: error.cc:405 I> ERRINJ_COIO_SENDFILE_CHUNK = 1
[006] 2026-04-21 10:26:53.117 [73513] main/120/console/unix/: error.cc:405 I> ERRINJ_COIO_SENDFILE_CHUNK = -1
[006] 2026-04-21 10:26:53.128 [73513] main/120/console/unix/: error.cc:401 I> ERRINJ_COIO_WRITE_CHUNK = true
[006] 2026-04-21 10:26:53.130 [73513] main/120/console/unix/: error.cc:401 I> ERRINJ_COIO_WRITE_CHUNK = false
```

Part of #12559

NO_DOC=test
NO_CHANGELOG=test