### PR TITLE
lua: disable graceful shutdown for application thread connections

### DIFF
--- a/changelogs/unreleased/gh-12790-app-threads-connection-shutdown-fix.md
+++ b/changelogs/unreleased/gh-12790-app-threads-connection-shutdown-fix.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug when application threads could not be called from shutdown
+  triggers (gh-12790).

--- a/src/box/lua/app_threads.lua
+++ b/src/box/lua/app_threads.lua
@@ -271,7 +271,15 @@ function box.internal.threads.init(cfg, group_name, id_in_group, conn_fd)
     if group_name ~= 'tx' then
         ffi.C.cord_set_name(string.format('%s%d', group_name, id_in_group))
     end
-    threads_conn = net.from_fd(conn_fd, {fetch_schema = false})
+    threads_conn = net.from_fd(conn_fd, {
+        -- We only send CALL/EVAL requests to application threads so
+        -- there's no need to sync the database schema.
+        fetch_schema = false,
+        -- Disable graceful shutdown handling so that connections to
+        -- application threads aren't closed while shutdown triggers
+        -- are running.
+        _disable_graceful_shutdown = true,
+    })
     init_thread_groups(cfg)
 end
 

--- a/test/box-luatest/app_threads_module_test.lua
+++ b/test/box-luatest/app_threads_module_test.lua
@@ -1,3 +1,4 @@
+local fio = require('fio')
 local net = require('net.box')
 
 local t = require('luatest')
@@ -798,3 +799,50 @@ g.test_thread_names_in_logs = function()
     t.assert_str_contains(cluster.server:grep_log('.*foobar3'),
                           'buzz2/%d+/pool', true)
 end
+
+g.before_test('test_threads_connection_on_shutdown', function(cg)
+    cg.server = server:new({box_cfg = {app_threads = 1}})
+    cg.server:start()
+end)
+
+g.test_threads_connection_on_shutdown = function(cg)
+    --
+    -- Check that application threads can be called from shutdown triggers.
+    --
+    local path = fio.pathjoin(cg.server.workdir, 'test.txt')
+    cg.server:exec(function(path)
+        local fio = require('fio')
+        local threads = require('experimental.threads')
+        box.ctl.on_shutdown(function()
+            local fh = fio.open(path, {'O_CREAT', 'O_WRONLY', 'O_TRUNC'},
+                                tonumber('666', 8))
+            for _ = 1, 10 do
+                local ok, err = pcall(threads.eval, 'app', [[return true]])
+                if ok then
+                    fh:write('OK')
+                else
+                    fh:write(tostring(err))
+                end
+                fh:write('\n')
+            end
+            fh:close()
+        end)
+    end, {path})
+    cg.server:stop()
+    local fh, err = fio.open(path, {'O_RDONLY'})
+    t.assert_is(err, nil)
+    local actual = fh:read(1024)
+    fh:close()
+    local expected = {}
+    for _ = 1, 10 do
+        table.insert(expected, 'OK')
+    end
+    table.insert(expected, '')
+    expected = table.concat(expected, '\n')
+    t.assert_equals(actual, expected)
+end
+
+g.after_test('test_threads_connection_on_shutdown', function(cg)
+    cg.server:drop()
+    cg.server = nil
+end)


### PR DESCRIPTION
The graceful shutdown of net.box connections is initiated before shutdown triggers are run. It breaks connections to application threads making it impossible to call them from shutdown triggers. Let's fix this issue by disabling graceful shutdown for connections to application threads because we don't really need it there: it's up to application roles to properly shutdown the code running on application threads.

Closes #12790