### PR TITLE
box: add recursion limit on mp_check with extensions

### DIFF
--- a/changelogs/unreleased/ghs-162-fix-mp_check_stack_overflow.md
+++ b/changelogs/unreleased/ghs-162-fix-mp_check_stack_overflow.md
@@ -1,0 +1,5 @@
+## bugfix/box
+
+* Fixed a stack overflow when checking MsgPack input with deeply nested values
+  containing extension types
+  ([ghs-162](https://github.com/tarantool/security/issues/162)).

--- a/src/box/mp_tuple.c
+++ b/src/box/mp_tuple.c
@@ -99,16 +99,35 @@ int
 mp_validate_tuple(const char *data, uint32_t len)
 {
 	const char *end = data + len;
-	if (data == end)
+	if (data == end) {
+		diag_set(ClientError, ER_INVALID_MSGPACK,
+			 "missing format id");
 		return -1;
+	}
 	enum mp_type type = mp_typeof(*data);
-	if (type != MP_UINT || mp_check_uint(data, end) > 0)
+	if (type != MP_UINT || mp_check_uint(data, end) > 0) {
+		diag_set(ClientError, ER_INVALID_MSGPACK,
+			 "malformed format id");
 		return -1;
+	}
 
 	mp_next(&data);
-	if (data == end)
+	if (data == end) {
+		diag_set(ClientError, ER_INVALID_MSGPACK,
+			 "missing tuple MsgPack");
 		return -1;
-	if (mp_typeof(*data) != MP_ARRAY)
+	}
+	if (mp_typeof(*data) != MP_ARRAY) {
+		diag_set(ClientError, ER_INVALID_MSGPACK,
+			 "tuple MsgPack is not array");
 		return -1;
-	return mp_check(&data, end) != 0 || data != end;
+	}
+	if (mp_check(&data, end) != 0)
+		return -1;
+	if (data != end) {
+		diag_set(ClientError, ER_INVALID_MSGPACK,
+			 "junk after tuple MsgPack");
+		return -1;
+	}
+	return 0;
 }

--- a/src/box/msgpack.c
+++ b/src/box/msgpack.c
@@ -99,60 +99,74 @@ msgpack_snprint_ext(char *buf, int size, const char **data, int depth)
 static int
 msgpack_check_ext_data(int8_t type, const char *data, uint32_t len)
 {
+	enum {
+		MSGPACK_MAX_NESTING = 16,
+	};
+	static __thread int msgpack_nesting;
+	int rc = -1;
+	msgpack_nesting++;
+	if (msgpack_nesting >= MSGPACK_MAX_NESTING) {
+		diag_set(ClientError, ER_INVALID_MSGPACK,
+			 "too much nesting");
+		goto out;
+	}
 	switch (type) {
 	case MP_DECIMAL:
 		if (mp_validate_decimal(data, len) != 0) {
 			diag_set(ClientError, ER_INVALID_MSGPACK,
 				 "cannot unpack decimal");
-			return -1;
+			goto out;
 		}
-		return 0;
+		break;
 	case MP_UUID:
 		if (mp_validate_uuid(data, len) != 0) {
 			diag_set(ClientError, ER_INVALID_MSGPACK,
 				 "cannot unpack uuid");
-			return -1;
+			goto out;
 		}
-		return 0;
+		break;
 	case MP_DATETIME:
 		if (mp_validate_datetime(data, len) != 0) {
 			diag_set(ClientError, ER_INVALID_MSGPACK,
 				 "cannot unpack datetime");
-			return -1;
+			goto out;
 		}
-		return 0;
+		break;
 	case MP_ERROR:
 		if (mp_validate_error(data, len) != 0) {
 			/* The error is set by error_unpack(). */
 			diag_add(ClientError, ER_INVALID_MSGPACK,
 				 "cannot unpack error");
-			return -1;
+			goto out;
 		}
-		return 0;
+		break;
 	case MP_INTERVAL:
 		if (mp_validate_interval(data, len) != 0) {
 			diag_set(ClientError, ER_INVALID_MSGPACK,
 				 "cannot unpack interval");
-			return -1;
+			goto out;
 		}
-		return 0;
+		break;
 	case MP_TUPLE:
 		if (mp_validate_tuple(data, len) != 0) {
 			diag_set(ClientError, ER_INVALID_MSGPACK,
 				 "cannot unpack tuple");
-			return -1;
+			goto out;
 		}
-		return 0;
+		break;
 	case MP_ARROW:
 		/*
 		 * The Arrow payload is not validated here, because it requires
 		 * full deserialization that is too costly.
 		 */
-		return 0;
 	case MP_COMPRESSION:
 	default:
-		return mp_check_ext_data_default(type, data, len);
+		break;
 	}
+	rc = 0;
+out:
+	msgpack_nesting--;
+	return rc;
 }
 
 /** Our handler invoked on mp_check() error. */

--- a/src/box/msgpack.c
+++ b/src/box/msgpack.c
@@ -149,7 +149,7 @@ msgpack_check_ext_data(int8_t type, const char *data, uint32_t len)
 		break;
 	case MP_TUPLE:
 		if (mp_validate_tuple(data, len) != 0) {
-			diag_set(ClientError, ER_INVALID_MSGPACK,
+			diag_add(ClientError, ER_INVALID_MSGPACK,
 				 "cannot unpack tuple");
 			goto out;
 		}

--- a/test/box-luatest/gh_6857_tuple_ext_validation_test.lua
+++ b/test/box-luatest/gh_6857_tuple_ext_validation_test.lua
@@ -103,3 +103,26 @@ g.test_extension_tuple_validation = function()
     end
     c:close()
 end
+
+-- tarantool/security#162
+g.test_mp_check_recursion_limit = function()
+    local c = net_box.connect(g.cluster.servers[1].net_box_uri)
+    t.assert_equals(c.state, 'active', 'Connection established')
+
+    local arg = box.error.new({})
+    for _ = 1, 16 do
+        arg = box.error.new({arg = arg})
+    end
+    local ok, err = pcall(c.eval, c, 'return ...', {arg})
+    t.assert_not(ok)
+    while err.prev ~= nil do
+        err = err.prev
+    end
+    t.assert_covers(err:unpack(), {
+        type = 'ClientError',
+        code = box.error.INVALID_MSGPACK,
+        message = 'Invalid MsgPack - too much nesting',
+    })
+
+    c:close()
+end

--- a/test/box-luatest/gh_6857_tuple_ext_validation_test.lua
+++ b/test/box-luatest/gh_6857_tuple_ext_validation_test.lua
@@ -59,7 +59,7 @@ end
 -- msgpack encoded string of any of these types represents a valid value.
 -- This isn't true for extension types, however. Types like decimal, uuid and
 -- others have complex internal structure, which requires additional validation.
-g.test_extension_tuple_validation = function()
+g.test_extension_types_validation = function()
     local correct_data = {
         ['decimal'] = msgpack.encode(decimal.new(fiber.time())),
         ['uuid'] = msgpack.encode(uuid.new()),
@@ -123,6 +123,34 @@ g.test_mp_check_recursion_limit = function()
         code = box.error.INVALID_MSGPACK,
         message = 'Invalid MsgPack - too much nesting',
     })
+
+    c:close()
+end
+
+g.test_extension_tuple_validation = function()
+    local c = net_box.connect(g.cluster.servers[1].net_box_uri)
+    t.assert_equals(c.state, 'active', 'Connection established')
+
+    local function check(data, details)
+        local ok, err = pcall(inject_call, c, string.fromhex(data))
+        t.assert_not(ok)
+        while err.prev ~= nil do
+            err = err.prev
+        end
+        t.assert_covers(err:unpack(), {
+            type = 'ClientError',
+            name = 'INVALID_MSGPACK',
+            details = details,
+        })
+    end
+
+    -- Check tuple validation.
+    check('c70007', 'missing format id')
+    check('c70107c2', 'malformed format id')
+    check('c70107cc', 'malformed format id')
+    check('c7010701', 'missing tuple MsgPack')
+    check('c702070101', 'tuple MsgPack is not array')
+    check('c7040701910100', 'junk after tuple MsgPack')
 
     c:close()
 end


### PR DESCRIPTION
Currently mp_check() with box extensions can overflow stack. mp_check() calls extension specific check and in case of MP_ERROR or MP_TUPLE mp_check is called again to check MsgPacks inside these type. The recursion is not limited. Let's fix it.

Closes tarantool/security#162