### PR TITLE
coro: build fix on recent gcc

### DIFF
--- a/third_party/coro/coro.h
+++ b/third_party/coro/coro.h
@@ -375,13 +375,8 @@ struct coro_context
   void **sp; /* must be at offset 0 */
 };
 
-#if !__arm__ && !__aarch64__
-void __attribute__ ((__noinline__, __regparm__(2)))
-coro_transfer (coro_context *prev, coro_context *next);
-#else
 void __attribute__ ((__noinline__))
 coro_transfer (coro_context *prev, coro_context *next);
-#endif
 
 # define coro_destroy(ctx) (void *)(ctx)
 


### PR DESCRIPTION
Build is failed on recent gcc. `__regparm__` attribute is for x86-32 only and we do not support it (at least Tarantool fails to compile for x86-32 currently). So let's just remove this optimization.

```
In file included from /home/shiny/dev/tarantool/src/lib/core/fiber.h:50,
                 from /home/shiny/dev/tarantool/src/on_shutdown.c:35:
/home/shiny/dev/tarantool/third_party/coro/coro.h:380:1: error: ‘regparm’ attribute ignored [-Werror=attributes]
  380 | coro_transfer (coro_context *prev, coro_context *next);
      | ^~~~~~~~~~~~~
```