### PR TITLE
replication: reconnect replicas on uri change

### DIFF
--- a/changelogs/unreleased/gh-12728-replication-ignores-credentials-change.md
+++ b/changelogs/unreleased/gh-12728-replication-ignores-credentials-change.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed a bug where replicas kept their old connection to the master and
+  ignored changes to replication parameters (gh-12728).

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -1059,7 +1059,9 @@ next:
 		struct replica *other = replica_hash_search(&uniq, replica);
 		if (keep_connect && other != NULL &&
 		    (replica->applier->state == APPLIER_FOLLOW ||
-		     replica->applier->state == APPLIER_SYNC)) {
+		     replica->applier->state == APPLIER_SYNC) &&
+		    uri_is_equal(&replica->applier->uri,
+				 &other->applier->uri)) {
 			/*
 			 * Try not to interrupt working appliers upon
 			 * reconfiguration.

--- a/test/replication-luatest/gh_12728_replication_ignores_credentials_change_test.lua
+++ b/test/replication-luatest/gh_12728_replication_ignores_credentials_change_test.lua
@@ -1,0 +1,48 @@
+local t = require('luatest')
+local cluster = require('luatest.replica_set')
+local uri = require('uri')
+
+local g = t.group()
+
+local function update_uri_param(uri_str, val)
+    local uri_parsed = uri.parse(uri_str)
+    uri_parsed.params = { test = val }
+    return uri.format(uri_parsed)
+end
+
+g.before_each(function()
+    g.cluster = cluster:new({})
+    g.master = g.cluster:build_server({alias = 'master'})
+    g.master.net_box_uri = update_uri_param(g.master.net_box_uri, "before")
+    local box_cfg = {
+        replication = g.master.net_box_uri,
+    }
+    g.replica = g.cluster:build_server({alias = 'replica', box_cfg = box_cfg})
+
+    g.cluster:add_server(g.master)
+    g.cluster:add_server(g.replica)
+    g.cluster:start()
+    t.helpers.retrying({}, function()
+        g.replica:assert_follows_upstream(1)
+    end)
+end)
+
+g.after_each(function()
+    g.cluster:drop()
+end)
+
+g.test_reconnect_uri_param_change = function(g)
+    local new_master_uri = update_uri_param(g.master.net_box_uri, "after")
+    g.master:update_box_cfg({listen = new_master_uri})
+    g.replica:update_box_cfg({replication = new_master_uri})
+    t.helpers.retrying({}, function()
+        g.replica:assert_follows_upstream(1)
+    end)
+    g.replica:exec(function()
+        local uri = require("uri")
+        local param_val = uri.parse(
+            box.info.replication[1].upstream.peer
+        ).params.test
+        t.assert_equals(param_val, {"after"})
+    end)
+end


### PR DESCRIPTION
Replicas used to keep the old connections on the reconfiguration, as long
as the uuid is the same and the old connection is alive. However, this
results in ignoring any credential changes, since they are encoded in
uri params. In the patch, this behavior has been changed, and peers are
now also compared by uris.

Closes https://github.com/tarantool/tarantool/issues/12728

NO_DOC=bugfix