### PR TITLE
lua: bump metrics module

### DIFF
--- a/changelogs/unreleased/bump-metrics-to-1.8.0.md
+++ b/changelogs/unreleased/bump-metrics-to-1.8.0.md
@@ -1,0 +1,17 @@
+## feature/metrics
+
+* Updated the metrics submodule to 1.8.0.
+
+  Changes in 1.8.0:
+
+  * Added selector-based filtering for custom metrics. Custom metrics can now
+    be associated with hierarchical selectors and controlled via
+    `metrics.set_filter()` or `metrics.cfg()` include/exclude options. Unknown
+    include/exclude entries are treated as custom selectors, while built-in
+    metric group names keep the existing behavior ([gh-543][mgh-543]).
+
+  * Added `metrics.namespace()` and `metrics.set_filter()` to mark custom
+    collectors and callbacks with selectors and filter them at collection time
+    ([gh-543][mgh-543]).
+
+[mgh-543]: https://github.com/tarantool/metrics/pull/543


### PR DESCRIPTION
Bump metric package submodule to 1.8.0. Commits from PR[1] add new functionality for selector-based filtering of custom metrics.

1. tarantool/metrics#543

NO_TEST=metrics submodule bump
NO_DOC=metrics submodule bump