### PR TITLE
Fix bugs in SQL built-in functions

### DIFF
--- a/changelogs/unreleased/ghs-160-segfault-in-replace.md
+++ b/changelogs/unreleased/ghs-160-segfault-in-replace.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Fixed a segfault in the SQL built-in function REPLACE (ghs-160).

--- a/changelogs/unreleased/ghs-161-integer-overflow-in-printf.md
+++ b/changelogs/unreleased/ghs-161-integer-overflow-in-printf.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Fixed an integer overflow in the SQL built-in function PRINTF (ghs-161).

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -1644,8 +1644,11 @@ replaceFunc(struct sql_context *context, int argc, const struct Mem *argv)
 	nStr = argv[0].n;
 	zPattern = (const unsigned char *)argv[1].z;
 	nPattern = argv[1].n;
-	if (nPattern == 0) {
-		if (mem_copy(context->pOut, &argv[0]) != 0)
+	if (nPattern == 0 || nPattern > nStr) {
+		/* Copy string if it is not empty. */
+		if (nStr == 0)
+			mem_set_str_static(context->pOut, "", 0);
+		else if (mem_copy(context->pOut, &argv[0]) != 0)
 			context->is_aborted = true;
 		return;
 	}

--- a/src/box/sql/printf.c
+++ b/src/box/sql/printf.c
@@ -289,10 +289,19 @@ sqlVXPrintf(StrAccum * pAccum,	/* Accumulate results here */
 		} else {
 			unsigned wx = 0;
 			while (c >= '0' && c <= '9') {
-				wx = wx * 10 + c - '0';
+				/*
+				 * If we know that we will get a value greater
+				 * than SQL_MAX_LENGTH, we replace it with
+				 * SQL_MAX_LENGTH + 1. This is done to prevent
+				 * integer overflow.
+				 */
+				if (wx > 0 && SQL_MAX_LENGTH / wx < 10)
+					wx = SQL_MAX_LENGTH + 1;
+				else
+					wx = wx * 10 + c - '0';
 				c = *++fmt;
 			}
-			width = wx & 0x7fffffff;
+			width = wx;
 		}
 		assert(width >= 0);
 

--- a/test/sql-luatest/builtin_test.lua
+++ b/test/sql-luatest/builtin_test.lua
@@ -24,3 +24,15 @@ g.test_segfault_in_replace = function(cg)
         t.assert_equals(res.rows, {{'a'}})
     end)
 end
+
+--
+-- ghs-161: The PRINTF built-in function could have an integer overflow.
+--
+g.test_integer_overflow_in_printf = function(cg)
+    cg.server:exec(function()
+        local exp = "Failed to execute SQL statement: string or blob too big"
+        local sql = [[SELECT LENGTH(PRINTF('%2200000000s', 'a'));]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, exp)
+    end)
+end

--- a/test/sql-luatest/builtin_test.lua
+++ b/test/sql-luatest/builtin_test.lua
@@ -1,0 +1,26 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--
+-- ghs-160: The built-in REPLACE function threw a segmentation fault if
+-- the length of the first argument was less than the length of the second.
+--
+g.test_segfault_in_replace = function(cg)
+    cg.server:exec(function()
+        local res = box.execute([[SELECT REPLACE('', 'ab', 'xy');]])
+        t.assert_equals(res.rows, {{''}})
+        res = box.execute([[SELECT REPLACE('a', 'ab', 'xy');]])
+        t.assert_equals(res.rows, {{'a'}})
+    end)
+end


### PR DESCRIPTION
This patch fixes segfault in REPLACE() and integer overflow in PRINTF().

Closes tarantool/security#160
Closes tarantool/security#161