### PR TITLE
lib/info: add `info_append_bool()`

### DIFF
--- a/src/lib/info/info.h
+++ b/src/lib/info/info.h
@@ -32,6 +32,7 @@
  */
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /**
  * @file
@@ -89,6 +90,9 @@ struct info_handler_vtab {
 	/** Set double value. */
 	void (*append_double)(struct info_handler *,
 			      const char *key, double value);
+	/** Set boolean value. */
+	void (*append_bool)(struct info_handler *info, const char *key,
+			    bool value);
 };
 
 /**
@@ -161,6 +165,18 @@ info_append_double(struct info_handler *info, const char *key,
 		   double value)
 {
 	return info->vtab->append_double(info, key, value);
+}
+
+/**
+ * Associates boolean value with @a key in the current associative array.
+ * @param info box.info() adapter.
+ * @param key key.
+ * @param value value.
+ */
+static inline void
+info_append_bool(struct info_handler *info, const char *key, bool value)
+{
+	return info->vtab->append_bool(info, key, value);
 }
 
 /*

--- a/src/lua/info.c
+++ b/src/lua/info.c
@@ -90,6 +90,16 @@ luaT_info_append_str(struct info_handler *info, const char *key,
 	lua_settable(L, -3);
 }
 
+/** Appends {key: boolean_value} to the table on the Lua stack. */
+static void
+luaT_info_append_bool(struct info_handler *info, const char *key, bool value)
+{
+	lua_State *L = (lua_State *)info->ctx;
+	lua_pushstring(L, key);
+	lua_pushboolean(L, value);
+	lua_settable(L, -3);
+}
+
 void
 luaT_info_handler_create(struct info_handler *h, struct lua_State *L)
 {
@@ -100,7 +110,8 @@ luaT_info_handler_create(struct info_handler *h, struct lua_State *L)
 		.end_table = luaT_info_end_table,
 		.append_int = luaT_info_append_int,
 		.append_str = luaT_info_append_str,
-		.append_double = luaT_info_append_double
+		.append_double = luaT_info_append_double,
+		.append_bool = luaT_info_append_bool,
 	};
 	h->vtab = &lua_vtab;
 	h->ctx = L;


### PR DESCRIPTION
There was no way to emit a boolean value in the info, implement it.

Needed for tarantool/tarantool-ee#833