### PR TITLE
Support `from_vclock` and `ttl` options in box.backup.start()

### DIFF
--- a/changelogs/unreleased/improve-backup-api.md
+++ b/changelogs/unreleased/improve-backup-api.md
@@ -1,0 +1,12 @@
+## feature/box
+
+* `box.backup.start()` has been enhanced to back up xlogs that are rotated at
+  the time of the call (gh-11729).
+* Added the `from_vclock` parameter to the `box.backup.start()` to enable
+  incremental backups (gh-11729).
+* Added the `ttl` parameter to the `box.backup.start()` to set expiration time
+  for backups (gh-11729).
+* Added the `box_backup_default_ttl` compatibility option to control the
+  default expiration time for backups (gh-11729).
+* Added a new API, `box.backup.info()` to retrieve information about running
+  backups (gh-11729).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -151,6 +151,9 @@ struct box_backup *box_backup;
 
 static struct latch backup_latch = LATCH_INITIALIZER(backup_latch);
 
+static double box_backup_default_ttl = TIMEOUT_INFINITY;
+TWEAK_DOUBLE(box_backup_default_ttl);
+
 bool box_read_ffi_is_disabled;
 
 /**
@@ -6021,6 +6024,7 @@ box_backup_free(struct box_backup *backup)
 		free(backup->files[i]);
 	free(backup->files);
 	gc_unref_checkpoint(backup->gc_checkpoint_ref);
+	ev_timer_stop(loop(), &backup->ttl_timer);
 	TRASH(backup);
 	free(backup);
 }
@@ -6061,8 +6065,19 @@ box_backup_collect_incremental(const struct vclock *from_vclock,
 	return 0;
 }
 
+static void
+backup_ttl_timeout(ev_loop *loop, ev_timer *watcher, int revents)
+{
+	(void)loop;
+	(void)watcher;
+	(void)revents;
+
+	box_backup_stop();
+}
+
 int
-box_backup_start(int checkpoint_idx, const struct vclock *from_vclock)
+box_backup_start(int checkpoint_idx, const struct vclock *from_vclock,
+		 double ttl)
 {
 	assert(checkpoint_idx >= 0);
 	latch_lock(&backup_latch);
@@ -6082,10 +6097,13 @@ box_backup_start(int checkpoint_idx, const struct vclock *from_vclock)
 		latch_unlock(&backup_latch);
 		return -1;
 	}
+	if (ttl == 0)
+		ttl = box_backup_default_ttl;
 	struct box_backup *backup =
 		(struct box_backup *)xmalloc(sizeof(*box_backup));
 	memset(backup, 0, sizeof(*backup));
 	backup->gc_checkpoint_ref = gc_ref_checkpoint(checkpoint, "backup");
+	ev_timer_init(&backup->ttl_timer, backup_ttl_timeout, ttl, 0);
 	if (checkpoint_idx == 0) {
 		struct box_checkpoint box_ckpt;
 		if (box_checkpoint_build_for_journal(&box_ckpt) != 0)
@@ -6107,6 +6125,10 @@ box_backup_start(int checkpoint_idx, const struct vclock *from_vclock)
 			goto error;
 	}
 	box_backup = backup;
+	/* Start here so that ttl doesn't run out while start is in progress. */
+	ev_timer_start(loop(), &backup->ttl_timer);
+	backup->start_time = ev_now(loop());
+	backup->ttl = ttl;
 	latch_unlock(&backup_latch);
 	return 0;
 error:

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6025,8 +6025,44 @@ box_backup_free(struct box_backup *backup)
 	free(backup);
 }
 
+/**
+ * Collect backup info for full backup starting from checkpoint at
+ * @checkpoint_vclock to xlog ending at @vclock. In particular if vclocks are
+ * the same then no xlogs are included.
+ */
+static int
+box_backup_collect_full(const struct vclock *checkpoint_vclock,
+			const struct vclock *vclock,
+			struct box_backup *backup)
+{
+	if (engine_backup(checkpoint_vclock, box_backup_add_path, backup) != 0)
+		return -1;
+	VERIFY(wal_backup(checkpoint_vclock, vclock, box_backup_add_path,
+			  backup) == 0);
+	vclock_copy(&backup->vclock, vclock);
+	vclock_clear(&backup->prev_vclock);
+	return 0;
+}
+
+/**
+ * Collect backup info for incremental backup starting from xlog immediately
+ * following @from_vclock to xlog ending at @vclock. In particular if vclocks
+ * are the same then no xlogs are included.
+ */
+static int
+box_backup_collect_incremental(const struct vclock *from_vclock,
+			       const struct vclock *vclock,
+			       struct box_backup *backup)
+{
+	if (wal_backup(from_vclock, vclock, box_backup_add_path, backup) != 0)
+		return -1;
+	vclock_copy(&backup->vclock, vclock);
+	vclock_copy(&backup->prev_vclock, from_vclock);
+	return 0;
+}
+
 int
-box_backup_start(int checkpoint_idx)
+box_backup_start(int checkpoint_idx, const struct vclock *from_vclock)
 {
 	assert(checkpoint_idx >= 0);
 	latch_lock(&backup_latch);
@@ -6054,17 +6090,21 @@ box_backup_start(int checkpoint_idx)
 		struct box_checkpoint box_ckpt;
 		if (box_checkpoint_build_for_journal(&box_ckpt) != 0)
 			goto error;
-		if (engine_backup(&checkpoint->vclock,
-				  box_backup_add_path, backup) != 0)
+		int rc;
+		if (vclock_is_set(from_vclock))
+			rc = box_backup_collect_incremental(
+				from_vclock, &box_ckpt.journal.vclock, backup);
+		else
+			rc = box_backup_collect_full(
+				&checkpoint->vclock, &box_ckpt.journal.vclock,
+				backup);
+		if (rc != 0)
 			goto error;
-		wal_backup(&checkpoint->vclock, &box_ckpt.journal.vclock,
-			   box_backup_add_path, backup);
-		vclock_copy(&backup->vclock, &box_ckpt.journal.vclock);
 	} else {
-		if (engine_backup(&checkpoint->vclock,
-				  box_backup_add_path, backup) != 0)
+		assert(!vclock_is_set(from_vclock));
+		if (box_backup_collect_full(&checkpoint->vclock,
+					    &checkpoint->vclock, backup) != 0)
 			goto error;
-		vclock_copy(&backup->vclock, &checkpoint->vclock);
 	}
 	box_backup = backup;
 	latch_unlock(&backup_latch);

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -33,6 +33,7 @@
 #include "trivia/util.h"
 #include "trigger.h"
 #include "vclock/vclock.h"
+#include "tarantool_ev.h"
 
 #include <stdbool.h>
 
@@ -314,6 +315,12 @@ struct box_backup {
 	 * backup WAL files) that are currently being backed up.
 	 */
 	struct gc_checkpoint_ref *gc_checkpoint_ref;
+	/** Backup start time. */
+	double start_time;
+	/** Backup TTL. */
+	double ttl;
+	/** Backup TTL timer. Backup will be stopped when it expires. */
+	struct ev_timer ttl_timer;
 };
 
 extern struct box_backup *box_backup;
@@ -331,11 +338,15 @@ extern struct box_backup *box_backup;
  * include only xlogs since @from_vclock. It is error if there is no xlog
  * starting precisely at this vclock.
  *
+ * @ttl defines backup time to live. After this time backup will be
+ * stopped. if @ttl is 0 then default time to live will be used.
+ *
  * The caller is supposed to call box_backup_stop() after he's
  * done copying the files.
  */
 int
-box_backup_start(int checkpoint_idx, const struct vclock *from_vclock);
+box_backup_start(int checkpoint_idx, const struct vclock *from_vclock,
+		 double ttl);
 
 /**
  * Finish backup started with box_backup_start().

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -304,6 +304,11 @@ struct box_backup {
 	/** Maximum vclock that can be restored using backup. */
 	struct vclock vclock;
 	/**
+	 * vclock of previous backup (@vclock) for incremental backups. Unset
+	 * vclock for full backups.
+	 */
+	struct vclock prev_vclock;
+	/**
 	 * Point to the gc reference object that prevents the garbage
 	 * collector from deleting the checkpoint file (and implicitly
 	 * backup WAL files) that are currently being backed up.
@@ -317,14 +322,20 @@ extern struct box_backup *box_backup;
  * Start a backup.
  *
  * The checkpoint is given by @checkpoint_idx. If @checkpoint_idx
- * is 0, the last checkpoint will be backed up; if it is 1, next
- * to last, and so on.
+ * is 0, the last checkpoint will be backed up together with xlogs
+ * to the moment of the backup, the last xlog will be rotated.
+ * If @checkpoint_idx is 1 or more then only snapshot will be backed up.
+ * Next to last if @checkpoint_idx is 1, and so on.
+ *
+ * If @from_vclock is not cleared then backup will be incremental. It will
+ * include only xlogs since @from_vclock. It is error if there is no xlog
+ * starting precisely at this vclock.
  *
  * The caller is supposed to call box_backup_stop() after he's
  * done copying the files.
  */
 int
-box_backup_start(int checkpoint_idx);
+box_backup_start(int checkpoint_idx, const struct vclock *from_vclock);
 
 /**
  * Finish backup started with box_backup_start().

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -447,6 +447,7 @@ struct errcode_record {
 	_(ER_UNABLE_TO_PROCESS_IN_THREAD, 300,	"Unable to process request in thread", "request", STRING, "thread_id", UINT) \
 	_(ER_DICT_OVERFLOW, 301,		"Dictionary has no space - too many unique values are used", "max_size", UINT) \
 	_(ER_NO_SUCH_THREAD_GROUP, 302,		"Thread group does not exist", "thread_group", STRING) \
+	_(ER_XLOG_NOT_FOUND, 303,		"xlog file not found", "vclock", STRING) \
 	TEST_ERROR_CODES(_) /** This one should be last. */
 
 /*

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -274,6 +274,13 @@ I['compat'] = format_text([[
     to the previous or the next major version.
 ]])
 
+I['compat.box_backup_default_ttl'] = format_text([[
+    Define default backup time to live:
+
+    - `new` (4.x default): 1 hour
+    - `old` (3.x default): infinity
+]])
+
 I['compat.binary_data_decoding'] = format_text([[
     Define how to store binary data fields in Lua after decoding:
 

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2348,6 +2348,12 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'old',
         }),
+        box_backup_default_ttl = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'old',
+        }),
     }),
     -- Instance labels.
     labels = schema.map({

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -802,6 +802,7 @@ lbox_backup_start(struct lua_State *L)
 {
 	int checkpoint_idx = 0;
 	struct vclock from_vclock;
+	double ttl = 0;
 	vclock_clear(&from_vclock);
 	if (lua_gettop(L) > 0) {
 		if (lua_isnumber(L, 1)) {
@@ -820,13 +821,28 @@ lbox_backup_start(struct lua_State *L)
 				return luaT_error(L);
 			}
 			lua_pop(L, 1);
+			lua_getfield(L, 1, "ttl");
+			if (!lua_isnil(L, -1)) {
+				if (!lua_isnumber(L, -1)) {
+					diag_set(IllegalParams,
+						 "invalid ttl");
+					return luaT_error(L);
+				}
+				ttl = lua_tonumber(L, -1);
+				if (ttl <= 0) {
+					diag_set(IllegalParams,
+						 "invalid ttl");
+					return luaT_error(L);
+				}
+			}
+			lua_pop(L, 1);
 		} else {
 			diag_set(IllegalParams,
 				 "expected number or table as 1 argument");
 			return luaT_error(L);
 		}
 	}
-	if (box_backup_start(checkpoint_idx, &from_vclock) != 0)
+	if (box_backup_start(checkpoint_idx, &from_vclock, ttl) != 0)
 		return luaT_error(L);
 
 	lua_createtable(L, box_backup->file_count, 0);
@@ -879,6 +895,11 @@ lbox_backup_info(struct lua_State *L)
 	} else {
 		lua_pushstring(L, "full");
 		lua_setfield(L, -2, "type");
+	}
+
+	if (backup->ttl != TIMEOUT_INFINITY) {
+		lua_pushnumber(L, backup->start_time + backup->ttl);
+		lua_setfield(L, -2, "expires_at");
 	}
 
 	return 1;

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -801,14 +801,32 @@ static int
 lbox_backup_start(struct lua_State *L)
 {
 	int checkpoint_idx = 0;
+	struct vclock from_vclock;
+	vclock_clear(&from_vclock);
 	if (lua_gettop(L) > 0) {
-		checkpoint_idx = luaT_checkint(L, 1);
-		if (checkpoint_idx < 0) {
-			diag_set(IllegalParams, "invalid checkpoint index");
+		if (lua_isnumber(L, 1)) {
+			checkpoint_idx = lua_tonumber(L, 1);
+			if (checkpoint_idx < 0) {
+				diag_set(IllegalParams,
+					 "invalid checkpoint index");
+				return luaT_error(L);
+			}
+		} else if (lua_istable(L, 1)) {
+			lua_getfield(L, 1, "from_vclock");
+			if (!lua_isnil(L, -1) &&
+			    !luaT_tovclock(L, -1, &from_vclock)) {
+				diag_set(IllegalParams,
+					 "invalid from_vclock");
+				return luaT_error(L);
+			}
+			lua_pop(L, 1);
+		} else {
+			diag_set(IllegalParams,
+				 "expected number or table as 1 argument");
 			return luaT_error(L);
 		}
 	}
-	if (box_backup_start(checkpoint_idx) != 0)
+	if (box_backup_start(checkpoint_idx, &from_vclock) != 0)
 		return luaT_error(L);
 
 	lua_createtable(L, box_backup->file_count, 0);
@@ -841,7 +859,7 @@ lbox_backup_info(struct lua_State *L)
 		return 1;
 	}
 
-	lua_createtable(L, 0, 2);
+	lua_createtable(L, 0, 4);
 
 	lua_createtable(L, backup->file_count, 0);
 	for (int i = 0; i < backup->file_count; i++) {
@@ -852,6 +870,16 @@ lbox_backup_info(struct lua_State *L)
 
 	luaT_pushvclock(L, &backup->vclock);
 	lua_setfield(L, -2, "vclock");
+
+	if (vclock_is_set(&backup->prev_vclock)) {
+		luaT_pushvclock(L, &backup->prev_vclock);
+		lua_setfield(L, -2, "prev_vclock");
+		lua_pushstring(L, "incremental");
+		lua_setfield(L, -2, "type");
+	} else {
+		lua_pushstring(L, "full");
+		lua_setfield(L, -2, "type");
+	}
 
 	return 1;
 }

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -1017,6 +1017,24 @@ wal_backup_f(struct cbus_call_msg *data)
 {
 	struct wal_writer *writer = &wal_writer_singleton;
 	struct wal_backup_msg *msg = (struct wal_backup_msg *)data;
+
+	struct vclock *vclock = vclockset_search(&writer->wal_dir.index,
+						 msg->begin_vclock);
+	/*
+	 * Begin vclock should point either to some existing xlog or
+	 * to xlog that will be created on next write.
+	 *
+	 * Note that msg->begin_vclock can be not comparable with vclocks
+	 * of index, in this case vclock is not NULL.
+	 */
+	if ((vclock == NULL ||
+	     vclock_compare(vclock, msg->begin_vclock) != 0) &&
+	    (xlog_is_open(&writer->current_wal) ||
+	     vclock_compare(&writer->vclock, msg->begin_vclock) != 0)) {
+		diag_set(ClientError, ER_XLOG_NOT_FOUND,
+			 vclock_to_string(msg->begin_vclock));
+		return -1;
+	}
 	enum {
 #ifdef NDEBUG
 		START_ARRAY_CAPACITY = 16,
@@ -1048,7 +1066,7 @@ wal_backup_f(struct cbus_call_msg *data)
 	return 0;
 }
 
-void
+int
 wal_backup(const struct vclock *begin_vclock, const struct vclock *end_vclock,
 	   wal_backup_cb cb, void *cb_arg)
 {
@@ -1056,13 +1074,15 @@ wal_backup(const struct vclock *begin_vclock, const struct vclock *end_vclock,
 	struct wal_backup_msg msg;
 	msg.begin_vclock = begin_vclock;
 	msg.end_vclock = end_vclock;
-	cbus_call(&writer->wal_pipe, &writer->tx_prio_pipe, &msg.base,
-		  wal_backup_f);
+	if (cbus_call(&writer->wal_pipe, &writer->tx_prio_pipe, &msg.base,
+		      wal_backup_f) != 0)
+		return -1;
 	for (int i = 0; i < msg.filename_count; i++) {
 		cb(msg.filenames[i], cb_arg);
 		free(msg.filenames[i]);
 	}
 	free(msg.filenames);
+	return 0;
 }
 
 static void

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -245,8 +245,12 @@ wal_collect_garbage(const struct vclock *vclock);
 
 /**
  * Backup up WAL. Calls @cb on every xlog from @begin_vclock to @end_vclock.
+ *
+ * It is error @begin_vclock does not point to some xlog.
+ *
+ * Return 0 on success, -1 on error (diag is set).
  */
-void
+int
 wal_backup(const struct vclock *begin_vclock, const struct vclock *end_vclock,
 	   wal_backup_cb cb, void *cb_arg);
 

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -74,7 +74,7 @@ mp_sizeof_vclock_ignore0(const struct vclock *vclock)
 					     mp_sizeof_uint(UINT64_MAX));
 }
 
-static inline uint32_t
+uint32_t
 mp_sizeof_vclock(const struct vclock *vclock)
 {
 	uint32_t size = vclock_size(vclock);
@@ -105,7 +105,7 @@ mp_encode_vclock_ignore0(char *data, const struct vclock *vclock)
 	return mp_encode_vclock_impl(data, vclock, true);
 }
 
-static inline char *
+char *
 mp_encode_vclock(char *data, const struct vclock *vclock)
 {
 	data = mp_encode_map(data, vclock_size(vclock));

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -792,14 +792,26 @@ int
 xrow_decode_applier_heartbeat(const struct xrow_header *row,
 			      struct applier_heartbeat *req);
 
-/** Encode vclock including 0th component. */
-/** Return the number of bytes an encoded vclock takes. */
+/**
+ * Return the number of bytes a vclock encoded ignoring local component takes.
+ */
 uint32_t
 mp_sizeof_vclock_ignore0(const struct vclock *vclock);
 
-/** Encode a vclock to a buffer as MP_MAP. Never fails. */
+/** Return the number of bytes an encoded vclock takes. */
+uint32_t
+mp_sizeof_vclock(const struct vclock *vclock);
+
+/**
+ * Encode a vclock to a buffer as MP_MAP ignoring local component.
+ * Never fails.
+ */
 char *
 mp_encode_vclock_ignore0(char *data, const struct vclock *vclock);
+
+/** Encode a vclock to a buffer as MP_MAP. Never fails. */
+char *
+mp_encode_vclock(char *data, const struct vclock *vclock);
 
 /**
  * Decode a vclock from MsgPack data, it should be MP_MAP.

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -3,6 +3,7 @@
 
 local NEW = true
 local OLD = false
+local TIMEOUT_INFINITY = 100 * 365 * 86400
 
 local ffi = require('ffi')
 local tweaks = require('internal.tweaks')
@@ -197,6 +198,10 @@ contain names yet.
 https://tarantool.io/compat/skip_replication_names
 ]]
 
+local BOX_BACKUP_DEFAULT_TTL_BRIEF = [[
+Default backup TTL values when it is not set explicitly in box.backup.start().
+]]
+
 -- Returns an action callback that toggles a tweak.
 local function tweak_action(tweak_name, old_tweak_value, new_tweak_value)
     return function(is_new)
@@ -238,7 +243,7 @@ local options = {
         obsolete = nil,
         brief = FIBER_SLICE_DEFAULT_BRIEF,
         action = function(is_new)
-            local slice = 100 * 365 * 86400 -- TIMEOUT_INFINITY
+            local slice = TIMEOUT_INFINITY
             -- ASAN build is slow. Turn slice check off to suppress noisy
             -- failures on exceeding slice limit in this case.
             if is_new and not tarantool.build.asan then
@@ -367,6 +372,13 @@ local options = {
         obsolete = nil,
         brief = SKIP_REPLICATION_NAMES_BRIEF,
         action = function() end,
+    },
+    box_backup_default_ttl = {
+        default = 'old',
+        obsolete = nil,
+        brief = BOX_BACKUP_DEFAULT_TTL_BRIEF,
+        action = tweak_action(
+            'box_backup_default_ttl', TIMEOUT_INFINITY, 3600),
     },
 }
 

--- a/src/lua/utils.c
+++ b/src/lua/utils.c
@@ -63,6 +63,9 @@ __thread uint32_t CTID_INTERVAL = 0;
 void
 (*tarantool_lua_exit_function)(int code) = exit;
 
+static inline int
+luaL_convertint64(lua_State *L, int idx, bool unsignd, int64_t *result);
+
 struct lua_State *
 luaT_newstate(void)
 {
@@ -171,6 +174,37 @@ luaT_pushvclock(struct lua_State *L, const struct vclock *vclock)
 		lua_settable(L, -3);
 	}
 	luaL_setmaphint(L, -1); /* compact flow */
+}
+
+bool
+luaT_tovclock(struct lua_State *L, int idx, struct vclock *vclock)
+{
+	if (!lua_istable(L, idx))
+		goto error;
+	int stable_idx = idx;
+	if (stable_idx < 0)
+		stable_idx += lua_gettop(L) + 1;
+	/* Push first key. */
+	lua_pushnil(L);
+	vclock_create(vclock);
+	while (lua_next(L, stable_idx) != 0) {
+		int64_t lsn;
+		int64_t replica_id;
+		if (luaL_convertint64(L, -2, /*unsigned=*/false,
+				      &replica_id) != 0)
+			goto error;
+		if (luaL_convertint64(L, -1, /*unsigned=*/false, &lsn) != 0)
+			goto error;
+		if (replica_id < 0 || replica_id >= VCLOCK_MAX)
+			goto error;
+		vclock_reset(vclock, replica_id, lsn);
+		/* Pop value */
+		lua_pop(L, 1);
+	}
+	return true;
+error:
+	vclock_clear(vclock);
+	return false;
 }
 
 /*

--- a/src/lua/utils.h
+++ b/src/lua/utils.h
@@ -115,6 +115,14 @@ void
 luaT_pushvclock(struct lua_State *L, const struct vclock *vclock);
 
 /**
+ * Checks whether the argument idx is vclock as table and returns it in
+ * @vclock output argument.
+ * \return true on success or false if argument can't be converted.
+ */
+bool
+luaT_tovclock(struct lua_State *L, int idx, struct vclock *vclock);
+
+/**
  * Allocate a new uuid on the Lua stack and return a pointer to it.
  */
 struct tt_uuid *

--- a/test/box-luatest/backup_test.lua
+++ b/test/box-luatest/backup_test.lua
@@ -14,16 +14,20 @@ g.after_each(function(cg)
     end
 end)
 
-local backup = function(cg, files)
-    if cg.backup_dir ~= nil then
-        fio.rmtree(cg.backup_dir)
-    end
-    cg.backup_dir = fio.tempdir()
+local backup_files = function(cg, files)
     for _, file in ipairs(files) do
         local path_src = fio.pathjoin(cg.server.workdir, file)
         local path_dst = fio.pathjoin(cg.backup_dir, file)
         fio.copyfile(path_src, path_dst)
     end
+end
+
+local backup = function(cg, files)
+    if cg.backup_dir ~= nil then
+        fio.rmtree(cg.backup_dir)
+    end
+    cg.backup_dir = fio.tempdir()
+    backup_files(cg, files)
 end
 
 local restore = function(cg)
@@ -188,6 +192,7 @@ g.test_backup_info = function(cg)
         t.assert_equals(box.backup.info(), {
             files = files,
             vclock = vclock,
+            type = 'full',
         })
         box.backup.stop()
         t.assert_equals(box.backup.info(), nil)
@@ -199,6 +204,7 @@ g.test_backup_info = function(cg)
         t.assert_equals(box.backup.info(), {
             files = files,
             vclock = vclock,
+            type = 'full',
         })
         box.backup.stop()
 
@@ -209,6 +215,7 @@ g.test_backup_info = function(cg)
         t.assert_equals(box.backup.info(), {
             files = files,
             vclock = vclock,
+            type = 'full',
         })
         box.backup.stop()
     end)
@@ -263,6 +270,83 @@ g.test_backup_concurrent_start = function(cg)
         t.assert_covers(err:unpack(), {
             type = 'ClientError',
             code = box.error.BACKUP_IN_PROGRESS,
+        })
+    end)
+end
+
+g.test_backup_from_vclock = function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    local info_0 = cg.server:exec(function()
+        local s = box.schema.create_space('test')
+        s:create_index('pk')
+        for i = 1, 10 do
+            s:insert({i})
+        end
+        box.backup.start()
+        for i = 11, 20 do
+            s:insert({i})
+        end
+        return box.backup.info()
+    end)
+    backup(cg, info_0.files)
+    local info_1 = cg.server:exec(function(prev_vclock)
+        box.backup.stop()
+        local vclock = box.info.vclock
+        local files = box.backup.start({from_vclock = prev_vclock})
+        local s = box.space.test
+        for i = 21, 30 do
+            s:insert({i})
+        end
+        t.assert_equals(box.backup.info(), {
+            files = files,
+            vclock = vclock,
+            prev_vclock = prev_vclock,
+            type = 'incremental',
+        })
+        return box.backup.info()
+    end, {info_0.vclock})
+    t.assert_items_exclude(info_0.files, info_1.files)
+    backup_files(cg, info_1.files)
+    cg.server:stop()
+    restore(cg)
+    cg.server:start()
+    cg.server:exec(function()
+        local s = box.space.test
+        local expected = {}
+        for i = 1, 20 do
+            table.insert(expected, {i})
+        end
+        t.assert_equals(s:select(), expected)
+
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = 'expected number or table as 1 argument',
+        }, box.backup.start, function() end)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = 'invalid from_vclock',
+        }, box.backup.start, {from_vclock = 1})
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'XLOG_NOT_FOUND',
+            vclock = '{1: 100500}',
+        }, box.backup.start, {from_vclock = {100500}})
+        -- The {1, 100500} is not comparable with some for xlog vclocks.
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'XLOG_NOT_FOUND',
+            vclock = '{1: 1, 2: 100500}',
+        }, box.backup.start, {from_vclock = {1, 100500}})
+
+        -- Empty incremental backup.
+        local vclock = box.info.vclock
+        t.assert_equals(box.backup.start({from_vclock = vclock}), {})
+        t.assert_equals(box.backup.info(), {
+            files = {},
+            vclock = vclock,
+            prev_vclock = vclock,
+            type = 'incremental',
         })
     end)
 end

--- a/test/box-luatest/backup_test.lua
+++ b/test/box-luatest/backup_test.lua
@@ -351,6 +351,44 @@ g.test_backup_from_vclock = function(cg)
     end)
 end
 
+g.test_backup_ttl = function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    cg.server:exec(function()
+        local compat = require('compat')
+        local fiber = require('fiber')
+
+        -- Error cases.
+        local err = {
+            type = 'IllegalParams',
+            message = 'invalid ttl',
+        }
+        t.assert_error_covers(err, box.backup.start, {ttl = 'unexpected'})
+        t.assert_error_covers(err, box.backup.start, {ttl = 0})
+        t.assert_error_covers(err, box.backup.start, {ttl = -1})
+
+        -- TTL functionality.
+        box.backup.start({ttl = 0.01})
+        t.assert_not_equals(box.backup.info(), nil)
+        t.helpers.retrying({}, function()
+            t.assert_equals(box.backup.info(), nil)
+        end)
+        box.backup.start({ttl = 7000})
+        t.assert_equals(box.backup.info().expires_at, fiber.time() + 7000)
+        box.backup.stop()
+
+        -- TTL compat.
+        compat.box_backup_default_ttl = 'old'
+        box.backup.start()
+        t.assert_equals(box.backup.info().expires_at, nil)
+        box.backup.stop()
+        compat.box_backup_default_ttl = 'new'
+        box.backup.start()
+        t.assert_equals(box.backup.info().expires_at, fiber.time() + 3600)
+        box.backup.stop()
+    end)
+end
+
 local g1 = t.group('replication')
 
 g1.before_all(function(cg)

--- a/test/box/backup.result
+++ b/test/box/backup.result
@@ -13,7 +13,7 @@ test_run:cleanup_cluster()
 -- Basic argument check.
 box.backup.start('test')
 ---
-- error: expected integer as 1 argument
+- error: expected number or table as 1 argument
 ...
 box.backup.start(-1)
 ---

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -511,6 +511,7 @@ t;
  |   300: box.error.UNABLE_TO_PROCESS_IN_THREAD
  |   301: box.error.DICT_OVERFLOW
  |   302: box.error.NO_SUCH_THREAD_GROUP
+ |   303: box.error.XLOG_NOT_FOUND
  | ...
 
 test_run:cmd("setopt delimiter ''");

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -456,6 +456,7 @@ g.test_defaults = function()
             box_recovery_triggers_deprecation = 'old',
             skip_replication_names = 'new',
             datetime_setfn_timestamp_type_check = 'old',
+            box_backup_default_ttl = 'old',
         },
         isolated = false,
         stateboard = {

--- a/test/unit/lua_utils.c
+++ b/test/unit/lua_utils.c
@@ -5,6 +5,7 @@
 #include "lualib.h"
 #include "memory.h"
 #include "reflection.h"
+#include "vclock/vclock.h"
 
 #include "lua/utils.h"
 
@@ -466,10 +467,103 @@ test_optint(lua_State *L)
 	check_plan();
 }
 
+static void
+test_tovclock(lua_State *L)
+{
+	plan(16);
+	header();
+
+	struct vclock vclock;
+	int64_t lsn;
+
+	lua_pushnil(L);
+	TRASH(&vclock);
+	ok(!luaT_tovclock(L, -1, &vclock), "vclock is not a table");
+	ok(!vclock_is_set(&vclock), "vclock is set");
+	lua_pop(L, 1);
+
+	lua_createtable(L, 0, 0);
+	lua_pushboolean(L, true);
+	lua_pushinteger(L, 100);
+	lua_settable(L, -3);
+	TRASH(&vclock);
+	ok(!luaT_tovclock(L, -1, &vclock), "unexpected replica_id type");
+	ok(!vclock_is_set(&vclock), "vclock is set");
+	lua_pop(L, 1);
+
+	lua_createtable(L, 0, 0);
+	lua_pushinteger(L, 32);
+	lua_pushinteger(L, 100);
+	lua_settable(L, -3);
+	TRASH(&vclock);
+	ok(!luaT_tovclock(L, -1, &vclock),
+	   "replica_id value is larger than maximum");
+	ok(!vclock_is_set(&vclock), "vclock is set");
+	lua_pop(L, 1);
+
+	lua_createtable(L, 0, 0);
+	lua_pushinteger(L, -1);
+	lua_pushinteger(L, 100);
+	lua_settable(L, -3);
+	TRASH(&vclock);
+	ok(!luaT_tovclock(L, -1, &vclock), "replica_id value is less than 0");
+	ok(!vclock_is_set(&vclock), "vclock is set");
+	lua_pop(L, 1);
+
+	lua_createtable(L, 0, 0);
+	lua_pushinteger(L, 0);
+	lua_pushboolean(L, true);
+	lua_settable(L, -3);
+	TRASH(&vclock);
+	ok(!luaT_tovclock(L, -1, &vclock), "unexpected lsn type");
+	ok(!vclock_is_set(&vclock), "vclock is set");
+	lua_pop(L, 1);
+
+	/* Empty vclock. */
+	lua_createtable(L, 0, 0);
+	TRASH(&vclock);
+	luaT_tovclock(L, -1, &vclock);
+	ok(vclock_is_set(&vclock), "vclock is set");
+	int i;
+	for (i = 0; i < VCLOCK_MAX; i++) {
+		if (vclock_get(&vclock, i) != 0)
+			break;
+	}
+	ok(i == VCLOCK_MAX, "got %d", i);
+	lua_pop(L, 1);
+
+	/* Non empty vclock. */
+	lua_createtable(L, 0, 0);
+	lua_pushinteger(L, 0);
+	lua_pushinteger(L, 100);
+	lua_settable(L, -3);
+	lua_pushinteger(L, 31);
+	lua_pushinteger(L, 200);
+	lua_settable(L, -3);
+	TRASH(&vclock);
+	luaT_tovclock(L, -1, &vclock);
+	ok(vclock_is_set(&vclock), "vclock is set");
+	lsn = vclock_get(&vclock, 0);
+	ok(lsn == 100, "got %ld", lsn);
+	lsn = vclock_get(&vclock, 31);
+	ok(lsn == 200, "got %ld", 200);
+	for (i = 0; i < VCLOCK_MAX; i++) {
+		if (i == 0 || i == 31)
+			continue;
+		if (vclock_get(&vclock, i) != 0)
+			break;
+	}
+	ok(i == VCLOCK_MAX, "got %d", i);
+	lua_pop(L, 1);
+
+	footer();
+	check_plan();
+}
+
 int
 main(void)
 {
-	plan(12);
+	plan(13);
 	header();
 
 	struct lua_State *L = luaL_newstate();
@@ -490,6 +584,7 @@ main(void)
 	test_checkudata(L);
 	test_checktype(L);
 	test_optint(L);
+	test_tovclock(L);
 
 	fiber_free();
 	memory_free();


### PR DESCRIPTION
Part of #11729.

