### PR TITLE
test: fix the signal sender PID logging test

### DIFF
--- a/test/app-luatest/gh_12477_signal_logging_test.lua
+++ b/test/app-luatest/gh_12477_signal_logging_test.lua
@@ -44,7 +44,7 @@ g.test_ev_signals = function(cg)
 
     -- Restart after each next test.
     test_signal(popen.signal.SIGINT)
-    cg.server:start()
+    cg.server:restart()
     test_signal(popen.signal.SIGTERM)
-    cg.server:start()
+    cg.server:restart()
 end


### PR DESCRIPTION
It used to start Tarantool after sending a signal. It might so happen that the previous instance haven't finished upon the new instance has started, which will lead to the locked WAL dir error. Let's fix that.

Follows-up #12477

NO_DOC=test
NO_CHANGELOG=test

(cherry picked from commit 4e1f67d4d21ae20eac4a62401e08d837dddcd1b5)