### PR TITLE
vinyl: validate field constraints on upsert

### DIFF
--- a/changelogs/unreleased/gh-12404-validate-field-constraints-on-upsert.md
+++ b/changelogs/unreleased/gh-12404-validate-field-constraints-on-upsert.md
@@ -1,0 +1,7 @@
+## bugfix/vinyl
+
+* In some cases, vinyl deferred UPSERT field constraint checks until a
+  read or a compaction. A violating UPSERT could then be skipped without
+  returning an error to the client. Constraints are now validated at
+  UPSERT time when update operations may modify constrained columns,
+  matching Memtx behavior (gh-12404).

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -180,10 +180,13 @@ space_init_constraints(struct space *space)
 	assert(space->def != NULL);
 	struct tuple_format *format = space->format;
 	bool has_foreign_keys = false;
+	bool has_func_constraints = false;
 	for (size_t j = 0; j < format->constraint_count; j++) {
 		struct tuple_constraint *constr = &format->constraint[j];
 		has_foreign_keys = has_foreign_keys ||
 				   constr->def.type == CONSTR_FKEY;
+		has_func_constraints = has_func_constraints ||
+				       constr->def.type == CONSTR_FUNC;
 		if (constr->check != tuple_constraint_noop_check)
 			continue;
 		if (constr->def.type == CONSTR_FUNC) {
@@ -202,6 +205,8 @@ space_init_constraints(struct space *space)
 			struct tuple_constraint *constr = &field->constraint[j];
 			has_foreign_keys = has_foreign_keys ||
 					   constr->def.type == CONSTR_FKEY;
+			has_func_constraints = has_func_constraints ||
+					       constr->def.type == CONSTR_FUNC;
 			if (constr->check != tuple_constraint_noop_check)
 				continue;
 			if (constr->def.type == CONSTR_FUNC) {
@@ -218,6 +223,7 @@ space_init_constraints(struct space *space)
 		}
 	}
 	space->has_foreign_keys = has_foreign_keys;
+	space->has_func_constraints = has_func_constraints;
 	return 0;
 }
 

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -235,6 +235,11 @@ struct space {
 	/** This space has foreign key constraints in its format. */
 	bool has_foreign_keys;
 	/**
+	 * This space has functional constraints in its format,
+	 * either at the tuple or field level.
+	 */
+	bool has_func_constraints;
+	/**
 	 * Space format, cannot be NULL.
 	 */
 	struct tuple_format *format;

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -2221,7 +2221,8 @@ vy_upsert(struct vy_env *env, struct vy_tx *tx, struct txn_stmt *stmt,
 		return -1;
 
 	if (space->index_count == 1 && !space_has_on_replace_triggers(space) &&
-	    !space->has_foreign_keys && space->wal_ext == NULL)
+	    !space->has_foreign_keys && !space->has_func_constraints &&
+	    space->wal_ext == NULL)
 		return vy_lsm_upsert(tx, pk, tuple, tuple_end, ops, ops_end);
 
 	const char *old_tuple, *old_tuple_end;

--- a/test/engine-luatest/gh_6436_field_constraint_test.lua
+++ b/test/engine-luatest/gh_6436_field_constraint_test.lua
@@ -303,7 +303,7 @@ g.test_field_constraint_upsert_update = function(cg)
         s:replace{1, 50}
     end, {engine})
 
-    local function check(engine)
+    local function check()
         local s = box.space.test
 
         t.assert_error_msg_content_equals(
@@ -311,28 +311,24 @@ g.test_field_constraint_upsert_update = function(cg)
             function() s:update({1}, {{'+', 2, 50}}) end
         )
 
-        if engine == 'memtx' then
-            t.assert_error_msg_content_equals(
-                "Check constraint 'field_constr' failed for field '2 (id2)'",
-                function() s:upsert({1, 50}, {{'+', 2, 50}}) end
-            )
-        else
-            s:upsert({1, 50}, {{'+', 2, 50}})
-        end
+        t.assert_error_msg_content_equals(
+            "Check constraint 'field_constr' failed for field '2 (id2)'",
+            function() s:upsert({1, 50}, {{'+', 2, 50}}) end
+        )
 
         t.assert_equals(s:select{}, {{1, 50}})
     end
 
-    cg.server:exec(check, {engine})
+    cg.server:exec(check)
 
     cg.server:restart()
 
-    cg.server:exec(check, {engine})
+    cg.server:exec(check)
 
     cg.server:eval('box.snapshot()')
     cg.server:restart()
 
-    cg.server:exec(check, {engine})
+    cg.server:exec(check)
 end
 
 g.test_field_constraint_nullable = function(cg)


### PR DESCRIPTION
When Vinyl squashes UPSERTs during dump/compaction, it applies ops and validates the resulting tuple in the vinyl worker cord (`vy_apply_upsert_on_terminal_stmt()` -> `tuple_validate_raw()`).

Before `box: make tuple format registry thread-local`, the worker reused the TX tuple format (`lsm->format` == `space->format`) with constraints already fully initialized on the main cord, so validation of Lua functional constraints tried to call into Lua from the worker and crashed (`tarantool_L == NULL`).

After the registry became thread-local, each dump/compaction task creates its own local tuple format from metadata (`vy_space_stmt_format_new()`), but that copy does not initialize constraints:
`tuple_constraint_array_new()` leaves the checkers as no-ops and `space_init_constraints()` is not run for the worker format. As a result, constraints are not enforced while squashing UPSERTs, and a violating UPSERT can be materialized into a run (e.g. `{1, 1000}`).

Let's simply disable generating fast-path UPSERTs for spaces with functional constraints (similar to how we avoid UPSERT generation when the space has foreign keys or on_replace triggers). This prevents producing UPSERT statements that Vinyl would later merge without properly enforcing constraints.

Closes https://github.com/tarantool/tarantool/issues/12404

NO_DOC=bugfix