### PR TITLE
wal: append async writes to the last queued batch

### DIFF
--- a/changelogs/unreleased/gh-11028-missing-system-space-rows.md
+++ b/changelogs/unreleased/gh-11028-missing-system-space-rows.md
@@ -1,0 +1,4 @@
+## bugfix/replication
+
+* Fixed an ordering bug in WAL batching that could make a joining replica miss
+  rows written by the master (gh-11028).

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -1539,8 +1539,8 @@ wal_write_async(struct journal *journal, struct journal_entry *entry)
 
 	struct wal_msg *batch;
 	if (!stailq_empty(&writer->wal_pipe.input) &&
-	    (batch = wal_msg(stailq_first_entry(&writer->wal_pipe.input,
-						struct cmsg, fifo)))) {
+	    (batch = wal_msg(stailq_last_entry(&writer->wal_pipe.input,
+					       struct cmsg, fifo)))) {
 
 		stailq_add_tail_entry(&batch->commit, entry, fifo);
 	} else {

--- a/test/replication-luatest/gh_11028_missing_rows_test.lua
+++ b/test/replication-luatest/gh_11028_missing_rows_test.lua
@@ -1,0 +1,86 @@
+local t = require("luatest")
+local server = require("luatest.server")
+
+local g = t.group()
+
+local replica_count = 8
+local ddl_worker_count = 8
+
+g.before_all(function(cg)
+    cg.replicas = {}
+    cg.master = server:new({
+        alias = "master",
+        box_cfg = {
+            bootstrap_strategy = "config",
+            bootstrap_leader = "master",
+            instance_name = "master",
+            replication_timeout = 1,
+        },
+    })
+    cg.master:start()
+end)
+
+g.after_all(function(cg)
+    cg.master:exec(function()
+        rawset(_G, "gh_11028_stop_ddl", true)
+        rawset(_G, "gh_11028_ddl_fibers", nil)
+    end)
+    for _, replica in ipairs(cg.replicas) do
+        replica:drop()
+    end
+    cg.master:drop()
+end)
+
+local function build_replica(cg, alias)
+    local box_cfg = table.deepcopy(cg.master.box_cfg)
+    box_cfg.instance_name = alias
+    box_cfg.replication = { cg.master.net_box_uri }
+    box_cfg.read_only = true
+    return server:new({
+        alias = alias,
+        box_cfg = box_cfg,
+    })
+end
+
+g.test_join_replicas_while_master_runs_ddl = function(cg)
+    cg.master:exec(function(ddl_worker_count)
+        local fiber = require("fiber")
+        rawset(_G, "gh_11028_stop_ddl", false)
+        rawset(_G, "gh_11028_ddl_fibers", {})
+        for worker_id = 1, ddl_worker_count do
+            local f = fiber.create(function()
+                local prefix = "test"
+                local iteration = 0
+                while not _G.gh_11028_stop_ddl do
+                    iteration = iteration + 1
+                    local space_name = string.format("%s%03d_%020d", prefix,
+                                                     worker_id, iteration)
+                    local s = box.schema.space.create(space_name)
+                    s:create_index("pk")
+                    s:create_index("bucket", {
+                        unique = false,
+                        parts = { { 2, "unsigned" } },
+                    })
+                    s:drop()
+                end
+            end)
+            f:set_joinable(true)
+            table.insert(_G.gh_11028_ddl_fibers, f)
+        end
+    end, { ddl_worker_count })
+
+    for i = 1, replica_count do
+        cg.replicas[i] = build_replica(cg, ("replica_%02d"):format(i))
+        cg.replicas[i]:start({ wait_until_ready = false })
+    end
+    for _, replica in ipairs(cg.replicas) do
+        replica:wait_until_ready()
+    end
+
+    cg.master:exec(function()
+        rawset(_G, "gh_11028_stop_ddl", true)
+        for _, f in ipairs(_G.gh_11028_ddl_fibers) do
+            assert(f:join())
+        end
+    end)
+end


### PR DESCRIPTION
wal_write_async() tries to batch a new journal entry with an already
queued WAL batch. Previously, if the first message in wal_pipe.input was
a WAL batch, the new entry was appended to it. This could break ordering
when the pipe already had more messages queued.

For example, after a checkpoint request was queued behind a batch, a
new write could still be appended to that batch and be written before the
checkpoint request. As a result, the checkpoint vclock could include rows
that were not present in the checkpoint data. A joining replica could
then skip fetching those rows during final join, so they went missing.

This patch fixes this by appending async writes only to the last
queued batch.

Closes #11028

NO_DOC=bugfix