### PR TITLE
ci: change workflow condition in perf_micro

### DIFF
--- a/.github/workflows/perf_micro.yml
+++ b/.github/workflows/perf_micro.yml
@@ -67,7 +67,8 @@ jobs:
             github.event_name != 'pull_request_target' ) ||
           ( github.event_name == 'pull_request' &&
             !contains(github.event.pull_request.labels.*.name, 'notest') ) ||
-          ( github.event_name == 'pull_request_target' &&
+          ( github.event.pull_request.head.repo.full_name == github.repository &&
+            github.event_name == 'pull_request_target' &&
             contains(github.event.pull_request.labels.*.name, 'performance') ) )
 
     # 'performance' label _must_ be set only for the single runner


### PR DESCRIPTION
The standard `pull_request` trigger runs in the context of a fork. It doesn't have access to repository secrets, making it safe for reviewing code from unknown contributors.

The `pull_request_target` trigger runs in the context of the base (target) repository. It has full access to secrets and the GITHUB_TOKEN with write permissions, even for PRs from forks.

The patch changes the condition for running perf_micro workflow - now the workflow will use `pull_request_target` trigger only when the branch is in tarantool/tarantool repository and a label `performance` is set. The better solution is suggested in [1].

The patch follows up the commit 8de85f5c15f0
("ci: run perf_micro workflow on performance label").

1. https://github.com/tarantool/tarantool/issues/12768

NO_CHANGELOG=ci
NO_DOC=ci
NO_TEST=ci