### PR TITLE
box: add yield_period option to index:pairs()

### DIFF
--- a/changelog/unreleased/box-index-pairs-yield-period.md
+++ b/changelog/unreleased/box-index-pairs-yield-period.md
@@ -1,0 +1,7 @@
+## feature/box
+
+* Added the `yield_period` option to `index:pairs()` and `space:pairs()`. When
+  set to a positive integer `N`, the iterator reschedules the current fiber once
+  every `N` tuples it returns, so that a long scan over a space cooperates with
+  the event loop instead of hogging the cord. The default (`0`/`nil`) keeps the
+  previous behavior of never yielding on its own.

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -2150,6 +2150,27 @@ base_index_mt.random_luac = function(index, rnd)
     return internal.random(index.space_id, index.id, rnd);
 end
 -- iteration
+
+-- Wrap an iterator generator so that it reschedules the current fiber once
+-- every `period` tuples it produces. Implements the `yield_period` pairs()
+-- option, letting a long scan cooperate with the event loop instead of
+-- hogging the cord. The counter lives in the closure, so each pairs() call
+-- gets its own independent state.
+local function iterator_gen_with_yield(gen, period)
+    local n = 0
+    return function(param, state)
+        local next_state, tuple = gen(param, state)
+        if next_state ~= nil then
+            n = n + 1
+            if n >= period then
+                n = 0
+                fiber.yield()
+            end
+        end
+        return next_state, tuple
+    end
+end
+
 base_index_mt.pairs_ffi = function(index, key, opts)
     check_index_arg(index, 'pairs', 2)
     -- Encode the key on cord ibuf. Note, since the ibuf may be
@@ -2160,7 +2181,8 @@ base_index_mt.pairs_ffi = function(index, key, opts)
     tuple_encode(ibuf, key, 2)
     local key_size = ibuf:size()
     local svp = builtin.box_region_used()
-    local itype, after, offset = check_pairs_opts(opts, key_size <= 1, 2)
+    local itype, after, offset, yield_period =
+        check_pairs_opts(opts, key_size <= 1, 2)
     local ok = iterator_pos_set(index, after, ibuf, 2)
     local keybuf = ffi.string(ibuf.rpos, key_size)
     cord_ibuf_put(ibuf)
@@ -2175,18 +2197,27 @@ base_index_mt.pairs_ffi = function(index, key, opts)
     if cdata == nil then
         box.error(box.error.last(), 2)
     end
-    return fun.wrap(iterator_gen, keybuf,
+    local gen = iterator_gen
+    if yield_period ~= nil and yield_period > 0 then
+        gen = iterator_gen_with_yield(iterator_gen, yield_period)
+    end
+    return fun.wrap(gen, keybuf,
         ffi.gc(cdata, builtin.box_iterator_free))
 end
 base_index_mt.pairs_luac = function(index, key, opts)
     check_index_arg(index, 'pairs', 2)
     key = keify(key)
-    local itype, after, offset = check_pairs_opts(opts, #key == 0, 2)
+    local itype, after, offset, yield_period =
+        check_pairs_opts(opts, #key == 0, 2)
     local keymp = msgpack.encode(key)
     local keybuf = ffi.string(keymp, #keymp)
     local cdata = internal.iterator(index.space_id, index.id, itype, keymp,
         after, offset, 2);
-    return fun.wrap(iterator_gen_luac, keybuf,
+    local gen = iterator_gen_luac
+    if yield_period ~= nil and yield_period > 0 then
+        gen = iterator_gen_with_yield(iterator_gen_luac, yield_period)
+    end
+    return fun.wrap(gen, keybuf,
         ffi.gc(cdata, builtin.box_iterator_free))
 end
 

--- a/src/box/lua/utils.lua
+++ b/src/box/lua/utils.lua
@@ -99,6 +99,7 @@ local function check_pairs_opts(opts, key_is_nil, level)
     local iterator = check_iterator_type(opts, key_is_nil, level and level + 1)
     local offset = 0
     local after = nil
+    local yield_period = nil
     if opts ~= nil and type(opts) == "table" then
         if opts.offset ~= nil then
             offset = opts.offset
@@ -110,8 +111,17 @@ local function check_pairs_opts(opts, key_is_nil, level)
                 box.error(box.error.ITERATOR_POSITION, level and level + 1)
             end
         end
+        if opts.yield_period ~= nil then
+            if type(opts.yield_period) ~= "number" or
+                    opts.yield_period < 0 or opts.yield_period % 1 ~= 0 then
+                box.error(box.error.ILLEGAL_PARAMS,
+                          "options.yield_period must be a non-negative " ..
+                          "integer", level and level + 1)
+            end
+            yield_period = opts.yield_period
+        end
     end
-    return iterator, after, offset
+    return iterator, after, offset, yield_period
 end
 box.internal.check_pairs_opts = check_pairs_opts
 

--- a/test/box-luatest/index_pairs_yield_period_test.lua
+++ b/test/box-luatest/index_pairs_yield_period_test.lua
@@ -1,0 +1,138 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    -- Define helpers in the server process; globals persist across exec calls.
+    cg.server:exec(function()
+        -- Fill a space with 1000 two-field tuples (field 2 lets us build
+        -- secondary indexes).
+        rawset(_G, 'fill', function(s)
+            box.begin()
+            for i = 1, 1000 do
+                s:replace({i, i})
+            end
+            box.commit()
+        end)
+        -- Scan `iter` (a space or an index) and report (count, did_yield).
+        --
+        -- did_yield uses a freshly created fiber: thanks to cooperative
+        -- scheduling it is ready but only actually runs if the scanning fiber
+        -- yields somewhere inside the loop. So `ran == true` after the loop is
+        -- a deterministic "the scan yielded at least once" detector.
+        rawset(_G, 'scan', function(iter, opts)
+            local fiber = require('fiber')
+            local ran = false
+            fiber.new(function() ran = true end)
+            local n = 0
+            for _ in iter:pairs({}, opts) do
+                n = n + 1
+            end
+            return n, ran
+        end)
+    end)
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+-- memtx TREE primary index (baseline).
+g.test_memtx_tree_primary = function(cg)
+    local n, ran, n2, ran2 = cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+        fill(s)
+        local a, b = scan(s, {yield_period = 100})
+        local c, d = scan(s, {})
+        return a, b, c, d
+    end)
+    t.assert_equals(n, 1000)
+    t.assert(ran, 'tree scan with yield_period must yield')
+    t.assert_equals(n2, 1000)
+    t.assert_not(ran2, 'default tree scan must not yield')
+end
+
+-- memtx TREE secondary index.
+g.test_memtx_tree_secondary = function(cg)
+    local n, ran, n2, ran2 = cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+        s:create_index('sk', {parts = {2, 'unsigned'}})
+        fill(s)
+        local a, b = scan(s.index.sk, {yield_period = 100})
+        local c, d = scan(s.index.sk, {})
+        return a, b, c, d
+    end)
+    t.assert_equals(n, 1000)
+    t.assert(ran, 'secondary tree scan with yield_period must yield')
+    t.assert_equals(n2, 1000)
+    t.assert_not(ran2, 'default secondary tree scan must not yield')
+end
+
+-- memtx HASH index.
+g.test_memtx_hash = function(cg)
+    local n, ran, n2, ran2 = cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('pk', {type = 'HASH'})
+        fill(s)
+        local a, b = scan(s, {yield_period = 100})
+        local c, d = scan(s, {})
+        return a, b, c, d
+    end)
+    t.assert_equals(n, 1000)
+    t.assert(ran, 'hash scan with yield_period must yield')
+    t.assert_equals(n2, 1000)
+    t.assert_not(ran2, 'default hash scan must not yield')
+end
+
+-- memtx BITSET secondary index (non-unique, ITER_ALL).
+g.test_memtx_bitset = function(cg)
+    local n, ran, n2, ran2 = cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+        s:create_index('bs', {type = 'BITSET', unique = false,
+                              parts = {2, 'unsigned'}})
+        fill(s)
+        local a, b = scan(s.index.bs, {yield_period = 100})
+        local c, d = scan(s.index.bs, {})
+        return a, b, c, d
+    end)
+    t.assert_equals(n, 1000)
+    t.assert(ran, 'bitset scan with yield_period must yield')
+    t.assert_equals(n2, 1000)
+    t.assert_not(ran2, 'default bitset scan must not yield')
+end
+
+-- Option validation (engine-agnostic).
+g.test_validation = function(cg)
+    cg.server:exec(function()
+        local tt = require('luatest')
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+        tt.assert_error_msg_contains(
+            'yield_period must be a non-negative integer',
+            function() s:pairs({}, {yield_period = -1}) end)
+        tt.assert_error_msg_contains(
+            'yield_period must be a non-negative integer',
+            function() s:pairs({}, {yield_period = 1.5}) end)
+        tt.assert_error_msg_contains(
+            'yield_period must be a non-negative integer',
+            function() s:pairs({}, {yield_period = 'x'}) end)
+        -- zero is allowed and means "never yield".
+        local n = 0
+        for _ in s:pairs({}, {yield_period = 0}) do n = n + 1 end
+        tt.assert_equals(n, 0)
+    end)
+end


### PR DESCRIPTION
When scanning a large space with index:pairs() or space:pairs(), a user previously had to insert periodic fiber.yield() calls by hand to avoid monopolizing the event loop. Add a `yield_period` option to pairs(): when set to a positive integer N, the iterator reschedules the current fiber once every N tuples it returns. The default (0/nil) preserves the previous behavior of never yielding on its own.

Closes: https://github.com/tarantool/tarantool/issues/10945