### PR TITLE
test/fuzz: fix test fails in pickle_unpack_test

### DIFF
--- a/test/fuzz/lua/pickle_unpack_test.lua
+++ b/test/fuzz/lua/pickle_unpack_test.lua
@@ -12,6 +12,10 @@ local function TestOneInput(buf)
   local res = {pcall(pickle.unpack, format_string, binary_string)}
   if res[1] then
     table.remove(res, 1)
+    local is_unpack_safe = pcall(unpack, res)
+    if not is_unpack_safe then
+      return
+    end
     local packed = pickle.pack(format_string, unpack(res))
     assert(#packed == #binary_string)
   end

--- a/test/fuzz/lua/pickle_unpack_test.lua
+++ b/test/fuzz/lua/pickle_unpack_test.lua
@@ -12,6 +12,10 @@ local function TestOneInput(buf)
   local res = {pcall(pickle.unpack, format_string, binary_string)}
   if res[1] then
     table.remove(res, 1)
+    local ok, _ = pcall(unpack, res)
+    if not ok then
+      return
+    end
     local packed = pickle.pack(format_string, unpack(res))
     assert(#packed == #binary_string)
   end


### PR DESCRIPTION
pickle_unpack_test uses the function `unpack()`, but `unpack()` has a limitation for a number unpacked elements [1]. The patch test whether a passed table is unpackable, if no the test goes to the next iteration.

1. https://github.com/LuaJIT/LuaJIT/blob/18b087cd2cd4ddc4a79782bf155383a689d5093d/src/lib_base.c#L237-L239

NO_CHANGELOG=testing
NO_DOC=testing
NO_TEST=testing