### PR TITLE
Synchronous Promote - Part 4 - Encapsulate promotion entirely inside the limbo

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3027,11 +3027,8 @@ box_wait_limbo_acked(double timeout)
 		if (lsn > 0 && txn_limbo_has_quorum_for(&txn_limbo, lsn))
 			return lsn;
 		struct trigger on_ack;
-		trigger_create(
-			&on_ack, [](struct trigger *trigger, void *) -> int {
-			fiber_wakeup((struct fiber *)trigger->data);
-			return 0;
-		}, fiber(), NULL);
+		trigger_create(&on_ack, fiber_wakeup_trigger_cb,
+			       fiber(), NULL);
 		trigger_add(&replicaset.on_ack, &on_ack);
 		int rc = fiber_cond_wait_deadline(&txn_limbo.queue.cond,
 						  deadline);
@@ -3135,12 +3132,8 @@ box_wait_for_rw_while_leader(struct raft *raft)
 			return -1;
 		}
 		struct trigger on_update;
-		trigger_create(
-			&on_update,
-			[](struct trigger *t, void *) -> int {
-				fiber_wakeup((struct fiber *)t->data);
-				return 0;
-			}, fiber(), NULL);
+		trigger_create(&on_update, fiber_wakeup_trigger_cb,
+			       fiber(), NULL);
 		raft_on_update(raft, &on_update);
 		int rc = fiber_cond_wait_deadline(&ro_cond, deadline);
 		trigger_clear(&on_update);

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2974,19 +2974,6 @@ box_check_promote_term_intact(uint64_t promote_term)
 	return 0;
 }
 
-/**
- * Check whether the raft term has changed since it was last read.
- */
-static int
-box_check_election_term_intact(uint64_t term)
-{
-	if (box_raft()->volatile_term != term) {
-		diag_set(ClientError, ER_INTERFERING_ELECTIONS);
-		return -1;
-	}
-	return 0;
-}
-
 /** Trigger a new election round but don't wait for its result. */
 static int
 box_trigger_elections(void)
@@ -3007,73 +2994,8 @@ box_try_wait_confirm(double timeout)
 	return box_check_promote_term_intact(promote_term);
 }
 
-/**
- * A helper to wait until all limbo entries are ready to be confirmed, i.e.
- * written to WAL and have gathered a quorum of ACKs from replicas.
- * Return lsn of the last limbo entry on success, -1 on error.
- */
-static int64_t
-box_wait_limbo_acked(double timeout)
-{
-	if (txn_limbo_is_empty(&txn_limbo))
-		return txn_limbo.queue.confirmed_lsn;
-#ifndef NDEBUG
-	++errinj(ERRINJ_WAIT_QUORUM_COUNT, ERRINJ_INT)->iparam;
-#endif
-	uint64_t promote_term = txn_limbo.term;
-	double deadline = fiber_clock() + timeout;
-	while (!fiber_is_cancelled()) {
-		int64_t lsn = txn_limbo_last_synchro_entry(&txn_limbo)->lsn;
-		if (lsn > 0 && txn_limbo_has_quorum_for(&txn_limbo, lsn))
-			return lsn;
-		struct trigger on_ack;
-		trigger_create(&on_ack, fiber_wakeup_trigger_cb,
-			       fiber(), NULL);
-		trigger_add(&replicaset.on_ack, &on_ack);
-		int rc = fiber_cond_wait_deadline(&txn_limbo.queue.cond,
-						  deadline);
-		trigger_clear(&on_ack);
-		if (rc != 0)
-			return -1;
-		if (box_check_promote_term_intact(promote_term) != 0)
-			return -1;
-		if (txn_limbo_is_empty(&txn_limbo))
-			return txn_limbo.queue.confirmed_lsn;
-	}
-	diag_set(FiberIsCancelled);
-	return -1;
-}
-
 /** A guard to block multiple simultaneous promote()/demote() invocations. */
 static bool is_in_box_promote = false;
-
-static int
-box_change_limbo_ownership(int64_t confirmed_lsn, uint16_t type)
-{
-	int rc = 0;
-	uint64_t term = box_raft()->term;
-	uint64_t promote_term = txn_limbo.term;
-	assert(confirmed_lsn >= 0);
-	rc = box_check_election_term_intact(term);
-	if (rc != 0)
-		return rc;
-	txn_limbo_begin(&txn_limbo);
-	rc = box_check_election_term_intact(term);
-	if (rc != 0)
-		goto end;
-	rc = box_check_promote_term_intact(promote_term);
-	if (rc != 0)
-		goto end;
-	rc = txn_limbo_req_promote(&txn_limbo, type, confirmed_lsn, term);
-end:
-	if (rc == 0) {
-		txn_limbo_commit(&txn_limbo);
-		assert(txn_limbo_is_empty(&txn_limbo));
-	} else {
-		txn_limbo_rollback(&txn_limbo);
-	}
-	return rc;
-}
 
 int
 box_promote_qsync(void)
@@ -3083,22 +3005,13 @@ box_promote_qsync(void)
 		return -1;
 	}
 	assert(is_box_configured);
-	struct raft *raft = box_raft();
+	assert(box_raft()->state == RAFT_STATE_LEADER);
 	is_in_box_promote = true;
 	auto promote_guard = make_scoped_guard([&] {
 		is_in_box_promote = false;
 	});
-	assert(raft->state == RAFT_STATE_LEADER);
-	if (txn_limbo_replica_term(&txn_limbo, instance_id) == raft->term)
-		return 0;
-	int64_t wait_lsn = box_wait_limbo_acked(TIMEOUT_INFINITY);
-	if (wait_lsn < 0)
-		return -1;
-	if (raft->state != RAFT_STATE_LEADER) {
-		diag_set(ClientError, ER_NOT_LEADER, raft->leader);
-		return -1;
-	}
-	return box_change_limbo_ownership(wait_lsn, IPROTO_RAFT_PROMOTE);
+	return txn_limbo_promote(&txn_limbo, IPROTO_RAFT_PROMOTE,
+				 TIMEOUT_INFINITY);
 }
 
 int
@@ -3196,12 +3109,8 @@ box_promote(void)
 	default:
 		unreachable();
 	}
-
-	int64_t wait_lsn = box_wait_limbo_acked(replication_synchro_timeout);
-	if (wait_lsn < 0)
-		return -1;
-
-	return box_change_limbo_ownership(wait_lsn, IPROTO_RAFT_PROMOTE);
+	return txn_limbo_promote(&txn_limbo, IPROTO_RAFT_PROMOTE,
+				 replication_synchro_timeout);
 }
 
 int
@@ -3243,10 +3152,8 @@ box_demote(void)
 		return -1;
 	if (box_try_wait_confirm(2 * replication_synchro_timeout) < 0)
 		return -1;
-	int64_t wait_lsn = box_wait_limbo_acked(replication_synchro_timeout);
-	if (wait_lsn < 0)
-		return -1;
-	return box_change_limbo_ownership(wait_lsn, IPROTO_RAFT_DEMOTE);
+	return txn_limbo_promote(&txn_limbo, IPROTO_RAFT_DEMOTE,
+				 replication_synchro_timeout);
 }
 
 int

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -2974,19 +2974,6 @@ box_check_promote_term_intact(uint64_t promote_term)
 	return 0;
 }
 
-/**
- * Check whether the raft term has changed since it was last read.
- */
-static int
-box_check_election_term_intact(uint64_t term)
-{
-	if (box_raft()->volatile_term != term) {
-		diag_set(ClientError, ER_INTERFERING_ELECTIONS);
-		return -1;
-	}
-	return 0;
-}
-
 /** Trigger a new election round but don't wait for its result. */
 static int
 box_trigger_elections(void)
@@ -3007,73 +2994,8 @@ box_try_wait_confirm(double timeout)
 	return box_check_promote_term_intact(promote_term);
 }
 
-/**
- * A helper to wait until all limbo entries are ready to be confirmed, i.e.
- * written to WAL and have gathered a quorum of ACKs from replicas.
- * Return lsn of the last limbo entry on success, -1 on error.
- */
-static int64_t
-box_wait_limbo_acked(double timeout)
-{
-	if (txn_limbo_is_empty(&txn_limbo))
-		return txn_limbo.queue.confirmed_lsn;
-#ifndef NDEBUG
-	++errinj(ERRINJ_WAIT_QUORUM_COUNT, ERRINJ_INT)->iparam;
-#endif
-	uint64_t promote_term = txn_limbo.term;
-	double deadline = fiber_clock() + timeout;
-	while (!fiber_is_cancelled()) {
-		int64_t lsn = txn_limbo_last_synchro_entry(&txn_limbo)->lsn;
-		if (lsn > 0 && txn_limbo_has_quorum_for(&txn_limbo, lsn))
-			return lsn;
-		struct trigger on_ack;
-		trigger_create(&on_ack, fiber_wakeup_trigger_cb,
-			       fiber(), NULL);
-		trigger_add(&replicaset.on_ack, &on_ack);
-		int rc = fiber_cond_wait_deadline(&txn_limbo.queue.cond,
-						  deadline);
-		trigger_clear(&on_ack);
-		if (rc != 0)
-			return -1;
-		if (box_check_promote_term_intact(promote_term) != 0)
-			return -1;
-		if (txn_limbo_is_empty(&txn_limbo))
-			return txn_limbo.queue.confirmed_lsn;
-	}
-	diag_set(FiberIsCancelled);
-	return -1;
-}
-
 /** A guard to block multiple simultaneous promote()/demote() invocations. */
 static bool is_in_box_promote = false;
-
-static int
-box_change_limbo_ownership(int64_t confirmed_lsn, uint16_t type)
-{
-	int rc = 0;
-	uint64_t term = box_raft()->term;
-	uint64_t promote_term = txn_limbo.term;
-	assert(confirmed_lsn >= 0);
-	rc = box_check_election_term_intact(term);
-	if (rc != 0)
-		return rc;
-	txn_limbo_begin(&txn_limbo);
-	rc = box_check_election_term_intact(term);
-	if (rc != 0)
-		goto end;
-	rc = box_check_promote_term_intact(promote_term);
-	if (rc != 0)
-		goto end;
-	rc = txn_limbo_req_promote(&txn_limbo, type, confirmed_lsn, term);
-end:
-	if (rc == 0) {
-		txn_limbo_commit(&txn_limbo);
-		assert(txn_limbo_is_empty(&txn_limbo));
-	} else {
-		txn_limbo_rollback(&txn_limbo);
-	}
-	return rc;
-}
 
 int
 box_promote_qsync(void)
@@ -3083,22 +3005,13 @@ box_promote_qsync(void)
 		return -1;
 	}
 	assert(is_box_configured);
-	struct raft *raft = box_raft();
+	assert(box_raft()->state == RAFT_STATE_LEADER);
 	is_in_box_promote = true;
 	auto promote_guard = make_scoped_guard([&] {
 		is_in_box_promote = false;
 	});
-	assert(raft->state == RAFT_STATE_LEADER);
-	if (txn_limbo_replica_term(&txn_limbo, instance_id) == raft->term)
-		return 0;
-	int64_t wait_lsn = box_wait_limbo_acked(TIMEOUT_INFINITY);
-	if (wait_lsn < 0)
-		return -1;
-	if (raft->state != RAFT_STATE_LEADER) {
-		diag_set(ClientError, ER_NOT_LEADER, raft->leader);
-		return -1;
-	}
-	return box_change_limbo_ownership(wait_lsn, IPROTO_RAFT_PROMOTE);
+	return txn_limbo_promote(&txn_limbo, IPROTO_RAFT_PROMOTE,
+				 TIMEOUT_INFINITY);
 }
 
 int
@@ -3174,7 +3087,8 @@ box_promote(void)
 			return -1;
 		if (box_trigger_elections() != 0)
 			return -1;
-		break;
+		return txn_limbo_promote(&txn_limbo, IPROTO_RAFT_PROMOTE,
+					 replication_synchro_timeout);
 	case ELECTION_MODE_VOTER:
 		assert(raft->state == RAFT_STATE_FOLLOWER);
 		diag_set(ClientError, ER_UNSUPPORTED, "election_mode='voter'",
@@ -3196,12 +3110,6 @@ box_promote(void)
 	default:
 		unreachable();
 	}
-
-	int64_t wait_lsn = box_wait_limbo_acked(replication_synchro_timeout);
-	if (wait_lsn < 0)
-		return -1;
-
-	return box_change_limbo_ownership(wait_lsn, IPROTO_RAFT_PROMOTE);
 }
 
 int
@@ -3243,10 +3151,8 @@ box_demote(void)
 		return -1;
 	if (box_try_wait_confirm(2 * replication_synchro_timeout) < 0)
 		return -1;
-	int64_t wait_lsn = box_wait_limbo_acked(replication_synchro_timeout);
-	if (wait_lsn < 0)
-		return -1;
-	return box_change_limbo_ownership(wait_lsn, IPROTO_RAFT_DEMOTE);
+	return txn_limbo_promote(&txn_limbo, IPROTO_RAFT_DEMOTE,
+				 replication_synchro_timeout);
 }
 
 int

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -137,6 +137,14 @@ txn_limbo_replica_confirmed_lsn(const struct txn_limbo *limbo,
 	return vclock_get(&limbo->queue.confirmed_vclock, replica_id);
 }
 
+bool
+txn_limbo_has_quorum_for(struct txn_limbo *limbo, int64_t lsn)
+{
+	assert(lsn > 0);
+	return vclock_count_ge(&limbo->queue.vclock, lsn) >=
+	       replication_synchro_quorum;
+}
+
 static void
 txn_limbo_ack(struct txn_limbo *limbo, uint32_t replica_id, int64_t lsn)
 {
@@ -316,6 +324,38 @@ end:
 	box_update_ro_summary();
 }
 
+int
+txn_limbo_req_promote(struct txn_limbo *limbo, uint16_t type, int64_t lsn,
+		      uint64_t term)
+{
+	txn_limbo_assert_locked(limbo);
+	/*
+	 * We make sure that promote is only written once everything this
+	 * instance has may be confirmed.
+	 */
+	struct txn_limbo_entry *e = txn_limbo_last_synchro_entry(limbo);
+	VERIFY(e == NULL || e->lsn <= lsn);
+	struct synchro_request req = {
+		.type = type,
+		.queue_owner_id = limbo->queue.owner_id,
+		.origin_id = instance_id,
+		.promote = {
+			.lsn = lsn,
+			.term = term,
+		},
+	};
+	/*
+	 * Confirmed_vclock is only persisted in checkpoints. It doesn't
+	 * appear in WALs and replication.
+	 */
+	vclock_clear(&req.promote.confirmed_vclock);
+	if (txn_limbo_req_prepare(limbo, &req) < 0)
+		return -1;
+	synchro_request_write_or_panic(&req);
+	txn_limbo_req_commit(limbo, &req);
+	return 0;
+}
+
 /*******************************************************************************
  * Public API
  ******************************************************************************/
@@ -462,39 +502,6 @@ txn_limbo_checkpoint(const struct txn_limbo *limbo,
 }
 
 int
-txn_limbo_req_promote(struct txn_limbo *limbo, uint16_t type, int64_t lsn,
-		      uint64_t term)
-{
-	txn_limbo_assert_locked(limbo);
-	/*
-	 * We make sure that promote is only written once everything this
-	 * instance has may be confirmed.
-	 */
-	struct txn_limbo_entry *e = txn_limbo_last_synchro_entry(limbo);
-	assert(e == NULL || e->lsn <= lsn);
-	(void) e;
-	struct synchro_request req = {
-		.type = type,
-		.queue_owner_id = limbo->queue.owner_id,
-		.origin_id = instance_id,
-		.promote = {
-			.lsn = lsn,
-			.term = term,
-		},
-	};
-	/*
-	 * Confirmed_vclock is only persisted in checkpoints. It doesn't
-	 * appear in WALs and replication.
-	 */
-	vclock_clear(&req.promote.confirmed_vclock);
-	if (txn_limbo_req_prepare(limbo, &req) < 0)
-		return -1;
-	synchro_request_write_or_panic(&req);
-	txn_limbo_req_commit(limbo, &req);
-	return 0;
-}
-
-int
 txn_limbo_wait_last_txn(struct txn_limbo *limbo, bool *is_rollback,
 			double timeout)
 {
@@ -506,14 +513,6 @@ int
 txn_limbo_wait_empty(struct txn_limbo *limbo, double timeout)
 {
 	return txn_limbo_queue_wait_empty(&limbo->queue, timeout);
-}
-
-bool
-txn_limbo_has_quorum_for(struct txn_limbo *limbo, int64_t lsn)
-{
-	assert(lsn > 0);
-	return vclock_count_ge(&limbo->queue.vclock, lsn) >=
-	       replication_synchro_quorum;
 }
 
 /**

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -137,7 +137,27 @@ txn_limbo_replica_confirmed_lsn(const struct txn_limbo *limbo,
 	return vclock_get(&limbo->queue.confirmed_vclock, replica_id);
 }
 
-bool
+/** Check limbo's term is unchanged. */
+static int
+txn_limbo_check_own_term_intact(const struct txn_limbo *limbo, uint64_t term)
+{
+	if (limbo->term == term)
+		return 0;
+	diag_set(ClientError, ER_INTERFERING_PROMOTE, limbo->queue.owner_id);
+	return -1;
+}
+
+/** Check Raft's term is unchanged. */
+static int
+txn_limbo_check_raft_term_intact(const struct txn_limbo *limbo, uint64_t term)
+{
+	if (limbo->raft->volatile_term == term)
+		return 0;
+	diag_set(ClientError, ER_INTERFERING_ELECTIONS);
+	return -1;
+}
+
+static bool
 txn_limbo_has_quorum_for(struct txn_limbo *limbo, int64_t lsn)
 {
 	assert(lsn > 0);
@@ -324,7 +344,44 @@ end:
 	box_update_ro_summary();
 }
 
-int
+/**
+ * A helper to wait until all limbo entries are ready to be confirmed, i.e.
+ * written to WAL and have gathered a quorum of ACKs from replicas.
+ * Return lsn of the last quorum-acked limbo entry on success.
+ */
+static int64_t
+txn_limbo_wait_acked(struct txn_limbo *limbo, double timeout)
+{
+	if (txn_limbo_is_empty(limbo))
+		return limbo->queue.confirmed_lsn;
+#ifndef NDEBUG
+	++errinj(ERRINJ_WAIT_QUORUM_COUNT, ERRINJ_INT)->iparam;
+#endif
+	uint64_t term = limbo->term;
+	double deadline = fiber_clock() + timeout;
+	while (!fiber_is_cancelled()) {
+		int64_t lsn = txn_limbo_last_synchro_entry(limbo)->lsn;
+		if (lsn > 0 && txn_limbo_has_quorum_for(limbo, lsn))
+			return lsn;
+		struct trigger on_ack;
+		trigger_create(&on_ack, fiber_wakeup_trigger_cb,
+			       fiber(), NULL);
+		trigger_add(&replicaset.on_ack, &on_ack);
+		int rc = fiber_cond_wait_deadline(&limbo->queue.cond, deadline);
+		trigger_clear(&on_ack);
+		if (rc != 0)
+			return -1;
+		if (txn_limbo_check_own_term_intact(limbo, term) != 0)
+			return -1;
+		if (txn_limbo_is_empty(limbo))
+			return limbo->queue.confirmed_lsn;
+	}
+	diag_set(FiberIsCancelled);
+	return -1;
+}
+
+/** Execute an ownership change request (PROMOTE/DEMOTE). */
+static int
 txn_limbo_req_promote(struct txn_limbo *limbo, uint16_t type, int64_t lsn,
 		      uint64_t term)
 {
@@ -499,6 +556,47 @@ txn_limbo_checkpoint(const struct txn_limbo *limbo,
 	req->promote.term = limbo->term;
 	vclock_copy(&req->promote.confirmed_vclock,
 		    &limbo->queue.confirmed_vclock);
+}
+
+int
+txn_limbo_promote(struct txn_limbo *limbo, uint16_t type, double timeout)
+{
+	struct raft *raft = limbo->raft;
+	uint64_t term = raft->term;
+	uint64_t limbo_term = limbo->term;
+	bool is_raft_enabled = raft_is_enabled(raft);
+	if (is_raft_enabled &&
+	    txn_limbo_replica_term(limbo, instance_id) == term)
+		return 0;
+	int64_t wait_lsn = txn_limbo_wait_acked(limbo, timeout);
+	if (wait_lsn < 0)
+		return -1;
+	if (is_raft_enabled && raft->state != RAFT_STATE_LEADER) {
+		diag_set(ClientError, ER_NOT_LEADER, raft->leader);
+		return -1;
+	}
+	int rc = txn_limbo_check_raft_term_intact(limbo, term);
+	if (rc != 0)
+		return rc;
+	/*
+	 * Fully ready to execute the promotion now.
+	 */
+	txn_limbo_begin(limbo);
+	rc = txn_limbo_check_raft_term_intact(limbo, term);
+	if (rc != 0)
+		goto tx_end;
+	rc = txn_limbo_check_own_term_intact(limbo, limbo_term);
+	if (rc != 0)
+		goto tx_end;
+	rc = txn_limbo_req_promote(limbo, type, wait_lsn, term);
+tx_end:
+	if (rc == 0) {
+		txn_limbo_commit(limbo);
+		assert(txn_limbo_is_empty(limbo));
+	} else {
+		txn_limbo_rollback(limbo);
+	}
+	return rc;
 }
 
 int

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -337,12 +337,6 @@ int
 txn_limbo_wait_empty(struct txn_limbo *limbo, double timeout);
 
 /**
- * True if enough ACKs are received for the given LSN to consider it confirmed.
- */
-bool
-txn_limbo_has_quorum_for(struct txn_limbo *limbo, int64_t lsn);
-
-/**
  * Persist limbo state to a given synchro request.
  */
 void
@@ -350,13 +344,11 @@ txn_limbo_checkpoint(const struct txn_limbo *limbo,
 		     struct synchro_request *req);
 
 /**
- * Write a PROMOTE/DEMOTE request. It will do CONFIRM(@a lsn) +
- * ROLLBACK(@a lsn + 1) + assign a new owner to the limbo (this node for
- * PROMOTE, nobody for DEMOTE).
+ * Execute promotion/demotion to catch up with the Raft state, in case this node
+ * is a Raft leader in a new term, and the limbo is behind.
  */
 int
-txn_limbo_req_promote(struct txn_limbo *limbo, uint16_t type, int64_t lsn,
-		      uint64_t term);
+txn_limbo_promote(struct txn_limbo *limbo, uint16_t type, double timeout);
 
 /**
  * Update qsync parameters dynamically.

--- a/src/box/txn_limbo_queue.c
+++ b/src/box/txn_limbo_queue.c
@@ -163,15 +163,6 @@ txn_limbo_queue_rollback_volatile_up_to(struct txn_limbo_queue *queue,
 }
 
 static int
-txn_write_cb(struct trigger *trigger, void *event)
-{
-	(void)event;
-	struct fiber *fiber = (struct fiber *)trigger->data;
-	fiber_wakeup(fiber);
-	return 0;
-}
-
-static int
 txn_commit_cb(struct trigger *trigger, void *event)
 {
 	(void)event;
@@ -920,7 +911,7 @@ retry:
 	if (e->lsn > 0)
 		return 0;
 	struct trigger on_wal_write;
-	trigger_create(&on_wal_write, txn_write_cb, fiber(), NULL);
+	trigger_create(&on_wal_write, fiber_wakeup_trigger_cb, fiber(), NULL);
 	txn_on_wal_write(e->txn, &on_wal_write);
 	/*
 	 * There is no spurious wakeup. This whole function is entirely

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -2293,6 +2293,14 @@ fiber_free(void)
 	cord_destroy(&main_cord);
 }
 
+int
+fiber_wakeup_trigger_cb(struct trigger *trigger, void *event)
+{
+	(void)event;
+	fiber_wakeup(trigger->data);
+	return 0;
+}
+
 /**
  * True if fiber_signal_init was called.
  * Needed for re-entrancy of fiber signal initialization.

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -604,6 +604,7 @@ struct credentials;
 struct runtime_credentials;
 struct lua_State;
 struct ipc_wait_pad;
+struct trigger;
 
 /**
  * Warning and error slices.
@@ -1042,6 +1043,13 @@ fiber_signal_init(void);
  */
 void
 fiber_signal_reset(void);
+
+/**
+ * A trigger callback which just wakes up the fiber stored in the
+ * trigger's data.
+ */
+int
+fiber_wakeup_trigger_cb(struct trigger *trigger, void *event);
 
 /**
  * Set fiber name.


### PR DESCRIPTION
```
limbo: encapsulate limbo promotion logic

Promotion logic of the limbo was scattered across the following
places quite messy:
1. box/raft which must invoke box_promote_qsync().
2. box/box's box_promote() had to check terms, collect acks,
  trigger the low-level promotion request.
3. box/txn_limbo's txn_limbo_req_promote() did the actual final
  write + commit.

While the code is still imperfect, it is quite clear, that box.cc
must not be digging so deeply into internals of the limbo.

This whole logic now is moved into the limbo's internal code and
exposed as one simple function call. Which does one thing - makes
sure the limbo ownership is caught up with Raft's state machine.

This in turn also allows to entirely hide the selection of
promotion LSN. It will be necessary in the future, when
synchronous PROMOTE will be implemented, and its commit LSN logic
will be relatively complicated and very internal.

As a bonus alongside the code just got quite simpler.

Part of #8095

NO_DOC=refactoring
NO_TEST=refactoring
NO_CHANGELOG=refactoring
```