### PR TITLE
[backport 3.2] datetime: fixed timestamp type check in set()

### DIFF
--- a/changelogs/unreleased/gh-12411-datetime-set-skips-ts-typecheck.md
+++ b/changelogs/unreleased/gh-12411-datetime-set-skips-ts-typecheck.md
@@ -1,0 +1,8 @@
+## bugfix/datetime
+
+* Fixed timestamp type checking in `set()` (gh-12411).
+
+For backward compatibility the `compat.datetime_setfn_timestamp_type_check`
+option has been introduced. It's disabled by default for now ('old' behaviour),
+which means no type check is performed. The 'new' behaviour (with type check)
+is planned to be set as the default in version 4.x.

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2491,6 +2491,12 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'old',
         }),
+        datetime_setfn_timestamp_type_check = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'old',
+        }),
     }),
     -- Instance labels.
     labels = schema.map({

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -23,6 +23,13 @@
 #include "mp_extension_types.h"
 
 #include "fiber.h"
+#include "core/tweaks.h"
+
+/**
+ * Enables timestamp type check in dt_obj:set().
+ */
+static bool datetime_setfn_timestamp_type_check = false;
+TWEAK_BOOL(datetime_setfn_timestamp_type_check);
 
 /**
  * Floored modulo and divide.

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -54,6 +54,15 @@ channel close.
 https://tarantool.io/compat/fiber_channel_close_mode
 ]]
 
+local DATETIME_SETFN_TIMESTAMP_TYPE_CHECK_BRIEF = [[
+Whether to check timestamp type in datetime obj:set().
+The new behaviour requires timestamp to be a number for set()
+function as new() function requires. The old behaviour skips
+type check for timestamp in set().
+
+https://tarantool.io/compat/datetime_setfn_timestamp_type_check
+]]
+
 local SQL_PRIV_BRIEF = [[
 Whether to enable access checks for SQL requests. The old behavior is to let
 any user execute an arbitrary SQL request over IPROTO. With the new behavior,
@@ -189,6 +198,13 @@ local options = {
         brief = FIBER_CHANNEL_GRACEFUL_CLOSE_BRIEF,
         action = tweak_action('fiber_channel_close_mode',
                               'forceful', 'graceful'),
+    },
+    datetime_setfn_timestamp_type_check = {
+        default = 'old',
+        obsolete = nil,
+        brief = DATETIME_SETFN_TIMESTAMP_TYPE_CHECK_BRIEF,
+        action = tweak_action('datetime_setfn_timestamp_type_check',
+                              false, true),
     },
     sql_priv = {
         default = 'new',

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -1,6 +1,7 @@
 local ffi = require('ffi')
 local buffer = require('buffer')
 local tz = require('timezones')
+local tweaks = require('internal.tweaks')
 
 --[[
     `c-dt` library functions handles properly both positive and negative `dt`
@@ -605,7 +606,8 @@ local function extract_obj_epoch_and_update_nsec(obj, ymd, hms, nsec, from_set)
     if hms then
         error('timestamp is not allowed if hour/min/sec provided', 3)
     end
-    if not from_set and type(ts) ~= 'number' then
+    if (not from_set or tweaks.datetime_setfn_timestamp_type_check) and
+        type(ts) ~= 'number' then
         error(("bad timestamp ('number' expected, got '%s')"):format(type(ts)))
     end
     local epoch, fraction = math_modf(ts)

--- a/test/app-luatest/datetime_test.lua
+++ b/test/app-luatest/datetime_test.lua
@@ -2194,6 +2194,11 @@ local INVALID_NEW_AND_SET_TIME_UNITS_ERRORS = {
         return ("%s: %s expected, but received %s"):format(key, what_expected, val)
     end,
 
+    expected_type3 = function(set_arg, what_expected)
+        local key, val = get_single_key_val(set_arg, true)
+        return ("bad %s ('%s' expected, got '%s')"):format(key, what_expected, type(val))
+    end,
+
     range_check_error_string = function(set_arg, range)
         local key, val = get_single_key_val(set_arg, true)
         return ('value %s of %s is out of allowed range [%s, %s]'):
@@ -2367,6 +2372,19 @@ local INVALID_NEW_AND_SET_TIME_UNITS = {
     {
         set = {nsec = 1.1},
         err_fn = 'only_integer_msg',
+    },
+    {
+        set_multiple = {{timestamp = '3600.1'}, {timestamp = true}},
+        err_fn = 'expected_type3',
+        err_fn_args = {'number'},
+        _set = {compat = {datetime_setfn_timestamp_type_check = 'new'}},
+    },
+    {
+        compat = {datetime_setfn_timestamp_type_check = 'old'},
+        set = {timestamp = true},
+        err_msg = 'bad argument #1 to \'math_modf\' '..
+            '(number expected, got boolean)',
+        _new = {skip = 'only set() - old behaviour'},
     },
     {
         set_multiple = {{tzoffset = {}}, {tzoffset = dt.new()}},

--- a/test/app-tap/datetime.test.lua
+++ b/test/app-tap/datetime.test.lua
@@ -7,6 +7,7 @@ local ffi = require('ffi')
 local json = require('json')
 local msgpack = require('msgpack')
 local TZ = date.TZ
+local compat = require('compat')
 
 test:plan(42)
 
@@ -2739,6 +2740,11 @@ test:test("Time :set{} operations", function(test)
     -- timestamp 1630359071.125 is 2021-08-30T21:31:11.125Z
     test:is(tostring(ts:set{ timestamp = 1630359071.125 }),
             '2021-08-30T21:31:11.125+0800', 'timestamp 1630359071.125' )
+    -- When 'new' is set, this leads to error. That is checked in luatest.
+    if compat.datetime_setfn_timestamp_type_check == 'old' then
+        test:is(tostring(ts:set{timestamp = '1630359071.125'}),
+                '2021-08-30T21:31:11.125+0800', 'timestamp 1630359071.125')
+    end
     test:is(tostring(ts:set{ msec = 123}), '2021-08-30T21:31:11.123+0800',
             'msec = 123')
     test:is(tostring(ts:set{ usec = 123}), '2021-08-30T21:31:11.000123+0800',

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -351,6 +351,7 @@ g.test_defaults = function()
             box_space_max = 'new',
             box_error_unpack_type_and_code = 'old',
             console_session_scope_vars = 'old',
+            datetime_setfn_timestamp_type_check = 'old',
         },
     }
     local res = cluster_config:apply_default({})


### PR DESCRIPTION
*(This PR is a backport of #12430 to `release/3.2`.)*

----

Missed 'invalid timestamp' tests for `new()` (regular behaviour) and for `set()` (old behaviour) added also.

Fixes #12411

@TarantoolBot document
Title: Datetime `set()` timestamp type check fixed.

For backward compatibility
the `compat.datetime_setfn_timestamp_type_check` option has been introduced. It's disabled by default for now ('old' behaviour), which means no type check is performed. The 'new' behaviour (with type check) is planned to be set as the default in version 4.x.

Required docu page: https://tarantool.io/compat/datetime_setfn_timestamp_type_check

See DATETIME_SETFN_TIMESTAMP_TYPE_CHECK_BRIEF in compat.lua for details.

(cherry picked from commit df461f1a2ed3a068a83901ad98f2436a98da74ca)