### PR TITLE
box: fix memcs snapshot recovery with deprecated triggers

### DIFF
--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -580,10 +580,11 @@ memtx_engine_recover_snapshot_row(struct memtx_engine *memtx,
 	 * We use transaction in case of force recovery merely to
 	 * simplify the code.
 	 */
-	if (recovering_system_spaces ||
+	if (recovering_system_spaces || !space_is_memtx(space) ||
 	    space_events_are_enabled() || txn_events_are_enabled() ||
 	    memtx->force_recovery) {
-		if (!recovering_system_spaces && !memtx->force_recovery)
+		if (!recovering_system_spaces && space_is_memtx(space) &&
+		    !memtx->force_recovery)
 			say_warn_once(
 				"snapshot recovery performance is better with"
 				" new value of"


### PR DESCRIPTION
Fix snapshot recovery crash for memcs spaces when `compat.box_recovery_triggers_deprecation` = 'new'.

Force memcs snapshot rows to be applied via the transactional recovery path instead of the memtx fast path to avoid invalid engine casts/assertions.

Closes https://github.com/tarantool/tarantool-ee/issues/1729

NO_DOC=bugfix
NO_TEST=ee
NO_CHANGELOG=ee