### PR TITLE
test: fix the signal sender PID logging test

### DIFF
--- a/test/app-luatest/gh_12477_signal_logging_test.lua
+++ b/test/app-luatest/gh_12477_signal_logging_test.lua
@@ -45,7 +45,7 @@ g.test_ev_signals = function(cg)
 
     -- Restart after each next test.
     test_signal(popen.signal.SIGINT)
-    cg.server:start()
+    cg.server:restart()
     test_signal(popen.signal.SIGTERM)
-    cg.server:start()
+    cg.server:restart()
 end


### PR DESCRIPTION
It used to start Tarantool after sending a signal. It might so happen that the previous instance haven't finished when the new instance is started, which will lead to the locked WAL dir error. Let's fix that.

Follows-up #12477

NO_DOC=test
NO_CHANGELOG=test