### PR TITLE
box: allow eval in application threads for admin only

### DIFF
--- a/src/box/app_threads.c
+++ b/src/box/app_threads.c
@@ -139,6 +139,15 @@ app_thread_process_call(struct call_request *request, struct port *port)
 int
 app_thread_process_eval(struct call_request *request, struct port *port)
 {
+	struct runtime_credentials *runtime_cr =
+			fiber()->storage.runtime_credentials;
+	const char *uname = runtime_cr->user_name != NULL ?
+			    runtime_cr->user_name : "guest";
+	if (strcmp(uname, "admin") != 0) {
+		diag_set(AccessDeniedError, priv_name(PRIV_X),
+			 schema_object_name(SC_UNIVERSE), "", uname);
+		return -1;
+	}
 	const char *expr = request->expr;
 	uint32_t expr_len = mp_decode_strl(&expr);
 	struct mp_box_ctx ctx;

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -448,7 +448,6 @@ struct errcode_record {
 	_(ER_DICT_OVERFLOW, 301,		"Dictionary has no space - too many unique values are used", "max_size", UINT) \
 	_(ER_NO_SUCH_THREAD_GROUP, 302,		"Thread group does not exist", "thread_group", STRING) \
 	_(ER_THREADS_NOT_CONFIGURED, 303,	"Threads are not configured") \
-	_(ER_THREAD_REQUESTS_DISABLED, 304,	"Requests to application threads are disabled for this session") \
 	TEST_ERROR_CODES(_) /** This one should be last. */
 
 /*

--- a/src/box/iproto.cc
+++ b/src/box/iproto.cc
@@ -1000,8 +1000,6 @@ struct iproto_connection
 	bool is_established;
 	/** Number of iproto requests in flight. */
 	size_t request_count;
-	/** Whether requests to application threads are allowed. */
-	bool may_set_thread_id;
 };
 
 /** Returns a string suitable for logging. */
@@ -1837,7 +1835,6 @@ iproto_connection_new(struct iproto_thread *iproto_thread)
 	con->is_in_replication = false;
 	con->is_drop_pending = false;
 	con->is_established = false;
-	con->may_set_thread_id = false;
 	rlist_create(&con->in_stop_list);
 	rlist_add_entry(&iproto_thread->connections, con, in_connections);
 	iproto_thread->connection_count++;
@@ -2001,10 +1998,6 @@ iproto_msg_prepare(struct iproto_msg *msg, const char **pos, const char *reqend)
 
 	type = msg->header.type;
 	thread_id = msg->header.thread_id;
-	if (thread_id != XROW_THREAD_UNSPEC && !con->may_set_thread_id) {
-		diag_set(ClientError, ER_THREAD_REQUESTS_DISABLED);
-		goto error;
-	}
 	if (thread_id != XROW_THREAD_UNSPEC &&
 	    thread_id >= (uint32_t)iproto_thread->srv_count) {
 		diag_set(ClientError, ER_NO_SUCH_THREAD, thread_id);
@@ -4995,35 +4988,6 @@ iproto_override(uint32_t req_type, iproto_handler_t cb,
 
 	iproto_override_finish(handlers, req_type, is_set);
 	return 0;
-}
-
-/**
- * Enable requests to application threads over the given connection.
- */
-static void
-net_enable_thread_requests(struct cmsg *m)
-{
-	struct iproto_service_msg *msg = (struct iproto_service_msg *)m;
-	msg->connection->may_set_thread_id = true;
-	iproto_service_msg_delete(msg);
-}
-
-void
-iproto_enable_thread_requests(void)
-{
-	assert(cord_is_main());
-	struct session *session = fiber_get_session(fiber());
-	if (session == NULL || session->type != SESSION_TYPE_BINARY)
-		return;
-	struct iproto_connection *connection =
-		(struct iproto_connection *)session->meta.connection;
-	struct cpipe *net_pipe = &connection->iproto_thread->srv[0].ret_pipe;
-	static const struct cmsg_hop route[] = {
-		{net_enable_thread_requests, NULL},
-	};
-	struct iproto_service_msg *msg = iproto_service_msg_new(route);
-	msg->connection = connection;
-	cpipe_push(net_pipe, &msg->base);
 }
 
 /**

--- a/src/box/iproto.h
+++ b/src/box/iproto.h
@@ -136,13 +136,6 @@ iproto_override(uint32_t req_type, iproto_handler_t cb,
 		iproto_handler_destroy_t destroy, void *ctx);
 
 /**
- * Allows clients of the current session direct requests to application threads.
- * Makes sense only if the current session type is "binary" (IPROTO).
- */
-void
-iproto_enable_thread_requests(void);
-
-/**
  * Lets IPROTO threads know that there's a function with the given name
  * in the current request-serving thread (tx or app).
  *

--- a/src/box/lua/app_threads.lua
+++ b/src/box/lua/app_threads.lua
@@ -219,7 +219,6 @@ function box.internal.threads.init(cfg, group_name, thread_id, conn_fd)
     this_group_name = group_name
     this_thread_id = thread_id
     threads_conn = net.from_fd(conn_fd, {fetch_schema = false})
-    threads_conn:call('box.iproto.internal.enable_thread_requests')
     init_thread_groups(cfg)
 end
 

--- a/src/box/lua/iproto.c
+++ b/src/box/lua/iproto.c
@@ -242,15 +242,6 @@ lbox_iproto_drop_connections(struct lua_State *L)
 	return 0;
 }
 
-/** Lua wrapper around iproto_enable_thread_requests(). */
-static int
-lbox_iproto_enable_thread_requests(struct lua_State *L)
-{
-	(void)L;
-	iproto_enable_thread_requests();
-	return 0;
-}
-
 /** Lua wrapper around iproto_register_func(). */
 static int
 lbox_iproto_register_func(struct lua_State *L)
@@ -639,7 +630,6 @@ box_lua_iproto_init(struct lua_State *L)
 	static const struct luaL_Reg internal_funcs_main[] = {
 		{"session_new", lbox_iproto_session_new},
 		{"drop_connections", lbox_iproto_drop_connections},
-		{"enable_thread_requests", lbox_iproto_enable_thread_requests},
 		{NULL, NULL}
 	};
 	static const struct luaL_Reg internal_funcs_common[] = {

--- a/test/box-luatest/app_threads_module_test.lua
+++ b/test/box-luatest/app_threads_module_test.lua
@@ -6,6 +6,14 @@ local cluster = require('luatest.cluster')
 
 local g = t.group()
 
+local BASE_CONFIG = cbuilder:new()
+    :set_global_option('credentials.users.admin.password', 'secret')
+    :config()
+
+local SERVER_OPTS = {
+    net_box_credentials = {user = 'admin', password = 'secret'},
+}
+
 --
 -- FIXME(gh-12546): For server.exec to be able to find the luatest module,
 -- searchroot must be set in the test server. For the main thread, this is
@@ -28,7 +36,7 @@ g.test_threads_config_propagation = function()
     -- Check that the threads configuration is propagated to box.cfg
     -- and the threads module.
     --
-    local config = cbuilder:new()
+    local config = cbuilder:new(BASE_CONFIG)
         :add_instance('server', {})
         :set_instance_option('server', 'threads.groups', {
             {name = 'test1', size = 1},
@@ -36,7 +44,7 @@ g.test_threads_config_propagation = function()
             {name = 'test3', size = 3},
         })
         :config()
-    local cluster = cluster:new(config)
+    local cluster = cluster:new(config, SERVER_OPTS)
     cluster:start()
     local expected_threads_info = {
         thread_id = 0,
@@ -57,7 +65,7 @@ g.test_threads_config_propagation = function()
     -- Check that the threads configuration is updated only after
     -- instance restart.
     --
-    config = cbuilder:new()
+    config = cbuilder:new(BASE_CONFIG)
         :add_instance('server', {})
         :set_instance_option('server', 'threads.groups', {
             {name = 'test1', size = 1},
@@ -123,10 +131,10 @@ g.test_threads_not_configured = function()
     -- Check that if the threads configuration is unset, no thread groups
     -- are created, not even tx.
     --
-    local config = cbuilder:new()
+    local config = cbuilder:new(BASE_CONFIG)
         :add_instance('server', {})
         :config()
-    local cluster = cluster:new(config)
+    local cluster = cluster:new(config, SERVER_OPTS)
     cluster:start()
     cluster.server:exec(function()
         local threads = require('experimental.threads')
@@ -144,11 +152,11 @@ g.test_thread_groups_not_configured = function()
     -- module is configured and the tx group is created even if no thread
     -- groups are configured.
     --
-    local config = cbuilder:new()
+    local config = cbuilder:new(BASE_CONFIG)
         :add_instance('server', {})
         :set_instance_option('server', 'threads', {})
         :config()
-    local cluster = cluster:new(config)
+    local cluster = cluster:new(config, SERVER_OPTS)
     cluster:start()
     cluster.server:exec(function()
         local threads = require('experimental.threads')
@@ -161,14 +169,14 @@ g.test_thread_groups_not_configured = function()
 end
 
 g.test_thread_function_export = function()
-    local config = cbuilder:new()
+    local config = cbuilder:new(BASE_CONFIG)
         :add_instance('server', {})
         :set_instance_option('server', 'threads.groups', {
             {name = 'test1', size = 3},
             {name = 'test2', size = 2},
         })
         :config()
-    local cluster = cluster:new(config)
+    local cluster = cluster:new(config, SERVER_OPTS)
     cluster:start()
     --
     -- Argument checking.
@@ -199,14 +207,14 @@ g.test_thread_function_export = function()
 end
 
 g.test_threads_call = function()
-    local config = cbuilder:new()
+    local config = cbuilder:new(BASE_CONFIG)
         :add_instance('server', {})
         :set_instance_option('server', 'threads.groups', {
             {name = 'test1', size = 3},
             {name = 'test2', size = 2},
         })
         :config()
-    local cluster = cluster:new(config)
+    local cluster = cluster:new(config, SERVER_OPTS)
     cluster:start()
     --
     -- Argument checking.
@@ -388,14 +396,14 @@ g.test_threads_call = function()
 end
 
 g.test_threads_eval = function()
-    local config = cbuilder:new()
+    local config = cbuilder:new(BASE_CONFIG)
         :add_instance('server', {})
         :set_instance_option('server', 'threads.groups', {
             {name = 'test1', size = 3},
             {name = 'test2', size = 2},
         })
         :config()
-    local cluster = cluster:new(config)
+    local cluster = cluster:new(config, SERVER_OPTS)
     cluster:start()
     --
     -- Argument checking.
@@ -544,7 +552,7 @@ g.test_threads_eval = function()
 end
 
 g.test_threads_priv = function()
-    local config = cbuilder:new()
+    local config = cbuilder:new(BASE_CONFIG)
         :set_global_option('credentials.users.guest.privileges', {
             {
                 permissions = {'execute'},
@@ -573,7 +581,7 @@ g.test_threads_priv = function()
             {name = 'test3', size = 3},
         })
         :config()
-    local cluster = cluster:new(config)
+    local cluster = cluster:new(config, SERVER_OPTS)
     cluster.server:start()
     cluster.server:exec(function()
         local threads = require('experimental.threads')

--- a/test/box-luatest/app_threads_module_test.lua
+++ b/test/box-luatest/app_threads_module_test.lua
@@ -104,7 +104,6 @@ g.test_threads_config_propagation = function()
     --
     -- Check configuration in other threads.
     --
-    cluster.server:call('box.iproto.internal.enable_thread_requests')
     setsearchroot(cluster.server)
     for i = 1, 10 do
         local group_name
@@ -367,7 +366,6 @@ g.test_threads_call = function()
     --
     -- Usage in other a non-tx thread.
     --
-    cluster.server:call('box.iproto.internal.enable_thread_requests')
     setsearchroot(cluster.server)
     cluster.server:exec(function()
         local threads = require('experimental.threads')
@@ -529,7 +527,6 @@ g.test_threads_eval = function()
     --
     -- Usage in other a non-tx thread.
     --
-    cluster.server:call('box.iproto.internal.enable_thread_requests')
     setsearchroot(cluster.server)
     cluster.server:exec(function()
         local threads = require('experimental.threads')

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -39,7 +39,6 @@ g.before_all(function(cg)
         net_box_credentials = {user = 'admin'}
     })
     cg.server:start()
-    cg.server:call('box.iproto.internal.enable_thread_requests')
     setsearchroot(cg.server)
 end)
 
@@ -47,26 +46,9 @@ g.after_all(function(cg)
     cg.server:drop()
 end)
 
-g.test_thread_requests_disabled = function(cg)
-    local conn = net.connect(cg.server.net_box_uri,
-                             cg.server.net_box_credentials)
-    local err = {type = 'ClientError', name = 'THREAD_REQUESTS_DISABLED'}
-    t.assert_error_covers(err, conn.call, conn, 'tonumber', {'123'},
-                          {_thread_id = 1})
-    t.assert_error_covers(err, conn.eval, conn, 'return tonumber(...)', {'123'},
-                          {_thread_id = 1})
-    conn:call('box.iproto.internal.enable_thread_requests')
-    t.assert_equals(conn:call('tonumber', {'123'},
-                              {_thread_id = 1}), 123)
-    t.assert_equals(conn:eval('return tonumber(...)', {'123'},
-                              {_thread_id = 1}), 123)
-    conn:close()
-end
-
 g.test_no_such_thread = function(cg)
     local conn = net.connect(cg.server.net_box_uri,
                              cg.server.net_box_credentials)
-    conn:call('box.iproto.internal.enable_thread_requests')
     t.assert_error_covers({
         type = 'ClientError',
         name = 'NO_SUCH_THREAD',
@@ -103,7 +85,6 @@ g.test_unable_to_process_in_thread = function(cg)
     end
     local conn = net.connect(cg.server.net_box_uri,
                              cg.server.net_box_credentials)
-    conn:call('box.iproto.internal.enable_thread_requests')
     t.assert(conn:ping())
     t.assert(conn:ping({_thread_id = 0}))
     t.assert_not(conn:ping({_thread_id = 1}))
@@ -127,7 +108,6 @@ end
 g.test_call_eval = function(cg)
     local conn = net.connect(cg.server.net_box_uri,
                              cg.server.net_box_credentials)
-    conn:call('box.iproto.internal.enable_thread_requests')
     -- Call a box function in the main thread.
     t.assert_covers(conn:call('box.info', {}, {_thread_id = 0}),
                     {status = 'running'})
@@ -182,14 +162,12 @@ g.test_call_eval_access = function(cg)
     end, {}, {_thread_id = 1})
     local conn = net.connect(cg.server.net_box_uri,
                              cg.server.net_box_credentials)
-    conn:call('box.iproto.internal.enable_thread_requests')
     t.assert_equals(conn:call('test_func_1', {}, {_thread_id = 1}), 1)
     t.assert_equals(conn:call('test_func_2', {}, {_thread_id = 1}), 2)
     t.assert_equals(conn:eval([[return 123]], {}, {_thread_id = 1}), 123)
     conn:close()
     conn = net.connect(cg.server.net_box_uri,
                        {user = 'client', password = 'secret'})
-    conn:call('box.iproto.internal.enable_thread_requests')
     t.assert_equals(conn:call('test_func_1', {}, {_thread_id = 1}), 1)
     t.assert_error_covers({
             type = 'AccessDeniedError',
@@ -211,7 +189,6 @@ end
 g.test_builtin_types_serialization = function(cg)
     local conn = net.connect(cg.server.net_box_uri,
                              cg.server.net_box_credentials)
-    conn:call('box.iproto.internal.enable_thread_requests')
     -- Check basic types.
     local function check(obj)
         local ret_obj = conn:eval([[return ...]], {obj}, {_thread_id = 1})
@@ -265,7 +242,6 @@ g.test_call_ret_tuple_extension_unset = function(cg)
                             box.iproto.feature.call_ret_tuple_extension)
     local conn = net.connect(cg.server.net_box_uri,
                              cg.server.net_box_credentials)
-    conn:call('box.iproto.internal.enable_thread_requests')
     local tuple = conn:eval([[
         local format = box.tuple.format.new({
             {'a', 'unsigned'}, {'b', 'unsigned'},
@@ -755,7 +731,6 @@ g.test_net_replicaset = function()
         net_box_credentials = {user = 'admin', password = 'secret'},
     })
     cluster:start()
-    cluster.router:call('box.iproto.internal.enable_thread_requests')
     setsearchroot(cluster.router)
     local connect_cfg = cluster.router:exec(function()
         local net_replicaset = require('internal.net.replicaset')

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -36,13 +36,11 @@ g.before_all(function(cg)
             iproto_threads = 2,
             app_threads = 4,
         },
+        net_box_credentials = {user = 'admin'}
     })
     cg.server:start()
     cg.server:call('box.iproto.internal.enable_thread_requests')
     setsearchroot(cg.server)
-    cg.server:exec(function()
-        box.schema.user.passwd('admin', 'secret')
-    end)
 end)
 
 g.after_all(function(cg)
@@ -50,9 +48,8 @@ g.after_all(function(cg)
 end)
 
 g.test_thread_requests_disabled = function(cg)
-    local conn = net.connect(cg.server.net_box_uri, {
-        user = 'admin', password = 'secret',
-    })
+    local conn = net.connect(cg.server.net_box_uri,
+                             cg.server.net_box_credentials)
     local err = {type = 'ClientError', name = 'THREAD_REQUESTS_DISABLED'}
     t.assert_error_covers(err, conn.call, conn, 'tonumber', {'123'},
                           {_thread_id = 1})
@@ -67,7 +64,8 @@ g.test_thread_requests_disabled = function(cg)
 end
 
 g.test_no_such_thread = function(cg)
-    local conn = net.connect(cg.server.net_box_uri)
+    local conn = net.connect(cg.server.net_box_uri,
+                             cg.server.net_box_credentials)
     conn:call('box.iproto.internal.enable_thread_requests')
     t.assert_error_covers({
         type = 'ClientError',
@@ -103,7 +101,8 @@ g.test_unable_to_process_in_thread = function(cg)
             end
         end)
     end
-    local conn = net.connect(cg.server.net_box_uri)
+    local conn = net.connect(cg.server.net_box_uri,
+                             cg.server.net_box_credentials)
     conn:call('box.iproto.internal.enable_thread_requests')
     t.assert(conn:ping())
     t.assert(conn:ping({_thread_id = 0}))
@@ -126,9 +125,8 @@ g.test_unable_to_process_in_thread = function(cg)
 end
 
 g.test_call_eval = function(cg)
-    local conn = net.connect(cg.server.net_box_uri, {
-        user = 'admin', password = 'secret',
-    })
+    local conn = net.connect(cg.server.net_box_uri,
+                             cg.server.net_box_credentials)
     conn:call('box.iproto.internal.enable_thread_requests')
     -- Call a box function in the main thread.
     t.assert_covers(conn:call('box.info', {}, {_thread_id = 0}),
@@ -159,8 +157,60 @@ g.test_call_eval = function(cg)
     conn:close()
 end
 
+g.after_test('test_call_eval_access', function(cg)
+    cg.server:exec(function()
+        box.schema.user.drop('client', {if_exists = true})
+    end)
+    cg.server:exec(function()
+        rawset(_G, 'test_func_1', nil)
+        rawset(_G, 'test_func_2', nil)
+        box.internal.lua_call_runtime_priv_reset()
+    end, {}, {_thread_id = 1})
+end)
+
+g.test_call_eval_access = function(cg)
+    cg.server:exec(function()
+        box.schema.user.create('client', {password = 'secret'})
+        box.schema.user.grant('client', 'super')
+    end)
+    cg.server:exec(function()
+        box.internal.lua_call_runtime_priv_grant('client', 'test_func_1')
+    end, {}, {_thread_id = 1})
+    cg.server:exec(function()
+        rawset(_G, 'test_func_1', function() return 1 end)
+        rawset(_G, 'test_func_2', function() return 2 end)
+    end, {}, {_thread_id = 1})
+    local conn = net.connect(cg.server.net_box_uri,
+                             cg.server.net_box_credentials)
+    conn:call('box.iproto.internal.enable_thread_requests')
+    t.assert_equals(conn:call('test_func_1', {}, {_thread_id = 1}), 1)
+    t.assert_equals(conn:call('test_func_2', {}, {_thread_id = 1}), 2)
+    t.assert_equals(conn:eval([[return 123]], {}, {_thread_id = 1}), 123)
+    conn:close()
+    conn = net.connect(cg.server.net_box_uri,
+                       {user = 'client', password = 'secret'})
+    conn:call('box.iproto.internal.enable_thread_requests')
+    t.assert_equals(conn:call('test_func_1', {}, {_thread_id = 1}), 1)
+    t.assert_error_covers({
+            type = 'AccessDeniedError',
+            access_type = 'Execute',
+            object_type = 'function',
+            object_name = 'test_func_2',
+            user = 'client'
+    }, conn.call, conn, 'test_func_2', {}, {_thread_id = 1})
+    t.assert_error_covers({
+            type = 'AccessDeniedError',
+            access_type = 'Execute',
+            object_type = 'universe',
+            object_name = '',
+            user = 'client'
+    }, conn.eval, conn, [[return 123]], {}, {_thread_id = 1})
+    conn:close()
+end
+
 g.test_builtin_types_serialization = function(cg)
-    local conn = net.connect(cg.server.net_box_uri)
+    local conn = net.connect(cg.server.net_box_uri,
+                             cg.server.net_box_credentials)
     conn:call('box.iproto.internal.enable_thread_requests')
     -- Check basic types.
     local function check(obj)
@@ -213,7 +263,8 @@ g.test_call_ret_tuple_extension_unset = function(cg)
     t.tarantool.skip_if_not_debug()
     box.error.injection.set('ERRINJ_NETBOX_FLIP_FEATURE',
                             box.iproto.feature.call_ret_tuple_extension)
-    local conn = net.connect(cg.server.net_box_uri)
+    local conn = net.connect(cg.server.net_box_uri,
+                             cg.server.net_box_credentials)
     conn:call('box.iproto.internal.enable_thread_requests')
     local tuple = conn:eval([[
         local format = box.tuple.format.new({
@@ -651,6 +702,7 @@ g.test_key_def = function(cg)
 end
 
 g.test_net_box = function(cg)
+    local connect_args = {cg.server.net_box_uri, cg.server.net_box_credentials}
     cg.server:eval([[
         local conn = require('net.box').connect(...)
         conn:eval("box.schema.space.create('test')")
@@ -660,18 +712,18 @@ g.test_net_box = function(cg)
         conn.space.test:insert({2, 'b'})
         conn.space.test:insert({3, 'c'})
         conn:close()
-    ]], {cg.server.net_box_uri}, {_thread_id = 1})
+    ]], connect_args, {_thread_id = 1})
     t.assert_equals(cg.server:eval([[
         local conn = require('net.box').connect(...)
         local ret = conn.space.test:select({}, {iterator = 'le'})
         conn:close()
         return ret
-    ]], {cg.server.net_box_uri}, {_thread_id = 2}), {
+    ]], connect_args, {_thread_id = 2}), {
         {3, 'c'}, {2, 'b'}, {1, 'a'},
     })
     t.assert(cg.server:eval([[
         return require('net.box').self == nil
-    ]], {cg.server.net_box_uri}, {_thread_id = 3}))
+    ]], {}, {_thread_id = 3}))
 end
 
 g.after_test('test_net_box', function(cg)
@@ -684,6 +736,7 @@ end)
 
 g.test_net_replicaset = function()
     local config = cbuilder:new()
+        :set_global_option('credentials.users.admin.password', 'secret')
         :set_global_option('credentials.users.storage.roles', {'super'})
         :set_global_option('credentials.users.storage.password', 'secret')
         :set_global_option('iproto.advertise.sharding.login', 'storage')
@@ -698,7 +751,9 @@ g.test_net_replicaset = function()
             {name = 'test', size = 1},
         })
         :config()
-    local cluster = cluster:new(config)
+    local cluster = cluster:new(config, {
+        net_box_credentials = {user = 'admin', password = 'secret'},
+    })
     cluster:start()
     cluster.router:call('box.iproto.internal.enable_thread_requests')
     setsearchroot(cluster.router)

--- a/test/box-luatest/iproto_export_test.lua
+++ b/test/box-luatest/iproto_export_test.lua
@@ -70,7 +70,10 @@ g2.test_invalid_arguments = function(cg)
 end
 
 g2.test_iproto_export_in_app_threads = function(cg)
-    cg.server = server:new({box_cfg = {app_threads = 2}})
+    cg.server = server:new({
+        box_cfg = {app_threads = 2},
+        net_box_credentials = {user = 'admin'},
+    })
     cg.server:start()
     cg.server:call('box.iproto.internal.enable_thread_requests')
     cg.server:exec(function()
@@ -119,6 +122,7 @@ g2.test_iproto_call_routing = function(cg)
             iproto_threads = 5,
             app_threads = 3,
         },
+        net_box_credentials = {user = 'admin'},
         env = {
             TARANTOOL_RUN_BEFORE_BOX_CFG = [[
                 box.iproto.export('test_func_1', function() return 0 end)

--- a/test/box-luatest/iproto_export_test.lua
+++ b/test/box-luatest/iproto_export_test.lua
@@ -75,7 +75,6 @@ g2.test_iproto_export_in_app_threads = function(cg)
         net_box_credentials = {user = 'admin'},
     })
     cg.server:start()
-    cg.server:call('box.iproto.internal.enable_thread_requests')
     cg.server:exec(function()
         box.schema.user.passwd('admin', 'secret')
     end)
@@ -94,7 +93,6 @@ g2.test_iproto_export_in_app_threads = function(cg)
     local conn = net.connect(cg.server.net_box_uri, {
         user = 'admin', password = 'secret',
     })
-    conn:call('box.iproto.internal.enable_thread_requests')
     local err = {type = 'ClientError', name = 'NO_SUCH_PROC'}
     t.assert_equals(conn:call('test.func_1', {'x'}, {_thread_id = 0}),
                     {1, 'x'})
@@ -130,7 +128,6 @@ g2.test_iproto_call_routing = function(cg)
         },
     })
     cg.server:start()
-    cg.server:call('box.iproto.internal.enable_thread_requests')
     cg.server:exec(function()
         box.schema.user.passwd('admin', 'secret')
     end)

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -512,7 +512,6 @@ t;
  |   301: box.error.DICT_OVERFLOW
  |   302: box.error.NO_SUCH_THREAD_GROUP
  |   303: box.error.THREADS_NOT_CONFIGURED
- |   304: box.error.THREAD_REQUESTS_DISABLED
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
This makes EVAL consistent with CALL, which is allowed only for admin and users that were explicitly granted runtime privileges. Also, it lets us get rid of the `box.iproto.internal.enable_thread_requests` hack.

Closes #12542