### PR TITLE
 config: introduce readiness and liveness probes

### DIFF
--- a/changelogs/unreleased/health-checks.md
+++ b/changelogs/unreleased/health-checks.md
@@ -1,0 +1,5 @@
+## feature/box
+
+* Added `box.info.health` with liveness and readiness checks. Applications can
+  register liveness probes with `box.ctl.liveness_probe()`, and roles can
+  provide readiness checks through the `health_check()` role method.

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -29,6 +29,7 @@ lua_source(lua_sources lua/version.lua internal_version_lua)
 lua_source(lua_sources lua/backup.lua backup_lua)
 lua_source(lua_sources lua/recovery_point_manager.lua recovery_point_manager_lua)
 lua_source(lua_sources lua/healthcheck.lua healthcheck_lua)
+lua_source(lua_sources lua/healthcheck_defaults.lua healthcheck_defaults_lua)
 
 # {{{ config
 lua_source(lua_sources lua/config/applier/app.lua          config_applier_app_lua)

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -28,6 +28,7 @@ lua_source(lua_sources lua/app_threads.lua app_threads_lua)
 lua_source(lua_sources lua/version.lua internal_version_lua)
 lua_source(lua_sources lua/backup.lua backup_lua)
 lua_source(lua_sources lua/recovery_point_manager.lua recovery_point_manager_lua)
+lua_source(lua_sources lua/healthcheck.lua healthcheck_lua)
 
 # {{{ config
 lua_source(lua_sources lua/config/applier/app.lua          config_applier_app_lua)

--- a/src/box/lua/config/applier/roles.lua
+++ b/src/box/lua/config/applier/roles.lua
@@ -2,6 +2,7 @@ local log = require('internal.config.utils.log')
 local file = require('internal.config.utils.file')
 local expression = require('internal.config.utils.expression')
 local fiber = require('fiber')
+local health = require('internal.healthcheck')
 
 local fail_if_vars = {
     tarantool_version = _TARANTOOL:match('^%d+%.%d+%.%d+'),
@@ -293,6 +294,24 @@ local function stop_roles(roles_to_skip)
         if not ok then
             error(('Error stopping role %s: %s'):format(role_name, err), 0)
         end
+        health.remove_health_check(('role.%s'):format(role_name), {
+            if_exists = true,
+        })
+    end
+end
+
+local function register_role_health_check(role_name, role, cfg)
+    if type(role.health_check) ~= 'function' then
+        return
+    end
+    local check_name = ('role.%s'):format(role_name)
+    health.remove_health_check(check_name, {if_exists = true})
+    local ok, err = health.add_health_check(check_name, function()
+        return role.health_check(cfg)
+    end)
+    if not ok then
+        error(('Failed to register health check for the role %s: %s'):format(
+            role_name, err), 0)
     end
 end
 
@@ -398,6 +417,8 @@ local function post_apply(config)
         if not ok then
             error(('Error applying role %s: %s'):format(role_name, err), 0)
         end
+        register_role_health_check(role_name, loaded[role_name],
+                                   roles_cfg[role_name])
     end
 
     roles_state.last_loaded = loaded

--- a/src/box/lua/config/applier/sharding.lua
+++ b/src/box/lua/config/applier/sharding.lua
@@ -1,3 +1,4 @@
+local health = require('internal.healthcheck')
 local log = require('internal.config.utils.log')
 local loaders = require('internal.loaders')
 _G.vshard = nil
@@ -5,10 +6,34 @@ _G.vshard = nil
 -- Watcher which will create all the necessary functions.
 local watcher = nil
 
+local function unregister_vshard_health_checks()
+    health.remove_health_check('vshard.router', {if_exists = true})
+end
+
+local function register_vshard_router_health_check()
+    unregister_vshard_health_checks()
+    local ok, err = health.add_health_check('vshard.router', function()
+        local info = _G.vshard.router.info()
+        local bucket = info and info.bucket
+        if bucket == nil or bucket.unknown == nil then
+            return false, 'bucket discovery status is unknown'
+        end
+        if bucket.unknown > 0 then
+            return false, 'buckets are not discovered yet'
+        end
+        return true
+    end)
+    if not ok then
+        error(('Failed to register vshard.router health check: %s'):format(
+            err), 0)
+    end
+end
+
 local function apply(config)
     local configdata = config._configdata
     local roles = configdata:get('sharding.roles')
     if roles == nil then
+        unregister_vshard_health_checks()
         return
     end
     -- VShard availability and its minimum version are ensured by the sharding
@@ -52,6 +77,9 @@ local function apply(config)
     if is_router then
         log.info('sharding: apply router config')
         _G.vshard.router.cfg(cfg)
+        register_vshard_router_health_check()
+    else
+        unregister_vshard_health_checks()
     end
 end
 

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -735,6 +735,11 @@ end
 function methods.info(self, version)
     selfcheck(self, 'info')
     version = version == nil and 'v1' or version
+    local health = package.loaded['internal.healthcheck']
+    if type(health) == 'table' and
+       type(health._sync_alerts) == 'function' then
+        pcall(health._sync_alerts, {skip = {config = true}})
+    end
     local info = {}
     local alerts = self._aboard:alerts()
     local hierarchy = self:_hierarchy_info()

--- a/src/box/lua/ctl.c
+++ b/src/box/lua/ctl.c
@@ -215,6 +215,22 @@ lbox_ctl_replica_gc(struct lua_State *L)
 	return 0;
 }
 
+/** Register a Lua liveness probe callback. */
+static int
+lbox_ctl_liveness_probe(struct lua_State *L)
+{
+	int argc = lua_gettop(L);
+	lua_getglobal(L, "require");
+	lua_pushliteral(L, "internal.healthcheck");
+	if (lua_pcall(L, 1, 1, 0) != 0)
+		return luaT_error(L);
+	lua_getfield(L, -1, "liveness_probe");
+	lua_remove(L, -2);
+	lua_insert(L, 1);
+	lua_call(L, argc, LUA_MULTRET);
+	return lua_gettop(L);
+}
+
 static const struct luaL_Reg lbox_ctl_lib[] = {
 	{"wait_ro", lbox_ctl_wait_ro},
 	{"wait_rw", lbox_ctl_wait_rw},
@@ -232,6 +248,7 @@ static const struct luaL_Reg lbox_ctl_lib[] = {
 	{"iproto_lockdown", lbox_ctl_set_iproto_lockdown},
 	{"wal_sync", lbox_ctl_wal_sync},
 	{"replica_gc", lbox_ctl_replica_gc},
+	{"liveness_probe", lbox_ctl_liveness_probe},
 	{NULL, NULL}
 };
 

--- a/src/box/lua/healthcheck.lua
+++ b/src/box/lua/healthcheck.lua
@@ -1,0 +1,140 @@
+local utils = require('internal.utils')
+
+local checks = {
+    liveness = {},
+}
+
+local function default_alert_code(kind, name)
+    return ('health.%s.%s'):format(kind, name)
+end
+
+local HEALTHCHECK_OPTION_TYPES = {
+    if_exists = 'boolean',
+    if_not_exists = 'boolean',
+    alert = 'boolean',
+    alert_code = 'string',
+}
+
+local LIVENESS_PROBE_TYPES = {
+    name = 'string',
+    check = 'function',
+}
+
+local function add_check(kind, name, fn, opts)
+    opts = opts or {}
+
+    utils.check_param(name, 'name', 'string')
+    utils.check_param(fn, 'fn', 'function')
+    utils.check_param_table(opts, HEALTHCHECK_OPTION_TYPES)
+
+    local registry = checks[kind]
+    if registry[name] ~= nil and not opts.if_not_exists then
+        return false, ('health check %q already exists'):format(name)
+    end
+
+    if registry[name] == nil then
+        local alert_code
+        if opts.alert ~= false then
+            alert_code = opts.alert_code or default_alert_code(kind, name)
+        end
+        registry[name] = {
+            fn = fn,
+            alert_code = alert_code,
+        }
+    end
+
+    return true
+end
+
+local function remove_check(kind, name, opts)
+    opts = opts or {}
+
+    utils.check_param(name, 'name', 'string')
+    utils.check_param_table(opts, HEALTHCHECK_OPTION_TYPES)
+
+    local registry = checks[kind]
+    if registry[name] == nil and not opts.if_exists then
+        return false, ('health check %q does not exist'):format(name)
+    end
+
+    registry[name] = nil
+
+    return true
+end
+
+local function evaluate(check, ok_status, fail_status)
+    local ok, res, reason = pcall(check.fn)
+
+    if not ok then
+        return {
+            status = fail_status,
+            reason = tostring(res),
+            alert_code = check.alert_code,
+        }
+    end
+
+    if res == true then
+        return { status = ok_status }
+    end
+
+    local failed = {
+        status = fail_status,
+        alert_code = check.alert_code,
+    }
+
+    if (res == false or res == nil) and type(reason) == 'string' then
+        failed.reason = reason
+    else
+        failed.reason = 'health check must return true or false, <string>'
+    end
+
+    return failed
+end
+
+local function evaluate_registry(kind, ok_status, fail_status)
+    local res = {}
+    for name, check in pairs(checks[kind]) do
+        res[name] = evaluate(check, ok_status, fail_status)
+    end
+    return res
+end
+
+local function liveness()
+    local registry_checks = evaluate_registry('liveness', 'ok', 'failed')
+
+    local res = {
+        verdict = true,
+        checks = registry_checks,
+    }
+
+    for _, check in pairs(res.checks) do
+        if check.status == 'failed' then
+            res.verdict = false
+        end
+    end
+    return res
+end
+
+local health = {}
+
+function health.liveness_probe(opts)
+    utils.check_param(opts, 'opts', 'table')
+    utils.check_param_table(opts, LIVENESS_PROBE_TYPES)
+    return add_check('liveness', opts.name, opts.check)
+end
+
+function health.remove_liveness_probe(name, opts)
+    return remove_check('liveness', name, opts)
+end
+
+function health.liveness()
+    return liveness()
+end
+
+function health.info()
+    return {
+        liveness = liveness(),
+    }
+end
+
+return health

--- a/src/box/lua/healthcheck.lua
+++ b/src/box/lua/healthcheck.lua
@@ -1,8 +1,144 @@
+local fiber = require('fiber')
 local utils = require('internal.utils')
+
+local function get_config()
+    local config = package.loaded.config
+    if type(config) ~= 'table' or type(config.info) ~= 'function' then
+        return nil
+    end
+    return config
+end
+
+local health_alerts_namespace
+
+local function get_health_alerts_namespace()
+    if health_alerts_namespace == nil then
+        local config = get_config()
+        if config ~= nil and config._aboard ~= nil then
+            health_alerts_namespace = config._aboard:new_namespace('health')
+        end
+    end
+
+    return health_alerts_namespace
+end
+
+local health_checks = {
+    liveness = {
+        alert_prefix = 'Liveness',
+        alerts = {},
+    },
+    readiness = {
+        alert_prefix = 'Readiness',
+        alerts = {},
+    },
+}
+
+-- {{{ Alert helpers
+
+local function alert_key(alert_code)
+    return alert_code:gsub(':', '.')
+end
+
+local function alert_message(kind, name, check)
+    local health_check = health_checks[kind]
+    assert(health_check ~= nil)
+
+    local reason = check.reason or check.status
+
+    return ('%s health check %q failed: %s'):format(health_check.alert_prefix,
+                                                    name, reason)
+end
+
+local function set_alert(kind, name, message, code)
+    assert(health_checks[kind] ~= nil)
+
+    local namespace = get_health_alerts_namespace()
+    if namespace == nil then
+        return
+    end
+
+    local key = alert_key(code)
+    local issued = health_checks[kind].alerts[name]
+
+    if issued ~= nil and issued.message == message and issued.key == key then
+        return
+    end
+
+    if issued ~= nil and issued.key ~= key then
+        namespace:unset(issued.key)
+    end
+
+    namespace:set(key, {
+        message = message,
+        alert_code = code,
+    })
+
+    health_checks[kind].alerts[name] = {
+        key = key,
+        message = message,
+    }
+end
+
+local function unset_alert(kind, name)
+    assert(health_checks[kind] ~= nil)
+
+    local issued = health_checks[kind].alerts[name]
+    if issued == nil then
+        return
+    end
+
+    local namespace = get_health_alerts_namespace()
+    if namespace ~= nil then
+        namespace:unset(issued.key)
+    end
+    health_checks[kind].alerts[name] = nil
+end
+
+local function sync_alerts(kind, results, ok_status)
+    assert(health_checks[kind] ~= nil)
+
+    local failed = {}
+
+    for name, check in pairs(results) do
+        if check.status ~= ok_status then
+            failed[name] = true
+            if check.alert_code ~= nil then
+                set_alert(kind, name, alert_message(kind, name, check),
+                          check.alert_code)
+            end
+        end
+    end
+
+    for name, _ in pairs(health_checks[kind].alerts) do
+        if not failed[name] then
+            unset_alert(kind, name)
+        end
+    end
+end
+
+-- }}} Alert helpers
 
 local checks = {
     liveness = {},
+    readiness = {},
 }
+
+local syncing_alerts = false
+local evaluating_health_checks = false
+
+local function evaluate_health_checks(fn)
+    if evaluating_health_checks then
+        error('recursive health check evaluation is forbidden', 0)
+    end
+
+    evaluating_health_checks = true
+    local ok, res = pcall(fn)
+    evaluating_health_checks = false
+    if not ok then
+        error(res, 0)
+    end
+    return res
+end
 
 local function default_alert_code(kind, name)
     return ('health.%s.%s'):format(kind, name)
@@ -18,6 +154,8 @@ local HEALTHCHECK_OPTION_TYPES = {
 local LIVENESS_PROBE_TYPES = {
     name = 'string',
     check = 'function',
+    alert = 'boolean',
+    alert_code = 'string',
 }
 
 local function add_check(kind, name, fn, opts)
@@ -40,6 +178,7 @@ local function add_check(kind, name, fn, opts)
         registry[name] = {
             fn = fn,
             alert_code = alert_code,
+            status = nil,
         }
     end
 
@@ -57,50 +196,65 @@ local function remove_check(kind, name, opts)
         return false, ('health check %q does not exist'):format(name)
     end
 
+    unset_alert(kind, name)
     registry[name] = nil
 
     return true
 end
 
-local function evaluate(check, ok_status, fail_status)
-    local ok, res, reason = pcall(check.fn)
+local function evaluate(check, ok_status, fail_status, use_degraded)
+    local fn = check.fn
+    local alert_code = check.alert_code
+    local function fail(reason)
+        local status = fail_status
+        if use_degraded and
+           (check.status == ok_status or check.status == 'degraded') then
+            status = 'degraded'
+        end
+        check.status = status
+        return {
+            status = status,
+            reason = reason,
+            alert_code = alert_code,
+        }
+    end
+    local csw = fiber.self():csw()
+    local ok, res, reason = pcall(fn)
 
     if not ok then
-        return {
-            status = fail_status,
-            reason = tostring(res),
-            alert_code = check.alert_code,
-        }
+        return fail(tostring(res))
+    end
+
+    if fiber.self():csw() ~= csw then
+        return fail('health check must not yield')
     end
 
     if res == true then
+        check.status = ok_status
         return { status = ok_status }
     end
 
-    local failed = {
-        status = fail_status,
-        alert_code = check.alert_code,
-    }
-
     if (res == false or res == nil) and type(reason) == 'string' then
-        failed.reason = reason
-    else
-        failed.reason = 'health check must return true or false, <string>'
+        return fail(reason)
     end
 
-    return failed
+    return fail('health check must return true or false, <string>')
 end
 
-local function evaluate_registry(kind, ok_status, fail_status)
+local function evaluate_registry(kind, ok_status, fail_status, skip)
     local res = {}
+    local use_degraded = kind == 'readiness'
     for name, check in pairs(checks[kind]) do
-        res[name] = evaluate(check, ok_status, fail_status)
+        if skip == nil or not skip[name] then
+            res[name] = evaluate(check, ok_status, fail_status, use_degraded)
+        end
     end
     return res
 end
 
 local function liveness()
     local registry_checks = evaluate_registry('liveness', 'ok', 'failed')
+    sync_alerts('liveness', registry_checks, 'ok')
 
     local res = {
         verdict = true,
@@ -115,12 +269,42 @@ local function liveness()
     return res
 end
 
+local function readiness()
+    local registry_checks = evaluate_registry('readiness', 'ready',
+                                              'not_ready')
+    sync_alerts('readiness', registry_checks, 'ready')
+
+    local res = {
+        status = true,
+        checks = registry_checks,
+    }
+
+    for _, check in pairs(res.checks) do
+        if check.status ~= 'ready' then
+            res.status = false
+            break
+        end
+    end
+    return res
+end
+
 local health = {}
+
+function health.add_health_check(name, fn, opts)
+    return add_check('readiness', name, fn, opts)
+end
+
+function health.remove_health_check(name, opts)
+    return remove_check('readiness', name, opts)
+end
 
 function health.liveness_probe(opts)
     utils.check_param(opts, 'opts', 'table')
     utils.check_param_table(opts, LIVENESS_PROBE_TYPES)
-    return add_check('liveness', opts.name, opts.check)
+    return add_check('liveness', opts.name, opts.check, {
+        alert = opts.alert,
+        alert_code = opts.alert_code,
+    })
 end
 
 function health.remove_liveness_probe(name, opts)
@@ -128,13 +312,43 @@ function health.remove_liveness_probe(name, opts)
 end
 
 function health.liveness()
-    return liveness()
+    return evaluate_health_checks(liveness)
+end
+
+function health.readiness()
+    return evaluate_health_checks(readiness)
+end
+
+function health._sync_alerts(opts)
+    if syncing_alerts or evaluating_health_checks then
+        return
+    end
+    syncing_alerts = true
+    opts = opts or {}
+    local ok, err = pcall(function()
+        evaluate_health_checks(function()
+            local liveness_checks = evaluate_registry('liveness', 'ok',
+                                                     'failed')
+            sync_alerts('liveness', liveness_checks, 'ok')
+
+            local readiness_checks = evaluate_registry('readiness', 'ready',
+                                                       'not_ready', opts.skip)
+            sync_alerts('readiness', readiness_checks, 'ready')
+        end)
+    end)
+    syncing_alerts = false
+    if not ok then
+        error(err, 0)
+    end
 end
 
 function health.info()
-    return {
-        liveness = liveness(),
-    }
+    return evaluate_health_checks(function()
+        return {
+            liveness = liveness(),
+            readiness = readiness(),
+        }
+    end)
 end
 
 return health

--- a/src/box/lua/healthcheck_defaults.lua
+++ b/src/box/lua/healthcheck_defaults.lua
@@ -1,0 +1,64 @@
+local health = require('internal.healthcheck')
+
+local function get_config()
+    local config = package.loaded.config
+    if type(config) ~= 'table' or type(config.info) ~= 'function' then
+        return nil
+    end
+    return config
+end
+
+local function add_box_check()
+    health.add_health_check('box', function()
+        if box.info.status == 'running' then
+            return true
+        end
+        return false, box.info.status
+    end, { if_not_exists = true })
+end
+
+local function config_is_initialized(config)
+    return config._status ~= 'uninitialized'
+end
+
+local function add_config_check(config)
+    health.add_health_check('config', function()
+        if type(config._aboard) ~= 'table' then
+            return false, 'config info is not available'
+        end
+
+        local status = config._status
+        local first_error_alert_message
+        for _, alert in ipairs(config._aboard:alerts()) do
+            if alert.type == 'error' then
+                first_error_alert_message = alert.message
+                break
+            end
+        end
+        if status == 'startup_in_progress' then
+            return false, status
+        end
+        return status ~= 'check_errors', first_error_alert_message
+    end, { if_not_exists = true, alert = false })
+end
+
+local function ensure()
+    add_box_check()
+
+    local config = get_config()
+    if config == nil or not config_is_initialized(config) then
+        health.remove_health_check('config', { if_exists = true })
+        return
+    end
+
+    add_config_check(config)
+end
+
+local defaults = {}
+
+function defaults.info()
+    ensure()
+    return health.info()
+end
+
+return defaults

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -804,6 +804,35 @@ error:
 	return 1;
 }
 
+/** Return health check information. */
+static int
+lbox_info_health(struct lua_State *L)
+{
+	/* require('internal.healthcheck').info() */
+	lua_getglobal(L, "require");
+	lua_pushliteral(L, "internal.healthcheck");
+	if (lua_pcall(L, 1, 1, 0) != 0)
+		goto error;
+	/* Stack: health. */
+	lua_getfield(L, -1, "info");
+	/* Stack: health, health.info. */
+	lua_insert(L, -2);
+	/* Stack: health.info, health. */
+	if (lua_pcall(L, 1, 1, 0) != 0)
+		goto error;
+	return 1;
+
+error:
+	/*
+	 * box.info() should keep working even if a Lua part of the
+	 * health implementation is broken.
+	 */
+	lua_newtable(L);
+	lua_insert(L, -2);
+	lua_setfield(L, -2, "error");
+	return 1;
+}
+
 static const struct luaL_Reg lbox_info_dynamic_meta[] = {
 	{"id", lbox_info_id},
 	{"uuid", lbox_info_uuid},
@@ -830,6 +859,7 @@ static const struct luaL_Reg lbox_info_dynamic_meta[] = {
 	{"schema_version", lbox_schema_version},
 	{"hostname", lbox_info_hostname},
 	{"config", lbox_info_config},
+	{"health", lbox_info_health},
 	{NULL, NULL}
 };
 

--- a/src/box/lua/info.c
+++ b/src/box/lua/info.c
@@ -804,13 +804,13 @@ error:
 	return 1;
 }
 
-/** Return health check information. */
+/** Return default health check information. */
 static int
 lbox_info_health(struct lua_State *L)
 {
-	/* require('internal.healthcheck').info() */
+	/* require('internal.healthcheck.defaults').info() */
 	lua_getglobal(L, "require");
-	lua_pushliteral(L, "internal.healthcheck");
+	lua_pushliteral(L, "internal.healthcheck.defaults");
 	if (lua_pcall(L, 1, 1, 0) != 0)
 		goto error;
 	/* Stack: health. */

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -114,6 +114,7 @@ extern char session_lua[],
 	merger_lua[],
 	iproto_lua[],
 	app_threads_lua[],
+	healthcheck_lua[],
 	checks_version_lua[],
 	checks_lua[],
 	backup_lua[],
@@ -338,6 +339,7 @@ static const char * const lua_sources_minimal[] = {
 static const char * const lua_sources_main[] = {
 	"box/session", NULL, session_lua,
 	"box/schema", NULL, schema_lua,
+	"box/healthcheck", "internal.healthcheck", healthcheck_lua,
 #if ENABLE_FEEDBACK_DAEMON
 	/*
 	 * It is important to initialize the daemon before

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -115,6 +115,7 @@ extern char session_lua[],
 	iproto_lua[],
 	app_threads_lua[],
 	healthcheck_lua[],
+	healthcheck_defaults_lua[],
 	checks_version_lua[],
 	checks_lua[],
 	backup_lua[],
@@ -340,6 +341,8 @@ static const char * const lua_sources_main[] = {
 	"box/session", NULL, session_lua,
 	"box/schema", NULL, schema_lua,
 	"box/healthcheck", "internal.healthcheck", healthcheck_lua,
+	"box/healthcheck_defaults", "internal.healthcheck.defaults",
+	healthcheck_defaults_lua,
 #if ENABLE_FEEDBACK_DAEMON
 	/*
 	 * It is important to initialize the daemon before

--- a/test/box-luatest/box_info_health_test.lua
+++ b/test/box-luatest/box_info_health_test.lua
@@ -1,0 +1,73 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group('box_info_health')
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_default_health = function(cg)
+    cg.server:exec(function()
+        local health = box.info.health
+
+        t.assert_equals(health, {
+            liveness = {
+                verdict = true,
+                checks = {},
+            },
+        })
+        t.assert_equals(box.info().health, health)
+    end)
+end
+
+g.test_liveness_probe = function(cg)
+    cg.server:exec(function()
+        local ok, err = box.ctl.liveness_probe({
+            name = 'event-loop',
+            check = function()
+                return nil, 'stalled'
+            end,
+        })
+        t.assert_equals(ok, true)
+        t.assert_equals(err, nil)
+
+        local liveness = box.info.health.liveness
+        t.assert_equals(liveness.verdict, false)
+        t.assert_equals(liveness.checks['event-loop'], {
+            status = 'failed',
+            reason = 'stalled',
+            alert_code = 'health.liveness.event-loop',
+        })
+
+        local health = require('internal.healthcheck')
+        t.assert_equals(health.remove_liveness_probe('event-loop'), true)
+        t.assert_equals(box.info.health.liveness.verdict, true)
+    end)
+end
+
+g.test_liveness_errors_are_isolated = function(cg)
+    cg.server:exec(function()
+        t.assert_equals(box.ctl.liveness_probe({
+            name = 'broken',
+            check = function()
+                error('bad check', 0)
+            end,
+        }), true)
+
+        local info = box.info.health.liveness
+        t.assert_equals(info.verdict, false)
+        t.assert_equals(info.checks.broken.status, 'failed')
+        t.assert_equals(info.checks.broken.alert_code,
+                        'health.liveness.broken')
+        t.assert_str_contains(info.checks.broken.reason, 'bad check')
+
+        local health = require('internal.healthcheck')
+        t.assert_equals(health.remove_liveness_probe('broken'), true)
+    end)
+end

--- a/test/box-luatest/box_info_health_test.lua
+++ b/test/box-luatest/box_info_health_test.lua
@@ -1,4 +1,6 @@
 local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('luatest.cluster')
 local server = require('luatest.server')
 
 local g = t.group('box_info_health')
@@ -16,13 +18,192 @@ g.test_default_health = function(cg)
     cg.server:exec(function()
         local health = box.info.health
 
-        t.assert_equals(health, {
-            liveness = {
-                verdict = true,
-                checks = {},
+        t.assert_equals(health.liveness, {
+            verdict = true,
+            checks = {},
+        })
+        t.assert_equals(health.readiness, {
+            status = true,
+            checks = {
+                box = {
+                    status = 'ready',
+                },
             },
         })
         t.assert_equals(box.info().health, health)
+    end)
+end
+
+g.test_health_with_config = function()
+    local config = cbuilder:new()
+        :use_group('g-001')
+        :use_replicaset('r-001')
+        :add_instance('i-001', {})
+        :config()
+    local cluster_obj = cluster:new(config)
+    cluster_obj:start()
+
+    cluster_obj['i-001']:exec(function()
+        t.assert_equals(box.info.health.readiness.status, true)
+        t.assert_equals(box.info.health.readiness.checks.config, {
+            status = 'ready',
+        })
+        t.assert_equals(box.info.health.readiness.checks.box, {
+            status = 'ready',
+        })
+
+        local health = require('internal.healthcheck')
+        local config = require('config')
+        local saved_status = config._status
+        config._status = 'startup_in_progress'
+        t.assert_equals(box.info.health.readiness.checks.config, {
+            status = 'degraded',
+            reason = 'startup_in_progress',
+        })
+        config._status = saved_status
+        t.assert_equals(box.info.health.readiness.checks.config, {
+            status = 'ready',
+        })
+
+        local call_count = 0
+        t.assert_equals(health.add_health_check('counted', function()
+            call_count = call_count + 1
+            return true
+        end, {alert = false}), true)
+        t.assert_equals(box.info.health.readiness.checks.counted, {
+            status = 'ready',
+        })
+        t.assert_equals(call_count, 1)
+        t.assert_equals(box.info.config.alerts, {})
+        t.assert_equals(call_count, 2)
+        t.assert_equals(health.remove_health_check('counted'), true)
+
+        t.assert_equals(health.add_health_check('app', function()
+            return false, 'warming up'
+        end, {alert_code = 'app.warming_up'}), true)
+        t.assert_equals(box.info.health.readiness.checks.app, {
+            status = 'not_ready',
+            reason = 'warming up',
+            alert_code = 'app.warming_up',
+        })
+        t.assert_equals(#box.info.config.alerts, 1)
+        t.assert_items_include(box.info.config.alerts[1], {
+            type = 'warn',
+            message = 'Readiness health check "app" failed: warming up',
+            alert_code = 'app.warming_up',
+        })
+
+        t.assert_equals(health.remove_health_check('app'), true)
+        t.assert_equals(box.info.health.readiness.status, true)
+        t.assert_equals(box.info.config.alerts, {})
+
+        t.assert_equals(health.add_health_check('app', function()
+            return false, 'starting'
+        end, {alert_code = 'app.starting'}), true)
+        t.assert_equals(#box.info.config.alerts, 1)
+        t.assert_items_include(box.info.config.alerts[1], {
+            type = 'warn',
+            message = 'Readiness health check "app" failed: starting',
+            alert_code = 'app.starting',
+        })
+        t.assert_equals(health.remove_health_check('app'), true)
+        t.assert_equals(box.info.config.alerts, {})
+
+        t.assert_equals(box.ctl.liveness_probe({
+            name = 'watchdog',
+            check = function()
+                return false, 'stopped'
+            end,
+        }), true)
+        t.assert_equals(#box.info.config.alerts, 1)
+        t.assert_items_include(box.info.config.alerts[1], {
+            type = 'warn',
+            message = 'Liveness health check "watchdog" failed: stopped',
+            alert_code = 'health.liveness.watchdog',
+        })
+        t.assert_equals(health.remove_liveness_probe('watchdog'), true)
+        t.assert_equals(box.info.config.alerts, {})
+
+        t.assert_equals(box.ctl.liveness_probe({
+            name = 'unalerted',
+            check = function()
+                return false, 'silent'
+            end,
+            alert = false,
+        }), true)
+        t.assert_equals(box.info.health.liveness.checks.unalerted, {
+            status = 'failed',
+            reason = 'silent',
+        })
+        t.assert_equals(box.info.config.alerts, {})
+        t.assert_equals(health.remove_liveness_probe('unalerted'), true)
+
+        t.assert_equals(box.ctl.liveness_probe({
+            name = 'custom-alert',
+            check = function()
+                return false, 'stalled'
+            end,
+            alert_code = 'app.liveness',
+        }), true)
+        t.assert_equals(#box.info.config.alerts, 1)
+        t.assert_items_include(box.info.config.alerts[1], {
+            type = 'warn',
+            message = 'Liveness health check "custom-alert" failed: stalled',
+            alert_code = 'app.liveness',
+        })
+        t.assert_equals(health.remove_liveness_probe('custom-alert'), true)
+        t.assert_equals(box.info.config.alerts, {})
+
+        t.assert_equals(box.ctl.liveness_probe({
+            name = 'event-loop',
+            check = function()
+                return false, 'stalled'
+            end,
+        }), true)
+        t.assert_equals(box.info.health.liveness.checks['event-loop'], {
+            status = 'failed',
+            reason = 'stalled',
+            alert_code = 'health.liveness.event-loop',
+        })
+        t.assert_equals(#box.info.config.alerts, 1)
+        t.assert_items_include(box.info.config.alerts[1], {
+            type = 'warn',
+            message = 'Liveness health check "event-loop" failed: stalled',
+            alert_code = 'health.liveness.event-loop',
+        })
+
+        t.assert_equals(health.remove_liveness_probe('event-loop'), true)
+        t.assert_equals(box.info.health.liveness.verdict, true)
+        t.assert_equals(box.info.config.alerts, {})
+    end)
+
+    cluster_obj:drop()
+end
+
+g.test_readiness_registry = function(cg)
+    cg.server:exec(function()
+        local health = require('internal.healthcheck')
+
+        t.assert_equals(health.add_health_check('app', function()
+            return false, 'warming up'
+        end), true)
+
+        local info = box.info.health.readiness
+        t.assert_equals(info.status, false)
+        t.assert_equals(info.checks.app, {
+            status = 'not_ready',
+            reason = 'warming up',
+            alert_code = 'health.readiness.app',
+        })
+
+        local ok, err = health.add_health_check('app', function()
+            return true
+        end)
+        t.assert_equals(ok, false)
+        t.assert_str_contains(err, 'already exists')
+
+        t.assert_equals(health.remove_health_check('app'), true)
+        t.assert_equals(box.info.health.readiness.status, true)
     end)
 end
 
@@ -51,23 +232,157 @@ g.test_liveness_probe = function(cg)
     end)
 end
 
-g.test_liveness_errors_are_isolated = function(cg)
+g.test_yielding_check_fails = function(cg)
     cg.server:exec(function()
+        local fiber = require('fiber')
+        local health = require('internal.healthcheck')
+
         t.assert_equals(box.ctl.liveness_probe({
-            name = 'broken',
+            name = 'yielding',
             check = function()
-                error('bad check', 0)
+                fiber.sleep(0)
+                return true
             end,
         }), true)
 
-        local info = box.info.health.liveness
-        t.assert_equals(info.verdict, false)
-        t.assert_equals(info.checks.broken.status, 'failed')
+        local liveness = box.info.health.liveness
+        t.assert_equals(liveness.verdict, false)
+        t.assert_equals(liveness.checks.yielding, {
+            status = 'failed',
+            reason = 'health check must not yield',
+            alert_code = 'health.liveness.yielding',
+        })
+        t.assert_equals(health.remove_liveness_probe('yielding'), true)
+
+        t.assert_equals(health.add_health_check('yielding', function()
+            fiber.sleep(0)
+            return true
+        end), true)
+
+        local readiness = box.info.health.readiness
+        t.assert_equals(readiness.status, false)
+        t.assert_equals(readiness.checks.yielding, {
+            status = 'not_ready',
+            reason = 'health check must not yield',
+            alert_code = 'health.readiness.yielding',
+        })
+        t.assert_equals(health.remove_health_check('yielding'), true)
+    end)
+end
+
+g.test_check_errors_are_isolated = function(cg)
+    cg.server:exec(function()
+        local health = require('internal.healthcheck')
+        t.assert_equals(health.add_health_check('broken', function()
+            error('bad check', 0)
+        end), true)
+
+        local info = box.info.health.readiness
+        t.assert_equals(info.status, false)
+        t.assert_equals(info.checks.broken.status, 'not_ready')
         t.assert_equals(info.checks.broken.alert_code,
-                        'health.liveness.broken')
+                        'health.readiness.broken')
         t.assert_str_contains(info.checks.broken.reason, 'bad check')
 
+        t.assert_equals(health.remove_health_check('broken'), true)
+    end)
+end
+
+g.test_recursive_health_evaluation_is_rejected = function(cg)
+    cg.server:exec(function()
         local health = require('internal.healthcheck')
-        t.assert_equals(health.remove_liveness_probe('broken'), true)
+
+        t.assert_equals(box.ctl.liveness_probe({
+            name = 'recursive',
+            check = function()
+                return health.info().liveness.verdict
+            end,
+        }), true)
+
+        local liveness = box.info.health.liveness
+        t.assert_equals(liveness.verdict, false)
+        t.assert_equals(liveness.checks.recursive.status, 'failed')
+        t.assert_str_contains(liveness.checks.recursive.reason,
+                              'recursive health check evaluation')
+        t.assert_equals(health.remove_liveness_probe('recursive'), true)
+
+        t.assert_equals(health.add_health_check('recursive', function()
+            return health.info().readiness.status
+        end), true)
+
+        local readiness = box.info.health.readiness
+        t.assert_equals(readiness.status, false)
+        t.assert_equals(readiness.checks.recursive.status, 'not_ready')
+        t.assert_str_contains(readiness.checks.recursive.reason,
+                              'recursive health check evaluation')
+        t.assert_equals(health.remove_health_check('recursive'), true)
+
+        local call_count = 0
+        t.assert_equals(health.add_health_check('config-alerts', function()
+            call_count = call_count + 1
+            t.assert_equals(box.info.config.alerts, {})
+            return true
+        end, {alert = false}), true)
+        t.assert_equals(box.info.health.readiness.checks['config-alerts'], {
+            status = 'ready',
+        })
+        t.assert_equals(call_count, 1)
+        t.assert_equals(health.remove_health_check('config-alerts'), true)
+    end)
+end
+
+g.test_readiness_degraded_after_ready = function(cg)
+    cg.server:exec(function()
+        local health = require('internal.healthcheck')
+        local mode = 'ready'
+
+        t.assert_equals(health.add_health_check('flaky', function()
+            if mode == 'ready' then
+                return true
+            end
+            error('lost dependency', 0)
+        end), true)
+
+        local info = box.info.health.readiness
+        t.assert_equals(info.status, true)
+        t.assert_equals(info.checks.flaky, {
+            status = 'ready',
+        })
+
+        mode = 'failed'
+        info = box.info.health.readiness
+        t.assert_equals(info.status, false)
+        t.assert_equals(info.checks.flaky.status, 'degraded')
+        t.assert_equals(info.checks.flaky.alert_code,
+                        'health.readiness.flaky')
+        t.assert_str_contains(info.checks.flaky.reason, 'lost dependency')
+
+        mode = 'ready'
+        info = box.info.health.readiness
+        t.assert_equals(info.status, true)
+        t.assert_equals(info.checks.flaky, {
+            status = 'ready',
+        })
+
+        t.assert_equals(health.remove_health_check('flaky'), true)
+    end)
+end
+
+g.test_invalid_check_result = function(cg)
+    cg.server:exec(function()
+        local health = require('internal.healthcheck')
+        t.assert_equals(health.add_health_check('invalid', function()
+            return nil
+        end), true)
+
+        local info = box.info.health.readiness
+        t.assert_equals(info.status, false)
+        t.assert_equals(info.checks.invalid, {
+            status = 'not_ready',
+            reason = 'health check must return true or false, <string>',
+            alert_code = 'health.readiness.invalid',
+        })
+
+        t.assert_equals(health.remove_health_check('invalid'), true)
     end)
 end

--- a/test/box/info.result
+++ b/test/box/info.result
@@ -82,6 +82,7 @@ t
   - config
   - election
   - gc
+  - health
   - hostname
   - id
   - listen

--- a/test/config-luatest/roles_test.lua
+++ b/test/config-luatest/roles_test.lua
@@ -40,6 +40,48 @@ g.test_single_role_success = function(g)
     })
 end
 
+g.test_role_health_check = function(g)
+    local one = [[
+        return {
+            validate = function() end,
+            apply = function() end,
+            stop = function() end,
+            health_check = function(cfg)
+                return cfg.ready, cfg.reason
+            end,
+        }
+    ]]
+    local verify = function()
+        local check = box.info.health.readiness.checks['role.one']
+        t.assert_equals(check, {
+            status = 'not_ready',
+            reason = 'warming up',
+            alert_code = 'health.readiness.role.one',
+        })
+        t.assert_equals(box.info.health.readiness.status, false)
+        t.assert_equals(#box.info.config.alerts, 1)
+        t.assert_items_include(box.info.config.alerts[1], {
+            type = 'warn',
+            message = 'Readiness health check "role.one" failed: warming up',
+            alert_code = 'health.readiness.role.one',
+        })
+    end
+
+    helpers.success_case(g, {
+        roles = {one = one},
+        options = {
+            ['roles_cfg'] = {
+                one = {
+                    ready = false,
+                    reason = 'warming up',
+                },
+            },
+            ['roles'] = {'one'},
+        },
+        verify = verify,
+    })
+end
+
 -- Make sure the role is loaded only once during each run.
 g.test_role_repeat_success = function(g)
     local one = [[

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -191,6 +191,13 @@ g.test_fixed_masters = function(g)
     exec = 'return vshard.router.internal.static_router.current_cfg'
     t.assert_covers(g.server_5:eval(exec), exp)
 
+    -- Check that vshard router readiness check is registered from config
+    -- roles.
+    exec = "return box.info.health.readiness.checks['vshard.router']"
+    local res = g.server_5:eval(exec)
+    t.assert_equals(res.status, 'not_ready')
+    t.assert_equals(res.alert_code, 'health.readiness.vshard.router')
+
     -- Check that basic sharding works.
     exec = [[
         function put(v)
@@ -235,6 +242,9 @@ g.test_fixed_masters = function(g)
         t.assert_equals(res, {{1, 1}})
         res = g.server_4:eval([[return box.space.a:select()]])
         t.assert_equals(res, {{800, 800}})
+        res = g.server_5:eval(
+            "return box.info.health.readiness.checks['vshard.router']")
+        t.assert_equals(res, {status = 'ready'})
     end)
 
     -- Make sure that the new master is auto-discovered when master is changed.


### PR DESCRIPTION
This patch set introduces a unified `box.info.health` API that exposes the current health status through separate liveness and readiness sections.

---

Doc Request: https://github.com/tarantool/doc/issues/5702

See [RFC](https://confluence.vk.team/pages/viewpage.action?pageId=1941671379)


