### PR TITLE
sql: remove ON CONFLICT clause for NULL

### DIFF
--- a/changelogs/unreleased/gh-12701-remove-on-conflict-for-null.md
+++ b/changelogs/unreleased/gh-12701-remove-on-conflict-for-null.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Removed the non-working ON CONFLICT clause for the NULL property
+  in column definitions within CREATE TABLE statements (gh-12701).

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -309,11 +309,8 @@ ccons ::= DEFAULT MINUS(A) number(X). {
 // In addition to the type name, we also care about the primary key and
 // UNIQUE constraints.
 //
-ccons ::= NULL onconf(R).        {
+ccons ::= NULL.        {
     sql_column_add_nullable_action(pParse, ON_CONFLICT_ACTION_NONE);
-    /* Trigger nullability mismatch error if required. */
-    if (R != ON_CONFLICT_ACTION_ABORT)
-        sql_column_add_nullable_action(pParse, R);
 }
 ccons ::= NOT NULL onconf(R).    {sql_column_add_nullable_action(pParse, R);}
 ccons ::= cconsname(N) PRIMARY KEY sortorder(Z). {

--- a/test/sql-luatest/create_table_test.lua
+++ b/test/sql-luatest/create_table_test.lua
@@ -120,6 +120,20 @@ g.test_duplicate_function = function(cg)
     end)
 end
 
+--
+-- gh-12701: remove the non-working ON CONFLICT clause for the NULL property
+-- in the column definition in the CREATE TABLE statement.
+--
+g.test_12701_remove_on_conflict_for_null = function(cg)
+    cg.server:exec(function()
+        local sql = [[
+            CREATE TABLE t(i INT PRIMARY KEY, a INT NULL ON CONFLICT ABORT);
+        ]]
+        local _, err = box.execute(sql)
+        t.assert_str_contains(err.message, "keyword 'ON' is reserved.")
+    end)
+end
+
 g = t.group("drop_table", {{engine = 'memtx'}, {engine = 'vinyl'}})
 
 g.before_all(function(cg)

--- a/test/sql-luatest/primary_key_test.lua
+++ b/test/sql-luatest/primary_key_test.lua
@@ -105,14 +105,6 @@ g.test_3473_primary_key_not_declared_null = function(cg)
         _, err = box.execute("CREATE TABLE te17 (s1 INT NULL PRIMARY KEY);")
         t.assert_equals(tostring(err), exp_err)
 
-        exp_err = "Failed to execute SQL statement: "..
-                  "NULL declaration for column 'b' of table 'test' "..
-                  "has been already set to 'none'"
-        sql = "CREATE TABLE test (a int PRIMARY KEY, "..
-              "b int NULL ON CONFLICT IGNORE);"
-        _, err = box.execute(sql)
-        t.assert_equals(tostring(err), exp_err)
-
         exp_err = "Primary index of space 'test' can not contain nullable parts"
         sql = "CREATE TABLE test (a int, b int NULL, "..
               "c int, PRIMARY KEY(a, b, c));"


### PR DESCRIPTION
This patch removes the ON CONFLICT clause for the NULL property in the CREATE TABLE command. This feature is currently non-working, and there's no point in adding this clause to a property that effectively eliminates conflicts when inserting NULL values.

Closes #12701

NO_DOC=this feature seems to be undocumented