### PR TITLE
[backport 2.11] datetime: fixed parse of time with h.hh or m.mm

### DIFF
--- a/changelogs/unreleased/gh-12082-datetime-parse-h-m-fractions.md
+++ b/changelogs/unreleased/gh-12082-datetime-parse-h-m-fractions.md
@@ -1,0 +1,3 @@
+## bugfix/datetime
+
+* Fixed parsing for time with a decimal fraction of hour or minute (gh-12082).

--- a/src/lib/core/datetime.c
+++ b/src/lib/core/datetime.c
@@ -293,8 +293,10 @@ dt_epoch(dt_t dt)
 /** Common timezone suffix parser */
 static inline ssize_t
 parse_tz_suffix(const char *str, size_t len, time_t base,
-		int16_t *tzindex, int32_t *offset)
+		int16_t *tzindex, int16_t *offset)
 {
+	int32_t offset_internal;
+
 	/* 1st attempt: decode as MSK */
 	const struct date_time_zone *zone;
 	long gmtoff = 0;
@@ -303,17 +305,36 @@ parse_tz_suffix(const char *str, size_t len, time_t base,
 		return l;
 	if (l > 0) {
 		assert(zone != NULL);
-		*offset = gmtoff / 60;
 		*tzindex = timezone_index(zone);
-		assert(l <= (ssize_t)len);
-		return l;
+		offset_internal = gmtoff / 60;
+		/*
+		 * FIXME: gh-12417.
+		 * Strong check TZOFFSET_MIN <= offset_internal <= TZOFFSET_MAX
+		 * may not be performed due to gh-12417. For some historical
+		 * timezone offsets we can get valid tzdata offset, which is
+		 * out of our current 'valid' range.
+		 * So, we make weakened check for rude errors.
+		 */
+		assert(offset_internal > -24 * 3600);
+		assert(offset_internal < 24 * 3600);
+		goto out;
 	}
 
 	/* 2nd attempt: decode as +03:00 */
 	*tzindex = 0;
-	l = dt_parse_iso_zone_lenient(str, len, offset);
-	assert(l <= (ssize_t)len);
+	int parsed_offset = 0;
+	size_t l2 = dt_parse_iso_zone_lenient(str, len, &parsed_offset);
+	/* We ignore parse errors: (len > 0) && (l2 == 0). */
+	/* dt_parse_iso_zone_lenient allows any hh:mm, need to check. */
+	if (l2 != 0 && (parsed_offset < TZOFFSET_MIN ||
+			parsed_offset > TZOFFSET_MAX))
+		return -1;
+	offset_internal = parsed_offset;
+	l = (ssize_t)l2;
 
+out:
+	*offset = (int16_t)offset_internal;
+	assert(l <= (ssize_t)len);
 	return l;
 }
 
@@ -326,7 +347,7 @@ datetime_parse_full(struct datetime *date, const char *str, size_t len)
 	char c;
 	int sec_of_day = 0, nanosecond = 0;
 	int16_t tzindex = 0;
-	int32_t offset = 0;
+	int16_t offset = 0;
 
 	n = dt_parse_iso_date(str, len, &dt);
 	if (n == 0)
@@ -379,13 +400,7 @@ ssize_t
 datetime_parse_tz(const char *str, size_t len, time_t base, int16_t *tzoffset,
 		  int16_t *tzindex)
 {
-	int32_t offset = 0;
-	ssize_t l = parse_tz_suffix(str, len, base, tzindex, &offset);
-	if (l <= 0)
-		return l;
-	assert(offset <= INT16_MAX);
-	*tzoffset = offset;
-	return l;
+	return parse_tz_suffix(str, len, base, tzindex, tzoffset);
 }
 
 int

--- a/test/app-luatest/datetime_test.lua
+++ b/test/app-luatest/datetime_test.lua
@@ -28,6 +28,8 @@ local MAX_DATE_DAY = 11
 
 local TZOFFSET_MIN = -12 * 60
 local TZOFFSET_MAX = 14 * 60
+local TZOFFSET_H_MIN = TZOFFSET_MIN / 60
+local TZOFFSET_H_MAX = TZOFFSET_MAX / 60
 
 local YEAR_RANGE = {MIN_DATE_YEAR, MAX_DATE_YEAR}
 local MONTH_RANGE = {1, 12}
@@ -64,7 +66,31 @@ local function get_single_key_val(arg, table_expected)
     return key, val
 end
 
+-- See ISO 8601-1:2019 5.3.4.1 for time shift format.
+local function tzoffset_str(x, shift_type)
+    checks('int64', 'string')
+    local h = x / 60
+    local m = math.abs(x) % 60
+    if shift_type == '' then
+        -- 'shift' format.
+        return ('%+03d%02d'):format(h, m)
+    elseif shift_type == 'X' then
+        -- 'shiftX' format.
+        return ('%+03d:%02d'):format(h, m)
+    elseif shift_type == 'H' then
+        -- 'shiftH' format.
+        assert(m == 0)
+        return ('%+03d'):format(h)
+    end
+    error('invalid shift_type')
+end
+
 -- }}} Common utils.
+
+-- {{{ Valid ISO parse test.
+
+local UTC_20240731_1430_EPOCH = 1722436200
+local UTC_20240731_1730_EPOCH = 1722447000
 
 local SUPPORTED_DATETIME_FORMATS = {
     ['RFC3339 AND ISO8601'] = {
@@ -197,18 +223,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y-%M-%DT%,1h',
             buf = '2024-07-31T17,5',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%.1h',
             buf = '2024-07-31T17.5',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%m',
             buf = '2024-07-31T17:30',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%,1m',
             buf = '2024-07-31T17:30,0',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%.1m',
             buf = '2024-07-31T17:30.0',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%m:%s',
             buf = '2024-07-31T17:30:02',
@@ -236,18 +267,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y-%M-%DT%,1hZ',
             buf = '2024-07-31T14,5Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%.1hZ',
             buf = '2024-07-31T14.5Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%mZ',
             buf = '2024-07-31T14:30Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%,1mZ',
             buf = '2024-07-31T14:30,0Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%.1mZ',
             buf = '2024-07-31T14:30.0Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%m:%,3sZ',
             buf = '2024-07-31T14:30:02,132Z',
@@ -260,18 +296,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y-%M-%DT%,1h%Z',
             buf = '2024-07-31T17,5+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%.1h%Z',
             buf = '2024-07-31T17.5+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%m%Z',
             buf = '2024-07-31T17:30+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%,1m%Z',
             buf = '2024-07-31T17:30,0+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%.1m%Z',
             buf = '2024-07-31T17:30.0+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%m:%s%Z',
             buf = '2024-07-31T17:30:02+03',
@@ -299,18 +340,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y-%M-%DT%,1h%Z:%z',
             buf = '2024-07-31T17,5+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%.1h%Z:%z',
             buf = '2024-07-31T17.5+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%m%Z:%z',
             buf = '2024-07-31T17:30+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%,1m%Z:%z',
             buf = '2024-07-31T17:30,0+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%.1m%Z:%z',
             buf = '2024-07-31T17:30.0+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%M-%DT%h:%m:%.1s%Z:%z',
             buf = '2024-07-31T17:30:02.1+03:00',
@@ -329,18 +375,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%V-W%W-%wT%,1h',
             buf = '2024-W31-3T17,5',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%.1h',
             buf = '2024-W31-3T17.5',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%m',
             buf = '2024-W31-3T17:30',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%,1m',
             buf = '2024-W31-3T17:30,0',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%.1m',
             buf = '2024-W31-3T17:30.0',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%m:%s',
             buf = '2024-W31-3T17:30:02',
@@ -368,18 +419,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%V-W%W-%wT%,1hZ',
             buf = '2024-W31-3T14,5Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%.1hZ',
             buf = '2024-W31-3T14.5Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%mZ',
             buf = '2024-W31-3T14:30Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%,1mZ',
             buf = '2024-W31-3T14:30,0Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%.1mZ',
             buf = '2024-W31-3T14:30.0Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%m:%sZ',
             buf = '2024-W31-3T14:30:02Z',
@@ -407,18 +463,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%V-W%W-%wT%,1h%Z',
             buf = '2024-W31-3T17,5+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%.1h%Z',
             buf = '2024-W31-3T17.5+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%m%Z',
             buf = '2024-W31-3T17:30+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%,1m%Z',
             buf = '2024-W31-3T17:30,0+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%.1m%Z',
             buf = '2024-W31-3T17:30.0+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%m:%s%Z',
             buf = '2024-W31-3T17:30:02+03',
@@ -446,18 +507,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%V-W%W-%wT%,1h%Z:%z',
             buf = '2024-W31-3T17,5+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%.1h%Z:%z',
             buf = '2024-W31-3T17.5+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%m%Z:%z',
             buf = '2024-W31-3T17:30+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%,1m%Z:%z',
             buf = '2024-W31-3T17:30,0+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%.1m%Z:%z',
             buf = '2024-W31-3T17:30.0+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%V-W%W-%wT%h:%m:%s%Z:%z',
             buf = '2024-W31-3T17:30:02+03:00',
@@ -485,18 +551,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y-%OT%,1h',
             buf = '2024-213T17,5',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y-%OT%.1h',
             buf = '2024-213T17.5',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%m',
             buf = '2024-213T17:30',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%,1m',
             buf = '2024-213T17:30,0',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%.1m',
             buf = '2024-213T17:30.0',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%m:%s',
             buf = '2024-213T17:30:02',
@@ -524,18 +595,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y-%OT%,1hZ',
             buf = '2024-213T14,5Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%.1hZ',
             buf = '2024-213T14.5Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%mZ',
             buf = '2024-213T14:30Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%,1mZ',
             buf = '2024-213T14:30,0Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%.1mZ',
             buf = '2024-213T14:30.0Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%m:%sZ',
             buf = '2024-213T14:30:02Z',
@@ -563,18 +639,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y-%OT%,1h%Z',
             buf = '2024-213T17,5+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%.1h%Z',
             buf = '2024-213T17.5+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%m%Z',
             buf = '2024-213T17:30+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%,1m%Z',
             buf = '2024-213T17:30,0+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%.1m%Z',
             buf = '2024-213T17:30.0+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%m:%s%Z',
             buf = '2024-213T17:30:02+03',
@@ -602,18 +683,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y-%OT%,1h%Z:%z',
             buf = '2024-213T17,5+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%.1h%Z:%z',
             buf = '2024-213T17.5+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%m%Z:%z',
             buf = '2024-213T17:30+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%,1m%Z:%z',
             buf = '2024-213T17:30,0+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%.1m%Z:%z',
             buf = '2024-213T17:30.0+03:00',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y-%OT%h:%m:%s%Z:%z',
             buf = '2024-213T17:30:02+03:00',
@@ -641,18 +727,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y%M%DT%,1h',
             buf = '20240731T17,5',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y%M%DT%.1h',
             buf = '20240731T17.5',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%m',
             buf = '20240731T1730',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%,1m',
             buf = '20240731T1730,0',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%.1m',
             buf = '20240731T1730.0',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%m%s',
             buf = '20240731T173002',
@@ -680,18 +771,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y%M%DT%,1hZ',
             buf = '20240731T14,5Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%.1hZ',
             buf = '20240731T14.5Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%mZ',
             buf = '20240731T1430Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%,1mZ',
             buf = '20240731T1430,0Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%.1mZ',
             buf = '20240731T1430.0Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%m%sZ',
             buf = '20240731T143002Z',
@@ -719,18 +815,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y%M%DT%,1h%Z',
             buf = '20240731T17,5+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%.1h%Z',
             buf = '20240731T17.5+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%m%Z',
             buf = '20240731T1730+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%,1m%Z',
             buf = '20240731T1730,0+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%.1m%Z',
             buf = '20240731T1730.0+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%m%s%Z',
             buf = '20240731T173002+03',
@@ -758,18 +859,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y%M%DT%,1h%Z%z',
             buf = '20240731T17,5+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%.1h%Z%z',
             buf = '20240731T17.5+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%m%Z%z',
             buf = '20240731T1730+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%,1m%Z%z',
             buf = '20240731T1730,0+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%.1m%Z%z',
             buf = '20240731T1730.0+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%M%DT%h%m%s%Z%z',
             buf = '20240731T173002+0300',
@@ -797,18 +903,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%VW%W%wT%,1h',
             buf = '2024W313T17,5',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%VW%W%wT%.1h',
             buf = '2024W313T17.5',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%m',
             buf = '2024W313T1730',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%,1m',
             buf = '2024W313T1730,0',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%.1m',
             buf = '2024W313T1730.0',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%m%s',
             buf = '2024W313T173002',
@@ -836,18 +947,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%VW%W%wT%,1hZ',
             buf = '2024W313T14,5Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%.1hZ',
             buf = '2024W313T14.5Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%mZ',
             buf = '2024W313T1430Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%,1mZ',
             buf = '2024W313T1430,0Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%.1mZ',
             buf = '2024W313T1430.0Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%m%sZ',
             buf = '2024W313T143002Z',
@@ -875,18 +991,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%VW%W%wT%,1h%Z',
             buf = '2024W313T17,5+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%.1h%Z',
             buf = '2024W313T17.5+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%m%Z',
             buf = '2024W313T1730+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%,1m%Z',
             buf = '2024W313T1730,0+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%.1m%Z',
             buf = '2024W313T1730.0+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%m%s%Z',
             buf = '2024W313T173002+03',
@@ -914,18 +1035,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%VW%W%wT%,1h%Z%z',
             buf = '2024W313T17,5+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%.1h%Z%z',
             buf = '2024W313T17.5+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%m%Z%z',
             buf = '2024W313T1730+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%,1m%Z%z',
             buf = '2024W313T1730,0+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%.1m%Z%z',
             buf = '2024W313T1730.0+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%VW%W%wT%h%m%s%Z%z',
             buf = '2024W313T173002+0300',
@@ -953,18 +1079,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y%OT%,1h',
             buf = '2024213T17,5',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y%OT%.1h',
             buf = '2024213T17.5',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y%OT%h%m',
             buf = '2024213T1730',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y%OT%h%,1m',
             buf = '2024213T1730,0',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y%OT%h%.1m',
             buf = '2024213T1730.0',
+            ts = UTC_20240731_1730_EPOCH,
         }, {
             fmt = '%Y%OT%h%m%s',
             buf = '2024213T173002',
@@ -992,18 +1123,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y%OT%,1hZ',
             buf = '2024213T14,5Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%.1hZ',
             buf = '2024213T14.5Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%h%mZ',
             buf = '2024213T1430Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%h%,1mZ',
             buf = '2024213T1430,0Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%h%.1mZ',
             buf = '2024213T1430.0Z',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%h%m%sZ',
             buf = '2024213T143002Z',
@@ -1031,18 +1167,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y%OT%,1h%Z',
             buf = '2024213T17,5+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%.1h%Z',
             buf = '2024213T17.5+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%h%m%Z',
             buf = '2024213T1730+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%h%,1m%Z',
             buf = '2024213T1730,0+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%h%.1m%Z',
             buf = '2024213T1730.0+03',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%h%m%s%Z',
             buf = '2024213T173002+03',
@@ -1070,18 +1211,23 @@ local SUPPORTED_DATETIME_FORMATS = {
         }, {
             fmt = '%Y%OT%,1h%Z%z',
             buf = '2024213T17,5+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%.1h%Z%z',
             buf = '2024213T17.5+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%h%m%Z%z',
             buf = '2024213T1730+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%h%,1m%Z%z',
             buf = '2024213T1730,0+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%h%.1m%Z%z',
             buf = '2024213T1730.0+0300',
+            ts = UTC_20240731_1430_EPOCH,
         }, {
             fmt = '%Y%OT%h%m%s%Z%z',
             buf = '2024213T173002+0300',
@@ -2114,6 +2260,7 @@ for supported_by, standard_cases in pairs(SUPPORTED_DATETIME_FORMATS) do
         local f = case.fmt
         local testcase_name = 'test_supported_format_' .. f:gsub('/', '_')
         local fmtmsg = "Format '%s' supported by %s not parsed by %s"
+        local invalmsg = 'invalid result: datetime:%s'
 
         if supported_by == 'RFC3339 AND ISO8601' then
             local buf = case.buf
@@ -2126,12 +2273,20 @@ for supported_by, standard_cases in pairs(SUPPORTED_DATETIME_FORMATS) do
                 t.assert(iso8601_ok, fmtmsg:format(f, supported_by, 'iso8601'))
                 t.assert(rfc3339_ok, fmtmsg:format(f, supported_by, 'rfc3339'))
                 t.assert_equals(iso8601_val, rfc3339_val, 'unequal results')
+                if case.ts ~= nil then
+                    t.assert_equals(iso8601_val.timestamp, case.ts,
+                                    invalmsg:format(iso8601_val:format(f)))
+                end
             end
         else
             local dtfmt = supported_by:gsub(' ONLY', ''):lower()
             pg[testcase_name] = function()
-                local ok, _ = pcall(dt.parse, case.buf, {format = dtfmt})
+                local ok, val = pcall(dt.parse, case.buf, {format = dtfmt})
                 t.assert(ok, fmtmsg:format(f, supported_by, dtfmt))
+                if case.ts ~= nil then
+                    t.assert_equals(val.timestamp, case.ts,
+                                    invalmsg:format(val:format(case.fmt)))
+                end
             end
         end
     end
@@ -2163,6 +2318,46 @@ for supported_by, standard_cases in pairs(UNSUPPORTED_DATETIME_FORMATS) do
         end
     end
 end
+
+-- }}} Valid ISO parse test.
+
+-- {{{ Invalid ISO parse test.
+
+local INVALID_ISO_STRINGS = {
+    {
+        buf = '8400329 10'..tzoffset_str((TZOFFSET_H_MIN - 1) * 60, 'H'),
+        comment = 'out of range tzoffset',
+    },
+    {
+        buf = '8400329 10'..tzoffset_str((TZOFFSET_H_MAX + 1) * 60, 'H'),
+        comment = 'out of range tzoffset',
+    },
+    {
+        buf = '8400329 10'..tzoffset_str(TZOFFSET_MIN - 1, ''),
+        comment = 'out of range tzoffset',
+    },
+    {
+        buf = '8400329 10'..tzoffset_str(TZOFFSET_MAX + 1, ''),
+        comment = 'out of range tzoffset',
+    },
+    {
+        buf = '8400329 10'..tzoffset_str(TZOFFSET_MIN - 1, 'X'),
+        comment = 'out of range tzoffset',
+    },
+    {
+        buf = '8400329 10'..tzoffset_str(TZOFFSET_MAX + 1, 'X'),
+        comment = 'out of range tzoffset',
+    },
+}
+
+local pg2 = t.group('parse_iso_fail', INVALID_ISO_STRINGS)
+
+pg2.test_parse_iso_fail = function(cg)
+    local p = cg.params
+    t.assert_error_msg_contains('could not parse', dt.parse, p.buf)
+end
+
+-- }}} Invalid ISO parse test.
 
 -- {{{ new() and set() invalid args test.
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -140,7 +140,7 @@ create_unit_test(PREFIX xmalloc
                  LIBRARIES unit
 )
 create_unit_test(PREFIX datetime
-                 SOURCES datetime.c
+                 SOURCES datetime.c core_test_utils.c
                  LIBRARIES tzcode core cdt unit
 )
 create_unit_test(PREFIX error

--- a/test/unit/datetime.c
+++ b/test/unit/datetime.c
@@ -11,21 +11,46 @@
 #include "mp_extension_types.h"
 #include "trivia/util.h"
 #include "tzcode/tzcode.h"
+#include "tt_static.h"
 
 #define UNIT_TAP_COMPATIBLE 1
 #include "unit.h"
 
 #define TAP_TEST_LOCATION() note("%s [%zu]", __func__, index + 1)
 
-static const char sample[] = "2012-12-24T15:30Z";
+#define TZOFFSET_H_MIN (TZOFFSET_MIN / 60)
+#define TZOFFSET_H_MAX (TZOFFSET_MAX / 60)
 
-void
-cord_on_yield(void) {}
+/** See ISO 8601-1:2019 5.3.4.1 for time shift format. */
+static const char *
+tzoffset_str(int16_t x, char shift_type)
+{
+	int h = x / 60, m = abs(x) % 60;
+	if (shift_type == 'X') {
+		return tt_sprintf("%+03d:%02d", h, m);
+	} else if (shift_type == 'H') {
+		assert(m == 0);
+		return tt_sprintf("%+03d", h);
+	}
+	assert(shift_type == ' ');
+	return tt_sprintf("%+03d%02d", h, m);
+}
 
-#define S(s) {s, sizeof(s) - 1}
+static const char *
+dt_tzoffset_str(const char *dt, int16_t tzoffset, char shift_type)
+{
+	return tt_sprintf("%s%s", dt, tzoffset_str(tzoffset, shift_type));
+}
+
+/** 1356363000 is 2012-12-24T15:30Z */
+#define DEFAULT_SAMPLE_EPOCH 1356363000
+#define S(s) {s, sizeof(s) - 1, DEFAULT_SAMPLE_EPOCH}
+#define SAMPLE_NON_DEF_EPOCH(s, sample_epoch) {s, sizeof(s) - 1, sample_epoch}
+#define DELTA(delta) (DEFAULT_SAMPLE_EPOCH + (delta))
 struct {
 	const char *str;
 	size_t len;
+	double sample_epoch;
 } tests[] = {
 	S("2012-12-24 15:30Z"),
 	S("2012-12-24 15:30z"),
@@ -104,50 +129,101 @@ struct {
 	S("2012-12-24T1630+01:00"),
 	S("20121224T16:30+01"),
 	S("20121224T16:30 +01"),
+	S("20121224T16,5+0100"),
+	S("20121224T16,5+01:00"),
+	SAMPLE_NON_DEF_EPOCH("20121224T16.75+0100", DELTA(15 * 60)),
+	SAMPLE_NON_DEF_EPOCH("20121224T16.625+0100", DELTA(7 * 60 + 30)),
+	S("2012-12-24T16,5+01:00"),
+	SAMPLE_NON_DEF_EPOCH("2012-12-24T16.75+01:00", DELTA(15 * 60)),
+	SAMPLE_NON_DEF_EPOCH("2012-12-24T16.625+01:00", DELTA(7 * 60 + 30)),
+	S("20121224T1630.0+0100"),
+	SAMPLE_NON_DEF_EPOCH("20121224T1630.5+0100", DELTA(30)),
+	S("20121224T16:30.0+0100"),
+	SAMPLE_NON_DEF_EPOCH("20121224T16:30.5+0100", DELTA(30)),
+	SAMPLE_NON_DEF_EPOCH("20121224T16:30,1+0100", DELTA(6)),
+	SAMPLE_NON_DEF_EPOCH("20121224T16:30,01666667+0100", DELTA(1)),
 };
 #undef S
+#undef SAMPLE_NON_DEF_EPOCH
+#undef DELTA
+#undef DEFAULT_SAMPLE_EPOCH
 
 static void
-datetime_test(void)
+datetime_parse_full_ok_test(void)
 {
 	size_t index;
-	struct datetime date_expected;
-
-	datetime_parse_full(&date_expected, sample, sizeof(sample) - 1);
 
 	const unsigned tap_tests_per_iter = 7;
 	plan(tap_tests_per_iter * lengthof(tests));
 	for (index = 0; index < lengthof(tests); index++) {
 		TAP_TEST_LOCATION();
+		/* Result of datetime_parse_full. */
+		ssize_t parse_len;
+		/* Results of datetime_(strftime|strptime). */
+		size_t flen, plen;
+		const char *test_str = tests[index].str;
+		size_t test_len = tests[index].len;
+		size_t test_sample_epoch = tests[index].sample_epoch;
 		struct datetime date;
-		ssize_t len = datetime_parse_full(&date, tests[index].str,
-						  tests[index].len);
-		is(len > 0, true, "correct parse_datetime return value "
-		   "for '%s'", tests[index].str);
-		is(date.epoch, date_expected.epoch,
-		   "correct parse_datetime output "
+
+		parse_len = datetime_parse_full(&date, test_str, test_len);
+		is((parse_len > 0) && ((size_t)parse_len == test_len), true,
+		   "correct datetime_parse_full "
+		   "parsed symbols for '%s'", test_str);
+		is(date.epoch, test_sample_epoch,
+		   "correct datetime_parse_full output "
 		   "seconds for '%s",
-		   tests[index].str);
+		   test_str);
 
 		/*
 		 * check that stringized literal produces the same date
 		 * time fields
 		 */
 		static char buff[DT_TO_STRING_BUFSIZE];
-		len = datetime_strftime(&date, buff, sizeof(buff), "%F %T%z");
-		ok(len > 0, "strftime");
+		flen = datetime_strftime(&date, buff, sizeof(buff), "%F %T%z");
+		ok(flen > 0, "datetime_strftime");
 		struct datetime date_strp;
-		len = datetime_strptime(&date_strp, buff, "%F %T%z");
-		is(len > 0, true, "correct parse_strptime return value "
-		   "for '%s'", buff);
+		plen = datetime_strptime(&date_strp, buff, "%F %T%z");
+		is(plen == flen, true, "correct datetime_strptime "
+		   "parsed symbols for '%s'", buff);
 		is(date.epoch, date_strp.epoch,
 		   "reversible seconds via datetime_strptime for '%s'", buff);
 		struct datetime date_parsed;
-		len = datetime_parse_full(&date_parsed, buff, len);
-		is(len > 0, true, "correct datetime_parse_full return value "
-		   "for '%s'", buff);
+		parse_len = datetime_parse_full(&date_parsed, buff, flen);
+		is((parse_len > 0) & ((size_t)parse_len == flen), true,
+		   "correct datetime_parse_full "
+		   "parsed symbols for '%s'", buff);
 		is(date.epoch, date_parsed.epoch,
 		   "reversible seconds via datetime_parse_full for '%s'", buff);
+	}
+	check_plan();
+}
+
+static void
+datetime_parse_full_fail_test(void)
+{
+	const char *const invalid_tests[] = {
+		/* Out of range tzoffset. */
+		dt_tzoffset_str("8400329 10", (TZOFFSET_H_MIN - 1) * 60, 'H'),
+		dt_tzoffset_str("8400329 10", (TZOFFSET_H_MAX + 1) * 60, 'H'),
+		dt_tzoffset_str("8400329 10", TZOFFSET_MIN - 1, ' '),
+		dt_tzoffset_str("8400329 10", TZOFFSET_MAX + 1, ' '),
+		dt_tzoffset_str("8400329 10", TZOFFSET_MIN - 1, 'X'),
+		dt_tzoffset_str("8400329 10", TZOFFSET_MAX + 1, 'X'),
+	};
+
+	const unsigned tap_tests_per_iter = 1;
+	plan(tap_tests_per_iter * lengthof(invalid_tests));
+	for (size_t index = 0; index < lengthof(invalid_tests); index++) {
+		TAP_TEST_LOCATION();
+		ssize_t parse_len;
+		const char *test_str = invalid_tests[index];
+		size_t test_len = strlen(test_str);
+		struct datetime date;
+
+		parse_len = datetime_parse_full(&date, test_str, test_len);
+		is(parse_len < 0, true, "datetime_parse_full "
+		   "fails for '%s'", test_str);
 	}
 	check_plan();
 }
@@ -679,8 +755,9 @@ interval_from_map_test(void)
 int
 main(void)
 {
-	plan(11);
-	datetime_test();
+	plan(12);
+	datetime_parse_full_ok_test();
+	datetime_parse_full_fail_test();
 	tostring_datetime_test();
 	parse_date_iso8601_valid_test();
 	parse_date_iso8601_invalid_test();


### PR DESCRIPTION
*(This PR is a backport of #12083 to `release/2.11` to a future `2.11.10` release.)*

_Also, it contains changes from #12436's commit 9d1eddfa0d00429754a6da4d9a9ef80753cab82a for datetime test unit._

----

- `datetime.c`, `parse_tz_suffix` and its clients refactored for better error detection & to simplify code:
  - offset value post-condition check is moved to `parse_tz_suffix`.
  - this check uses tzoffset valid range instead of int16_t min/max.
  - offset arg type of `parse_tz_suffix` fixed to valid for TZoffset (int16_t).
- Fixed range checking for tzoffset parsed by `dt_parse_iso_zone_lenient`.
- The better error detection lead to assertion fails of datetime tests with decimal fraction of hours and minutes. The fix is the first way to solve the problem. (The other way is to comment out the tests.)

Fixes #12082

@TarantoolBot document
Title: Parse of time with hour and minute decimal fraction implemented

Datetime module now supports formats, which are defined in ISO 8601-1:2019 (5.3.1.4, b-c).

Implementation details:
  - As for decimal fraction of the second (5.3.1.4, a), the tail after 9 fraciton digits is truncated. `0.123456789999` is the same as `0.123456789`.
  - The hour (format c) or minute (format b) fractions are truncated to seconds precision. If somebody want a second fraction, they must use explicit representation (format a).

```
datetime.parse('2024-07-31T17,5', {format = 'iso8601'})
---
- 2024-07-31T17:30:00Z

datetime.parse('2024-07-31T17:30.333333333', {format = 'iso8601'})
---
- 2024-07-31T17:30:19Z
```

(cherry picked from commit 5b51d7c7698beb62efdf7c41667f1d2aed2f7aad)