### PR TITLE
doc: introduce files for Claude LLM usage

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.claude/skills/tnt-general-dev/SKILL.md
+++ b/.claude/skills/tnt-general-dev/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: tnt-general-dev
+description: >-
+  Enables standards for writing and reviewing Tarantool patches: commit
+  structure and message format, rules for modularity, performance, comments, and
+  code style. MUST use when writing or editing code and committing.
+---
+
+Read `doc/agents/general-dev.md` (relative to the repo root) for the full
+guidance.

--- a/.claude/skills/tnt-replication-dev/SKILL.md
+++ b/.claude/skills/tnt-replication-dev/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: tnt-replication-dev
+description: >-
+  Enables knowledge for replication-specific tasks. MUST use when developing or
+  reasoning about replication overall, applier, relay, txn_limbo, raft,
+  synchronous and asynchronous replication, replicas.
+---
+
+Read `doc/agents/replication-dev.md` (relative to the repo root) for the full
+guidance.

--- a/.claude/skills/tnt-replication-test/SKILL.md
+++ b/.claude/skills/tnt-replication-test/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: tnt-replication-test
+description: >-
+  Enables writing and running tests for replication-specific code. MUST use when
+  editing/adding tests under `test/replication/` or `test/replication-luatest/`.
+---
+
+Read `doc/agents/replication-test.md` (relative to the repo root) for the full
+guidance.

--- a/.claude/skills/tnt-setup-dev/SKILL.md
+++ b/.claude/skills/tnt-setup-dev/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: tnt-setup-dev
+description: >-
+  Enables access to user-specific development setup: sources fetch, configure,
+  build, tests, static analysis. MUST use when `doc/agents/local_setup.md` is
+  missing or seems outdated, and you need to do any of the previously listed
+  activities.
+---
+
+Read `doc/agents/setup-dev.md` (relative to the repo root) for the full
+guidance.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ states/
 
 # Lua Rocks
 .rocks/
+
+# Per-developer local setup notes (agent-generated, machine-specific)
+doc/agents/local_setup.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,145 @@
+## Tarantool
+
+Tarantool is a DB with an application server on board.
+
+The product is considered a low-level framework for building actual databases,
+as it provides the strong basics: storage engines in-memory and on-disk,
+replication (synchronous and asynchronous), transaction journal, network API
+(IProto protocol), C-compatible API with Lua API built on top of it.
+
+The runtime of the DB is threads having specific roles with cooperative
+multitasking inside almost all the threads.
+
+- WAL thread for journal writes.
+- TX thread for work with the data and transaction execution.
+- IProto thread pool for networking.
+- Applier threads for receiving replication from an upstream.
+- Relay threads for sending replication to a downstream. Thus relays send data
+  to appliers.
+
+The cooperative multitasking is implemented using cord module, which runs an
+event-loop in a thread, and the coroutines (fibers) are running in this event
+loop. The library also provides various synchronization and communication means
+for these fibers: condvars, channels, explicit wakeup, sleeps, yields, and more.
+
+### Storage engines
+
+There are 2 storage engines: memtx and vinyl. Their sources can be found in
+`src/box/` across multiple files having specific prefixes `memtx_...` and
+`vy_...`.
+
+Memtx is an in-memory engine which has various index types such as hash, B-tree,
+R-tree. Vinyl is an on-disk engine which uses LSM trees for indexes.
+
+Each engine has its own transaction manager. The managers are joined together
+by an upper level API so cross-engine transactions are possible.
+
+### Replication
+
+Replication in Tarantool works via the journal. Transactions get written into
+the journal, and then from there are sent to remote replicas via relay objects
+(`src/box/relay.cc` is the core).
+
+On the other side the replica receives the data using an applier object
+(`src/box/applier.cc`).
+
+Relay -> applier is a unidirectional channel. For cross-replication the
+instances establish 2 channels relay -> applier and applier -> relay, which in
+turn is often used to build fullmesh replication in a replicaset.
+
+The replication can be asynchronous and synchronous. Asynchronous is just
+transactions being sent eventually, and the originator of the txns doesn't wait
+for their replication.
+
+Synchronous replication makes the transaction author wait until the transaction
+is confirmed by a quorum of nodes until it can be committed and its changes
+become visible. It is implemented using Raft protocol:
+- Base election library in `src/lib/raft`.
+- Tarantool wrapper around Raft in `src/box/raft.*`.
+- Synchronous transactions queue in `src/box/txn_limbo*`.
+
+### Structure
+
+The project is highly modular and values performance and simplicity, in this
+order, over everything else. The performance becomes secondary only in code
+which is not on hot paths.
+
+The main language is C and is the primary language for all internal new code.
+Lua is used for public non-perf-critical API, and uses LuaJIT under the hood.
+C++ remains in some places, is not growing, but can still be used without STL.
+
+- `src/` is all the sources.
+- `test/` is all the tests.
+- `src/box/` is storage-aware code which is Tarantool-specific.
+- `src/lib/` are storage-agnostic self-sufficient libraries.
+- `src/lua/` are storage-agnostic Lua modules.
+
+Orphan files directly in `src/` are mostly like `src/lib/` and things related to
+the process management.
+
+### Testing
+
+Tests are entirely located in `test/`. There are several ways of testing,
+depending on what is being tested. The most widely used ones are listed below.
+
+- C/C++ unit tests. They are handy for covering C APIs which don't require the
+  full storage being configured. Such tests use TAP library, and are located in
+  `test/unit/`. They are fast, simple, and offer very low-level access to
+  internals of Tarantool.
+
+- Lua Diff tests. These are legacy tests, their files all end with `.test.lua`.
+  Code in such Lua files is executed like in an interactive console, the correct
+  output is saved into `.result` files, and on each run the actual output is
+  compared to the `.result` file. They must match. New tests do not use this
+  method anymore.
+
+- Lua Luatest tests. These are the majority of all tests. They all end with
+  `_test.lua`, and are usually located in folders `test/*-luatest`, grouped by
+  what they are testing - application server, fibers, replication, SQL, a
+  specific engine, etc. These are the default way of testing unless it is
+  possible to write a C/C++ unit test.
+
+Testing usually tries to cover 100% of new code. When some cases are very tricky
+to cover, sometimes the tests use error injections - a debug-build option added
+right in the code which allows to simulate an error or a delay, which are very
+hard to achieve using only public APIs. See `src/lib/core/errinj*` and its
+usages, if you need more.
+
+### Task-specific guidance
+
+The files under `doc/agents/` hold deeper, task-specific knowledge - the
+agent-agnostic equivalent of Claude Code "skills". Each has a description below.
+
+**Do not read these files up front.** Load a file into context only once your
+current task matches its description, and only the one(s) that match. You can
+make this decision without opening the files first, by looking at the
+descriptions here.
+
+- `doc/agents/general-dev.md` - Enables standards for writing and reviewing
+  Tarantool patches: commit structure and message format, rules for modularity,
+  performance, comments, and code style. MUST use when writing or editing code
+  and committing.
+
+- `doc/agents/replication-dev.md` - Enables knowledge for replication-specific
+  tasks. MUST use when developing or reasoning about replication overall,
+  applier, relay, txn_limbo, raft, synchronous and asynchronous replication,
+  replicas.
+
+- `doc/agents/replication-test.md` - Enables writing and running tests for
+  replication-specific code. MUST use when editing/adding tests under
+  `test/replication/` or `test/replication-luatest/`.
+
+- `doc/agents/setup-dev.md` - Enables access to user-specific development setup:
+  sources fetch, configure, build, tests, static analysis. MUST use when
+  `doc/agents/local_setup.md` is missing or seems outdated, and you need to do
+  any of the previously listed activities.
+
+These descriptions are copied from the `description` field of the matching
+Claude skill files in `.claude/skills/*/SKILL.md`. If at some point you open one
+such skill file and notice its description differs from the copy above, it must
+be flagged to the user.
+
+---
+
+If anything in the overview seems outdated from how the code actually works,
+then it must be immediately flagged to the user.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/doc/agents/general-dev.md
+++ b/doc/agents/general-dev.md
@@ -1,0 +1,151 @@
+# Development in Tarantool
+
+This document explains how to write code in Tarantool, the expected standards,
+approaches, style, formatting, and other rules.
+
+## Commits
+
+Patches for Tarantool are always organized as a sequence of atomic commits. That
+is, such commits which are fully self-sufficient and make sense and bring value
+on their own.
+
+Each commit must be such that nothing can be removed from it without making it
+lose its sense, and nothing needs to be added to make it valuable and working.
+
+Each commit must compile and pass all tests.
+
+The commit messages have a specific structure:
+- Title has the format `system: imperative title`. For example,
+  `limbo: reorganize the code`. It is limited by 50 chars max, unless it is
+  impossible for some reason.
+- The message is descriptive, not narrating the code, explaining the reason for
+  the commit, perhaps some general outline of what is done if the code is highly
+  complex. The message lines are limited by 72 symbols in width unless it is
+  impossible (for example, a long link is inserted).
+
+The body of the message must reference a specific GitHub ticket when work is
+related to one.
+
+Commit message must have in its end some tags:
+- `NO_DOC=<reason>` - specified when the commit changes no documented behavior
+  (no new public features or changes to existing ones), and thus has no
+  `@TarantoolBot document` label in the message.
+- `NO_CHANGELOG=<reason>` - changelogs are added to `changelogs/unreleased/`
+  when anything visible for users is changed. That includes bug fixes and any
+  other observable behavior changes. Add the tag when no changelog file is
+  added/modified.
+- `NO_TEST=<reason>` - when no tests are added or modified in the commit. It
+  might normally happen for refactoring commits which change already covered
+  code.
+
+Commit message might have to add a documentation request when a feature is added
+or modified or deprecated. This is done in the form of:
+```
+@TarantoolBot document
+Title: <title ...>
+Multiline description ...
+```
+When the commit is merged into the main branch, there will be a GitHub ticket
+automatically created with the given title and message. This text is encouraged
+to use markdown formatting to make the ticket look nice. When no doc request is
+added, the commit message must specify `NO_DOC` tag.
+
+The ordering of commit message sections is: title -> message -> ticket ref ->
+tags -> doc request.
+
+Commit title, message, and the diff must exclusively use ASCII characters. The
+only exception allowed can be something that explicitly requires a non-ASCII
+character. For example, string collations testing.
+
+## Code
+
+Tarantool's main language is C. This enforces very careful treatment of memory
+management, but opens up great performance possibilities.
+
+Code must be modular. That is, new functions must be added exactly to where they
+belong, and ideally must be scoped inside a single .c/.cc file as `static`
+functions unless we absolutely need to reuse the function in other places.
+Changed functions might need to be moved to other modules if their scope
+changes.
+
+It is very important that the code remains modular, because it greatly reduces
+the cognitive complexity, allowing to work on various parts of Tarantool without
+having to be aware of most of the other parts.
+
+Code must be performant. We avoid using the heap at all costs in hot code,
+preferring the stack, the fiber-local and transaction-local region memory, and
+intrusive heap-free containers such as `rlist` and `stailq`. We also must avoid
+`if`-branching where possible and copying of all sorts.
+
+The performance value is superseded by the huge value of simplicity only off the
+hot paths, and only when chasing a small performance gain would require
+disproportionately complex code. In any code that isn't hot we must at all costs
+keep the code very simple. Simple short functions, linear code, good deep
+comments where necessary.
+
+Existing code is encouraged to be changed when it helps to reuse it, or when it
+can be even dropped as superseded by newer code. Legacy code, when possible,
+must not be kept for any sort of "backward compatibility" or "for later rework",
+unless it maintains some public behavior.
+
+Comments in the code must never be narrative. If a comment just narrates the
+next lines, then it must be deleted. If a comment somehow speaks about commits
+and our current development plan, then it must be deleted. If a comment is just
+obvious in any way, then it must be deleted. Do not write comments at all unless
+the commented code is extremely complex and external context is needed for
+understanding it.
+
+The only allowed cases of obvious comments are the ones enforced by our code
+style:
+- Every struct must have a comment.
+- Every struct member must have a comment.
+- Every inline function longer than 5 lines must have a comment.
+- Every function declaration must have a comment, when the definition is
+  somewhere else.
+- Every global variable must have a comment.
+
+## Style
+
+- Text file line lengths (code, text, Markdown, etc) are limited by 80 chars.
+- Naming for variables, functions, structs, aliases is `like_this`.
+- Only C++ classes are named `LikeThis`.
+- Function declaration arguments wrapped on more than one line must be aligned
+  by the `(` char of the function. Same applies to alignment of multi-line
+  `while (...)`, `for (...)`, `if (...)`.
+- Indentation is tabs, 8 chars wide.
+- Comments inside functions are always wrapped into `/* ... */`. If it fits
+  into one line, then it is just `/*...*/`. Otherwise it is `/*` - line 1,
+  ` *` - next lines, `*/` - last line. Comments outside functions are same, but
+  start with `/**`.
+
+## Tests
+
+Each changed line, unless it is a simple refactoring like a rename or a code
+move, MUST be covered by tests.
+
+Older tests might already exist sometimes, covering this place implicitly. Or
+the refactoring might be such that some tests cover the changed code naturally
+and explicitly.
+
+But much more often than not, new tests should be written.
+
+For third-party libs, internal core libs, storage-agnostic, and other very
+isolated modules written in C/C++ it is preferable to write unit tests in C.
+Examples can be found in `test/unit/`.
+
+For all other changes the preferable way of testing is Luatest. Examples can be
+found in `test/*-luatest/` folders.
+
+## Setup
+
+Development in Tarantool is quite individual. You MUST load
+`doc/agents/local_setup.md` to understand how to work in user's environment for
+configuring, building, testing, static analysis.
+
+If and only if that file is missing or seems outdated, you must load
+`doc/agents/setup-dev.md` to create/update the local setup file.
+
+---
+
+If anything in this document seems outdated from how the code actually works,
+then it must be immediately flagged to the user.

--- a/doc/agents/replication-dev.md
+++ b/doc/agents/replication-dev.md
@@ -1,0 +1,84 @@
+# Development of replication
+
+This document explains more details about the replication system in Tarantool.
+It gives more context when working specifically with replication code and its
+logic.
+
+## Overview
+
+The replication code is primarily located in the `src/box/` library, in files:
+- `applier.*`
+- `relay.*`
+- `txn_limbo*`
+- `raft*`.
+
+Instances in a replicaset are identified by 3 ids:
+- UUID - unique and usually auto-generated.
+- Instance name - optional, always provided manually.
+- Numeric ID - a number between 1 and 31. It is assigned to new replicas by any
+  writable instance in the replicaset, as the replicas join it.
+
+In Tarantool the journal is not linear. Its position isn't by a single sequence
+number, but instead by an array of sequence numbers: vclock.
+
+Vclock is a vector where item with index `[ID]` stores LSN of the instance
+having this numeric ID as its identifier.
+
+Vclock size is hard-limited to 32, where the `[0]`-component is reserved for
+so-called local transactions, which are never replicated.
+
+This means that max number of identified replicas in a replicaset is 31.
+
+Users can also connect so-called anonymous replicas. They do not get a numeric
+ID or a name, they only have a UUID. Such replicas do not participate in
+synchronous replication or any quorums in any way.
+
+## Synchronous replication
+
+While asynchronous replication is pretty simple and doesn't have much
+complexity, the synchronous replication is the most complex part of this all.
+
+It uses Raft protocol as its basis, and tries to implement it to the letter. But
+historically there were some bumps on this road, because of which Tarantool has
+some legacy logic which violates Raft.
+
+Besides, vanilla Raft by design has a linear journal with single sequence number
+on all replicas. Tarantool, OTOH, has a vector clock in its journal, which
+originally was made this way to support asynchronous multi-master replication.
+
+Also, vanilla Raft by design is able to roll back transactions right from the
+end of its journal. In Tarantool it is not possible. What gets written into the
+journal, can no longer be removed. And any sort of cancellation or rollback must
+be done via another entry in the journal, while the transaction data for undoing
+it must be kept in memory.
+
+To make the cognitive load easier Tarantool splits Raft into election and
+synchronous transaction processing.
+
+The election is almost entirely vanilla, in `src/lib/raft/` is the base and in
+`src/box/raft*` is a storage-aware wrapper.
+
+The transaction processing had to be altered significantly due to the
+fundamental differences of Tarantool journal and Raft's vanilla journal. It is
+all located in `src/box/txn_limbo*` files.
+
+The idea is embodied in the `txn_limbo` object. It is a queue of synchronous
+transactions, and other transactions which depend on the synchronous ones. Here
+the transactions are stored after their WAL write until they gain enough ACKs
+and the leader writes `CONFIRM` entry for them, making them committed.
+
+As `CONFIRM` reaches the replicas via the replication channels, they also apply
+it, and commit these transactions from their copies of the limbo.
+
+The biggest difference with Raft is a new entry called `PROMOTE`. It is what an
+instance emits when it wins the Raft elections, and needs to persist this fact
+in the journal.
+
+Essentially, this `PROMOTE` entry in vanilla Raft terms could be called "the
+first transaction in the new term". And it does the same job in Tarantool - it
+commits pending transactions from the previous terms, if there are any.
+
+---
+
+If anything in this document seems outdated from how the code actually works,
+then it must be immediately flagged to the user.

--- a/doc/agents/replication-test.md
+++ b/doc/agents/replication-test.md
@@ -1,0 +1,46 @@
+# Testing of replication
+
+This document explains more details about testing the replication code in
+Tarantool. It gives more context about testing when developing or reviewing
+patches related to the replication in any way.
+
+## Overview
+
+The replication tests are almost entirely located in `test/replication/` and
+`test/replication-luatest/`.
+
+Tests there usually start a replicaset with 1 or more instances, using
+`luatest.replica_set` Luatest module for managing multiple instances at once, or
+`luatest.server` for managing them one by one.
+
+The tests by their very nature are probably the most flaky in the whole test
+suite of Tarantool, because they involve network communication between nodes
+with many different timeouts, leading to disconnects, reconnects, and races.
+
+Such tests need to be very robust. It is very important, that if a test needs to
+cover a sequence of certain events, then it must explicitly find a way to
+observe these events, and make sure they don't run through without us observing
+them one by one.
+
+This means being creative with error injections such as `ERRINJ_WAL_DELAY` and
+`ERRINJ_WAL_DELAY_COUNTDOWN` (the most frequently used ones) and careful with
+timeouts (set huge timeouts for things which aren't expected to fail - even
+5 sec is too small, 2 minutes is usually enough).
+
+Tests must be fast. Each test ideally must run in sub-second time. Longer
+duration needs to be very justified.
+
+The tests must never assume that something is guaranteed to happen in N seconds.
+All waiting must be in loops, retrying with `t.helpers.retrying(...)`.
+
+The tests must never assume that something happens in N WAL writes. This is a
+very frequent case in replication tests. Instead, let WAL writes through one by
+one, checking the needed state after each of them. For example, do not assume
+that Raft election will write new term -> new vote -> `PROMOTE` exactly like
+this in single journal entries and in this order. Instead, block WAL writes and
+limbo transactions one by one, checking the needed state after each step.
+
+---
+
+If anything in this document seems outdated from how the code actually works,
+then it must be immediately flagged to the user.

--- a/doc/agents/setup-dev.md
+++ b/doc/agents/setup-dev.md
@@ -1,0 +1,107 @@
+# Development setup
+
+The document explains how to set up Tarantool's sources for development: coding,
+building, running tests, installing or finding dependencies.
+
+The setup is very individual: some people prefer building in the sources, some
+make a `build/` folder, some usually compile in Debug while others in Release,
+some will run tests using raw `luatest`, others would use `test-run.py`.
+
+The user must be questioned about their local setup, their preferences, their
+ways of development.
+
+The questions need to enable you to do the things explained below, unless the
+user explicitly opts out some of them and wants to do certain things manually.
+
+## Build
+
+Tarantool uses CMake build system. Usually it is convenient to create a separate
+`build` folder somewhere (very individual preference) and configure + compile
+the sources in there. Having all the artifacts in one folder allows to delete it
+easily if something goes wrong.
+
+The supported CMake options are all the usual ones, like
+`-DCMAKE_BUILD_TYPE=Debug` or `=Release`.
+
+Once cmake is configured, you must avoid reconfiguration when possible, because
+it is expensive.
+
+Tarantool has external dependencies - for example, it needs a compiler at the
+very least. Also many other libraries like `libicu`, `libcurl`, and more. Their
+installation is very individual. Developers are using various Linux
+distributions with different package managers. There is no one standard way of
+installing everything.
+
+## Tests
+
+The ways of testing depend on task and its scope. But in general all or almost
+all tests can be run using `test-run.py`, from inside of the `./test` folder.
+
+An example of usage is:
+```Bash
+python3 test-run.py --var <artifacts_dir> --builddir <build_dir> <param_i>...
+```
+
+The `--var` argument is optional. But it might be convenient to control, if you
+want to see and analyze the artifacts in specific easily reachable location. It
+can also help to reduce the path length to the artifacts, which can be important
+because the servers in the tests will use Unix sockets. Their path is limited by
+approximately 128 chars.
+
+The `--builddir` is optional, but it is necessary in practically all cases. It
+points to the directory where Tarantool sources were cmake-configured and
+compiled (from the **Build** step, for example).
+
+The `<param_i>...` is what the test runner will be looking for in the folder and
+file names recursively in `./test`, and will run all the tests whose path
+contains at least one of the positional params. For example, 2 params
+`replication box` will run all tests whose file path names contain `box` or
+`replication`. Such as `./box-luatest/*`, `./replication/*`,
+`./replication-luatest/*` and so on.
+
+But some users might want to run certain tests in different ways.
+
+## Static analysis
+
+All patches in Tarantool are subjects for static code analysis which is strictly
+enforced in CI.
+
+The local cheap must-have checks are `checkpatch` and `luacheck` tools.
+
+Installation of these tools is highly individual. User needs to be asked about
+that, and might even opt out and decide to do it manually.
+
+Otherwise, when these tools are available (user will tell how to run them then),
+they can be run as follows:
+```Bash
+perl -X -- checkpatch.pl --color=always --git <commit>
+luacheck --codes --config .luacheckrc <file_i>...
+```
+
+`Checkpatch` is a Perl tool which will validate the commit message and its diff.
+
+`Luacheck` must be used on all files having `.lua` extension. The tool via the
+provided config will automatically decide which Lua files can be ignored, and
+which will be validated. That includes all Lua files, including Luatest
+`..._test.lua` files.
+
+## Local setup file
+
+The results of your survey must be persisted in the `doc/agents/local_setup.md`
+file. The file MUST be loaded when you plan to operate in this codebase not just
+in read-only mode.
+
+If the file is missing or outdated and you intend to build or update it, tell
+the user explicitly.
+
+If the local setup file seems outdated (for instance, user frequently corrects
+you or asks to do some specific missing things regularly), you MUST suggest the
+user to update this file.
+
+When updating or creating the local setup file, you MUST save the updates BEFORE
+doing anything else, to not lose the context later.
+
+---
+
+If anything in this document seems outdated from how the code actually works,
+then it must be immediately flagged to the user.


### PR DESCRIPTION
The general CLAUDE.md file + a few skills.

The idea is that Tarantool is quite a big system. But usually development of a single patch is concentrated in a certain area of the code such as memtx engine internals, or replication, or vinyl engine internals, or replication, or synchronous transactions management, and so on.

To reduce the scope of the model and its token usage, it is suggested to represent details of each subsystem in Tarantool as skills: development of that subsystem, its testing, and potentially more skills.

This commit introduces such subsystem-skills for replication specifically, and one skill for development in Tarantool in general.

NO_DOC=dev
NO_CHANGELOG=dev
NO_TEST=just text