### PR TITLE
lua: use configured group name in application thread name

### DIFF
--- a/changelogs/unreleased/gh-12643-app-threads-names.md
+++ b/changelogs/unreleased/gh-12643-app-threads-names.md
@@ -1,0 +1,10 @@
+## feature/core
+
+* Application threads are now named `<group><id>`, where `<group>` is the name
+  of the configured group the thread belongs to and `<id>` is the ID of the
+  thread within that group. Thread names are used in logs, so this change helps
+  identify the thread that logged a particular message. Additionally, the
+  meaning of the `thread_id` field returned by the `info()` function of
+  the `experimental.threads` Lua module has been changed: it now shows the
+  thread's ID within the group, rather than the global thread ID used
+  internally (gh-12643).

--- a/extra/exports
+++ b/extra/exports
@@ -190,6 +190,7 @@ cord_ibuf_drop
 cord_ibuf_put
 cord_ibuf_take
 cord_is_main
+cord_set_name
 crc32_calc
 crypto_ERR_error_string
 crypto_ERR_get_error

--- a/src/box/lua/app_threads.lua
+++ b/src/box/lua/app_threads.lua
@@ -1,7 +1,13 @@
 local errno = require('errno')
+local ffi = require('ffi')
 local net = require('net.box')
 local socket = require('socket')
 local utils = require('internal.utils')
+
+ffi.cdef([[
+    void
+    cord_set_name(const char *name);
+]])
 
 -- This module.
 local threads = {}
@@ -228,6 +234,9 @@ function box.internal.threads.init(cfg, group_name, id_in_group, conn_fd)
     threads_cfg = cfg
     this_group_name = group_name
     this_thread_id_in_group = id_in_group
+    if group_name ~= 'tx' then
+        ffi.C.cord_set_name(string.format('%s%d', group_name, id_in_group))
+    end
     threads_conn = net.from_fd(conn_fd, {fetch_schema = false})
     init_thread_groups(cfg)
 end

--- a/src/box/lua/app_threads.lua
+++ b/src/box/lua/app_threads.lua
@@ -15,8 +15,8 @@ local threads_cfg
 -- Name of the group this thread belongs to.
 local this_group_name
 
--- Identifier of this thread.
-local this_thread_id
+-- Identifier of this thread in the group, 1 <= N <= group size.
+local this_thread_id_in_group
 
 -- Connection used to call threads.
 local threads_conn
@@ -61,6 +61,7 @@ local function create_thread_group(group_name, first_thread_id, last_thread_id)
     assert(thread_groups[group_name] == nil)
     assert(last_thread_id >= first_thread_id)
     thread_groups[group_name] = setmetatable({
+        name = group_name,
         first_thread_id = first_thread_id,
         last_thread_id = last_thread_id,
     }, thread_group_mt)
@@ -151,18 +152,19 @@ end
 --
 local function thread_init_cb(args, thread_id)
     assert(threads_conn ~= nil)
-    local cfg, group_name = unpack(args)
+    local cfg, group = unpack(args)
+    local id_in_group = thread_id - group.first_thread_id + 1
     return threads_conn:call('box.internal.threads.init',
-                             {cfg, group_name, thread_id, make_conn_fd()},
+                             {cfg, group.name, id_in_group, make_conn_fd()},
                              {_thread_id = thread_id, is_async = true})
 end
 
 --
 -- Initializes the subsystem in all threads of this group.
 --
-function thread_group_methods:init(cfg, group_name)
+function thread_group_methods:init(cfg)
     assert(threads_conn ~= nil)
-    return self:_dispatch(thread_init_cb, {cfg, group_name}, {target = 'all'})
+    return self:_dispatch(thread_init_cb, {cfg, self}, {target = 'all'})
 end
 
 --
@@ -221,11 +223,11 @@ end
 --
 -- Initializes the subsystem in the current thread.
 --
-function box.internal.threads.init(cfg, group_name, thread_id, conn_fd)
+function box.internal.threads.init(cfg, group_name, id_in_group, conn_fd)
     assert(threads_cfg == nil)
     threads_cfg = cfg
     this_group_name = group_name
-    this_thread_id = thread_id
+    this_thread_id_in_group = id_in_group
     threads_conn = net.from_fd(conn_fd, {fetch_schema = false})
     init_thread_groups(cfg)
 end
@@ -251,11 +253,11 @@ function box.internal.threads.cfg(cfg)
         return threads_cfg
     end
     assert(threads_cfg == nil)
-    box.internal.threads.init(cfg, 'tx', 0, make_conn_fd())
+    box.internal.threads.init(cfg, 'tx', 1, make_conn_fd())
     -- Initialize the subsystem in threads.
     for group_name, group in pairs(thread_groups) do
         if group_name ~= this_group_name then
-            group:init(cfg, group_name)
+            group:init(cfg)
         end
     end
 end
@@ -369,7 +371,7 @@ end
 function threads.info()
     check_configured()
     local info = {
-        thread_id = this_thread_id,
+        thread_id = this_thread_id_in_group,
         group_name = this_group_name,
         groups = {
             {name = 'tx', size = 1},

--- a/src/lib/core/fiber_pool.c
+++ b/src/lib/core/fiber_pool.c
@@ -143,7 +143,7 @@ fiber_pool_cb(ev_loop *loop, struct ev_watcher *watcher, int events)
 			 * by client then it can just set system flag during
 			 * it's execution.
 			 */
-			f = fiber_new_system(cord_name(cord()), fiber_pool_f);
+			f = fiber_new_system("pool", fiber_pool_f);
 			if (f == NULL) {
 				diag_log();
 				break;

--- a/test/box-luatest/app_threads_module_test.lua
+++ b/test/box-luatest/app_threads_module_test.lua
@@ -48,7 +48,7 @@ g.test_threads_config_propagation = function()
     local cluster = cluster:new(config, SERVER_OPTS)
     cluster:start()
     local expected_threads_info = {
-        thread_id = 0,
+        thread_id = 1,
         group_name = 'tx',
         groups = {
             {name = 'tx', size = 1},
@@ -87,7 +87,7 @@ g.test_threads_config_propagation = function()
     end, {expected_threads_info})
     cluster.server:restart()
     local expected_threads_info = {
-        thread_id = 0,
+        thread_id = 1,
         group_name = 'tx',
         groups = {
             {name = 'tx', size = 1},
@@ -107,17 +107,21 @@ g.test_threads_config_propagation = function()
     --
     setsearchroot(cluster.server)
     for i = 1, 10 do
-        local group_name
+        local group_name, thread_id
         if i < 2 then
             group_name = 'test1'
+            thread_id = i
         elseif i < 4 then
             group_name = 'test2'
+            thread_id = i - 1
         elseif i < 7 then
             group_name = 'test3'
+            thread_id = i - 3
         else
             group_name = 'test4'
+            thread_id = i - 6
         end
-        expected_threads_info.thread_id = i
+        expected_threads_info.thread_id = thread_id
         expected_threads_info.group_name = group_name
         cluster.server:exec(function(expected_threads_info)
             t.assert_equals(require('experimental.threads').info(),
@@ -161,7 +165,7 @@ g.test_thread_groups_not_configured = function()
     cluster.server:exec(function()
         local threads = require('experimental.threads')
         t.assert_equals(threads.info(), {
-            thread_id = 0,
+            thread_id = 1,
             group_name = 'tx',
             groups = {{name = 'tx', size = 1}},
         })
@@ -310,8 +314,8 @@ g.test_threads_call = function()
         t.assert_equals(threads.call('test1', func, {}, {target = 2}), {{2}})
         t.assert_equals(threads.call('test1', func, {}, {target = 3}), {{3}})
         threads.eval('test2', func_def)
-        t.assert_equals(threads.call('test2', func, {}, {target = 1}), {{4}})
-        t.assert_equals(threads.call('test2', func, {}, {target = 2}), {{5}})
+        t.assert_equals(threads.call('test2', func, {}, {target = 1}), {{1}})
+        t.assert_equals(threads.call('test2', func, {}, {target = 2}), {{2}})
     end)
     --
     -- Default arguments.
@@ -394,7 +398,7 @@ g.test_threads_call = function()
     cluster.server:exec(function()
         local threads = require('experimental.threads')
         t.assert_covers(threads.info(), {
-            thread_id = 5,
+            thread_id = 2,
             group_name = 'test2',
         })
         local func = 'test_func_6'
@@ -409,11 +413,11 @@ g.test_threads_call = function()
         threads.eval('test1', expr)
         threads.eval('test2', expr)
         t.assert_equals(threads.call('tx', func, {}, {target = 'all'}),
-                        {{'tx', 0}})
+                        {{'tx', 1}})
         t.assert_equals(threads.call('test1', func, {}, {target = 'all'}),
                         {{'test1', 1}, {'test1', 2}, {'test1', 3}})
         t.assert_equals(threads.call('test2', func, {}, {target = 'all'}),
-                        {{'test2', 4}, {'test2', 5}})
+                        {{'test2', 1}, {'test2', 2}})
     end, {}, {_thread_id = 5})
 end
 
@@ -506,8 +510,8 @@ g.test_threads_eval = function()
         t.assert_equals(threads.eval('test1', expr, {}, {target = 1}), {{1}})
         t.assert_equals(threads.eval('test1', expr, {}, {target = 2}), {{2}})
         t.assert_equals(threads.eval('test1', expr, {}, {target = 3}), {{3}})
-        t.assert_equals(threads.eval('test2', expr, {}, {target = 1}), {{4}})
-        t.assert_equals(threads.eval('test2', expr, {}, {target = 2}), {{5}})
+        t.assert_equals(threads.eval('test2', expr, {}, {target = 1}), {{1}})
+        t.assert_equals(threads.eval('test2', expr, {}, {target = 2}), {{2}})
     end)
     --
     -- Default arguments.
@@ -576,7 +580,7 @@ g.test_threads_eval = function()
     cluster.server:exec(function()
         local threads = require('experimental.threads')
         t.assert_covers(threads.info(), {
-            thread_id = 5,
+            thread_id = 2,
             group_name = 'test2',
         })
         local expr = [[
@@ -585,11 +589,11 @@ g.test_threads_eval = function()
             return info.group_name, info.thread_id
         ]]
         t.assert_equals(threads.eval('tx', expr, {}, {target = 'all'}),
-                        {{'tx', 0}})
+                        {{'tx', 1}})
         t.assert_equals(threads.eval('test1', expr, {}, {target = 'all'}),
                         {{'test1', 1}, {'test1', 2}, {'test1', 3}})
         t.assert_equals(threads.eval('test2', expr, {}, {target = 'all'}),
-                        {{'test2', 4}, {'test2', 5}})
+                        {{'test2', 1}, {'test2', 2}})
     end, {}, {_thread_id = 5})
 end
 
@@ -731,7 +735,7 @@ g.test_box_cfg = function(cg)
     cg.server:exec(function()
         local threads = require('experimental.threads')
         t.assert_equals(threads.info(), {
-            thread_id = 0,
+            thread_id = 1,
             group_name = 'tx',
             groups = {
                 {name = 'tx', size = 1},

--- a/test/box-luatest/app_threads_module_test.lua
+++ b/test/box-luatest/app_threads_module_test.lua
@@ -759,3 +759,31 @@ g.after_test('test_box_cfg', function(cg)
     cg.server:drop()
     cg.server = nil
 end)
+
+g.test_thread_names_in_logs = function()
+    local config = cbuilder:new(BASE_CONFIG)
+        :add_instance('server', {})
+        :set_instance_option('server', 'threads.groups', {
+            {name = 'fuzz', size = 1},
+            {name = 'buzz', size = 2},
+        })
+        :config()
+    local cluster = cluster:new(config, SERVER_OPTS)
+    cluster:start()
+    cluster.server:exec(function()
+        local threads = require('experimental.threads')
+        require('log').info('foobar1')
+        threads.eval('fuzz', [[
+            require('log').info('foobar2')
+        ]], {}, {target = 1})
+        threads.eval('buzz', [[
+            require('log').info('foobar3')
+        ]], {}, {target = 2})
+    end)
+    t.assert_str_contains(cluster.server:grep_log('.*foobar1'),
+                          'main/%d+/pool', true)
+    t.assert_str_contains(cluster.server:grep_log('.*foobar2'),
+                          'fuzz1/%d+/pool', true)
+    t.assert_str_contains(cluster.server:grep_log('.*foobar3'),
+                          'buzz2/%d+/pool', true)
+end

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -479,7 +479,8 @@ g.test_log = function(cg)
 
     -- Check that logging works and the thread name is logged.
     eval([[require('log').info('fuzzbuzz')]])
-    t.assert_str_contains(cg.server:grep_log('.*fuzzbuzz.*'), '/app1/')
+    t.assert_str_contains(cg.server:grep_log('.*fuzzbuzz.*'),
+                          'app1/%d+/pool', true)
 
     -- Check that log levels are propagated.
     local old_level = cg.server:exec(function()

--- a/test/box-luatest/gh_12006_syslog_rfc3164_test.lua
+++ b/test/box-luatest/gh_12006_syslog_rfc3164_test.lua
@@ -53,7 +53,7 @@ local function syslog_check_plain(cg, expected_msg)
     t.assert_str_matches(
         hdr,
         '<%d+>%a+%s+%d%d?%s+%d%d:%d%d:%d%d%s+tt%[' .. cg.pid .. '%]:%s' ..
-        'main/%d+/main/test%.box%-luatest%.' .. TEST_NAME ..  '%s' ..
+        'main/%d+/pool/test%.box%-luatest%.' .. TEST_NAME ..  '%s' ..
         TEST_NAME .. '%.lua:37')
     t.assert_equals(msg, expected_msg)
 end
@@ -149,7 +149,7 @@ local function syslog_check_json(cg, expected_msg)
     result.file = nil
     t.assert_equals(result, {
         cord_name = 'main',
-        fiber_name = 'main',
+        fiber_name = 'pool',
         line = 37,
         level = 'WARN',
         module = 'test.box-luatest.' .. TEST_NAME,

--- a/test/box-luatest/gh_7860_syslog_json_test.lua
+++ b/test/box-luatest/gh_7860_syslog_json_test.lua
@@ -46,7 +46,7 @@ g.before_all(function(cg)
         result.file = nil
         t.assert_equals(result, {
             cord_name = 'main',
-            fiber_name = 'main',
+            fiber_name = 'pool',
             line = 29,
             level = 'WARN',
             message = expected_msg,
@@ -61,7 +61,7 @@ g.before_all(function(cg)
         t.assert_str_matches(
             hdr,
             '<%d+>%a+%s+%d%d?%s+%d%d:%d%d:%d%d%s+tt%[' .. cg.pid .. '%]:%s' ..
-            'main/%d+/main/test%.box%-luatest%.gh_7860_syslog_json_test%s' ..
+            'main/%d+/pool/test%.box%-luatest%.gh_7860_syslog_json_test%s' ..
             'gh_7860_syslog_json_test%.lua:29')
         t.assert_equals(msg, expected_msg)
     end


### PR DESCRIPTION
Currently, application threads are named `app<id>` where `<id>` is the global thread identifier used internally. This makes it difficult to figure out which group an application thread belongs to. In particular, this complicates matching logged messages to application threads. Let's name application threads `<group><id>` where `<group>` is the name of the configured thread group and `<id>` is the identifier of the thread in the group. We also change the meaning of the `thread_id` field returned by `threads.info()`: now it shows the identifier of the thread in its group instead of the global identifier used internally. We do it for consistency with the new thread naming policy and the new `target` option of `threads.call()` and `eval()` introduced recently.

Closes #12643