### PR TITLE
limbo: handle volatile LSN lagging behind

### DIFF
--- a/src/box/txn_limbo_queue.c
+++ b/src/box/txn_limbo_queue.c
@@ -680,6 +680,17 @@ txn_limbo_queue_apply_confirm(struct txn_limbo_queue *queue, int64_t lsn)
 		queue->confirmed_lsn = lsn;
 		vclock_follow(&queue->confirmed_vclock, queue->owner_id, lsn);
 	}
+	if (queue->confirmed_lsn > queue->volatile_confirmed_lsn) {
+		/*
+		 * This can happen when CONFIRM was made with a smaller quorum
+		 * than known right now. Then the volatile LSN is collecting
+		 * acks by a bigger quorum and can actually be smaller. Bump it
+		 * forward when this happens to keep the invariant of the
+		 * volatile LSN being the present or the future of the confirmed
+		 * LSN.
+		 */
+		queue->volatile_confirmed_lsn = queue->confirmed_lsn;
+	}
 	if (queue_was_full && !txn_limbo_queue_is_full(queue))
 		fiber_cond_broadcast(&queue->cond);
 }

--- a/test/replication-luatest/election_restart_with_new_quorum_test.lua
+++ b/test/replication-luatest/election_restart_with_new_quorum_test.lua
@@ -1,0 +1,53 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+--
+-- The test covers the case when synchronous transactions got CONFIRM entry
+-- written with a smaller quorum than was set after a restart.
+--
+-- Then the transactions having seemingly not enough ACKs are getting CONFIRMs
+-- right during recovery, which could, before a fix, break an invariant in the
+-- synchronous queue implementation. Specifically, the in-memory volatile
+-- confirmed LSN was lagging behind the actually persisted confirmed LSN, and
+-- there was an assertion failure because of that.
+--
+
+g.before_each(function(cg)
+    cg.master = server:new({
+        box_cfg = {
+            election_mode = 'manual',
+        }
+    })
+    cg.master:start()
+end)
+
+g.after_each(function(cg)
+    cg.master:drop()
+end)
+
+g.test_case = function(cg)
+    cg.master:exec(function()
+        -- Force the quorum 1 to keep confirming txns without having to
+        -- start a second instance.
+        box.cfg{replication_synchro_quorum = 1}
+        local s = box.schema.create_space('test', {is_sync = true})
+        s:create_index('pk')
+        s:replace{1}
+        -- Simulate like a new replica has joined and acked the
+        -- next txn.
+        box.space._cluster:replace{2, require('uuid').str()}
+        s:replace{2}
+    end)
+    --
+    -- On restart the synchro queue will replay CONFIRM for {1}. Then will see a
+    -- quorum increase due to a new entry in _cluster. And then will replay the
+    -- CONFIRM for {2}, without the ack from a second instance.
+    --
+    cg.master:restart()
+    cg.master:exec(function()
+        t.assert_equals(box.info.synchro.quorum, 2)
+        t.assert_equals(box.space.test:select{}, {{1}, {2}})
+    end)
+end


### PR DESCRIPTION
The volatile confirmed LSN can legally lag behind the persisted confirmed LSN, when the incoming CONFIRMations were done with a smaller quorum somehow. Then the volatile LSN was still counting acks, while the persisted LSN was moving forward on CONFIRM entries.

Lets keep them in sync. The volatile LSN must be the present or the future of the persisted LSN.

Otherwise the limbo worker saw the invariant broken and was asserting.

The bug was only present in the Debug build, and it was introduced in commit 516a3cc5026f24400ecefe80d0bac4dc488287ed ("limbo: collect ACKs on replicas").

Part of #8095

NO_DOC=bugfix
NO_CHANGELOG=the bug wasn't released yet