### PR TITLE
[backport 2.11] txn: forbid waiting for acks on fully local transactions

### DIFF
--- a/changelogs/unreleased/gh-12585-qsync-truncate-local-space.md
+++ b/changelogs/unreleased/gh-12585-qsync-truncate-local-space.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a bug where a local space could not be truncated when the `_truncate`
+  space was synchronous (gh-12585).

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -880,8 +880,19 @@ txn_journal_entry_new(struct txn *txn)
 
 		if (stmt->row->type != IPROTO_NOP) {
 			is_fully_nop = false;
-			is_sync = is_sync || (stmt->space != NULL &&
-					      space_is_sync(stmt->space));
+			/*
+			 * _truncate is the only space which can be synchronous
+			 * and produce local rows at the same time (when
+			 * truncation is done for a local space). Do not treat
+			 * such row as synchronous.
+			 */
+			assert(stmt->row->group_id != GROUP_LOCAL ||
+			       !space_is_sync(stmt->space) ||
+			       space_id(stmt->space) == BOX_TRUNCATE_ID);
+			is_sync = is_sync ||
+				(stmt->space != NULL &&
+				 space_is_sync(stmt->space) &&
+				 stmt->row->group_id != GROUP_LOCAL);
 		}
 
 		if (stmt->row->replica_id == 0)
@@ -893,11 +904,13 @@ txn_journal_entry_new(struct txn *txn)
 	}
 	/*
 	 * There is no a check for all-local rows, because a local
-	 * space can't be synchronous. So if there is at least one
+	 * space can't be synchronous (the only exception is _truncate,
+	 * which is filtered above). So if there is at least one
 	 * synchronous space, the transaction is not local.
 	 */
 	if (!txn_has_flag(txn, TXN_FORCE_ASYNC) && !is_fully_nop) {
 		if (is_sync) {
+			assert(!txn_is_fully_local(txn));
 			txn_set_flags(txn, TXN_WAIT_SYNC | TXN_WAIT_ACK);
 		} else if (!txn_limbo_is_empty(&txn_limbo)) {
 			/*

--- a/test/replication-luatest/gh_12585_qsync_truncate_with_local_space_test.lua
+++ b/test/replication-luatest/gh_12585_qsync_truncate_with_local_space_test.lua
@@ -1,0 +1,114 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
+
+local g = t.group('qsync-truncate-with-local-space')
+
+g.before_all(function(g)
+    g.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication_timeout = 0.1,
+        replication_synchro_quorum = 3,
+        replication_synchro_timeout = 600,
+        election_fencing_mode = 'off',
+        election_mode = 'manual',
+        replication = {
+            server.build_listen_uri('master', g.replica_set.id),
+            server.build_listen_uri('replica', g.replica_set.id),
+        },
+    }
+    g.master = g.replica_set:build_and_add_server{
+        alias = 'master', box_cfg = box_cfg}
+    g.replica = g.replica_set:build_and_add_server{
+        alias = 'replica', box_cfg = box_cfg}
+    g.replica_set:start()
+    g.replica_set:wait_for_fullmesh()
+    g.master:exec(function()
+        t.assert(pcall(box.ctl.promote))
+        box.ctl.wait_rw()
+        box.schema.space.create('sync', {is_sync = true}):create_index('pk')
+        box.schema.space.create('test', {is_local = true}):create_index('pk')
+        box.space._truncate:alter{is_sync = true}
+    end)
+    g.replica:wait_for_vclock_of(g.master)
+end)
+
+g.after_all(function(g)
+    g.replica_set:drop()
+end)
+
+g.before_each(function(g)
+    -- After restart manual promote is required.
+    g.replica_set:wait_for_fullmesh()
+    g.master:exec(function()
+        t.assert(pcall(box.ctl.promote))
+        box.ctl.wait_rw()
+    end)
+    -- Make local space non-empty.
+    for _, s in ipairs{'replica', 'master'} do
+        g[s]:exec(function()
+            box.space.test:replace{1}
+        end)
+    end
+end)
+
+local function test_server_can_truncate_template(server)
+    server:exec(function()
+        box.space.test:truncate()
+    end)
+    server:restart()
+    server:exec(function()
+        t.assert_equals(box.space.test:count(), 0)
+    end)
+end
+
+g.test_master_can_truncate = function(g)
+    test_server_can_truncate_template(g.master)
+end
+
+g.test_replica_can_truncate = function(g)
+    test_server_can_truncate_template(g.replica)
+end
+
+local function wait_synchro_queue_len(len)
+    t.helpers.retrying({timeout = 10}, function()
+        t.assert_equals(box.info.synchro.queue.len, len)
+    end)
+end
+
+local function test_server_truncate_with_non_empty_limbo(server)
+    g.master:exec(function()
+        local fiber = require('fiber')
+        local count = box.space._cluster:count()
+        t.assert_gt(box.cfg.replication_synchro_quorum, count)
+        rawset(_G, 'sync_replace_f', fiber.create(function()
+            fiber.self():set_joinable(true)
+            box.space.sync:replace{1}
+        end))
+    end)
+    server:exec(wait_synchro_queue_len, {1})
+    server:exec(function()
+        require('fiber').create(function()
+            box.space.test:truncate()
+        end)
+    end)
+    server:exec(wait_synchro_queue_len, {2})
+    g.master:update_box_cfg{replication_synchro_quorum = 2}
+    g.master:exec(function()
+        _G.sync_replace_f:join()
+        _G.sync_replace_f = nil
+    end)
+    server:exec(wait_synchro_queue_len, {0})
+    server:exec(function()
+        t.assert_equals(box.space.test:count(), 0)
+    end)
+    g.master:update_box_cfg{replication_synchro_quorum = 3}
+end
+
+g.test_master_truncate_with_non_empty_limbo = function(g)
+    test_server_truncate_with_non_empty_limbo(g.master)
+end
+
+g.test_replica_truncate_with_non_empty_limbo = function(g)
+    test_server_truncate_with_non_empty_limbo(g.replica)
+end


### PR DESCRIPTION
The changes:

 * The patch itself is changed, since 2.11 doesn't support `IPROTO_IS_SYNC` and consequently, no need to majorly change the comment below, it's already almost fully correct. Though, added the assertion, which confirms that comment in the `is_sync` if condition.
  * Fixed the test, now it creates the truncate transaction with fiber and not `box.atomic({wait = 'submit'})`, since 2.11 doesn't support it. After promote we wait for rw, since promote itself doesn't do that, as in master.
  * Fixed the commit msg, since the behavior on 2.11 is not the error, as it was in the master. It's way worse. 