### PR TITLE
[backport 3.6] ci: run fuzzing workflow only for master branch

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'master'
-      - 'release/**'
     tags:
       - '**'
     paths:
@@ -19,6 +18,8 @@ on:
       - 'third_party/tz/**'
   pull_request:
     types: [opened, reopened, synchronize, labeled]
+    branches:
+      - 'master'
 
 concurrency:
   # Update of a developer branch cancels the previously scheduled workflow


### PR DESCRIPTION
*(This PR is a backport of #12511 to `release/3.6` to a future `3.6.3` release.)*

----

The use of this workflow for release branches is excessive, since we only cherry-pick patches to them, so there is no reason to run fuzzing twice.

NO_CHANGELOG=ci
NO_DOC=ci
NO_TEST=ci