### PR TITLE
lua: export trigger to application threads

### DIFF
--- a/changelogs/unreleased/gh-12707-app-threads-trigger-module.md
+++ b/changelogs/unreleased/gh-12707-app-threads-trigger-module.md
@@ -1,0 +1,3 @@
+## feature/core
+
+* The Lua module `trigger` is now available in application threads (gh-12707).

--- a/src/box/app_threads.c
+++ b/src/box/app_threads.c
@@ -16,6 +16,7 @@
 #include "cord_buf.h"
 #include "call.h"
 #include "diag.h"
+#include "event.h"
 #include "fiber.h"
 #include "fiber_pool.h"
 #include "mp_box_ctx.h"
@@ -44,6 +45,7 @@ app_thread_f(void *arg)
 	app_thread_id = (intptr_t)arg;
 	assert(app_thread_id >= 1 && app_thread_id <= app_thread_count);
 	coio_enable();
+	event_init();
 	tuple_init();
 	app_thread_lua_init();
 	struct fiber_pool fiber_pool;
@@ -62,6 +64,7 @@ app_thread_f(void *arg)
 	app_thread_lua_free();
 	box_lua_call_runtime_priv_reset();
 	tuple_free();
+	event_free();
 	cord_buf_free();
 	return NULL;
 }

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -942,6 +942,7 @@ box_lua_init_minimal(struct lua_State *L)
 	box_lua_tuple_init(L);
 	box_lua_call_init(L);
 	box_lua_iproto_init(L);
+	box_lua_trigger_init(L);
 
 	luaopen_key_def(L);
 	lua_pop(L, 1);
@@ -993,7 +994,6 @@ box_lua_init(struct lua_State *L)
 	box_lua_xlog_init(L);
 	box_lua_sql_init(L);
 	box_lua_watcher_init(L);
-	box_lua_trigger_init(L);
 	box_lua_expression_lexer_init(L);
 	box_lua_extras_init(L);
 

--- a/src/lib/core/event.c
+++ b/src/lib/core/event.c
@@ -15,10 +15,10 @@
 #include "say.h"
 
 /** Registry of all events: name -> event. */
-static struct mh_strnptr_t *event_registry;
+static __thread struct mh_strnptr_t *event_registry;
 
 /** Internal triggers fired on event change. */
-RLIST_HEAD(on_change_triggers);
+static __thread struct rlist on_change_triggers;
 
 /**
  * A named node of the list, containing func_adapter. Every event_trigger is
@@ -400,6 +400,7 @@ void
 event_init(void)
 {
 	event_registry = mh_strnptr_new();
+	rlist_create(&on_change_triggers);
 }
 
 void

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -786,3 +786,30 @@ g.test_metrics = function(cg)
         })
     end, {}, {_thread_id = 1})
 end
+
+g.test_trigger = function(cg)
+    cg.server:exec(function()
+        local trigger = require('trigger')
+        t.assert_equals(trigger.info(), {})
+        local data = {}
+        local function f1(val) data.t1 = val end
+        local function f2(val) data.t2 = val end
+        trigger.set('test.event', 't1', f1)
+        trigger.set('test.event', 't2', f2)
+        t.assert_equals(trigger.info(), {
+            ['test.event'] = {{'t2', f2}, {'t1', f1}},
+        })
+        trigger.call('test.event', 1)
+        t.assert_equals(data, {t1 = 1, t2 = 1})
+        trigger.del('test.event', 't2')
+        t.assert_equals(trigger.info(), {
+            ['test.event'] = {{'t1', f1}},
+        })
+        trigger.call('test.event', 2)
+        t.assert_equals(data, {t1 = 2, t2 = 1})
+        trigger.del('test.event', 't1')
+        trigger.call('test.event', 3)
+        t.assert_equals(data, {t1 = 2, t2 = 1})
+        t.assert_equals(trigger.info(), {})
+    end)
+end


### PR DESCRIPTION
To make the trigger module available in application threads, we just need to make the event registry thread-local. Note that one can use the module only for registering custom event triggers. Built-in Tarantool events are still unavailable in application threads.

Closes #12707