### PR TITLE
ci: disable crud integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -149,11 +149,12 @@ jobs:
     with:
       artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
-  crud:
-    needs: tarantool
-    uses: tarantool/crud/.github/workflows/reusable_test.yml@master
-    with:
-      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
+  # FIXME: Disabled due to https://jira.vk.team/browse/TNTP-7897
+  # crud:
+  #   needs: tarantool
+  #   uses: tarantool/crud/.github/workflows/reusable_test.yml@master
+  #   with:
+  #     artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   # FIXME: Disabled due to tarantool/ddl#130.
   # ddl:


### PR DESCRIPTION
Crud integration uses vshard version from master. Recent changes there made rebalancing slower [1], which made crud tests timeout on waiting for rebalancing to finish.

The tests will be fixed by using a smaller bucket count and changing some timeouts [2], but until it's done, let's disable crud integration in tarantool. Its current failures are due to crud and vshard interaction and have nothing to do with tarantool.

[1]: https://github.com/tarantool/vshard/pull/649
[2]: https://jira.vk.team/browse/TNTP-7897

NO_DOC=ci
NO_TEST=ci
NO_CHANGELOG=ci