### PR TITLE
box: wake up all active fibers at application thread exit

### DIFF
--- a/changelogs/unreleased/gh-12792-app-threads-fiber-cond-exit-fix.md
+++ b/changelogs/unreleased/gh-12792-app-threads-fiber-cond-exit-fix.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug when Tarantool crashed at exit if there was a fiber waiting on
+  a condition variable created in an application thread (gh-12792).

--- a/src/box/app_threads.c
+++ b/src/box/app_threads.c
@@ -61,6 +61,17 @@ app_thread_f(void *arg)
 	cbus_endpoint_destroy(&fiber_pool.endpoint, NULL);
 	while (!rlist_empty(&fiber_pool.idle))
 		rlist_shift(&fiber_pool.idle);
+	/*
+	 * XXX: There may be fibers waiting on a condition variable created
+	 * from Lua code. If we don't wake them up, we'll get an assertion
+	 * failure in fiber_cond_destroy() when we try to destroy this
+	 * condition variable in lua_close(). Waking them up here like this
+	 * looks like a hack. We need to implement something like
+	 * fiber_shutdown() for application threads.
+	 */
+	struct fiber *fiber;
+	rlist_foreach_entry(fiber, &cord()->alive, link)
+		fiber_wakeup(fiber);
 	app_thread_lua_free();
 	box_lua_call_runtime_priv_reset();
 	tuple_free();

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -8,7 +8,9 @@ local varbinary = require('varbinary')
 
 local cbuilder = require('luatest.cbuilder')
 local cluster = require('luatest.cluster')
+local justrun = require('luatest.justrun')
 local server = require('luatest.server')
+local treegen = require('luatest.treegen')
 local t = require('luatest')
 
 local g = t.group()
@@ -812,4 +814,21 @@ g.test_trigger = function(cg)
         t.assert_equals(data, {t1 = 2, t2 = 1})
         t.assert_equals(trigger.info(), {})
     end)
+end
+
+g.test_fiber_cond_exit = function()
+    local dir = treegen.prepare_directory({}, {})
+    treegen.write_file(dir, 'test.lua', [=[
+        local threads = require('experimental.threads')
+        box.cfg{app_threads = 1, log_level = 'warn'}
+        threads.eval('app', [[
+            local fiber = require('fiber')
+            local cond = fiber.cond()
+            fiber.create(cond.wait, cond)
+        ]])
+        os.exit(0)
+    ]=])
+    local res = justrun.tarantool(dir, {}, {'test.lua'},
+                                  {stderr = true, nojson = true})
+    t.assert_covers(res, {exit_code = 0, stderr = ''})
 end


### PR DESCRIPTION
When an application thread exits, its Lua state is destroyed. This includes all condition variables created from Lua code. If there's a fiber waiting on a condition variable, `fiber_cond_destroy()` will fail the assertion checking that the condition variable is unused. If assertions are disabled, Tarantool is likely to crash later, when it deletes all fibers in `cord_join()`. Let's wake up all fibers before destroying the Lua state. This is actually a hack. We should probably implement something like `fiber_shutdown()` for application threads.

Closes #12792