### PR TITLE
Revert "ci: disable crud integration tests"

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -149,12 +149,11 @@ jobs:
     with:
       artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
-  # FIXME: Disabled due to https://jira.vk.team/browse/TNTP-7897
-  # crud:
-  #   needs: tarantool
-  #   uses: tarantool/crud/.github/workflows/reusable_test.yml@master
-  #   with:
-  #     artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
+  crud:
+    needs: tarantool
+    uses: tarantool/crud/.github/workflows/reusable_test.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   # FIXME: Disabled due to tarantool/ddl#130.
   # ddl:


### PR DESCRIPTION
This reverts commit 4c67c4bb73ca16c4838061ba94b1efc6635cb27d.

The recent crud PR [1] fixed test timeouts due to slow rebalancing, so it's time to enable the workflow back.

[1]: https://github.com/tarantool/crud/pull/498

NO_CHANGELOG=CI
NO_TEST=CI
NO_DOC=CI