### PR TITLE
lua: allow to use threads module when thread groups are not configured

### DIFF
--- a/changelogs/unreleased/gh-12709-app-threads-module-without-config.md
+++ b/changelogs/unreleased/gh-12709-app-threads-module-without-config.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* The `experimental.threads` Lua module can now be used for calling the `tx`
+  thread when thread groups are not configured (gh-12709).

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -447,7 +447,6 @@ struct errcode_record {
 	_(ER_UNABLE_TO_PROCESS_IN_THREAD, 300,	"Unable to process request in thread", "request", STRING, "thread_id", UINT) \
 	_(ER_DICT_OVERFLOW, 301,		"Dictionary has no space - too many unique values are used", "max_size", UINT) \
 	_(ER_NO_SUCH_THREAD_GROUP, 302,		"Thread group does not exist", "thread_group", STRING) \
-	_(ER_THREADS_NOT_CONFIGURED, 303,	"Threads are not configured") \
 	TEST_ERROR_CODES(_) /** This one should be last. */
 
 /*

--- a/src/box/lua/app_threads.lua
+++ b/src/box/lua/app_threads.lua
@@ -19,10 +19,10 @@ box.internal.threads = {}
 local threads_cfg
 
 -- Name of the group this thread belongs to.
-local this_group_name
+local this_group_name = 'tx'
 
 -- Identifier of this thread in the group, 1 <= N <= group size.
-local this_thread_id_in_group
+local this_thread_id_in_group = 1
 
 -- Connection used to call threads.
 local threads_conn
@@ -32,6 +32,39 @@ local thread_groups = {}
 
 -- Map: name -> function exported with threads.export().
 local exported_functions = {}
+
+-- Install a stub for calling the tx thread directly when thread groups
+-- are not configured.
+thread_groups.tx = {
+    _check_call_eval_opts = function(opts)
+        if type(opts.target) == 'number' and opts.target > 1 then
+            box.error(box.error.NO_SUCH_THREAD, opts.target, 3)
+        end
+    end,
+    _handle_call_eval_result = function(status, ...)
+        if status then
+            return {{...}}
+        end
+        local err = ...
+        if not box.error.is(err) then
+            err = box.error.new(box.error.PROC_LUA, err)
+        end
+        box.error(err, 2)
+    end,
+    call = function(self, func_name, args, opts)
+        self._check_call_eval_opts(opts)
+        return self._handle_call_eval_result(pcall(box.internal.threads.call,
+                                                   func_name, args))
+    end,
+    eval = function(self, expr, args, opts)
+        self._check_call_eval_opts(opts)
+        local proc, errmsg = loadstring(expr)
+        if proc == nil then
+            box.error(box.error.PROC_LUA, errmsg, 2)
+        end
+        return self._handle_call_eval_result(pcall(proc, unpack(args)))
+    end,
+}
 
 --
 -- Creates an IPROTO connection to the local instance over a socket pair.
@@ -91,6 +124,7 @@ end
 -- the main thread.
 --
 local function init_thread_groups(cfg)
+    thread_groups.tx = nil
     create_thread_group('tx', 0, 0)
     local thread_id = 1
     for _, group_cfg in ipairs(cfg.groups) do
@@ -306,15 +340,6 @@ function threads.export(func_name, func)
     exported_functions[func_name] = func
 end
 
---
--- Raises an error if the threads module hasn't been configured.
---
-local function check_configured()
-    if threads_cfg == nil then
-        box.error(box.error.THREADS_NOT_CONFIGURED, 3)
-    end
-end
-
 -- call/eval options template used with utils.check_param_table().
 local CALL_EVAL_OPTS = {
     target = 'string, number',
@@ -347,7 +372,6 @@ end
 function threads.call(group_name, func_name, args, opts)
     args = args or {}
     opts = opts or {}
-    check_configured()
     utils.check_param(group_name, 'group name', 'string', 2)
     utils.check_param(func_name, 'function name', 'string', 2)
     utils.check_param(args, 'function arguments', 'table', 2)
@@ -366,7 +390,6 @@ end
 function threads.eval(group_name, expr, args, opts)
     args = args or {}
     opts = opts or {}
-    check_configured()
     utils.check_param(group_name, 'group name', 'string', 2)
     utils.check_param(expr, 'expression', 'string', 2)
     utils.check_param(args, 'expression arguments', 'table', 2)
@@ -378,7 +401,6 @@ end
 -- Returns information about configured thread groups.
 --
 function threads.info()
-    check_configured()
     local info = {
         thread_id = this_thread_id_in_group,
         group_name = this_group_name,
@@ -386,7 +408,7 @@ function threads.info()
             {name = 'tx', size = 1},
         },
     }
-    for _, group_cfg in ipairs(threads_cfg.groups) do
+    for _, group_cfg in ipairs(threads_cfg and threads_cfg.groups or {}) do
         table.insert(info.groups, {
             name = group_cfg.name,
             size = group_cfg.size,

--- a/test/box-luatest/app_threads_module_test.lua
+++ b/test/box-luatest/app_threads_module_test.lua
@@ -130,46 +130,63 @@ g.test_threads_config_propagation = function()
     end
 end
 
-g.test_threads_not_configured = function()
-    --
-    -- Check that if the threads configuration is unset, no thread groups
-    -- are created, not even tx.
-    --
-    local config = cbuilder:new(BASE_CONFIG)
-        :add_instance('server', {})
-        :config()
-    local cluster = cluster:new(config, SERVER_OPTS)
-    cluster:start()
-    cluster.server:exec(function()
-        local threads = require('experimental.threads')
-        t.assert_equals(box.cfg.app_threads, 0)
-        local err = {type = 'ClientError', name = 'THREADS_NOT_CONFIGURED'}
-        t.assert_error_covers(err, threads.info)
-        t.assert_error_covers(err, threads.call)
-        t.assert_error_covers(err, threads.eval)
+--
+-- Check the threads module when no thread groups are configured.
+--
+local function test_threads_not_configured()
+    local threads = require('experimental.threads')
+    t.assert_equals(box.cfg.app_threads, 0)
+    t.assert_equals(threads.info(), {
+        thread_id = 1,
+        group_name = 'tx',
+        groups = {{name = 'tx', size = 1}},
+    })
+    local err = {type = 'ClientError', name = 'NO_SUCH_THREAD_GROUP'}
+    t.assert_error_covers(err, threads.eval, 'app', [[return 123]])
+    t.assert_error_covers(err, threads.call, 'app', 'test_func')
+    local opts = {target = 2}
+    err = {type = 'ClientError', name = 'NO_SUCH_THREAD', thread_id = 2}
+    t.assert_error_covers(err, threads.eval, 'tx', [[return 123]], {}, opts)
+    t.assert_error_covers(err, threads.call, 'tx', 'test_func', {}, opts)
+    t.assert_error_msg_contains("unexpected symbol near '123'",
+                                threads.eval, 'tx', [[123]])
+    err = {type = 'ClientError', name = 'NO_SUCH_FUNCTION', func = 'test'}
+    t.assert_error_covers(err, threads.call, 'tx', 'test')
+    threads.export('test1', function(x, y) return y, x end)
+    threads.export('test2', function() error('foobar') end)
+    threads.export('test3', function()
+        box.error({type = 'Foo', name = 'Bar'})
     end)
+    t.assert_equals(threads.call('tx', 'test1', {1, 2}), {{2, 1}})
+    t.assert_error_msg_contains('foobar', threads.call, 'tx', 'test2')
+    t.assert_error_covers({type = 'Foo', name = 'Bar'},
+                          threads.call, 'tx', 'test3')
+    t.assert_equals(threads.eval('tx', [[return ...]], {1, 2}), {{1, 2}})
+    t.assert_error_msg_contains('foobar', threads.eval, 'tx',
+                                [[error('foobar')]])
+    t.assert_error_covers({type = 'Foo', name = 'Bar'}, threads.eval, 'tx',
+                          [[box.error({type = 'Foo', name = 'Bar'})]])
 end
 
-g.test_thread_groups_not_configured = function()
-    --
-    -- Check that if the threads section is set in the config, the threads
-    -- module is configured and the tx group is created even if no thread
-    -- groups are configured.
-    --
+g.test_threads_not_configured = function()
     local config = cbuilder:new(BASE_CONFIG)
         :add_instance('server', {})
-        :set_instance_option('server', 'threads', {})
         :config()
     local cluster = cluster:new(config, SERVER_OPTS)
     cluster:start()
-    cluster.server:exec(function()
-        local threads = require('experimental.threads')
-        t.assert_equals(threads.info(), {
-            thread_id = 1,
-            group_name = 'tx',
-            groups = {{name = 'tx', size = 1}},
-        })
-    end)
+    cluster.server:exec(test_threads_not_configured)
+    config = cbuilder:new(config)
+        :set_instance_option('server', 'threads', {})
+        :config()
+    cluster:reload(config)
+    cluster.server:restart()
+    cluster.server:exec(test_threads_not_configured)
+    config = cbuilder:new(config)
+        :set_instance_option('server', 'threads.groups', {})
+        :config()
+    cluster:reload(config)
+    cluster.server:restart()
+    cluster.server:exec(test_threads_not_configured)
 end
 
 g.test_thread_function_export = function()
@@ -724,13 +741,7 @@ g.test_box_cfg = function(cg)
     -- Check that the threads module is initialized with the default thread
     -- group if box.cfg.app_threads is set from application code.
     --
-    cg.server:exec(function()
-        local threads = require('experimental.threads')
-        local err = {type = 'ClientError', name = 'THREADS_NOT_CONFIGURED'}
-        t.assert_error_covers(err, threads.info)
-        t.assert_error_covers(err, threads.call)
-        t.assert_error_covers(err, threads.eval)
-    end)
+    cg.server:exec(test_threads_not_configured)
     cg.server:restart({box_cfg = {app_threads = 4}})
     cg.server:exec(function()
         local threads = require('experimental.threads')

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -511,7 +511,6 @@ t;
  |   300: box.error.UNABLE_TO_PROCESS_IN_THREAD
  |   301: box.error.DICT_OVERFLOW
  |   302: box.error.NO_SUCH_THREAD_GROUP
- |   303: box.error.THREADS_NOT_CONFIGURED
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
It will be useful to develop multi-threaded application roles that can work on the tx thread if thread groups aren't configured. Instead of raising an error, we now simply execute call/eval directly.

Closes #12709