### PR TITLE
sql: fix types and rows for named bind variables

### DIFF
--- a/src/box/bind.c
+++ b/src/box/bind.c
@@ -176,13 +176,10 @@ sql_bind_list_decode(const char *data, struct sql_bind **out_bind)
 int
 sql_bind_column(struct Vdbe *stmt, const struct sql_bind *p, uint32_t pos)
 {
-	if (p->name != NULL) {
-		pos = sql_bind_parameter_lindex(stmt, p->name, p->name_len);
-		if (pos == 0) {
-			diag_set(ClientError, ER_SQL_BIND_NOT_FOUND,
-				 sql_bind_name(p));
-			return -1;
-		}
+	if (pos == 0) {
+		diag_set(ClientError, ER_SQL_BIND_NOT_FOUND,
+			 sql_bind_name(p));
+		return -1;
 	}
 	switch (p->type) {
 	case MP_INT:
@@ -227,6 +224,28 @@ sql_bind_column(struct Vdbe *stmt, const struct sql_bind *p, uint32_t pos)
 		}
 	default:
 		unreachable();
+	}
+	return 0;
+}
+
+int
+sql_bind(struct Vdbe *stmt, const struct sql_bind *bind, uint32_t bind_count)
+{
+	assert(stmt != NULL);
+	if (bind_count > 0) {
+	    for (uint32_t i = 0; i < sql_get_count_original_names(stmt); i++) {
+		 uint32_t n = sql_get_original_names_len(stmt, i);
+		    char *name = sql_get_original_names(stmt, i);
+		    for (uint32_t j = 0; j < bind_count; j++) {
+			    if (bind[j].name_len == n) {
+				    if (strcmp(name, bind[j].name) == 0) {
+					    if (sql_bind_column(stmt, &bind[j], i + 1) != 0)
+						    return -1;
+					    break;
+				    }
+			    }
+		    }
+	    }
 	}
 	return 0;
 }

--- a/src/box/bind.c
+++ b/src/box/bind.c
@@ -183,14 +183,14 @@ sql_bind_column(struct Vdbe *stmt, const struct sql_bind *p, uint32_t pos)
 	}
 	switch (p->type) {
 	case MP_INT:
-		return sql_bind_int64(stmt, pos, p->i64);
+		return sql_bind_int64(stmt, pos);
 	case MP_UINT:
-		return sql_bind_uint64(stmt, pos, p->u64);
+		return sql_bind_uint64(stmt, pos);
 	case MP_BOOL:
-		return sql_bind_boolean(stmt, pos, p->b);
+		return sql_bind_boolean(stmt, pos);
 	case MP_DOUBLE:
 	case MP_FLOAT:
-		return sql_bind_double(stmt, pos, p->d);
+		return sql_bind_double(stmt, pos);
 	case MP_STR:
 		/*
 		 * Parameters are allocated within message pack,
@@ -200,25 +200,25 @@ sql_bind_column(struct Vdbe *stmt, const struct sql_bind *p, uint32_t pos)
 		 * there is no need to copy the packet and we can
 		 * use SQL_STATIC.
 		 */
-		return sql_bind_str_static(stmt, pos, p->s, p->bytes);
+		return sql_bind_str_static(stmt, pos);
 	case MP_NIL:
 		return sql_bind_null(stmt, pos);
 	case MP_BIN:
-		return sql_bind_bin_static(stmt, pos, p->s, p->bytes);
+		return sql_bind_bin_static(stmt, pos);
 	case MP_ARRAY:
-		return sql_bind_array_static(stmt, pos, p->s, p->bytes);
+		return sql_bind_array_static(stmt, pos);
 	case MP_MAP:
-		return sql_bind_map_static(stmt, pos, p->s, p->bytes);
+		return sql_bind_map_static(stmt, pos);
 	case MP_EXT:
 		switch (p->ext_type) {
 		case MP_UUID:
-			return sql_bind_uuid(stmt, pos, &p->uuid);
+			return sql_bind_uuid(stmt, pos);
 		case MP_DECIMAL:
-			return sql_bind_dec(stmt, pos, &p->dec);
+			return sql_bind_dec(stmt, pos);
 		case MP_DATETIME:
-			return sql_bind_datetime(stmt, pos, &p->dt);
+			return sql_bind_datetime(stmt, pos);
 		case MP_INTERVAL:
-			return sql_bind_interval(stmt, pos, &p->itv);
+			return sql_bind_interval(stmt, pos);
 		default:
 			unreachable();
 		}
@@ -232,20 +232,110 @@ int
 sql_bind(struct Vdbe *stmt, const struct sql_bind *bind, uint32_t bind_count)
 {
 	assert(stmt != NULL);
+	uint32_t last_idx = 0;
 	if (bind_count > 0) {
 	    for (uint32_t i = 0; i < sql_get_count_original_names(stmt); i++) {
-		 uint32_t n = sql_get_original_names_len(stmt, i);
+		    uint32_t n = sql_get_original_names_len(stmt, i);
 		    char *name = sql_get_original_names(stmt, i);
-		    for (uint32_t j = 0; j < bind_count; j++) {
-			    if (bind[j].name_len == n) {
-				    if (strcmp(name, bind[j].name) == 0) {
-					    if (sql_bind_column(stmt, &bind[j], i + 1) != 0)
-						    return -1;
-					    break;
+		    int flag = 1;
+		    if (n == 1) {
+			    if (name[0] == '?') {
+					last_idx++;
+				    if (sql_bind_column(stmt, &bind[last_idx], i + 1) != 0)
+					    return -1;
+			    }
+		    }
+		    else if (n > 1) {
+			    if (name[0] == '$') {
+				    flag = 0;
+				    uint32_t number = 0;
+				    for (uint32_t idx = 1; idx < n; idx++) {
+					    number += name[idx] - '0';
+				    }
+				    if (number > bind_count) {
+					    printf("Very Bad\n");
+				    }
+				    last_idx = number;
+				    if (sql_bind_column(stmt, &bind[number - 1], i + 1) != 0)
+					    return -1;
+			    }
+		    }
+		    if (flag) {
+			    for (uint32_t j = 0; j < bind_count; j++) {
+				    if (bind[j].name_len == n) {
+					    if (strcmp(name, bind[j].name) == 0) {
+						    last_idx = j;
+						    if (sql_bind_column(stmt, &bind[j], i + 1) != 0)
+							    return -1;
+						    break;
+					    }
 				    }
 			    }
 		    }
 	    }
 	}
+	for (uint32_t i = 0; i < bind_count; i++) {
+		const struct sql_bind *p = &bind[i];
+		switch (p->type) {
+		case MP_INT:
+			mem_set_int2(stmt, i, (int64_t)p->i64);
+			break;
+		case MP_UINT:
+			mem_set_uint2(stmt, i, p->u64);
+			break;
+		case MP_BOOL:
+			mem_set_boolean2(stmt, i, p->b);
+			break;
+		case MP_DOUBLE:
+		case MP_FLOAT:
+			mem_set_double2(stmt, i, p->d);
+			break;
+		case MP_STR:
+			/*
+			 * Parameters are allocated within message pack,
+			 * received from the iproto thread. IProto thread
+			 * now is waiting for the response and it will not
+			 * free the packet until sql_stmt_finalize. So
+			 * there is no need to copy the packet and we can
+			 * use SQL_STATIC.
+			 */
+			mem_set_str_static2(stmt, i, p->s, p->bytes);
+			break;
+		case MP_NIL:
+			break;
+		case MP_BIN:
+			mem_set_bin_static2(stmt, i, p->s, p->bytes);
+			break;
+		case MP_ARRAY:
+			mem_set_array_static2(stmt, i, p->s, p->bytes);
+			break;
+		case MP_MAP:
+			mem_set_map_static2(stmt, i, p->s, p->bytes);
+			break;
+		case MP_EXT:
+			switch (p->ext_type) {
+			case MP_UUID:
+				mem_set_uuid2(stmt, i, &p->uuid);
+				break;
+			case MP_DECIMAL:
+				mem_set_dec2(stmt, i, &p->dec);
+				break;
+			case MP_DATETIME:
+				mem_set_datetime2(stmt, i, &p->dt);
+				break;
+			case MP_INTERVAL:
+				mem_set_interval2(stmt, i, &p->itv);
+				break;
+			default:
+				unreachable();
+				break;
+			}
+			break;
+		default:
+			unreachable();
+			break;
+		}
+	}
+	return 0;
 	return 0;
 }

--- a/src/box/bind.h
+++ b/src/box/bind.h
@@ -139,17 +139,8 @@ sql_bind_column(struct Vdbe *stmt, const struct sql_bind *p, uint32_t pos);
  * @retval  0 Success.
  * @retval -1 Client or memory error.
  */
-static inline int
-sql_bind(struct Vdbe *stmt, const struct sql_bind *bind, uint32_t bind_count)
-{
-	assert(stmt != NULL);
-	uint32_t pos = 1;
-	for (uint32_t i = 0; i < bind_count; pos = ++i + 1) {
-		if (sql_bind_column(stmt, &bind[i], pos) != 0)
-			return -1;
-	}
-	return 0;
-}
+int
+sql_bind(struct Vdbe *stmt, const struct sql_bind *bind, uint32_t bind_count);
 
 #if defined(__cplusplus)
 } /* extern "C" { */

--- a/src/box/execute.c
+++ b/src/box/execute.c
@@ -126,7 +126,7 @@ sql_reprepare(struct Vdbe **stmt)
 	const char *sql_str = sql_stmt_query_str(*stmt);
 	struct Vdbe *new_stmt;
 	if (sql_stmt_compile(sql_str, strlen(sql_str), NULL,
-			     &new_stmt, NULL) != 0)
+			     &new_stmt, NULL, 0, NULL, NULL) != 0)
 		return -1;
 	if (sql_stmt_cache_update(*stmt, new_stmt) != 0)
 		return -1;
@@ -146,7 +146,7 @@ sql_prepare(const char *sql, int len, struct port *port)
 	struct Vdbe *stmt = sql_stmt_cache_find(stmt_id);
 	rmean_collect(rmean_box, IPROTO_PREPARE, 1);
 	if (stmt == NULL) {
-		if (sql_stmt_compile(sql, len, NULL, &stmt, NULL) != 0)
+		if (sql_stmt_compile(sql, len, NULL, &stmt, NULL, 0, NULL, NULL) != 0)
 			return -1;
 		if (sql_stmt_cache_insert(stmt) != 0) {
 			sql_stmt_finalize(stmt);
@@ -256,13 +256,22 @@ sql_execute_prepared(uint32_t stmt_id, const struct sql_bind *bind,
 	enum sql_serialization_format format = sql_column_count(stmt) > 0 ?
 					       DQL_EXECUTE : DML_EXECUTE;
 	port_sql_create(port, stmt, format, false);
+
+	const char **bind_names = xmalloc(sizeof(char *) * bind_count);
+	uint32_t *bind_names_len = xmalloc(sizeof(uint32_t *) * bind_count);
+	for (uint32_t j = 0; j < bind_count; j++) {
+		bind_names[j] = bind[j].name;
+		bind_names_len[j] = bind[j].name_len;
+	}
+	sql_set_bind_count(stmt, bind_count, bind_names, bind_names_len);
 	if (sql_execute(stmt, port, region) != 0) {
 		port_destroy(port);
 		sql_stmt_reset(stmt);
 		return -1;
 	}
 	sql_stmt_reset(stmt);
-
+	free(bind_names);
+	free(bind_names_len);
 	return 0;
 }
 
@@ -272,7 +281,13 @@ sql_prepare_and_execute(const char *sql, int len, const struct sql_bind *bind,
 			struct region *region)
 {
 	struct Vdbe *stmt;
-	if (sql_stmt_compile(sql, len, NULL, &stmt, NULL) != 0)
+	const char **bind_names = xmalloc(sizeof(char *) * bind_count);
+	uint32_t *bind_names_len = xmalloc(sizeof(uint32_t *) * bind_count);
+	for (uint32_t j = 0; j < bind_count; j++) {
+		bind_names[j] = bind[j].name;
+		bind_names_len[j] = bind[j].name_len;
+	}
+	if (sql_stmt_compile(sql, len, NULL, &stmt, NULL, bind_count, bind_names, bind_names_len) != 0)
 		return -1;
 	assert(stmt != NULL);
 	enum sql_serialization_format format = sql_column_count(stmt) > 0 ?
@@ -282,6 +297,8 @@ sql_prepare_and_execute(const char *sql, int len, const struct sql_bind *bind,
 	    sql_execute(stmt, port, region) == 0)
 		return 0;
 	port_destroy(port);
+	free(bind_names);
+	free(bind_names_len);
 	return -1;
 }
 

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -1205,6 +1205,26 @@ sqlExprAssignVarNumber(Parse * pParse, Expr * pExpr, u32 n)
 	assert(!ExprHasProperty
 	       (pExpr, EP_IntValue | EP_Reduced | EP_TokenOnly));
 	z = pExpr->u.zToken;
+	if (pParse->count_original_names == 0) {
+		pParse->original_names = xmalloc(sizeof(char *));
+		pParse->original_names_len = xmalloc(sizeof(u32 *));
+		pParse->max_count_original_names = 1;
+	} else if (pParse->max_count_original_names ==
+		   pParse->count_original_names) {
+		pParse->max_count_original_names = 2 *
+		    pParse->max_count_original_names;
+		pParse->original_names =
+		xrealloc(pParse->original_names,
+			 (pParse->max_count_original_names) *
+			 sizeof(char *));
+		pParse->original_names_len =
+		xrealloc(pParse->original_names_len,
+			 (pParse->max_count_original_names) *
+			 sizeof(u32 *));
+	}
+	pParse->original_names[pParse->count_original_names] = pExpr->u.zToken;
+	pParse->original_names_len[pParse->count_original_names] = n;
+	pParse->count_original_names += 1;
 	assert(z != 0);
 	assert(z[0] != 0);
 	assert(n == sqlStrlen30(z));

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -1199,6 +1199,7 @@ sqlExprAssignVarNumber(Parse * pParse, Expr * pExpr, u32 n)
 {
 	const char *z;
 	ynVar x;
+	ynVar x2 = 0;
 
 	if (pExpr == 0)
 		return;
@@ -1232,6 +1233,7 @@ sqlExprAssignVarNumber(Parse * pParse, Expr * pExpr, u32 n)
 		/* Wildcard of the form "?".  Assign the next variable number */
 		assert(z[0] == '?');
 		x = (ynVar) (++pParse->nVar);
+		x2 = (ynVar) pParse->last_idx + 1;
 	} else {
 		int doAdd = 0;
 		assert(z[0] != '?');
@@ -1245,6 +1247,7 @@ sqlExprAssignVarNumber(Parse * pParse, Expr * pExpr, u32 n)
 			bool is_neg;
 			bool is_ok = 0 == sql_atoi64(&z[1], &i, &is_neg, n - 1);
 			x = (ynVar) i;
+			x2 = x;
 			if (is_neg || i < 1) {
 				diag_set(ClientError, ER_SQL_PARSER_GENERIC,
 					 "Index of binding slots must start "\
@@ -1275,17 +1278,29 @@ sqlExprAssignVarNumber(Parse * pParse, Expr * pExpr, u32 n)
 				x = (ynVar) (++pParse->nVar);
 				doAdd = 1;
 			}
+			for (uint32_t j = 0; j < pParse->count_bind_names; j++) {
+				if (pParse->bind_names[j] != NULL) {
+					if (strcmp(pParse->bind_names[j], z) == 0) {
+						x2 = (ynVar) (j + 1);
+						break;
+					}
+				}
+			}
 		}
 		if (doAdd) {
 			pParse->pVList = sqlVListAdd(pParse->pVList, z, n, x);
 		}
 	}
-	pExpr->iColumn = x;
+	pExpr->iColumn = x2;
+	pParse->last_idx = x2;
 	if (x > SQL_BIND_PARAMETER_MAX) {
 		diag_set(ClientError, ER_SQL_BIND_PARAMETER_MAX,
 			 SQL_BIND_PARAMETER_MAX);
 		pParse->is_aborted = true;
 	}
+	//pParse->nVar = (int) pParse->count_bind_names;
+	pParse->nVar2 ++;
+	pParse->nVar = pParse->nVar2;
 }
 
 struct Expr *
@@ -3633,6 +3648,15 @@ exprCodeVector(Parse * pParse, Expr * p, int *piFreeable)
 	return iResult;
 }
 
+const char *
+sqlVListNumToName2(Parse *pParse, int ival)
+{
+	if ((ival <= 0) || (pParse->count_bind_names < (uint32_t)ival)) {
+		return NULL;
+	}
+	return pParse->bind_names[ival - 1];
+}
+
 /*
  * Generate code into the current Vdbe to evaluate the given
  * expression.  Attempt to store the results in register "target".
@@ -3769,8 +3793,11 @@ sqlExprCodeTarget(Parse * pParse, Expr * pExpr, int target)
 					  target);
 			if (pExpr->u.zToken[1] != 0) {
 				const char *z =
-				    sqlVListNumToName(pParse->pVList,
-							  pExpr->iColumn);
+				    sqlVListNumToName2(pParse,
+						       pExpr->iColumn);
+				if (z == NULL) {
+					z = pExpr->u.zToken;
+				}
 				assert(pExpr->u.zToken[0] == '$'
 				       || strcmp(pExpr->u.zToken, z) == 0);
 				pParse->pVList[0] = 0;	/* Indicate VList may no longer be enlarged */

--- a/src/box/sql/prepare.c
+++ b/src/box/sql/prepare.c
@@ -41,12 +41,18 @@
 
 int
 sql_stmt_compile(const char *zSql, int nBytes, struct Vdbe *pReprepare,
-		 struct Vdbe **ppStmt, const char **pzTail)
+		 struct Vdbe **ppStmt, const char **pzTail,
+		 uint32_t bind_count, const char **bind_names,
+		 uint32_t *bind_names_len)
 {
 	int rc = 0;	/* Result code */
 	Parse sParse;		/* Parsing context */
 	sql_parser_create(&sParse, current_session()->sql_flags);
+	sParse.count_bind_names = bind_count;
+	sParse.bind_names = bind_names;
+	sParse.bind_names_len = bind_names_len;
 	sParse.pReprepare = pReprepare;
+	sParse.nVar2 = 0;
 	*ppStmt = NULL;
 
 	/* Check to verify that it is possible to get a read lock on all
@@ -174,7 +180,7 @@ sqlReprepare(Vdbe * p)
 
 	zSql = sql_sql(p);
 	assert(zSql != 0);
-	if (sql_stmt_compile(zSql, -1, p, &pNew, 0) != 0) {
+	if (sql_stmt_compile(zSql, -1, p, &pNew, 0, 0, NULL, NULL) != 0) {
 		assert(pNew == 0);
 		return -1;
 	}
@@ -195,6 +201,8 @@ sql_parser_create(struct Parse *parser, uint32_t sql_flags)
 	parser->line_pos = 1;
 	parser->has_autoinc = false;
 	region_create(&parser->region, &cord()->slabc);
+	parser->count_original_names = 0;
+	parser->last_idx = 0;
 	parser->count_original_names = 0;
 }
 

--- a/src/box/sql/prepare.c
+++ b/src/box/sql/prepare.c
@@ -195,6 +195,7 @@ sql_parser_create(struct Parse *parser, uint32_t sql_flags)
 	parser->line_pos = 1;
 	parser->has_autoinc = false;
 	region_create(&parser->region, &cord()->slabc);
+	parser->count_original_names = 0;
 }
 
 void

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -314,7 +314,9 @@ sql_vsnprintf(int, char *, const char *, va_list);
  */
 int
 sql_stmt_compile(const char *sql, int bytes_count, struct Vdbe *re_prepared,
-		 struct Vdbe **stmt, const char **sql_tail);
+		 struct Vdbe **stmt, const char **sql_tail,
+		 uint32_t bind_count, const char **bind_names,
+		 uint32_t *bind_names_len);
 
 /** This is the top-level implementation of sqlStep(). */
 int
@@ -489,7 +491,7 @@ sql_reset_autoinc_id_list(struct Vdbe *stmt);
 
 /** Perform double parameter binding for the sql statement. */
 int
-sql_bind_double(struct Vdbe *v, int i, double value);
+sql_bind_double(struct Vdbe *v, int i);
 
 /**
  * Perform boolean parameter binding for the prepared sql
@@ -500,19 +502,19 @@ sql_bind_double(struct Vdbe *v, int i, double value);
  * @retval 0 On Success, not 0 otherwise.
  */
 int
-sql_bind_boolean(struct Vdbe *v, int i, bool value);
+sql_bind_boolean(struct Vdbe *v, int i);
 
 /** Perform integer parameter binding for the sql statement. */
 int
-sql_bind_int(struct Vdbe *v, int i, int value);
+sql_bind_int(struct Vdbe *v, int i);
 
 /** Perform 64-bit negative integer parameter binding for the sql statement. */
 int
-sql_bind_int64(struct Vdbe *v, int i, int64_t value);
+sql_bind_int64(struct Vdbe *v, int i);
 
 /** Perform 64-bit unsigned integer parameter binding for the sql statement. */
 int
-sql_bind_uint64(struct Vdbe *v, int i, uint64_t value);
+sql_bind_uint64(struct Vdbe *v, int i);
 
 /** Perform NULL parameter binding for the sql statement. */
 int
@@ -520,35 +522,87 @@ sql_bind_null(struct Vdbe *v, int i);
 
 /** Perform string parameter binding for the sql statement. */
 int
-sql_bind_str_static(struct Vdbe *v, int i, const char *str, uint32_t len);
+sql_bind_str_static(struct Vdbe *v, int i);
 
 /** Perform binary string parameter binding for the sql statement. */
 int
-sql_bind_bin_static(struct Vdbe *v, int i, const char *str, uint32_t size);
+sql_bind_bin_static(struct Vdbe *v, int i);
 
 /** Perform array parameter binding for the sql statement. */
 int
-sql_bind_array_static(struct Vdbe *v, int i, const char *str, uint32_t size);
+sql_bind_array_static(struct Vdbe *v, int i);
 
 /** Perform map parameter binding for the sql statement. */
 int
-sql_bind_map_static(struct Vdbe *v, int i, const char *str, uint32_t size);
+sql_bind_map_static(struct Vdbe *v, int i);
 
 /** Perform UUID parameter binding for the sql statement. */
 int
-sql_bind_uuid(struct Vdbe *v, int i, const struct tt_uuid *uuid);
+sql_bind_uuid(struct Vdbe *v, int i);
 
 /** Perform decimal parameter binding for the sql statement. */
 int
-sql_bind_dec(struct Vdbe *v, int i, const decimal_t *dec);
+sql_bind_dec(struct Vdbe *v, int i);
 
 /** Perform DATETIME parameter binding for the sql statement. */
 int
-sql_bind_datetime(struct Vdbe *v, int i, const struct datetime *dt);
+sql_bind_datetime(struct Vdbe *v, int i);
 
 /** Perform INTERVAL parameter binding for the SQL statement. */
 int
-sql_bind_interval(struct Vdbe *v, int i, const struct interval *itv);
+sql_bind_interval(struct Vdbe *v, int i);
+
+/** Request function mem_set_double. */
+void
+mem_set_double2(struct Vdbe *p, int i, double rValue);
+
+/** Request function mem_set_boolean. */
+void
+mem_set_boolean2(struct Vdbe *p, int i, bool value);
+
+/** Request function mem_set_datetime. */
+void
+mem_set_datetime2(struct Vdbe *p, int i, const struct datetime *dt);
+
+/** Request function mem_set_interval. */
+void
+mem_set_interval2(struct Vdbe *p, int i, const struct interval *itv);
+
+/** Request function mem_set_int. */
+void
+mem_set_int2(struct Vdbe *stmt, uint32_t i, int64_t value);
+
+/** Request function mem_set_uint. */
+void
+mem_set_uint2(struct Vdbe *stmt, uint32_t i, uint64_t val);
+
+/** Request function mem_set_ptr. */
+void
+mem_set_ptr2(struct Vdbe *stmt, uint32_t i, void *ptr);
+
+/** Request function mem_set_str_static. */
+void
+mem_set_str_static2(struct Vdbe *vdbe, int i, const char *str, uint32_t len);
+
+/** Request function mem_set_bin_static. */
+void
+mem_set_bin_static2(struct Vdbe *vdbe, int i, const char *str, uint32_t size);
+
+/** Request function mem_array_static. */
+void
+mem_set_array_static2(struct Vdbe *vdbe, int i, const char *str, uint32_t size);
+
+/** Request function mem_map_static. */
+void
+mem_set_map_static2(struct Vdbe *vdbe, int i, const char *str, uint32_t size);
+
+/** Request function mem_set_uuid. */
+void
+mem_set_uuid2(struct Vdbe *p, int i, const struct tt_uuid *uuid);
+
+/** Request function mem_set_dec. */
+void
+mem_set_dec2(struct Vdbe *p, int i, const decimal_t *dec);
 
 /**
  * Return the number of wildcards that should be bound to.
@@ -573,6 +627,19 @@ sql_get_original_names(const struct Vdbe *p, uint32_t i);
  */
 uint32_t
 sql_get_original_names_len(const struct Vdbe *p, uint32_t i);
+
+/** Put in struct Vdbe bind names and lens. */
+int
+sql_set_bind(struct Vdbe *stmt, const char *name,
+	     uint32_t name_len, int i);
+
+/** Free in struct Vdbe arrays with bind names and lens. */
+int
+sql_free_bind(struct Vdbe *stmt);
+
+/** Put in struct Vdbe count bind variables. */
+int
+sql_set_bind_count(struct Vdbe *stmt, int bind_count, const char **bind_names, uint32_t *bind_names_len);
 
 /**
  * Return the name of a wildcard parameter. Return NULL if the index
@@ -2052,6 +2119,7 @@ struct Parse {
 	 */
 	int line_pos;
 	ynVar nVar;		/* Number of '?' variables seen in the SQL so far */
+	ynVar nVar2;
 	u8 explain;		/* True if the EXPLAIN flag is found on the query */
 	int nHeight;		/* Expression tree height of current sub-select */
 	int iSelectId;		/* ID of current select for EXPLAIN output */
@@ -2131,6 +2199,15 @@ struct Parse {
 		struct Select *select;
 		struct sql_trigger *trigger;
 	} parsed_ast;
+
+	/** Array with names of bind variables. */
+	const char **bind_names;
+	/** Array with lens of names of bind variables. */
+	uint32_t *bind_names_len;
+	/** Count of bind variables. */
+	uint32_t count_bind_names;
+
+	uint32_t last_idx;
 };
 
 /*

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -557,6 +557,24 @@ int
 sql_bind_parameter_count(const struct Vdbe *v);
 
 /**
+ * Return count of original names in request.
+ */
+uint32_t
+sql_get_count_original_names(const struct Vdbe *p);
+
+/**
+ * Return structure with original names in request.
+ */
+char *
+sql_get_original_names(const struct Vdbe *p, uint32_t i);
+
+/**
+ * Return structure with lengths original names in request.
+ */
+uint32_t
+sql_get_original_names_len(const struct Vdbe *p, uint32_t i);
+
+/**
  * Return the name of a wildcard parameter. Return NULL if the index
  * is out of range or if the wildcard is unnamed. Parameter's index
  * is 0-based.
@@ -1991,6 +2009,15 @@ struct Parse {
 	struct region region;
 	/** True, if error should be raised after parsing. */
 	bool is_aborted;
+
+	/** Array of names in original request. */
+	char **original_names;
+	/** Array of lens of names in original request. */
+	u32 *original_names_len;
+	/** Len of array of names in original request. */
+	u32 count_original_names;
+	/** Now max as possible len of array of names in original request. */
+	u32 max_count_original_names;
 
   /**************************************************************************
   * Fields above must be initialized to zero.  The fields that follow,

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -861,9 +861,20 @@ case OP_Blob: {                /* out2 */
  */
 case OP_Variable: {            /* out2 */
 	Mem *pVar;       /* Value being transferred */
-
-	assert(pOp->p1>0 && pOp->p1<=p->nVar);
-	assert(pOp->p4.z==0 || pOp->p4.z==sqlVListNumToName(p->pVList,pOp->p1));
+	if (pOp->p1 == 0) {
+	    if (pOp->p4.z != 0) {
+		for (uint32_t i = 0; i < p->count_bind_names; i++) {
+			if (p->bind_names[i] != 0) {
+			    if (strcmp(p->bind_names[i], pOp->p4.z) == 0)
+				pOp->p1 = i + 1;
+			}
+		}
+	    }
+	}
+	assert(pOp->p1>0);
+	assert(((uint32_t) pOp->p1<=p->count_bind_names) || (p->count_bind_names == 0));
+	//assert(pOp->p1>0 && pOp->p1<=p->nVar);
+	//assert(pOp->p4.z==0 || pOp->p4.z==sqlVListNumToName(p->pVList,pOp->p1));
 	pVar = &p->aVar[pOp->p1 - 1];
 	if (sqlVdbeMemTooBig(pVar)) {
 		goto too_big;

--- a/src/box/sql/vdbeInt.h
+++ b/src/box/sql/vdbeInt.h
@@ -304,6 +304,14 @@ struct Vdbe {
 	uint32_t sql_flags;
 	/* Anonymous savepoint for aborts only */
 	struct txn_savepoint *anonymous_savepoint;
+	/** Array of names in original request. */
+	char **original_names;
+	/** Array of lens of names in original request. */
+	u32 *original_names_len;
+	/** Len of array of names in original request. */
+	u32 count_original_names;
+	/** Now max as possible len of array of names in original request. */
+	u32 max_count_original_names;
 };
 
 /*

--- a/src/box/sql/vdbeInt.h
+++ b/src/box/sql/vdbeInt.h
@@ -312,6 +312,13 @@ struct Vdbe {
 	u32 count_original_names;
 	/** Now max as possible len of array of names in original request. */
 	u32 max_count_original_names;
+
+	/** Array with names of bind variables. */
+	const char **bind_names;
+	/** Array with lens of names of bind variables. */
+	uint32_t *bind_names_len;
+	/** Count of bind variables. */
+	uint32_t count_bind_names;
 };
 
 /*

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -385,8 +385,11 @@ sql_reset_autoinc_id_list(struct Vdbe *v)
 int
 sql_bind_double(struct Vdbe *p, int i, double rValue)
 {
-	if (vdbeUnbind(p, i) != 0)
+	if ((uint32_t)i > (uint32_t)p->nVar) {
+		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
+			 "parameters is too large");
 		return -1;
+	}
 	int rc = sql_bind_type(p, i, "numeric");
 	mem_set_double(&p->aVar[i - 1], rValue);
 	return rc;
@@ -395,8 +398,11 @@ sql_bind_double(struct Vdbe *p, int i, double rValue)
 int
 sql_bind_boolean(struct Vdbe *p, int i, bool value)
 {
-	if (vdbeUnbind(p, i) != 0)
+	if ((uint32_t)i > p->res_var_count) {
+		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
+			 "parameters is too large");
 		return -1;
+	}
 	int rc = sql_bind_type(p, i, "boolean");
 	mem_set_bool(&p->aVar[i - 1], value);
 	return rc;
@@ -411,8 +417,11 @@ sql_bind_int(struct Vdbe *p, int i, int iValue)
 int
 sql_bind_int64(struct Vdbe *p, int i, int64_t iValue)
 {
-	if (vdbeUnbind(p, i) != 0)
+	if ((uint32_t)i > p->res_var_count) {
+		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
+			 "parameters is too large");
 		return -1;
+	}
 	int rc = sql_bind_type(p, i, "integer");
 	mem_set_int(&p->aVar[i - 1], iValue);
 	return rc;
@@ -421,8 +430,11 @@ sql_bind_int64(struct Vdbe *p, int i, int64_t iValue)
 int
 sql_bind_uint64(struct Vdbe *p, int i, uint64_t value)
 {
-	if (vdbeUnbind(p, i) != 0)
+	if ((uint32_t)i > p->res_var_count) {
+		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
+			 "parameters is too large");
 		return -1;
+	}
 	int rc = sql_bind_type(p, i, "integer");
 	mem_set_uint(&p->aVar[i - 1], value);
 	return rc;
@@ -431,15 +443,24 @@ sql_bind_uint64(struct Vdbe *p, int i, uint64_t value)
 int
 sql_bind_null(struct Vdbe *p, int i)
 {
-	if (vdbeUnbind(p, i) != 0)
+	if ((uint32_t)i > p->res_var_count) {
+		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
+			 "parameters is too large");
 		return -1;
+	}
 	return sql_bind_type(p, i, "boolean");
 }
 
 int
 sql_bind_ptr(struct Vdbe *p, int i, void *ptr)
 {
-	int rc = vdbeUnbind(p, i);
+	int rc = 0;
+	/*
+	if ((uint32_t)i > p->res_var_count) {
+		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
+			 "parameters is too large");
+		rc = -1;
+	}*/
 	if (rc == 0) {
 		rc = sql_bind_type(p, i, "varbinary");
 		mem_set_ptr(&p->aVar[i - 1], ptr);
@@ -478,7 +499,13 @@ sql_bind_map_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
 int
 sql_bind_uuid(struct Vdbe *p, int i, const struct tt_uuid *uuid)
 {
-	if (vdbeUnbind(p, i) != 0 || sql_bind_type(p, i, "uuid") != 0)
+	int rc = 0;
+	if ((uint32_t)i > p->res_var_count) {
+		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
+			 "parameters is too large");
+		rc = -1;
+	}
+	if (rc != 0 || sql_bind_type(p, i, "uuid") != 0)
 		return -1;
 	mem_set_uuid(&p->aVar[i - 1], uuid);
 	return 0;
@@ -487,7 +514,13 @@ sql_bind_uuid(struct Vdbe *p, int i, const struct tt_uuid *uuid)
 int
 sql_bind_dec(struct Vdbe *p, int i, const decimal_t *dec)
 {
-	if (vdbeUnbind(p, i) != 0 || sql_bind_type(p, i, "decimal") != 0)
+	int rc = 0;
+	if ((uint32_t)i > p->res_var_count) {
+		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
+			 "parameters is too large");
+		rc = -1;
+	}
+	if (rc != 0 || sql_bind_type(p, i, "decimal") != 0)
 		return -1;
 	mem_set_dec(&p->aVar[i - 1], dec);
 	return 0;
@@ -496,7 +529,13 @@ sql_bind_dec(struct Vdbe *p, int i, const decimal_t *dec)
 int
 sql_bind_datetime(struct Vdbe *p, int i, const struct datetime *dt)
 {
-	if (vdbeUnbind(p, i) != 0 || sql_bind_type(p, i, "datetime") != 0)
+	int rc = 0;
+	if ((uint32_t)i > p->res_var_count) {
+		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
+			 "parameters is too large");
+		rc = -1;
+	}
+	if (rc != 0 || sql_bind_type(p, i, "datetime") != 0)
 		return -1;
 	mem_set_datetime(&p->aVar[i - 1], dt);
 	return 0;
@@ -505,7 +544,13 @@ sql_bind_datetime(struct Vdbe *p, int i, const struct datetime *dt)
 int
 sql_bind_interval(struct Vdbe *p, int i, const struct interval *itv)
 {
-	if (vdbeUnbind(p, i) != 0 || sql_bind_type(p, i, "interval") != 0)
+	int rc = 0;
+	if ((uint32_t)i > p->res_var_count) {
+		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
+			 "parameters is too large");
+		rc = -1;
+	}
+	if (rc != 0 || sql_bind_type(p, i, "interval") != 0)
 		return -1;
 	mem_set_interval(&p->aVar[i - 1], itv);
 	return 0;
@@ -523,6 +568,33 @@ sql_bind_parameter_name(const struct Vdbe *p, int i)
 	if (p == NULL)
 		return NULL;
 	return sqlVListNumToName(p->pVList, i+1);
+}
+
+/**
+ * Return count of original names in request.
+ */
+uint32_t
+sql_get_count_original_names(const struct Vdbe *p)
+{
+	return p->count_original_names;
+}
+
+/**
+ * Return structure with original names in request.
+ */
+char *
+sql_get_original_names(const struct Vdbe *p, uint32_t i)
+{
+	return p->original_names[i];
+}
+
+/**
+ * Return structure with lengths original names in request.
+ */
+uint32_t
+sql_get_original_names_len(const struct Vdbe *p, uint32_t i)
+{
+	return p->original_names_len[i];
 }
 
 /*

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -382,68 +382,167 @@ sql_reset_autoinc_id_list(struct Vdbe *v)
 	stailq_create(&v->autoinc_id_list);
 }
 
-int
-sql_bind_double(struct Vdbe *p, int i, double rValue)
+void
+mem_set_double2(struct Vdbe *p, int i, double rValue)
 {
-	if ((uint32_t)i > (uint32_t)p->nVar) {
+	mem_set_double(&p->aVar[i], rValue);
+}
+
+void
+mem_set_boolean2(struct Vdbe *p, int i, bool value)
+{
+	mem_set_bool(&p->aVar[i], value);
+}
+
+void
+mem_set_datetime2(struct Vdbe *p, int i, const struct datetime *dt)
+{
+	mem_set_datetime(&p->aVar[i], dt);
+}
+
+void
+mem_set_interval2(struct Vdbe *p, int i, const struct interval *itv)
+{
+	mem_set_interval(&p->aVar[i], itv);
+}
+
+void
+mem_set_int2(struct Vdbe *stmt, uint32_t i, int64_t value)
+{
+	mem_set_int(&stmt->aVar[i], value);
+}
+
+void
+mem_set_uint2(struct Vdbe *stmt, uint32_t i, uint64_t val)
+{
+	mem_set_uint(&stmt->aVar[i], val);
+}
+
+void
+mem_set_ptr2(struct Vdbe *stmt, uint32_t i, void *ptr)
+{
+	mem_set_ptr(&stmt->aVar[i], ptr);
+}
+
+void
+mem_set_str_static2(struct Vdbe *vdbe, int i, const char *str, uint32_t len)
+{
+	mem_set_str_static(&vdbe->aVar[i], (char *)str, len);
+}
+
+void
+mem_set_bin_static2(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
+{
+	mem_set_bin_static(&vdbe->aVar[i], (char *)str, size);
+}
+
+void
+mem_set_array_static2(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
+{
+	mem_set_array_static(&vdbe->aVar[i], (char *)str, size);
+}
+
+void
+mem_set_map_static2(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
+{
+	mem_set_map_static(&vdbe->aVar[i], (char *)str, size);
+}
+
+void
+mem_set_uuid2(struct Vdbe *p, int i, const struct tt_uuid *uuid)
+{
+	mem_set_uuid(&p->aVar[i], uuid);
+}
+
+void
+mem_set_dec2(struct Vdbe *p, int i, const decimal_t *dec)
+{
+	mem_set_dec(&p->aVar[i], dec);
+}
+
+int
+sql_set_bind_count(struct Vdbe *stmt, int bind_count, const char **bind_names, uint32_t *bind_names_len)
+{
+	stmt->count_bind_names = bind_count;
+	stmt->bind_names = bind_names;
+	stmt->bind_names_len = bind_names_len;
+	return 0;
+}
+
+int
+sql_free_bind(struct Vdbe *stmt)
+{
+	free(stmt->bind_names);
+	free(stmt->bind_names_len);
+	return 0;
+}
+
+int
+sql_set_bind(struct Vdbe *stmt, const char *name,
+	     uint32_t name_len, int i)
+{
+	stmt->bind_names[i] = name;
+	stmt->bind_names_len[i] = name_len;
+	return 0;
+}
+int
+sql_bind_double(struct Vdbe *p, int i)
+{
+	if ((uint32_t)i > p->count_original_names) {
 		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
 			 "parameters is too large");
 		return -1;
 	}
 	int rc = sql_bind_type(p, i, "numeric");
-	mem_set_double(&p->aVar[i - 1], rValue);
 	return rc;
 }
 
 int
-sql_bind_boolean(struct Vdbe *p, int i, bool value)
+sql_bind_boolean(struct Vdbe *p, int i)
 {
-	if ((uint32_t)i > p->res_var_count) {
+	if ((uint32_t)i > p->count_original_names) {
 		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
 			 "parameters is too large");
 		return -1;
 	}
 	int rc = sql_bind_type(p, i, "boolean");
-	mem_set_bool(&p->aVar[i - 1], value);
 	return rc;
 }
 
 int
-sql_bind_int(struct Vdbe *p, int i, int iValue)
+sql_bind_int(struct Vdbe *p, int i)
 {
-	return sql_bind_int64(p, i, (i64) iValue);
+	return sql_bind_int64(p, i);
 }
 
 int
-sql_bind_int64(struct Vdbe *p, int i, int64_t iValue)
+sql_bind_int64(struct Vdbe *p, int i)
 {
-	if ((uint32_t)i > p->res_var_count) {
+	if ((uint32_t)i > p->count_original_names) {
 		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
 			 "parameters is too large");
 		return -1;
 	}
 	int rc = sql_bind_type(p, i, "integer");
-	mem_set_int(&p->aVar[i - 1], iValue);
 	return rc;
 }
 
 int
-sql_bind_uint64(struct Vdbe *p, int i, uint64_t value)
+sql_bind_uint64(struct Vdbe *p, int i)
 {
-	if ((uint32_t)i > p->res_var_count) {
+	if ((uint32_t)i > p->count_original_names) {
 		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
 			 "parameters is too large");
 		return -1;
 	}
 	int rc = sql_bind_type(p, i, "integer");
-	mem_set_uint(&p->aVar[i - 1], value);
 	return rc;
 }
 
 int
 sql_bind_null(struct Vdbe *p, int i)
 {
-	if ((uint32_t)i > p->res_var_count) {
+	if ((uint32_t)i > p->count_original_names) {
 		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
 			 "parameters is too large");
 		return -1;
@@ -454,105 +553,91 @@ sql_bind_null(struct Vdbe *p, int i)
 int
 sql_bind_ptr(struct Vdbe *p, int i, void *ptr)
 {
-	int rc = 0;
-	/*
-	if ((uint32_t)i > p->res_var_count) {
-		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
-			 "parameters is too large");
-		rc = -1;
-	}*/
+	int rc = vdbeUnbind(p, i);
 	if (rc == 0) {
 		rc = sql_bind_type(p, i, "varbinary");
-		mem_set_ptr(&p->aVar[i - 1], ptr);
 	}
+	mem_set_ptr(&p->aVar[i - 1], ptr);
 	return rc;
 }
 
 int
-sql_bind_str_static(struct Vdbe *vdbe, int i, const char *str, uint32_t len)
+sql_bind_str_static(struct Vdbe *vdbe, int i)
 {
-	mem_set_str_static(&vdbe->aVar[i - 1], (char *)str, len);
 	return sql_bind_type(vdbe, i, "text");
 }
 
 int
-sql_bind_bin_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
+sql_bind_bin_static(struct Vdbe *vdbe, int i)
 {
-	mem_set_bin_static(&vdbe->aVar[i - 1], (char *)str, size);
 	return sql_bind_type(vdbe, i, "text");
 }
 
 int
-sql_bind_array_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
+sql_bind_array_static(struct Vdbe *vdbe, int i)
 {
-	mem_set_array_static(&vdbe->aVar[i - 1], (char *)str, size);
 	return sql_bind_type(vdbe, i, "array");
 }
 
 int
-sql_bind_map_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
+sql_bind_map_static(struct Vdbe *vdbe, int i)
 {
-	mem_set_map_static(&vdbe->aVar[i - 1], (char *)str, size);
 	return sql_bind_type(vdbe, i, "map");
 }
 
 int
-sql_bind_uuid(struct Vdbe *p, int i, const struct tt_uuid *uuid)
+sql_bind_uuid(struct Vdbe *p, int i)
 {
 	int rc = 0;
-	if ((uint32_t)i > p->res_var_count) {
+	if ((uint32_t)i > p->count_original_names) {
 		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
 			 "parameters is too large");
 		rc = -1;
 	}
 	if (rc != 0 || sql_bind_type(p, i, "uuid") != 0)
 		return -1;
-	mem_set_uuid(&p->aVar[i - 1], uuid);
 	return 0;
 }
 
 int
-sql_bind_dec(struct Vdbe *p, int i, const decimal_t *dec)
+sql_bind_dec(struct Vdbe *p, int i)
 {
 	int rc = 0;
-	if ((uint32_t)i > p->res_var_count) {
+	if ((uint32_t)i > p->count_original_names) {
 		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
 			 "parameters is too large");
 		rc = -1;
 	}
 	if (rc != 0 || sql_bind_type(p, i, "decimal") != 0)
 		return -1;
-	mem_set_dec(&p->aVar[i - 1], dec);
 	return 0;
 }
 
 int
-sql_bind_datetime(struct Vdbe *p, int i, const struct datetime *dt)
+sql_bind_datetime(struct Vdbe *p, int i)
 {
 	int rc = 0;
-	if ((uint32_t)i > p->res_var_count) {
+	if ((uint32_t)i > p->count_original_names) {
 		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
 			 "parameters is too large");
 		rc = -1;
 	}
 	if (rc != 0 || sql_bind_type(p, i, "datetime") != 0)
 		return -1;
-	mem_set_datetime(&p->aVar[i - 1], dt);
 	return 0;
 }
 
 int
-sql_bind_interval(struct Vdbe *p, int i, const struct interval *itv)
+sql_bind_interval(struct Vdbe *p, int i)
 {
 	int rc = 0;
-	if ((uint32_t)i > p->res_var_count) {
+	if ((uint32_t)i > p->count_original_names) {
 		diag_set(ClientError, ER_SQL_EXECUTE, "The number of "
 			 "parameters is too large");
 		rc = -1;
 	}
 	if (rc != 0 || sql_bind_type(p, i, "interval") != 0)
 		return -1;
-	mem_set_interval(&p->aVar[i - 1], itv);
 	return 0;
 }
 

--- a/src/box/sql/vdbeaux.c
+++ b/src/box/sql/vdbeaux.c
@@ -1463,6 +1463,11 @@ sqlVdbeMakeReady(Vdbe * p,	/* The VDBE */
 		p->original_names = pParse->original_names;
 		p->original_names_len = pParse->original_names_len;
 	}
+	p->count_bind_names = pParse->count_bind_names;
+	if (pParse->count_bind_names > 0) {
+		p->bind_names = pParse->bind_names;
+		p->bind_names_len = pParse->bind_names_len;
+	}
 	pParse->original_names = 0;
 	pParse->original_names_len = 0;
 	pParse->pVList = 0;

--- a/src/box/sql/vdbeaux.c
+++ b/src/box/sql/vdbeaux.c
@@ -1458,6 +1458,13 @@ sqlVdbeMakeReady(Vdbe * p,	/* The VDBE */
 	} while (true);
 
 	p->pVList = pParse->pVList;
+	p->count_original_names = pParse->count_original_names;
+	if (p->count_original_names > 0) {
+		p->original_names = pParse->original_names;
+		p->original_names_len = pParse->original_names_len;
+	}
+	pParse->original_names = 0;
+	pParse->original_names_len = 0;
 	pParse->pVList = 0;
 	p->explain = pParse->explain;
 	p->nCursor = nCursor;
@@ -1990,6 +1997,10 @@ sqlVdbeClearObject(struct Vdbe *p)
 		releaseMemArray(p->aVar, p->nVar);
 		sql_xfree(p->pVList);
 		sql_xfree(p->pFree);
+		if (p->count_original_names > 0) {
+			free(p->original_names);
+			free(p->original_names_len);
+		}
 	}
 	vdbeFreeOpArray(p->aOp, p->nOp);
 	sql_xfree(p->zSql);

--- a/test/sql-luatest/metadata_test.lua
+++ b/test/sql-luatest/metadata_test.lua
@@ -289,3 +289,44 @@ g.test_4755_scalar_collation_metadata = function(cg)
         t.assert_equals(box.space.t, nil)
     end, {cg.params.engine})
 end
+
+g = t.group("gh-6551")
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--
+-- gh-6551: check types in select request
+-- with bind variables.
+--
+g.test_6551_types_with_bind_variables = function(cg)
+    cg.server:exec(function()
+        local sql = [[SELECT :a, :a, :a, :b]]
+        local res = box.execute(sql, {{[':a'] = 123}, {[':b'] = 'asd'}})
+        local exp = {
+            {
+                name = "COLUMN_1",
+                type = "integer",
+            },
+            {
+                name = "COLUMN_2",
+                type = "integer",
+            },
+            {
+                name = "COLUMN_3",
+                type = "integer",
+            },
+            {
+                name = "COLUMN_4",
+                type = "text",
+            },
+        }
+        t.assert_equals(res.metadata, exp)
+    end)
+end

--- a/test/sql-luatest/select_test.lua
+++ b/test/sql-luatest/select_test.lua
@@ -43,3 +43,43 @@ g.test_select_null = function(cg)
         box.execute([[DROP TABLE t3;]])
     end)
 end
+
+g = t.group("gh-12733")
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--
+-- This test checks behaviour with positional request in select
+-- statement with bind variables.
+--
+g.test_12733_select_positional_bindings = function(cg)
+    cg.server:exec(function()
+        local res = box.execute([[select :a, $1;]], {{[':a'] = 123}})
+        t.assert_equals(res.rows, {{123, 123}})
+
+        res = box.execute([[select $1, :a;]], {{[':a'] = 123}})
+        t.assert_equals(res.rows, {{123, 123}})
+
+        res = box.execute([[select $1, :a;]], {321, {[':a'] = 123}})
+        t.assert_equals(res.rows, {{321, 123}})
+
+        res = box.execute([[select $2, :a;]], {321, {[':a'] = 123}})
+        t.assert_equals(res.rows, {{123, 123}})
+
+        res = box.execute([[select :a, $1;]], {321, {[':a'] = 123}})
+        t.assert_equals(res.rows, {{123, 321}})
+
+        res = box.execute([[select :a, $2;]], {321, {[':a'] = 123}})
+        t.assert_equals(res.rows, {{123, 123}})
+
+        res = box.execute([[select $2, $1;]], {321, {['a'] = 123}})
+        t.assert_equals(res.rows, {{123, 321}})
+    end)
+end


### PR DESCRIPTION
This patch fixes metadata and rows for named variables in SELECT.

Closes #6551, #12733

NO_DOC=bugfix