### PR TITLE
lua: allow to use thread id as target for threads.call and eval

### DIFF
--- a/changelogs/unreleased/gh-12628-app-threads-target-id.md
+++ b/changelogs/unreleased/gh-12628-app-threads-target-id.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* It is now possible to use a thread ID as a target for the `call` and `eval`
+  functions provided by the `experimental.threads` module (gh-12628).

--- a/src/box/lua/app_threads.lua
+++ b/src/box/lua/app_threads.lua
@@ -102,21 +102,29 @@ end
 -- future object.
 --
 -- Available options:
--- * target := all | any: determines whether the callback is invoked for
---   all threads of the group or just one picked randomly.
+-- * target := all | any | N: determines whether the callback is invoked for
+--   all threads of the group, just one thread picked randomly, or the thread
+--   with the given id N, 1 <= N <= thread group size.
 --
 -- On success returns an array of future results, one for each target thread.
 -- If any of the returned futures fails with an error, re-throws the last
 -- error.
 --
 function thread_group_methods:_dispatch(cb, args, opts)
-    local first_thread_id = self.first_thread_id
-    local last_thread_id = self.last_thread_id
-    if opts.target == 'any' then
-        local thread_id = math.random(first_thread_id, last_thread_id)
+    local first_thread_id, last_thread_id
+    if opts.target == nil or opts.target == 'all' then
+        first_thread_id = self.first_thread_id
+        last_thread_id = self.last_thread_id
+    elseif opts.target == 'any' then
+        local thread_id = math.random(self.first_thread_id, self.last_thread_id)
         first_thread_id, last_thread_id = thread_id, thread_id
     else
-        assert(opts.target == nil or opts.target == 'all')
+        local thread_id = self.first_thread_id + opts.target - 1
+        if thread_id < self.first_thread_id or
+                thread_id > self.last_thread_id then
+            box.error(box.error.NO_SUCH_THREAD, opts.target, 2)
+        end
+        first_thread_id, last_thread_id = thread_id, thread_id
     end
     local futures = {}
     for thread_id = first_thread_id, last_thread_id do
@@ -298,7 +306,7 @@ end
 
 -- call/eval options template used with utils.check_param_table().
 local CALL_EVAL_OPTS = {
-    target = 'string',
+    target = 'string, number',
 }
 
 --
@@ -307,10 +315,12 @@ local CALL_EVAL_OPTS = {
 --
 local function check_call_eval_opts(opts)
     utils.check_param_table(opts, CALL_EVAL_OPTS, 3)
-    if opts.target ~= nil and opts.target ~= 'all' and opts.target ~= 'any' then
+    if type(opts.target) == 'string' and
+            opts.target ~= 'all' and opts.target ~= 'any' then
         box.error(box.error.ILLEGAL_PARAMS,
                   "unexpected value for option parameter 'target': " ..
-                  "got '" .. opts.target .. "', expected 'any' or 'all'", 3)
+                  "got '" .. opts.target .. "', " ..
+                  "expected 'any', 'all', or a number", 3)
     end
 end
 

--- a/test/box-luatest/app_threads_module_test.lua
+++ b/test/box-luatest/app_threads_module_test.lua
@@ -243,12 +243,13 @@ g.test_threads_call = function()
         }, threads.call, 'test1', 'test_func', {123}, {foo = 'bar'})
         t.assert_error_covers({
             type = 'IllegalParams',
-            message = "options parameter 'target' should be of type string",
-        }, threads.call, 'test1', 'test_func', {123}, {target = 123})
+            message = "options parameter 'target' should be one of types: " ..
+                      "string, number",
+        }, threads.call, 'test1', 'test_func', {123}, {target = {}})
         t.assert_error_covers({
             type = 'IllegalParams',
             message = "unexpected value for option parameter 'target': " ..
-                      "got 'foo', expected 'any' or 'all'",
+                      "got 'foo', expected 'any', 'all', or a number",
         }, threads.call, 'test1', 'test_func', {123}, {target = 'foo'})
     end)
     --
@@ -260,6 +261,21 @@ g.test_threads_call = function()
             type = 'ClientError',
             name = 'NO_SUCH_THREAD_GROUP',
         }, threads.call, 'test3', 'test_func', {}, {target = 'all'})
+    end)
+    --
+    -- Unknown thread.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        for _, p in ipairs({{'test1', -1}, {'test2', 0},
+                            {'test1', 4}, {'test2', 3}}) do
+            local group, target = unpack(p)
+            t.assert_error_covers({
+                type = 'ClientError',
+                name = 'NO_SUCH_THREAD',
+                thread_id = target,
+            }, threads.call, group, 'test_func', {}, {target = target})
+        end
     end)
     --
     -- Unknown function.
@@ -278,17 +294,24 @@ g.test_threads_call = function()
         local threads = require('experimental.threads')
         local group = 'test1'
         local func = 'test_func_1'
-        threads.eval(group, [[
+        local func_def = [[
             local threads = require('experimental.threads')
             threads.export('test_func_1', function()
                 return threads.info().thread_id
             end)
-        ]])
+        ]]
+        threads.eval('test1', func_def)
         local ret_all = threads.call(group, func, {}, {target = 'all'})
         t.assert_equals(ret_all, {{1}, {2}, {3}})
         local ret_any = threads.call(group, func, {}, {target = 'any'})
         t.assert_equals(#ret_any, 1)
         t.assert_items_include(ret_all, ret_any)
+        t.assert_equals(threads.call('test1', func, {}, {target = 1}), {{1}})
+        t.assert_equals(threads.call('test1', func, {}, {target = 2}), {{2}})
+        t.assert_equals(threads.call('test1', func, {}, {target = 3}), {{3}})
+        threads.eval('test2', func_def)
+        t.assert_equals(threads.call('test2', func, {}, {target = 1}), {{4}})
+        t.assert_equals(threads.call('test2', func, {}, {target = 2}), {{5}})
     end)
     --
     -- Default arguments.
@@ -431,12 +454,13 @@ g.test_threads_eval = function()
         }, threads.eval, 'test1', 'return ...', {123}, {foo = 'bar'})
         t.assert_error_covers({
             type = 'IllegalParams',
-            message = "options parameter 'target' should be of type string",
-        }, threads.eval, 'test1', 'return ...', {123}, {target = 123})
+            message = "options parameter 'target' should be one of types: " ..
+                      "string, number",
+        }, threads.eval, 'test1', 'return ...', {123}, {target = {}})
         t.assert_error_covers({
             type = 'IllegalParams',
             message = "unexpected value for option parameter 'target': " ..
-                      "got 'foo', expected 'any' or 'all'",
+                      "got 'foo', expected 'any', 'all', or a number",
         }, threads.eval, 'test1', 'return ...', {123}, {target = 'foo'})
     end)
     --
@@ -448,6 +472,21 @@ g.test_threads_eval = function()
             type = 'ClientError',
             name = 'NO_SUCH_THREAD_GROUP',
         }, threads.eval, 'test3', 'return ...', {}, {target = 'all'})
+    end)
+    --
+    -- Unknown thread.
+    --
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        for _, p in ipairs({{'test1', -1}, {'test2', 0},
+                            {'test1', 4}, {'test2', 3}}) do
+            local group, target = unpack(p)
+            t.assert_error_covers({
+                type = 'ClientError',
+                name = 'NO_SUCH_THREAD',
+                thread_id = target,
+            }, threads.eval, group, 'return ...', {}, {target = target})
+        end
     end)
     --
     -- Target handling.
@@ -464,6 +503,11 @@ g.test_threads_eval = function()
         local ret_any = threads.eval(group, expr, {}, {target = 'any'})
         t.assert_equals(#ret_any, 1)
         t.assert_items_include(ret_all, ret_any)
+        t.assert_equals(threads.eval('test1', expr, {}, {target = 1}), {{1}})
+        t.assert_equals(threads.eval('test1', expr, {}, {target = 2}), {{2}})
+        t.assert_equals(threads.eval('test1', expr, {}, {target = 3}), {{3}})
+        t.assert_equals(threads.eval('test2', expr, {}, {target = 1}), {{4}})
+        t.assert_equals(threads.eval('test2', expr, {}, {target = 2}), {{5}})
     end)
     --
     -- Default arguments.


### PR DESCRIPTION
Currently, it's possible to direct a request to either all application threads or a random thread. Sometimes it may be useful to direct a request to a specific thread, for example, to parallelize a workload. This patch updates the `experimental.threads` module so that now the `call` and `eval` functions can accept a numeric thread id as a value of the `target` option. A thread id must be >= 1 and <= the number of threads in the target thread group.

Closes #12628