### PR TITLE
datetime: fix strptime stack overflow on timezones

### DIFF
--- a/changelogs/unreleased/ghs-146-datetime-strptime-tz-stack-overflow-fix.md
+++ b/changelogs/unreleased/ghs-146-datetime-strptime-tz-stack-overflow-fix.md
@@ -1,0 +1,4 @@
+## bugfix/datetime
+
+* Fixed a stack overflow `strptime()` function when parsing
+  timezones (ghs-146).

--- a/src/lib/tzcode/strptime.c
+++ b/src/lib/tzcode/strptime.c
@@ -117,6 +117,7 @@ tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
 	int year = -1;
 	const char *ptr = fmt;
 	bool week_date = false;
+	char zonestr[TZ_NAME_MAX_LEN + 1];
 
 	static int start_of_month[2][13] = {
 		{ 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 },
@@ -548,21 +549,29 @@ tnt_strptime(const char *__restrict buf, const char *__restrict fmt,
 
 		case 'Z': {
 			const char *cp;
-			char *zonestr;
 
+			/* Timezone name heuristic. */
 			for (cp = buf; *cp && isupper((u_char)*cp); ++cp)
 				/* empty */;
-			if (cp - buf) {
-				zonestr = alloca(cp - buf + 1);
-				strlcpy(zonestr, buf, cp - buf + 1);
+			int len = cp - buf;
+			if (0 < len && len <= TZ_NAME_MAX_LEN) {
+				strlcpy(zonestr, buf, sizeof(zonestr));
 
 				const struct date_time_zone *zone;
-				size_t n = timezone_tm_lookup(zonestr, cp - buf,
+				size_t n = timezone_tm_lookup(zonestr, len,
 							      &zone, tm);
 				if (n <= 0)
 					return NULL;
 
-				buf += cp - buf;
+				buf += len;
+			} else if (len > TZ_NAME_MAX_LEN) {
+				return NULL;
+			} else {
+				/*
+				 * XXX: is it good to ignore absence of
+				 * timezone name? E.g. in "1999" with "%Z%Y".
+				 */
+				assert(len == 0);
 			}
 		} break;
 

--- a/src/lib/tzcode/timezone.c
+++ b/src/lib/tzcode/timezone.c
@@ -44,7 +44,7 @@ compare_zones(const void *a, const void *b)
 static void __attribute__((constructor))
 sort_array(void)
 {
-	size_t i;
+	size_t i, calculated_max_len = 0;
 	/* 1st save zones in id order for stringization */
 	for (i = 0; i < lengthof(zones_raw); i++) {
 		size_t id = zones_raw[i].id;
@@ -52,7 +52,13 @@ sort_array(void)
 		/* save to unsorted array if it's not an alias */
 		if ((zones_raw[i].flags & TZ_ALIAS) == 0)
 			zones_unsorted[id] = zones_raw[i];
+		/* Collect maximum name length. */
+		size_t name_len = strlen(zones_raw[i].name);
+		if (calculated_max_len < name_len)
+			calculated_max_len = name_len;
 	}
+	/* Check estimated maximum length. */
+	assert(calculated_max_len <= TZ_NAME_MAX_LEN);
 	/* 2nd copy raw to be sorted and prepare them for bsearch */
 	assert(sizeof(zones_sorted) == sizeof(zones_raw));
 	memcpy(zones_sorted, zones_raw, sizeof(zones_raw));
@@ -238,3 +244,13 @@ timezone_tzindex_lookup(int16_t tzindex, struct tnt_tm *tm)
 		return false;
 	return true;
 }
+
+int
+date_time_zone_snprint(char *buf, int len, struct date_time_zone *z)
+{
+	if (z == NULL)
+		return snprintf(buf, len, "<NULL>");
+	return snprintf(buf, len, "{name:\"%s\", id:%" PRId16
+		", flags:0x%" PRIX16 ", offset:%" PRId16 "}",
+		z->name, z->id, z->flags, z->offset);
+};

--- a/src/lib/tzcode/timezone.h
+++ b/src/lib/tzcode/timezone.h
@@ -24,6 +24,8 @@ enum {
 	TZ_DST = 0x80,
 
 	TZ_ERROR_MASK = TZ_AMBIGUOUS | TZ_NYI,
+
+	TZ_NAME_MAX_LEN = 64,
 };
 
 /**
@@ -90,6 +92,10 @@ timezone_isdst(const struct date_time_zone *zone);
 /** Translate tzindex to zone name */
 const char*
 timezone_name(int64_t index);
+
+/** JSON-like printer for @sa date_time_zone struct. */
+int
+date_time_zone_snprint(char *buf, int len, struct date_time_zone *z);
 
 #ifdef __cplusplus
 }

--- a/test/app-luatest/datetime_test.lua
+++ b/test/app-luatest/datetime_test.lua
@@ -2707,3 +2707,33 @@ g_fail_time_units.test_set = function(cg)
 end
 
 -- }}} new() and set() invalid args test.
+
+-- {{{ ghs-146 stack overflow test.
+
+local g_ghs_146_stack_overflow = t.group('ghs_146_stack_overflow')
+
+g_ghs_146_stack_overflow.test_too_long_zone_like_str = function()
+    -- The number was selected empirically to be large enough to trigger stack
+    -- overflow and to be not so large to broke the test due to any resource
+    -- limitation.
+    local n = 10 * 1024 * 1024
+    -- The pattern must be accepted by strptime() heuristic for '%Z'.
+    local buf = string.rep('Z', n)
+    local fmt = '%Z'
+    t.assert_error(function() dt.parse(buf, {format = fmt}) end)
+end
+
+g_ghs_146_stack_overflow.test_many_zones_pollutes_stack = function()
+    -- The number was selected empirically to be large enough to trigger stack
+    -- overflow and to be not so large to broke the test due to any resource
+    -- limitation. Also lesser n reduces test execution time.
+    local n = 50 * 1024
+    local buf = string.rep('HOVDST ', n)
+    local fmt = string.rep('%Z ', n)
+    -- Protect test log from pollution with too long message if any error
+    -- occurs (see gh-12715).
+    local ok, _ = pcall(function() dt.parse(buf, {format = fmt}) end)
+    t.assert(ok, 'expect success')
+end
+
+-- }}} ghs-146 stack overflow test.


### PR DESCRIPTION
Fixed `strptime()` function stack overflow when parsing timezones.

Fixes tarantool/security#146

NO_DOC=bugfix
