### PR TITLE
config: fix bootstrap error without manual leader

### DIFF
--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -1089,7 +1089,8 @@ local function force_ro_on_startup(configdata, box_cfg)
 
     -- Require at least one writable instance in the
     -- replicaset if the instance is to be bootstrapped (has
-    -- no existing snapshot). Otherwise there is no one who
+    -- no existing snapshot) and the instance itself is not
+    -- configured as writable. Otherwise there is no one who
     -- would register the instance in the _cluster system
     -- space.
     --
@@ -1102,15 +1103,17 @@ local function force_ro_on_startup(configdata, box_cfg)
     --
     -- Note: an anonymous replica is not to be registered in
     -- _cluster. So, it can subscribe to such a replicaset.
-    if in_replicaset and not has_snap and not is_anon then
+    if not configured_as_rw and not has_snap and not is_anon then
         local has_rw = false
         if failover == 'off' then
             for _, peer_name in ipairs(configdata:peers()) do
                 local opts = {instance = peer_name, use_default = true}
                 local mode = configdata:get('database.mode', opts)
-                -- NB: The default is box.NULL that is
-                -- interpreted as 'ro' for a replicaset with
-                -- more than one instance.
+                assert(in_replicaset or mode ~= nil or configured_as_rw)
+
+                -- NB: The default is box.NULL. It means 'rw'
+                -- for a singleton replicaset and 'ro' for a
+                -- replicaset with more than one instance.
                 if mode == 'rw' then
                     has_rw = true
                     break

--- a/test/config-luatest/basic_test.lua
+++ b/test/config-luatest/basic_test.lua
@@ -148,6 +148,65 @@ local err_msg_cannot_find_user = 'Cannot find user unknown ' ..
 local err_msg_no_suitable_uris = 'replication.peers construction for ' ..
     'instance "instance-001" of replicaset "replicaset-001" of group ' ..
     '"group-001": no suitable peer URIs found'
+local err_msg_no_leader_to_register = 'Startup failure.\n' ..
+    'No leader to register new instance "instance-001". All the ' ..
+    'instances in replicaset "replicaset-001" of group "group-001" are ' ..
+    'configured to the read-only mode.'
+
+g.test_no_leader_to_register_singleton_manual_failover = function()
+    local dir = treegen.prepare_directory({}, {})
+
+    local config = {
+        credentials = {
+            users = {
+                replicator = {
+                    password = 'topsecret',
+                    roles = {'replication'},
+                },
+            },
+        },
+        iproto = {
+            listen = {{
+                uri = 'unix/:./{{ instance_name }}.iproto',
+            }},
+            advertise = {
+                peer = {
+                    login = 'replicator',
+                },
+            },
+        },
+        replication = {
+            failover = 'manual',
+        },
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        instances = {
+                            ['instance-001'] = {},
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    local config_file = treegen.write_file(dir, 'config.yaml',
+        yaml.encode(config))
+    local env = {}
+    local args = {'--name', 'instance-001', '--config', config_file}
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, env, args, opts)
+
+    t.assert_equals({
+        exit_code = res.exit_code,
+        stderr = last_n_lines(res.stderr,
+                              count_lines(err_msg_no_leader_to_register)),
+    }, {
+        exit_code = 1,
+        stderr = err_msg_no_leader_to_register,
+    })
+end
 
 -- Bad cases for building replicaset.
 for case_name, case in pairs({
@@ -236,10 +295,7 @@ for case_name, case in pairs({
         -- All the instances are  configured to the read-only mode
         -- (and instance-001 has no existing snapshot).
         mode = 'ro',
-        exp_err = 'Startup failure.\nNo leader to register new instance ' ..
-            '"instance-001". All the instances in replicaset ' ..
-            '"replicaset-001" of group "group-001" are configured to the ' ..
-            'read-only mode.',
+        exp_err = err_msg_no_leader_to_register,
     },
     failover_off_leader_is_set = {
         -- The leader option is set together with failover =


### PR DESCRIPTION
This patch fixes a bug when a singleton replicaset with `replication.failover = 'manual'` and no leader failed with a low-level `BOOTSTRAP_READONLY` error instead of a proper configuration startup error.

Closes #11116