### PR TITLE
[backport: release/3.7] sql: remove ON CONFLICT clause for NULL

### DIFF
--- a/changelogs/unreleased/gh-12701-remove-on-conflict-for-null.md
+++ b/changelogs/unreleased/gh-12701-remove-on-conflict-for-null.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Removed the non-working ON CONFLICT clause for the NULL property
+  in column definitions within CREATE TABLE statements (gh-12701).

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -309,11 +309,8 @@ ccons ::= DEFAULT MINUS(A) number(X). {
 // In addition to the type name, we also care about the primary key and
 // UNIQUE constraints.
 //
-ccons ::= NULL onconf(R).        {
+ccons ::= NULL.        {
     sql_column_add_nullable_action(pParse, ON_CONFLICT_ACTION_NONE);
-    /* Trigger nullability mismatch error if required. */
-    if (R != ON_CONFLICT_ACTION_ABORT)
-        sql_column_add_nullable_action(pParse, R);
 }
 ccons ::= NOT NULL onconf(R).    {sql_column_add_nullable_action(pParse, R);}
 ccons ::= cconsname(N) PRIMARY KEY sortorder(Z). {

--- a/test/sql-luatest/create_table_test.lua
+++ b/test/sql-luatest/create_table_test.lua
@@ -103,3 +103,17 @@ g.test_4422_allow_specify_engine_in_create_table = function(cg)
         t.assert_equals(tostring(err), exp_err)
     end)
 end
+
+--
+-- gh-12701: remove the non-working ON CONFLICT clause for the NULL property
+-- in the column definition in the CREATE TABLE statement.
+--
+g.test_12701_remove_on_conflict_for_null = function(cg)
+    cg.server:exec(function()
+        local sql = [[
+            CREATE TABLE t(i INT PRIMARY KEY, a INT NULL ON CONFLICT ABORT);
+        ]]
+        local _, err = box.execute(sql)
+        t.assert_str_contains(err.message, "keyword 'ON' is reserved.")
+    end)
+end

--- a/test/sql/on-conflict.result
+++ b/test/sql/on-conflict.result
@@ -78,12 +78,6 @@ box.execute("CREATE TABLE te17 (s1 INT NULL PRIMARY KEY);")
 - null
 - Primary index of space 'te17' can not contain nullable parts
 ...
-box.execute("CREATE TABLE test (a int PRIMARY KEY, b int NULL ON CONFLICT IGNORE);")
----
-- null
-- 'Failed to execute SQL statement: NULL declaration for column ''b'' of table ''test''
-  has been already set to ''none'''
-...
 box.execute("CREATE TABLE test (a int, b int NULL, c int, PRIMARY KEY(a, b, c))")
 ---
 - null

--- a/test/sql/on-conflict.test.lua
+++ b/test/sql/on-conflict.test.lua
@@ -23,7 +23,6 @@ box.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, a INTEGER CHECK (a > 5) ON 
 --
 box.execute("CREATE TABLE te17 (s1 INT NULL PRIMARY KEY NOT NULL);")
 box.execute("CREATE TABLE te17 (s1 INT NULL PRIMARY KEY);")
-box.execute("CREATE TABLE test (a int PRIMARY KEY, b int NULL ON CONFLICT IGNORE);")
 box.execute("CREATE TABLE test (a int, b int NULL, c int, PRIMARY KEY(a, b, c))")
 
 -- Several NOT NULL REPLACE constraints work


### PR DESCRIPTION
This patch removes the ON CONFLICT clause for the NULL property in the CREATE TABLE command. This feature is currently non-working, and there's no point in adding this clause to a property that effectively eliminates conflicts when inserting NULL values.

Closes #12701

NO_DOC=this feature seems to be undocumented

(cherry picked from commit cf27a6fe57259d0cafa53a9212155752c79071e6)