### PR TITLE
sql: check privileges on `CREATE TRIGGER`

### DIFF
--- a/changelogs/unreleased/ghs-163-check-privileges-on-create-trigger.md
+++ b/changelogs/unreleased/ghs-163-check-privileges-on-create-trigger.md
@@ -1,0 +1,5 @@
+## bugfix/sql
+
+* Added permission checks when creating a trigger in SQL.
+  Now only users with 'alter' privileges on a table can create
+  triggers for that table (ghs-163).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -5671,6 +5671,9 @@ on_replace_dd_trigger(struct trigger * /* trigger */, void *event)
 				 "temporary spaces");
 			return -1;
 		}
+		if (access_check_ddl(space->def->name, space->def->uid,
+				     space->access, SC_SPACE, PRIV_A) != 0)
+			return -1;
 
 		struct sql_trigger *old_trigger;
 		if (sql_trigger_replace(trigger_name,

--- a/test/sql-luatest/triggers_test.lua
+++ b/test/sql-luatest/triggers_test.lua
@@ -680,3 +680,43 @@ end)
         t.assert_equals(box.space.test2, nil)
     end)
 end
+
+--
+-- ghs-163: Check access privileges when creating triggers.
+--
+ g.test_163_check_privileges_on_create_trigger = function(cg)
+    cg.server:exec(function()
+        local admin = box.session.user()
+        box.execute([[CREATE TABLE t1 (i INT PRIMARY KEY);]])
+        box.execute([[CREATE TABLE t2 (i INT PRIMARY KEY);]])
+        box.schema.user.create('user')
+        box.schema.user.grant('user', 'read,write,create', 'space', '_trigger')
+        box.schema.user.grant('user', 'read', 'space', '_space')
+        box.session.su('user')
+        local exp_err = "Alter access to space 't1' is denied for user 'user'"
+        local sql = "CREATE TRIGGER t1t AFTER INSERT ON t1 "..
+                    "FOR EACH ROW BEGIN INSERT INTO t2 VALUES(1); END;"
+
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, exp_err)
+
+        box.session.su(admin)
+        box.schema.user.grant('user', 'read,write,create', 'space', 't1')
+        box.session.su('user')
+        _, err = box.execute(sql)
+        t.assert_equals(err.message, exp_err)
+
+        box.session.su(admin)
+        box.schema.user.grant('user', 'alter', 'space', 't1')
+        box.session.su('user')
+        local res, err = box.execute(sql)
+        t.assert_equals(res, {row_count = 1})
+        t.assert_equals(err, nil)
+
+        box.session.su(admin)
+        box.schema.user.drop('user')
+        box.execute([[DROP TRIGGER t1t;]])
+        box.execute([[DROP TABLE t1;]])
+        box.execute([[DROP TABLE t2;]])
+    end)
+end


### PR DESCRIPTION
After this patch, only users with `alter` permissions will be able to create triggers for a table.

Closes tarantool/security#163

NO_DOC=bugfix