### PR TITLE
uri: fix a crash due to long URI in uri.format()

### DIFF
--- a/changelogs/unreleased/ghs-151-uri.format-use-after-poison.md
+++ b/changelogs/unreleased/ghs-151-uri.format-use-after-poison.md
@@ -1,0 +1,4 @@
+## bugfix/uri
+
+* Fixed a Use-After-Poison crash in uri.format() caused by a long
+  URI (ghs-151).

--- a/src/lua/uri.lua
+++ b/src/lua/uri.lua
@@ -46,7 +46,7 @@ void
 uri_set_destroy(struct uri_set *uri_set);
 
 int
-uri_format(char *str, size_t len, struct uri *uri, bool write_password);
+uri_format(char *str, int len, struct uri *uri, bool write_password);
 
 size_t
 uri_escape(const char *src, size_t src_size, char *dst,
@@ -250,9 +250,15 @@ local function format(uri, write_password)
     end
     fill_uribuf_params(uribuf, uri)
     local ibuf = cord_ibuf_take()
-    local str = ibuf:alloc(1024)
-    local len = builtin.uri_format(str, 1024, uribuf,
-                                   write_password and 1 or 0)
+    local default_len = 1024
+    local str = ibuf:alloc(default_len)
+    local write_sensitive = write_password and 1 or 0
+    local len = builtin.uri_format(str, default_len, uribuf, write_sensitive)
+    if len >= default_len then
+        ibuf:reset()
+        str = ibuf:alloc(len + 1)
+        len = builtin.uri_format(str, len + 1, uribuf, write_sensitive)
+    end
     uri_stash_put(uribuf)
     str = ffi.string(str, len)
     cord_ibuf_put(ibuf)

--- a/test/app-tap/uri.test.lua
+++ b/test/app-tap/uri.test.lua
@@ -97,7 +97,7 @@ local function test_parse(test)
 end
 
 local function test_format(test)
-    test:plan(14)
+    test:plan(20)
     local u = uri.parse("user:password@localhost")
     test:is(uri.format(u), "user@localhost", "password removed")
     test:is(uri.format(u, false), "user@localhost", "password removed")
@@ -158,6 +158,16 @@ local function test_format(test)
 
     test:is(uri.format{host = "unix/", service = "/tmp/unix.sock"},
             "unix/:/tmp/unix.sock", "URI format")
+
+    -- Check URI format with default length and boundaries.
+    local lens = { 1023, 1024, 1025 }
+    for _, len in ipairs(lens) do
+        local path = string.rep("x", len)
+        local url = uri.format({path = path})
+        local msg = ("format URI with length == %d"):format(len)
+        test:is(#url, #path, msg .. ", check length")
+        test:is(url, path,  msg .. ", check result")
+    end
 end
 
 local function test_parse_uri_query_params(test)

--- a/test/fuzz/lua/CMakeLists.txt
+++ b/test/fuzz/lua/CMakeLists.txt
@@ -57,8 +57,6 @@ LIST(APPEND BROKEN_LUZER_TESTS
   box_execute_test.lua
   # To be enabled in scope tarantool/tarantool#11898.
   json_decode_test.lua
-  # To be enabled in scope tarantool/security#151.
-  uri_parse_test.lua
   # To be enabled in scope tarantool/tarantool#12063.
   pickle_unpack_test.lua
   # To be enabled in scope tarantool/security#153.


### PR DESCRIPTION
The function `uri.format()` create a Lua string using `ffi.string()` with a length greater than a length of the passed buffer, this will lead to crash under AddressSanitizer due to use-after-poison. The patch fixes the aforementioned problem. First time the function `builtin.uri_format()` is calling with default length (1024) and if returned length is greater than default length, then `builtin.uri_format()` is called second time.

The patch also fixes a wrong type in an FFI function declaration.

Fixes tarantool/security#151

NO_DOC=bugfix