### PR TITLE
box: rotate and put xlogs into backup

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -106,6 +106,7 @@
 #include "tweaks.h"
 #include "memtx_tx.h"
 #include "coll_id_cache.h"
+#include "latch.h"
 
 static char status[64] = "unconfigured";
 
@@ -153,6 +154,8 @@ waiting_for_own_rows_trigger
  * If there is no in-progress backup, is set to NULL.
  */
 static struct gc_checkpoint_ref *backup_gc;
+
+static struct latch backup_latch = LATCH_INITIALIZER(backup_latch);
 
 bool box_read_ffi_is_disabled;
 
@@ -6072,31 +6075,49 @@ box_backup_start(int checkpoint_idx, box_backup_cb cb, void *cb_arg)
 		diag_set(ClientError, ER_BACKUP_IN_PROGRESS);
 		return -1;
 	}
+	latch_lock(&backup_latch);
 	struct gc_checkpoint *checkpoint;
+	int i = 0;
 	gc_foreach_checkpoint_reverse(checkpoint) {
-		if (checkpoint_idx-- == 0)
+		if (i++ == checkpoint_idx)
 			break;
 	}
-	if (checkpoint_idx >= 0) {
+	if (i <= checkpoint_idx) {
 		diag_set(ClientError, ER_MISSING_SNAPSHOT);
+		latch_unlock(&backup_latch);
 		return -1;
 	}
 	backup_gc = gc_ref_checkpoint(checkpoint, "backup");
-	int rc = engine_backup(&checkpoint->vclock, cb, cb_arg);
-	if (rc != 0) {
-		gc_unref_checkpoint(backup_gc);
-		backup_gc = NULL;
+	if (checkpoint_idx == 0) {
+		struct box_checkpoint box_ckpt;
+		if (box_checkpoint_build_for_journal(&box_ckpt) != 0)
+			goto error;
+		if (engine_backup(&checkpoint->vclock, cb, cb_arg) != 0)
+			goto error;
+		wal_backup(&checkpoint->vclock, &box_ckpt.journal.vclock,
+			   cb, cb_arg);
+	} else {
+		if (engine_backup(&checkpoint->vclock, cb, cb_arg) != 0)
+			goto error;
 	}
-	return rc;
+	latch_unlock(&backup_latch);
+	return 0;
+error:
+	gc_unref_checkpoint(backup_gc);
+	backup_gc = NULL;
+	latch_unlock(&backup_latch);
+	return -1;
 }
 
 void
 box_backup_stop(void)
 {
+	latch_lock(&backup_latch);
 	if (backup_gc != NULL) {
 		gc_unref_checkpoint(backup_gc);
 		backup_gc = NULL;
 	}
+	latch_unlock(&backup_latch);
 }
 
 API_EXPORT const char *

--- a/src/box/checkpoint.c
+++ b/src/box/checkpoint.c
@@ -124,14 +124,21 @@ txn_checkpoint_build(struct box_checkpoint *out, bool do_journal_rotation)
 	 * committed. Lets make sure they are, so the checkpoint won't have any
 	 * rolled back data.
 	 */
+	double deadline = fiber_clock() + replication_synchro_timeout;
 	while (!ctx.is_rollback && !ctx.is_commit) {
 		if (fiber_is_cancelled()) {
-			trigger_clear(&on_commit);
-			trigger_clear(&on_rollback);
 			diag_set(FiberIsCancelled);
-			return -1;
+			break;
 		}
-		fiber_yield();
+		if (fiber_yield_deadline(deadline)) {
+			diag_set(TimedOut);
+			break;
+		}
+	}
+	if (!ctx.is_rollback && !ctx.is_commit) {
+		trigger_clear(&on_commit);
+		trigger_clear(&on_rollback);
+		return -1;
 	}
 	if (ctx.is_rollback) {
 		diag_set(ClientError, ER_SYNC_ROLLBACK);
@@ -183,3 +190,9 @@ box_checkpoint_build_from_snapshot(struct box_checkpoint *out,
 	return -1;
 }
 #endif
+
+int
+box_checkpoint_build_for_journal(struct box_checkpoint *out)
+{
+	return txn_checkpoint_build(out, true /* do journal rotation */);
+}

--- a/src/box/checkpoint.h
+++ b/src/box/checkpoint.h
@@ -62,6 +62,13 @@ int
 box_checkpoint_build_from_snapshot(struct box_checkpoint *out,
 				   const struct vclock *vclock);
 
+/**
+ * Creates checkpoint in journal - the journal is rotated and prepared txns
+ * written into rotated journal are committed.
+ */
+int
+box_checkpoint_build_for_journal(struct box_checkpoint *out);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -997,6 +997,74 @@ wal_collect_garbage(const struct vclock *vclock)
 		  wal_collect_garbage_f);
 }
 
+/** Message to exchange data between TX and WAL threads on backup. */
+struct wal_backup_msg {
+	/** Base struct. */
+	struct cbus_call_msg base;
+	/** vclock of the first xlog in backup. */
+	const struct vclock *begin_vclock;
+	/** vclock of the last (exclusive) xlog in backup. */
+	const struct vclock *end_vclock;
+	/** xlog filenames in backup. Each name is allocated on heap. */
+	char **filenames;
+	/** Filenames count. */
+	int filename_count;
+};
+
+/** Backup done in WAL thread. */
+static int
+wal_backup_f(struct cbus_call_msg *data)
+{
+	struct wal_writer *writer = &wal_writer_singleton;
+	struct wal_backup_msg *msg = (struct wal_backup_msg *)data;
+	enum {
+#ifdef NDEBUG
+		START_ARRAY_CAPACITY = 16,
+#else
+		START_ARRAY_CAPACITY = 1,
+#endif
+	};
+	int capacity = START_ARRAY_CAPACITY;
+	int count = 0;
+	char **filenames = xmalloc(sizeof(char *) * capacity);
+	for (struct vclock *vclock = vclockset_first(&writer->wal_dir.index);
+	     vclock != NULL;
+	     vclock = vclockset_next(&writer->wal_dir.index, vclock)) {
+		if (vclock_compare(vclock, msg->begin_vclock) < 0)
+			continue;
+		if (vclock_compare(vclock, msg->end_vclock) >= 0)
+			break;
+		const char *filename = xdir_format_filename(
+					&writer->wal_dir, vclock_sum(vclock));
+		if (count >= capacity) {
+			capacity *= 2;
+			filenames = xrealloc(
+					filenames, sizeof(char *) * capacity);
+		}
+		filenames[count++] = xstrdup(filename);
+	}
+	msg->filenames = filenames;
+	msg->filename_count = count;
+	return 0;
+}
+
+void
+wal_backup(const struct vclock *begin_vclock, const struct vclock *end_vclock,
+	   wal_backup_cb cb, void *cb_arg)
+{
+	struct wal_writer *writer = &wal_writer_singleton;
+	struct wal_backup_msg msg;
+	msg.begin_vclock = begin_vclock;
+	msg.end_vclock = end_vclock;
+	cbus_call(&writer->wal_pipe, &writer->tx_prio_pipe, &msg.base,
+		  wal_backup_f);
+	for (int i = 0; i < msg.filename_count; i++) {
+		cb(msg.filenames[i], cb_arg);
+		free(msg.filenames[i]);
+	}
+	free(msg.filenames);
+}
+
 static void
 wal_notify_watchers(struct wal_writer *writer, unsigned events);
 

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -41,6 +41,12 @@ struct fiber;
 struct wal_writer;
 struct tt_uuid;
 
+/**
+ * Callback called by wal_backup().
+ */
+typedef int
+(*wal_backup_cb)(const char *path, void *arg);
+
 enum wal_mode {
 	/**
 	 * Do not write data at all.
@@ -236,6 +242,13 @@ wal_get_retention_vclock(struct vclock *vclock);
  */
 void
 wal_collect_garbage(const struct vclock *vclock);
+
+/**
+ * Backup up WAL. Calls @cb on every xlog from @begin_vclock to @end_vclock.
+ */
+void
+wal_backup(const struct vclock *begin_vclock, const struct vclock *end_vclock,
+	   wal_backup_cb cb, void *cb_arg);
 
 void
 wal_init_vy_log(void);

--- a/test/box-luatest/backup_test.lua
+++ b/test/box-luatest/backup_test.lua
@@ -1,0 +1,389 @@
+local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
+local fio = require('fio')
+local t = require('luatest')
+
+local g = t.group()
+
+g.after_each(function(cg)
+    if cg.server ~= nil then
+        cg.server:drop()
+    end
+    if cg.backup_dir ~= nil then
+        fio.rmtree(cg.backup_dir)
+    end
+end)
+
+local backup = function(cg, files)
+    if cg.backup_dir ~= nil then
+        fio.rmtree(cg.backup_dir)
+    end
+    cg.backup_dir = fio.tempdir()
+    for _, file in ipairs(files) do
+        local path_src = fio.pathjoin(cg.server.workdir, file)
+        local path_dst = fio.pathjoin(cg.backup_dir, file)
+        fio.copyfile(path_src, path_dst)
+    end
+end
+
+local restore = function(cg)
+    assert(cg.backup_dir)
+    fio.rmtree(cg.server.workdir)
+    fio.mkdir(cg.server.workdir)
+    fio.copytree(cg.backup_dir, cg.server.workdir)
+    fio.rmtree(cg.backup_dir)
+    cg.backup_dir = nil
+end
+
+g.test_backup_rotated_xlog = function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    local files = cg.server:exec(function()
+        box.cfg{}
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+        for i = 1, 10 do
+            s:insert({i})
+        end
+        box.snapshot()
+        for i = 11, 20 do
+            s:insert({i})
+        end
+        local files = box.backup.start()
+        for i = 21, 30 do
+            s:insert({i})
+        end
+        return files
+    end)
+    t.assert_equals(#files, 2)
+    backup(cg, files)
+    cg.server:exec(function()
+        local s = box.space.test
+        box.backup.stop()
+        for i = 31, 40 do
+            s:insert({i})
+        end
+    end)
+    cg.server:stop()
+    restore(cg)
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.space.test
+        local expected = {}
+        for i = 1, 20 do
+            table.insert(expected, {i})
+        end
+        t.assert_equals(s:select(), expected)
+    end)
+end
+
+g.test_backup_many_xlogs = function(cg)
+    cg.server = server:new({box_cfg = {wal_max_size = 16384}})
+    cg.server:start()
+    local files = cg.server:exec(function()
+        local digest = require('digest')
+
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+        for i = 1, 10 do
+            s:insert({i})
+        end
+        box.snapshot()
+        for i = 11, 20 do
+            s:insert({i, digest.urandom(16384)})
+        end
+        local files = box.backup.start()
+        for i = 21, 30 do
+            s:insert({i, digest.urandom(16384)})
+        end
+        return files
+    end)
+    t.assert_equals(#files, 11)
+    backup(cg, files)
+    cg.server:stop()
+    restore(cg)
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.space.test
+        t.assert_equals(s:count(), 20)
+    end)
+end
+
+g.test_backup_no_xlogs = function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    local files = cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+        for i = 1, 10 do
+            s:insert({i})
+        end
+        box.snapshot()
+        local files = box.backup.start()
+        for i = 11, 20 do
+            s:insert({i})
+        end
+        return files
+    end)
+    t.assert_equals(#files, 1)
+    backup(cg, files)
+    cg.server:stop()
+    restore(cg)
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.space.test
+        t.assert_equals(s:count(), 10)
+    end)
+end
+
+g.test_backup_xlogs_pinned = function(cg)
+    cg.server = server:new({box_cfg = {checkpoint_count = 1}})
+    cg.server:start()
+    local files = cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+        for i = 1, 10 do
+            s:insert({i})
+        end
+        box.snapshot()
+        for i = 11, 20 do
+            s:insert({i})
+        end
+        local files = box.backup.start()
+        box.snapshot()
+        return files
+    end)
+    t.assert_equals(#files, 2)
+    for _, file in ipairs(files) do
+        local path = fio.pathjoin(g.server.workdir, file)
+        t.assert(fio.path.exists(path))
+    end
+    backup(cg, files)
+    cg.server:stop()
+    restore(cg)
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.space.test
+        t.assert_equals(s:count(), 20)
+    end)
+end
+
+local g1 = t.group('replication')
+
+g1.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.replica_set = replica_set:new({})
+    local uris = {}
+    for i = 1, 3 do
+        uris[i] = server.build_listen_uri('replica' .. i, cg.replica_set.id)
+    end
+    local box_cfg = {
+        replication_synchro_quorum = 2,
+        election_mode = 'manual',
+        replication = uris,
+        election_timeout = 1000,
+    }
+    for i = 1, 3 do
+        cg.replica_set:build_and_add_server({
+            alias = 'replica' .. i, box_cfg = box_cfg
+        })
+    end
+    cg.replica_set:start()
+    local replica1 = cg.replica_set:get_server('replica1')
+    cg.replication_synchro_timeout_default = replica1:exec(function()
+        return box.cfg.replication_synchro_timeout
+    end)
+end)
+
+g1.after_all(function(cg)
+    cg.replica_set:drop()
+end)
+
+g1.before_each(function(cg)
+    cg.replica_set:wait_for_fullmesh()
+end)
+
+g1.after_each(function(cg)
+    local replica1 = cg.replica_set:get_server('replica1')
+    replica1:exec(function(timeout)
+        box.cfg{replication_synchro_timeout = timeout}
+        box.ctl.promote()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end, cg.replication_synchro_timeout)
+end)
+
+g1.after_test('test_backup_replication_commited_master', function(cg)
+    local replica1 = cg.replica_set:get_server('replica1')
+    replica1:exec(function()
+        box.error.injection.set('ERRINJ_RELAY_SEND_DELAY', false)
+        box.backup.stop()
+    end)
+end)
+
+g1.test_backup_replication_commited_master = function(cg)
+    local replica1 = cg.replica_set:get_server('replica1')
+    local replica2 = cg.replica_set:get_server('replica2')
+    replica1:exec(function()
+        local fiber = require('fiber')
+
+        box.ctl.promote()
+        local s = box.schema.create_space('test', {is_sync = true})
+        s:create_index('pk')
+        s:insert({1})
+        box.error.injection.set('ERRINJ_RELAY_SEND_DELAY', true)
+        box.cfg{replication_synchro_timeout = 1000}
+        local f = fiber.new(function()
+            local f = fiber.new(function()
+                box.backup.start()
+            end)
+            f:set_joinable(true)
+            rawset(_G, 'backup_fiber', f)
+            s:insert({2})
+        end)
+        f:set_joinable(true)
+        rawset(_G, 'dml_fiber', f)
+        fiber.yield()
+    end)
+    replica2:exec(function()
+        box.ctl.promote()
+    end)
+    replica1:exec(function()
+        local join_err = function(f)
+            local ok, err = f:join()
+            if not ok then
+                error(err)
+            end
+            return true
+        end
+        local f = rawget(_G, 'dml_fiber')
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.SYNC_ROLLBACK,
+        }, join_err, f)
+        local f = rawget(_G, 'backup_fiber')
+        t.assert_error_covers({
+            type = 'ClientError',
+            code = box.error.SYNC_ROLLBACK,
+        }, join_err, f)
+    end)
+end
+
+g1.after_test('test_backup_replication_timeout', function(cg)
+    local replica1 = cg.replica_set:get_server('replica1')
+    replica1:exec(function()
+        local compat = require('compat')
+        compat.replication_synchro_timeout = 'default'
+        box.error.injection.set('ERRINJ_RELAY_SEND_DELAY', false)
+        box.backup.stop()
+    end)
+end)
+
+g1.test_backup_replication_timeout = function(cg)
+    local replica1 = cg.replica_set:get_server('replica1')
+    replica1:exec(function()
+        local fiber = require('fiber')
+        local compat = require('compat')
+
+        box.ctl.promote()
+        local s = box.schema.create_space('test', {is_sync = true})
+        s:create_index('pk')
+        s:insert({1})
+        box.cfg{replication_synchro_timeout = 1}
+        box.error.injection.set('ERRINJ_RELAY_SEND_DELAY', true)
+        compat.replication_synchro_timeout = 'new'
+        local f = fiber.new(function()
+            box.backup.start()
+        end)
+        f:set_joinable(true)
+        fiber.create(function()
+            s:insert({2})
+        end)
+        local ok, err = f:join()
+        t.assert_not(ok)
+        t.assert_covers(err:unpack(), {type = 'TimedOut'})
+    end)
+end
+
+g1.after_test('test_backup_replication_commited_replica', function(cg)
+    local replica1 = cg.replica_set:get_server('replica1')
+    local replica2 = cg.replica_set:get_server('replica2')
+    replica1:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', -1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end)
+    replica2:exec(function()
+        box.backup.stop()
+    end)
+end)
+
+-- Make sure we got committed xlog even is backup is done on replica.
+g1.test_backup_replication_commited_replica = function(cg)
+    local replica1 = cg.replica_set:get_server('replica1')
+    local replica2 = cg.replica_set:get_server('replica2')
+    replica1:exec(function()
+        local fiber = require('fiber')
+
+        box.ctl.promote()
+        local s = box.schema.create_space('test', {is_sync = true})
+        s:create_index('pk')
+        s:insert({1})
+        fiber.create(function()
+            -- Delay writing IPROTO_RAFT_CONFIRM.
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 1)
+            s:insert({2})
+        end)
+        local lsn = box.info.lsn
+        -- Wait INSERT is written to WAL.
+        t.helpers.retrying({}, function()
+            t.assert_equals(box.info.lsn, lsn + 1)
+        end)
+    end)
+    -- Wait INSERT is written to WAL of replica.
+    replica2:wait_for_vclock_of(replica1)
+    replica2:exec(function()
+        t.assert_error_covers({
+            type = 'TimedOut',
+        }, box.backup.start)
+    end)
+end
+
+g1.after_test('test_backup_concurrent_stop', function(cg)
+    local replica1 = cg.replica_set:get_server('replica1')
+    replica1:exec(function()
+        local compat = require('compat')
+        compat.replication_synchro_timeout = 'default'
+        box.error.injection.set('ERRINJ_RELAY_SEND_DELAY', false)
+        box.backup.stop()
+    end)
+end)
+
+g1.test_backup_concurrent_stop = function(cg)
+    local replica1 = cg.replica_set:get_server('replica1')
+    replica1:exec(function()
+        local fiber = require('fiber')
+        local compat = require('compat')
+
+        box.ctl.promote()
+        local s = box.schema.create_space('test', {is_sync = true})
+        s:create_index('pk')
+        s:insert({1})
+        box.cfg{replication_synchro_timeout = 1}
+        box.error.injection.set('ERRINJ_RELAY_SEND_DELAY', true)
+        compat.replication_synchro_timeout = 'new'
+        local f = fiber.new(function()
+            fiber.new(function()
+                box.backup.stop()
+            end)
+            box.backup.start()
+        end)
+        f:set_joinable(true)
+        fiber.create(function()
+            s:insert({2})
+        end)
+        local ok, err = f:join()
+        t.assert_not(ok)
+        t.assert_covers(err:unpack(), {type = 'TimedOut'})
+    end)
+end

--- a/test/box/backup.result
+++ b/test/box/backup.result
@@ -130,15 +130,15 @@ _ = test_run:cmd('switch copy1')
 ...
 box.space.memtx:select()
 ---
-- - [1, 'memtx1', 1]
-  - [2, 'memtx2', 1]
-  - [3, 'memtx3', 1]
+- - [1, 'memtx1', 2]
+  - [2, 'memtx2', 2]
+  - [3, 'memtx3', 2]
 ...
 box.space.vinyl:select()
 ---
-- - [1, 'vinyl1', 1]
-  - [2, 'vinyl2', 1]
-  - [3, 'vinyl3', 1]
+- - [1, 'vinyl1', 2]
+  - [2, 'vinyl2', 2]
+  - [3, 'vinyl3', 2]
 ...
 _ = test_run:cmd('switch default')
 ---


### PR DESCRIPTION
If backup is done with latest checkpoint we rotate current xlog and add all xlogs after snapshot to the list of backup files.

Make sure every statement from rotated xlog is committed in replica set.  If some statement is not committed then it can be rolled back later. In this case in backup we have not committed statements. On restore these statements can be committed, in particular if replica set is restored from backup of single replica the statemement will be committed for sure. So after restore we get database state that never existed in original database.

Timeout for committing is box.cfg.replication_synchro_timeout. The timeout is added to common code, so that snapshot/join can fail on same timeout if txns in checkpoint are not committed in replicaset in time.

I also added a latch to box_backup_start()/box_backup_stop() so they won't run concurrently. box_backup_start() may yield, so box_backup_stop() can step in and unref the checkpoint. This alone is not a big deal though. But in case of error we will try to unref NULL checkpoint and will get a crash.

Part of #11729