### PR TITLE
datetime: refactored to use MIN/MAX timezone offset constants

### DIFF
--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -1080,7 +1080,7 @@ datetime_from_fields(struct datetime *dt, const struct dt_fields *fields)
 		      fields->nsec;
 	if (nsec < 0 || nsec >= MAX_NANOS_PER_SEC)
 		return -1;
-	if (fields->tzoffset < -720 || fields->tzoffset > 840)
+	if (fields->tzoffset < MIN_TZOFFSET || fields->tzoffset > MAX_TZOFFSET)
 		return -1;
 	if (fields->timestamp < (double)INT32_MIN * SECS_PER_DAY ||
 	    fields->timestamp > (double)INT32_MAX * SECS_PER_DAY)

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -1080,7 +1080,7 @@ datetime_from_fields(struct datetime *dt, const struct dt_fields *fields)
 		      fields->nsec;
 	if (nsec < 0 || nsec >= MAX_NANOS_PER_SEC)
 		return -1;
-	if (fields->tzoffset < -720 || fields->tzoffset > 840)
+	if (fields->tzoffset < TZOFFSET_MIN || fields->tzoffset > TZOFFSET_MAX)
 		return -1;
 	if (fields->timestamp < (double)INT32_MIN * SECS_PER_DAY ||
 	    fields->timestamp > (double)INT32_MAX * SECS_PER_DAY)

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -67,8 +67,8 @@ struct tnt_tm;
  * At the moment the range of known timezones is UTC-12:00..UTC+14:00
  * https://en.wikipedia.org/wiki/List_of_UTC_time_offsets
  */
-#define MAX_TZOFFSET (14L * 60)
-#define MIN_TZOFFSET (-12L * 60)
+#define TZOFFSET_MAX (14L * 60)
+#define TZOFFSET_MIN (-12L * 60)
 
 /**
  * Actually we have lesser number of generated timezones, but 1024
@@ -420,8 +420,8 @@ datetime_validate(const struct datetime *date)
 	if (unlikely(date->nsec < 0) ||
 	    unlikely(date->nsec >= MAX_NANOS_PER_SEC))
 		return false;
-	if (unlikely(date->tzoffset < MIN_TZOFFSET) ||
-	    unlikely(date->tzoffset > MAX_TZOFFSET))
+	if (unlikely(date->tzoffset < TZOFFSET_MIN) ||
+	    unlikely(date->tzoffset > TZOFFSET_MAX))
 		return false;
 	if (unlikely(date->tzindex < 0) ||
 	    unlikely(date->tzindex > MAX_TZINDEX))

--- a/src/lib/tzcode/strptime.c
+++ b/src/lib/tzcode/strptime.c
@@ -110,7 +110,7 @@ tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
 	char c;
 	int day_offset, wday_offset;
 	int week_offset;
-	int i, len;
+	int i, j, len;
 	int Ealternative, Oalternative;
 	enum flags flags = FLAG_NONE;
 	int century = -1;
@@ -600,11 +600,24 @@ tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
 					return NULL;
 			}
 
-			if (i > 1400 || (sign == -1 && i > 1200) ||
-			    (i % 100) >= 60)
+			if (i % 100 >= 60)
 				return NULL;
-			tm->tm_gmtoff =
-				sign * ((i / 100) * 3600 + i % 100 * 60);
+
+			/* Min/max as in datetime.h, converted to sec. */
+			#define MAX_TZOFFSET_SEC (14L * 60) * 60
+			#define MIN_TZOFFSET_SEC (-12L * 60) * 60
+			/*
+			 * TODO: This check must be moved to datetime.c,
+			 * where the range is defined. Here we must
+			 * check max range [-23:59..+23:59] as in
+			 * dt_parse_iso_zone_lenient.
+			 */
+			j = sign * ((i / 100) * 3600 + i % 100 * 60);
+			if (j < MIN_TZOFFSET_SEC || j > MAX_TZOFFSET_SEC)
+				return NULL;
+			tm->tm_gmtoff = j;
+			#undef MAX_TZOFFSET_SEC
+			#undef MIN_TZOFFSET_SEC
 		} break;
 
 		case 'n':

--- a/src/lib/tzcode/strptime.c
+++ b/src/lib/tzcode/strptime.c
@@ -110,7 +110,7 @@ tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
 	char c;
 	int day_offset, wday_offset;
 	int week_offset;
-	int i, len;
+	int i, j, len;
 	int Ealternative, Oalternative;
 	enum flags flags = FLAG_NONE;
 	int century = -1;
@@ -600,11 +600,24 @@ tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
 					return NULL;
 			}
 
-			if (i > 1400 || (sign == -1 && i > 1200) ||
-			    (i % 100) >= 60)
+			if (i % 100 >= 60)
 				return NULL;
-			tm->tm_gmtoff =
-				sign * ((i / 100) * 3600 + i % 100 * 60);
+
+			/* Min/max as in datetime.h, converted to sec. */
+			#define TZOFFSET_SEC_MAX (14L * 60) * 60
+			#define TZOFFSET_SEC_MIN (-12L * 60) * 60
+			/*
+			 * TODO: This check must be moved to datetime.c,
+			 * where the range is defined. Here we must
+			 * check max range [-23:59..+23:59] as in
+			 * dt_parse_iso_zone_lenient.
+			 */
+			j = sign * ((i / 100) * 3600 + i % 100 * 60);
+			if (j < TZOFFSET_SEC_MIN || j > TZOFFSET_SEC_MAX)
+				return NULL;
+			tm->tm_gmtoff = j;
+			#undef TZOFFSET_SEC_MAX
+			#undef TZOFFSET_SEC_MIN
 		} break;
 
 		case 'n':

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -117,6 +117,11 @@ local TOSTRING_BUFSIZE  = 64
 local IVAL_TOSTRING_BUFSIZE = 96
 local STRFTIME_BUFSIZE  = 128
 
+-- At the moment the range of known timezones is UTC-12:00..UTC+14:00. See [1].
+-- 1. https://en.wikipedia.org/wiki/List_of_UTC_time_offsets.
+local MIN_TZOFFSET = -12 * 60
+local MAX_TZOFFSET = 14 * 60
+
 -- minimum supported date - -5879610-06-22
 local MIN_DATE_YEAR = -5879610
 local MIN_DATE_MONTH = 6
@@ -645,9 +650,7 @@ local function extract_obj_tzoffset_tzindex(obj, base_epoch)
     elseif obj_tzoffset ~= nil then
         tzindex = 0
         tzoffset = get_timezone(obj_tzoffset, 'tzoffset', 1)
-        -- at the moment the range of known timezones is UTC-12:00..UTC+14:00
-        -- https://en.wikipedia.org/wiki/List_of_UTC_time_offsets
-        check_range(tzoffset, -720, 840, 'tzoffset', nil, 1)
+        check_range(tzoffset, MIN_TZOFFSET, MAX_TZOFFSET, 'tzoffset', nil, 1)
     end
     return tzoffset, tzindex
 end
@@ -966,7 +969,7 @@ local function datetime_parse_from(str, obj)
 
     if tzoffset ~= nil then
         local offset = get_timezone(tzoffset, 'tzoffset')
-        check_range(offset, -720, 840, 'tzoffset')
+        check_range(offset, MIN_TZOFFSET, MAX_TZOFFSET, 'tzoffset')
     end
 
     if tzname ~= nil then

--- a/src/lua/datetime.lua
+++ b/src/lua/datetime.lua
@@ -117,6 +117,11 @@ local TOSTRING_BUFSIZE  = 64
 local IVAL_TOSTRING_BUFSIZE = 96
 local STRFTIME_BUFSIZE  = 128
 
+-- At the moment the range of known timezones is UTC-12:00..UTC+14:00. See [1].
+-- 1. https://en.wikipedia.org/wiki/List_of_UTC_time_offsets.
+local TZOFFSET_MIN = -12 * 60
+local TZOFFSET_MAX = 14 * 60
+
 -- minimum supported date - -5879610-06-22
 local MIN_DATE_YEAR = -5879610
 local MIN_DATE_MONTH = 6
@@ -645,9 +650,7 @@ local function extract_obj_tzoffset_tzindex(obj, base_epoch)
     elseif obj_tzoffset ~= nil then
         tzindex = 0
         tzoffset = get_timezone(obj_tzoffset, 'tzoffset', 1)
-        -- at the moment the range of known timezones is UTC-12:00..UTC+14:00
-        -- https://en.wikipedia.org/wiki/List_of_UTC_time_offsets
-        check_range(tzoffset, -720, 840, 'tzoffset', nil, 1)
+        check_range(tzoffset, TZOFFSET_MIN, TZOFFSET_MAX, 'tzoffset', nil, 1)
     end
     return tzoffset, tzindex
 end
@@ -966,7 +969,7 @@ local function datetime_parse_from(str, obj)
 
     if tzoffset ~= nil then
         local offset = get_timezone(tzoffset, 'tzoffset')
-        check_range(offset, -720, 840, 'tzoffset')
+        check_range(offset, TZOFFSET_MIN, TZOFFSET_MAX, 'tzoffset')
     end
 
     if tzname ~= nil then

--- a/test/app-luatest/datetime_test.lua
+++ b/test/app-luatest/datetime_test.lua
@@ -26,8 +26,8 @@ local MAX_DATE_YEAR = 5879611
 local MAX_DATE_MONTH = 7
 local MAX_DATE_DAY = 11
 
-local MIN_TZOFFSET = -12 * 60
-local MAX_TZOFFSET = 14 * 60
+local TZOFFSET_MIN = -12 * 60
+local TZOFFSET_MAX = 14 * 60
 
 local YEAR_RANGE = {MIN_DATE_YEAR, MAX_DATE_YEAR}
 local MONTH_RANGE = {1, 12}
@@ -39,7 +39,7 @@ local TIMESTAMP_RANGE = {MIN_EPOCH_SECS_VALUE, MAX_EPOCH_SECS_VALUE}
 local MSEC_RANGE = {0, 1E3}
 local USEC_RANGE = {0, 1E6}
 local NSEC_RANGE = {0, 1E9}
-local TZOFFSET_RANGE = {MIN_TZOFFSET, MAX_TZOFFSET}
+local TZOFFSET_RANGE = {TZOFFSET_MIN, TZOFFSET_MAX}
 
 -- }}} Datetime module and related helper constants.
 

--- a/test/sql-luatest/datetime_test.lua
+++ b/test/sql-luatest/datetime_test.lua
@@ -2292,8 +2292,11 @@ end
 -- Make sure an error is thrown if the DATETIME value cannot be constructed from
 -- the corresponding table.
 --
-g.test_datetime_33_2 = function()
+g.test_datetime_new_invalid_time_units = function()
     g.server:exec(function()
+        local MIN_TZOFFSET = -12 * 60
+        local MAX_TZOFFSET = 14 * 60
+
         local sql = [[SELECT CAST(#v AS DATETIME);]]
 
         -- "year" cannot be more than 5879611.
@@ -2408,18 +2411,18 @@ g.test_datetime_33_2 = function()
         res = [[Type mismatch: can not convert map({"nsec": -1}) to datetime]]
         t.assert_equals(err.message, res)
 
-        -- "tzoffset" cannot be more than 840.
-        v = {tzoffset = 841}
+        -- "tzoffset" cannot be more than MAX_TZOFFSET.
+        v = {tzoffset = MAX_TZOFFSET + 1}
         _, err = box.execute(sql, {{['#v'] = v}})
-        res = [[Type mismatch: can not convert map({"tzoffset": 841}) ]]..
-              [[to datetime]]
+        res = ([[Type mismatch: can not convert map({"tzoffset": %d}) ]]
+               ):format(v.tzoffset)..[[to datetime]]
         t.assert_equals(err.message, res)
 
-        -- "tzoffset" cannot be less than -720.
-        v = {tzoffset = -721}
+        -- "tzoffset" cannot be less than MIN_TZOFFSET.
+        v = {tzoffset = MIN_TZOFFSET - 1}
         _, err = box.execute(sql, {{['#v'] = v}})
-        res = [[Type mismatch: can not convert map({"tzoffset": -721}) ]]..
-              [[to datetime]]
+        res = ([[Type mismatch: can not convert map({"tzoffset": %d}) ]]
+               ):format(v.tzoffset)..[[to datetime]]
         t.assert_equals(err.message, res)
 
         -- Only one of "msec", "usec" and "nsec" can be specified.

--- a/test/sql-luatest/datetime_test.lua
+++ b/test/sql-luatest/datetime_test.lua
@@ -2292,8 +2292,11 @@ end
 -- Make sure an error is thrown if the DATETIME value cannot be constructed from
 -- the corresponding table.
 --
-g.test_datetime_33_2 = function()
+g.test_datetime_new_invalid_time_units = function()
     g.server:exec(function()
+        local TZOFFSET_MIN = -12 * 60
+        local TZOFFSET_MAX = 14 * 60
+
         local sql = [[SELECT CAST(#v AS DATETIME);]]
 
         -- "year" cannot be more than 5879611.
@@ -2408,18 +2411,18 @@ g.test_datetime_33_2 = function()
         res = [[Type mismatch: can not convert map({"nsec": -1}) to datetime]]
         t.assert_equals(err.message, res)
 
-        -- "tzoffset" cannot be more than 840.
-        v = {tzoffset = 841}
+        -- "tzoffset" cannot be more than TZOFFSET_MAX.
+        v = {tzoffset = TZOFFSET_MAX + 1}
         _, err = box.execute(sql, {{['#v'] = v}})
-        res = [[Type mismatch: can not convert map({"tzoffset": 841}) ]]..
-              [[to datetime]]
+        res = ([[Type mismatch: can not convert map({"tzoffset": %d}) ]]
+               ):format(v.tzoffset)..[[to datetime]]
         t.assert_equals(err.message, res)
 
-        -- "tzoffset" cannot be less than -720.
-        v = {tzoffset = -721}
+        -- "tzoffset" cannot be less than TZOFFSET_MIN.
+        v = {tzoffset = TZOFFSET_MIN - 1}
         _, err = box.execute(sql, {{['#v'] = v}})
-        res = [[Type mismatch: can not convert map({"tzoffset": -721}) ]]..
-              [[to datetime]]
+        res = ([[Type mismatch: can not convert map({"tzoffset": %d}) ]]
+               ):format(v.tzoffset)..[[to datetime]]
         t.assert_equals(err.message, res)
 
         -- Only one of "msec", "usec" and "nsec" can be specified.

--- a/test/unit/datetime.c
+++ b/test/unit/datetime.c
@@ -538,8 +538,8 @@ mp_datetime_unpack_ok_test(void)
 		{.epoch = MIN_EPOCH_SECS_VALUE},
 		{.nsec = MAX_NANOS_PER_SEC - 1},
 		{.nsec = 0},
-		{.tzoffset = MIN_TZOFFSET},
-		{.tzoffset = MAX_TZOFFSET},
+		{.tzoffset = TZOFFSET_MIN},
+		{.tzoffset = TZOFFSET_MAX},
 		{.tzindex = MAX_TZINDEX},
 		{.tzindex = 0},
 	};
@@ -570,8 +570,8 @@ mp_datetime_unpack_fail_test(void)
 		{.epoch = MIN_EPOCH_SECS_VALUE - 1},
 		{.nsec = MAX_NANOS_PER_SEC},
 		{.nsec = -1},
-		{.tzoffset = MIN_TZOFFSET - 1},
-		{.tzoffset = MAX_TZOFFSET + 1},
+		{.tzoffset = TZOFFSET_MIN - 1},
+		{.tzoffset = TZOFFSET_MAX + 1},
 		{.tzindex = MAX_TZINDEX + 1},
 		{.tzindex = -1},
 	};

--- a/tools/tarantool-gdb.py
+++ b/tools/tarantool-gdb.py
@@ -1119,8 +1119,8 @@ if find_type('struct datetime') is not None:
         MAX_EPOCH_SECS_VALUE = MAX_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_1970_OFFSET
         MIN_EPOCH_SECS_VALUE = MIN_DT_DAY_VALUE * SECS_PER_DAY - SECS_EPOCH_1970_OFFSET
 
-        MAX_TZOFFSET = 14 * 60
-        MIN_TZOFFSET = -12 * 60
+        TZOFFSET_MAX = 14 * 60
+        TZOFFSET_MIN = -12 * 60
         MAX_TZINDEX = 1024
 
         def __init__(self, val):
@@ -1131,7 +1131,7 @@ if find_type('struct datetime') is not None:
                 return False
             if self.val['nsec'] < 0 or self.val['nsec'] >= self.MAX_NANOS_PER_SEC:
                 return False
-            if self.val['tzoffset'] < self.MIN_TZOFFSET or self.val['tzoffset'] > self.MAX_TZOFFSET:
+            if self.val['tzoffset'] < self.TZOFFSET_MIN or self.val['tzoffset'] > self.TZOFFSET_MAX:
                 return False
             if self.val['tzindex'] < 0 or self.val['tzindex'] > self.MAX_TZINDEX:
                 return False


### PR DESCRIPTION
Constants `TZOFFSET_MIN` and `TZOFFSET_MAX` are introduced
in `datetime.lua` and in Lua test modules for better evolvability.
Also, they are used in C sources instead of literals.

Existing constants `MIN_TZOFFSET` and `MAX_TZOFFSET` were renamed
for consistently with other similar constants in standard C/C++
headers and other Tarantool libraries.

NO_CHANGELOG=no visible changes
NO_TEST=no new behavior
NO_DOC=no new behavior

----

This PR was separated: it is a first commit from #12191