### PR TITLE
dependency management: fixed c-dt version

### DIFF
--- a/extra/dependencies.yaml
+++ b/extra/dependencies.yaml
@@ -4,7 +4,7 @@ dependencies:
   - name: c-ares
     version: 1.88.1
   - name: c-dt
-    version: edeaa5f98219ee87ea9c8416e470a88a12dabb38
+    version: 5bd1b4e651b597c106976f08d4c05b9ccb3efabd
   - name: decNumber
     version: 7a598bf5fc24e3abdc2062e3530e70a7591e4363
   - name: libcurl


### PR DESCRIPTION
The commit 5b51d7c7698b ("datetime: fixed parse of time with h.hh or m.mm") updates submodule version of c-dt library. `dependencies.yaml` synced with it.

Follows up #12082

NO_CHANGELOG=dm
NO_DOC=dm
NO_TEST=dm