### PR TITLE
console: fix crash when completion_handler() called without arguments

### DIFF
--- a/src/box/lua/console.c
+++ b/src/box/lua/console.c
@@ -1185,6 +1185,9 @@ lua_rl_complete(lua_State *L, const char *text, int start, int end)
 	size_t i, n, dot, items_checked;
 	int loop, savetop, is_method_ref = 0;
 
+	if (text == NULL)
+		return NULL;
+
 	if (!(text[0] == '\0' || isalpha(text[0]) || text[0] == '_'))
 		return NULL;
 


### PR DESCRIPTION
## Problem

`console.completion_handler()` crashes with a segmentation fault when called without arguments from Lua.

`lua_rl_complete()` dereferences `text[0]` at the start of the function without checking if `text` is NULL. When `lbox_console_completion_handler()` receives no arguments, `lua_tostring(L, 1)` returns NULL, which is passed directly to `lua_rl_complete()`.

**Reproduction:**
```lua
tarantool> console.completion_handler()
Segmentation fault
```

**Backtrace:**
```
lua_rl_complete(L, NULL, 0, 0)  →  text[0]  →  SEGV
```

## Fix

Add a NULL check at the start of `lua_rl_complete()` to return early when `text` is NULL, consistent with how the function already handles invalid first characters.

Fixes #12747
