### PR TITLE
box: improve replication/election logs verbosity

### DIFF
--- a/changelogs/unreleased/gh-12697-improve-logs-verbosity.md
+++ b/changelogs/unreleased/gh-12697-improve-logs-verbosity.md
@@ -1,0 +1,5 @@
+## feature/core
+
+* Replication errors and Raft messages now include extended node
+  representations (`name`/`uuid`, `id`, and `addr`) for both local and
+  remote nodes (gh-12697).

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -668,7 +668,7 @@ applier_connect(struct applier *applier)
 	if (applier->version_id != greeting.version_id) {
 		say_info("remote master %s at %s running Tarantool %s",
 			 tt_uuid_str(&greeting.uuid),
-			 sio_strfaddr(&applier->addr, applier->addr_len),
+			 applier_addr_str(applier),
 			 version_id_to_string(greeting.version_id));
 	}
 
@@ -2962,4 +2962,10 @@ applier_uri_str(const struct applier *applier)
 	char *uri = (char *)static_alloc(APPLIER_SOURCE_MAXLEN);
 	uri_format(uri, APPLIER_SOURCE_MAXLEN, &applier->uri, false);
 	return uri;
+}
+
+const char *
+applier_addr_str(const struct applier *applier)
+{
+	return sio_strfaddr(&applier->addr, applier->addr_len);
 }

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -115,6 +115,12 @@ applier_log_error(struct applier *applier, struct error *e, bool try_reconnect)
 	default:
 		break;
 	}
+	const char *remote_addr = applier_addr_str(applier);
+	struct replica *remote = replica_by_uuid(&applier->uuid);
+	struct replica *self = replica_by_uuid(&INSTANCE_UUID);
+	say_error("Applier to %s disconnected. Self: %s",
+		  replica_to_string(remote, remote_addr),
+		  replica_to_string(self, applier->local_addr_str));
 	error_log(e);
 	if (try_reconnect)
 		say_info("will retry every %.2lf second",
@@ -322,7 +328,8 @@ apply_nop(struct xrow_header *row)
 static void
 applier_connection_init(struct iostream *io, const struct uri *uri,
 			struct sockaddr *addr, socklen_t *addr_len,
-			struct iostream_ctx *io_ctx, struct greeting *greeting)
+			struct iostream_ctx *io_ctx, struct greeting *greeting,
+			struct applier *applier)
 {
 	assert(!iostream_is_initialized(io));
 	char greetingbuf[IPROTO_GREETING_SIZE];
@@ -341,6 +348,9 @@ applier_connection_init(struct iostream *io, const struct uri *uri,
 			      uri_param(uri, "interface", 0));
 	if (fd < 0)
 		diag_raise();
+	/* Cache the local address of this connection. */
+	strlcpy(applier->local_addr_str, sio_getsockname_str(fd),
+		sizeof(applier->local_addr_str));
 	if (iostream_create(io, fd, io_ctx) != 0) {
 		close(fd);
 		diag_raise();
@@ -471,7 +481,7 @@ applier_watch_ballot(struct applier *applier)
 	applier->addr_len = sizeof(applier->addrstorage);
 	applier_connection_init(&io, &applier->uri, &applier->addr,
 				&applier->addr_len, &applier->io_ctx,
-				&greeting);
+				&greeting, applier);
 	if (!iproto_features_test(&applier->features,
 				  IPROTO_FEATURE_WATCHERS)) {
 		goto try_vote;
@@ -660,7 +670,7 @@ applier_connect(struct applier *applier)
 	applier->addr_len = sizeof(applier->addrstorage);
 	applier_connection_init(io, &applier->uri, &applier->addr,
 				&applier->addr_len, &applier->io_ctx,
-				&greeting);
+				&greeting, applier);
 
 	applier->last_row_time = ev_monotonic_now(loop());
 	applier->txn_last_tm = 0;

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -39,6 +39,7 @@
 
 #include "fiber_cond.h"
 #include "iostream.h"
+#include "sio.h"
 #include "trigger.h"
 #include "trivia/util.h"
 #include "tt_uuid.h"
@@ -177,6 +178,8 @@ struct applier {
 	struct iostream_ctx io_ctx;
 	/** I/O stream */
 	struct iostream io;
+	/** Local address string (ephemeral addr:port) cached at connect. */
+	char local_addr_str[SERVICE_NAME_MAXLEN];
 	/** Input buffer */
 	struct ibuf ibuf;
 	/** Triggers invoked on state change or ballot update. */

--- a/src/box/applier.h
+++ b/src/box/applier.h
@@ -369,6 +369,10 @@ applier_wait_bootstrap_leader_uuid_is_set(struct applier *applier);
 const char *
 applier_uri_str(const struct applier *applier);
 
+/** Return string, which represents remote addr for this @a applier. */
+const char *
+applier_addr_str(const struct applier *applier);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5305,7 +5305,7 @@ bootstrap_from_master(struct replica *master)
 	vclock_clear(&instance_vclock_storage);
 	say_info("bootstrapping replica from %s at %s",
 		 tt_uuid_str(&master->uuid),
-		 sio_strfaddr(&applier->addr, applier->addr_len));
+		 applier_addr_str(applier));
 
 	/*
 	 * Send JOIN request to master

--- a/src/box/raft.c
+++ b/src/box/raft.c
@@ -722,6 +722,23 @@ box_raft_finish_recovery(void)
 	raft_cfg_is_enabled(box_raft(), true);
 }
 
+/**
+ * Return a string representation of a Raft node for logging.
+ * Unlike relay/applier, Raft operates without a direct connection
+ * context - it only knows the node ID. For remote nodes the address
+ * is taken from the corresponding applier.
+ */
+static const char *
+box_raft_node_to_string(uint32_t node_id)
+{
+	const char *addr = NULL;
+	struct replica *replica = replica_by_id(node_id);
+	if (node_id != instance_id && replica != NULL &&
+	    replica->applier != NULL)
+		addr = applier_addr_str(replica->applier);
+	return replica_to_string(replica, addr);
+}
+
 void
 box_raft_init(void)
 {
@@ -729,6 +746,7 @@ box_raft_init(void)
 		.broadcast = box_raft_broadcast,
 		.write = box_raft_write,
 		.schedule_async = box_raft_schedule_async,
+		.node_to_string = box_raft_node_to_string,
 	};
 	raft_create(&box_raft_global, &box_raft_vtab);
 	trigger_create(&box_raft_on_update, box_raft_on_update_f, NULL, NULL);

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -236,6 +236,10 @@ struct relay {
 	 * be cancelled through it.
 	 */
 	struct fiber *subscribe_fiber;
+	/** Local address the remote replica connected to us. */
+	char listen_addr_str[SERVICE_NAME_MAXLEN];
+	/** Remote peer address (the replica that connected to us). */
+	char peer_addr_str[SERVICE_NAME_MAXLEN];
 };
 
 struct diag*
@@ -345,6 +349,12 @@ relay_start(struct relay *relay, struct iostream *io, uint64_t sync,
 	/* Never send rows for REPLICA_ID_NIL to anyone */
 	relay->id_filter = 1 << REPLICA_ID_NIL;
 	memset(&relay->status_msg, 0, sizeof(relay->status_msg));
+	/* Store the local address the remote connected to. */
+	strlcpy(relay->listen_addr_str, sio_getsockname_str(io->fd),
+		sizeof(relay->listen_addr_str));
+	/* Store the peer address of the connected replica. */
+	strlcpy(relay->peer_addr_str, sio_getpeername_str(io->fd),
+		sizeof(relay->peer_addr_str));
 }
 
 /**
@@ -1141,7 +1151,12 @@ relay_subscribe_f(va_list ap)
 	 * Don't clear the error for status reporting.
 	 */
 	assert(!diag_is_empty(&relay->diag));
-	diag_set_error(diag_get(), diag_last_error(&relay->diag));
+	struct error *err = diag_last_error(&relay->diag);
+	diag_set_error(diag_get(), err);
+	struct replica *self = replica_by_uuid(&INSTANCE_UUID);
+	say_error("Relay to %s disconnected. Self: %s",
+		  replica_to_string(relay->replica, relay->peer_addr_str),
+		  replica_to_string(self, relay->listen_addr_str));
 	diag_log();
 	say_info("exiting the relay loop");
 

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -1867,6 +1867,21 @@ replica_by_id(uint32_t replica_id)
 	return replicaset.replica_by_id[replica_id];
 }
 
+const char *
+replica_to_string(const struct replica *replica, const char *addr)
+{
+	if (replica == NULL)
+		return tt_sprintf("unknown");
+
+	const char *replica_label = *replica->name != 0 ?
+		replica->name : tt_uuid_str(&replica->uuid);
+
+	if (addr != NULL)
+		return tt_sprintf("%s (id = %u, addr: %s)", replica_label,
+				  replica->id, addr);
+	return tt_sprintf("%s (id = %u)", replica_label, replica->id);
+}
+
 int
 replica_find_new_id(uint32_t *replica_id)
 {

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -1479,8 +1479,7 @@ replicaset_needs_rejoin(struct replica **master)
 		}
 
 		const char *uuid_str = tt_uuid_str(&replica->uuid);
-		const char *addr_str = sio_strfaddr(&applier->addr,
-						applier->addr_len);
+		const char *addr_str = applier_addr_str(applier);
 		const char *local_vclock_str =
 			vclock_to_string(instance_vclock);
 		const char *remote_vclock_str = vclock_to_string(&ballot->vclock);

--- a/src/box/replication.h
+++ b/src/box/replication.h
@@ -516,6 +516,14 @@ struct replica *
 replica_by_name(const char *name);
 
 /**
+ * Return representation of the replica in the next format:
+ * <replica_name or replica_uuid> (id = <replica_id>).
+ * If addr is not NULL, appends ", addr: <addr>" to the result.
+ */
+const char *
+replica_to_string(const struct replica *replica, const char *addr);
+
+/**
  * Find a replica by ID
  */
 struct replica *

--- a/src/lib/core/sio.c
+++ b/src/lib/core/sio.c
@@ -471,6 +471,22 @@ invalid_uri:
 	return -1;
 }
 
+const char *
+sio_getsockname_str(int fd)
+{
+	struct sockaddr_storage addr;
+	socklen_t addr_len = sizeof(addr);
+	if (sio_getsockname(fd, (struct sockaddr *)&addr, &addr_len) == 0)
+		return sio_strfaddr((struct sockaddr *)&addr, addr_len);
+	/*
+	 * Since only transient ENOBUFS is reachable during
+	 * sio_getsockname, we need to make diag_clear in order to
+	 * avoid spurious setting of SocketError in diag.
+	 */
+	diag_clear(diag_get());
+	return "<unresolved>";
+}
+
 #ifdef __APPLE__
 /**
  * 'man' on getprotobyname/number() on MacOS locally says "These functions use

--- a/src/lib/core/sio.c
+++ b/src/lib/core/sio.c
@@ -487,6 +487,18 @@ sio_getsockname_str(int fd)
 	return "<unresolved>";
 }
 
+const char *
+sio_getpeername_str(int fd)
+{
+	struct sockaddr_storage addr;
+	socklen_t addr_len = sizeof(addr);
+	if (sio_getpeername(fd, (struct sockaddr *)&addr, &addr_len) == 0)
+		return sio_strfaddr((struct sockaddr *)&addr, addr_len);
+	/** The same as in sio_getsockname_str. */
+	diag_clear(diag_get());
+	return "<unresolved>";
+}
+
 #ifdef __APPLE__
 /**
  * 'man' on getprotobyname/number() on MacOS locally says "These functions use

--- a/src/lib/core/sio.h
+++ b/src/lib/core/sio.h
@@ -122,6 +122,13 @@ const char *
 sio_getsockname_str(int fd);
 
 /**
+ * Return a string representation of sockaddr (a socket for the remote node)
+ * which is hidden behind the fd.
+ */
+const char *
+sio_getpeername_str(int fd);
+
+/**
  * Advance write position in the iovec array
  * based on its current value and the number of
  * bytes written.

--- a/src/lib/core/sio.h
+++ b/src/lib/core/sio.h
@@ -115,6 +115,13 @@ int
 sio_getsockname(int fd, struct sockaddr *addr, socklen_t *addrlen);
 
 /**
+ * Return a string representation of sockaddr (a socket of the current node)
+ * which is hidden behind the fd.
+ */
+const char *
+sio_getsockname_str(int fd);
+
+/**
  * Advance write position in the iovec array
  * based on its current value and the number of
  * bytes written.

--- a/src/lib/raft/raft.c
+++ b/src/lib/raft/raft.c
@@ -54,6 +54,12 @@ raft_state_str(uint64_t state)
 	return "invalid (x)";
 };
 
+static const char *
+raft_node_info(const struct raft *raft, uint32_t node_id)
+{
+	return raft->vtab->node_to_string(node_id);
+}
+
 /** Shortcut for vtab 'broadcast' method. */
 static inline void
 raft_broadcast(struct raft *raft, const struct raft_msg *req)
@@ -487,7 +493,8 @@ raft_leader_resign(struct raft *raft)
 int
 raft_process_msg(struct raft *raft, const struct raft_msg *req, uint32_t source)
 {
-	say_info("RAFT: message %s from %u", raft_msg_to_string(req), source);
+	say_info("RAFT: message %s from %s", raft_msg_to_string(req),
+		 raft_node_info(raft, source));
 	assert(source > 0);
 	assert(source != raft->self);
 	if (req->term == 0 || req->state == 0 || req->state >= raft_state_MAX) {
@@ -532,8 +539,8 @@ raft_process_msg(struct raft *raft, const struct raft_msg *req, uint32_t source)
 			}
 			if (raft->leader != 0) {
 				say_info("RAFT: vote request is skipped - the "
-					 "leader is already known - %u",
-					 raft->leader);
+					 "leader is already known - %s",
+					 raft_node_info(raft, raft->leader));
 				break;
 			}
 			if (req->vote == raft->self) {
@@ -588,8 +595,9 @@ raft_process_msg(struct raft *raft, const struct raft_msg *req, uint32_t source)
 	}
 	if (req->state != RAFT_STATE_LEADER) {
 		if (source == raft->leader) {
-			say_info("RAFT: the node %u has resigned from the "
-				 "leader role", raft->leader);
+			say_info("RAFT: the node %s has resigned from the "
+				 "leader role",
+				 raft_node_info(raft, raft->leader));
 			/*
 			 * Candidate node clears leader and stops the timer
 			 * implicitly when starts a new term, but non-candidate
@@ -621,7 +629,9 @@ raft_process_msg(struct raft *raft, const struct raft_msg *req, uint32_t source)
 	 */
 	if (raft->leader != 0) {
 		say_warn("RAFT: conflicting leader detected in one term - "
-			 "known is %u, received %u", raft->leader, source);
+			 "known is %s, received %s",
+			 raft_node_info(raft, raft->leader),
+			 raft_node_info(raft, source));
 		return 0;
 	}
 
@@ -743,9 +753,9 @@ end_dump:
 		if (raft->volatile_term > raft->term)
 			goto do_dump;
 		if (!raft_can_vote_for(raft, &raft->candidate_vclock)) {
-			say_info("RAFT: vote request for %u is canceled - the "
+			say_info("RAFT: vote request for %s is canceled - the "
 				 "vclock is not acceptable anymore",
-				 raft->volatile_vote);
+				 raft_node_info(raft, raft->volatile_vote));
 			raft_revoke_vote(raft);
 			assert(raft_is_fully_on_disk(raft));
 			goto end_dump;
@@ -838,7 +848,8 @@ raft_sm_become_leader(struct raft *raft)
 static void
 raft_sm_follow_leader(struct raft *raft, uint32_t leader)
 {
-	say_info("RAFT: leader is %u, follow", leader);
+	say_info("RAFT: leader is %s, follow",
+		 raft_node_info(raft, leader));
 	assert(raft->state != RAFT_STATE_LEADER);
 	assert(raft->leader == 0);
 	raft->state = RAFT_STATE_FOLLOWER;
@@ -909,7 +920,8 @@ static void
 raft_sm_schedule_new_vote(struct raft *raft, uint32_t candidate_id,
 			  const struct vclock *candidate_vclock)
 {
-	say_info("RAFT: vote for %u, follow", candidate_id);
+	say_info("RAFT: vote for %s, follow",
+		 raft_node_info(raft, candidate_id));
 	assert(raft_can_vote_for(raft, candidate_vclock));
 	assert(raft->volatile_vote == 0);
 	assert(!vclock_is_set(&raft->candidate_vclock));
@@ -929,8 +941,9 @@ raft_sm_try_new_vote(struct raft *raft, uint32_t candidate_id,
 {
 	if (!raft_can_vote_for(raft, candidate_vclock)) {
 		assert(candidate_id != raft->self);
-		say_info("RAFT: vote request for %u is skipped - the vclock "
-			 "is not acceptable", candidate_id);
+		say_info("RAFT: vote request for %s is skipped - the vclock "
+			 "is not acceptable",
+			 raft_node_info(raft, candidate_id));
 		return;
 	}
 	raft_sm_schedule_new_vote(raft, candidate_id, candidate_vclock);
@@ -1320,7 +1333,8 @@ raft_process_term(struct raft *raft, uint64_t term, uint32_t source)
 {
 	if (term <= raft->volatile_term)
 		return;
-	say_info("RAFT: received a newer term from %u", (unsigned)source);
+	say_info("RAFT: received a newer term from %s",
+		 raft_node_info(raft, source));
 	raft_sm_schedule_new_term(raft, term);
 }
 

--- a/src/lib/raft/raft.h
+++ b/src/lib/raft/raft.h
@@ -129,6 +129,8 @@ struct raft_msg {
 typedef void (*raft_broadcast_f)(struct raft *raft, const struct raft_msg *req);
 typedef void (*raft_write_f)(struct raft *raft, const struct raft_msg *req);
 typedef void (*raft_schedule_async_f)(struct raft *raft);
+typedef const char*
+(*raft_node_info_f)(uint32_t node_id);
 
 /**
  * Raft connection to the environment, via which it talks to other nodes, to
@@ -144,6 +146,8 @@ struct raft_vtab {
 	 * right now.
 	 */
 	raft_schedule_async_f schedule_async;
+	/** Get an extended information about raft node: name/uuid, id, uri. */
+	raft_node_info_f node_to_string;
 };
 
 /** Vote descriptor of a single node. */

--- a/test/replication-luatest/gh_12697_improve_logs_verbosity_test.lua
+++ b/test/replication-luatest/gh_12697_improve_logs_verbosity_test.lua
@@ -113,6 +113,8 @@ end
 
 local APPLIER_NET_ERR = 'Applier to %s.*disconnected. Self: %s'
 
+local RELAY_NET_ERR = 'Relay to %s.*disconnected. Self: %s'
+
 g.test_relay_applier_net_errors_has_extended_node_info = function(g)
     local remote_a_eph_info = get_remote_node_info(
         g.server_a, {is_ephemeral = true})
@@ -122,6 +124,11 @@ g.test_relay_applier_net_errors_has_extended_node_info = function(g)
     g.server_b:stop()
     t.assert(g.server_a:grep_log(string.format(
         APPLIER_NET_ERR, remote_b_info, 'server_a')))
+
+    local server_b_uuid = g.server_b:get_instance_uuid():gsub(
+        '([%-%(%)])', '%%%1')
+    t.assert(g.server_b:grep_log(string.format(
+        RELAY_NET_ERR, remote_a_eph_info, server_b_uuid)))
     g.server_b:start()
 end
 
@@ -149,4 +156,16 @@ g.test_anon_replica_applier_net_error_has_extended_node_info = function(g)
     t.assert(g.anon_server:grep_log(string.format(
         APPLIER_NET_ERR, remote_a_info, anon_server_uuid)))
     g.server_a:start()
+end
+
+g.test_relay_net_errors_to_anon_replica_has_extended_node_info = function(g)
+    local anon_server_eph_info = get_remote_node_info(
+        g.anon_server, {is_ephemeral = true})
+    g.anon_server:stop()
+
+    local server_b_uuid = g.server_b:get_instance_uuid():gsub(
+        '([%-%(%)])', '%%%1')
+    t.assert(g.server_b:grep_log(string.format(
+                RELAY_NET_ERR, anon_server_eph_info, server_b_uuid)))
+    g.anon_server:start()
 end

--- a/test/replication-luatest/gh_12697_improve_logs_verbosity_test.lua
+++ b/test/replication-luatest/gh_12697_improve_logs_verbosity_test.lua
@@ -1,0 +1,112 @@
+local t = require('luatest')
+local server = require('luatest.server')
+local replica_set = require('luatest.replica_set')
+
+local g = t.group()
+
+g.before_all(function(g)
+    g.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication_timeout = 0.1,
+        election_mode = 'manual',
+        replication = {
+            server.build_listen_uri('server_a', g.replica_set.id),
+            server.build_listen_uri('server_b', g.replica_set.id),
+        },
+    }
+    g.server_a = g.replica_set:build_and_add_server{
+        alias = 'server_a', box_cfg = box_cfg}
+    g.server_b = g.replica_set:build_and_add_server{
+        alias = 'server_b', box_cfg = box_cfg}
+    g.replica_set:start()
+    g.replica_set:wait_for_fullmesh()
+    g.server_b:exec(function() box.ctl.promote() end)
+    g.server_b:wait_for_election_leader()
+end)
+
+g.after_all(function(g)
+    g.replica_set:drop()
+end)
+
+local function re_promote_server(server)
+    server:exec(function() box.ctl.demote() end)
+    server:wait_for_election_state('follower')
+    server:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            box.ctl.promote()
+        end)
+    end)
+    server:wait_for_election_leader()
+end
+
+local function format_node(node_label, node_id, node_addr)
+    local representation
+    if node_addr ~= nil then
+        representation = string.format('%s (id = %s, addr: %s)',
+                                       node_label, node_id, node_addr)
+    else
+        representation = string.format('%s (id = %s)',
+                                      node_label, node_id)
+    end
+    return representation:gsub('([%-%(%)])', '%%%1')
+end
+
+local function get_node_identity(server)
+    local id = server:get_instance_id()
+    local uuid = server:get_instance_uuid()
+    local name = server:exec(function()
+        return box.info.name ~= box.NULL and box.info.name or nil
+    end)
+    return name, uuid, id
+end
+
+local function get_remote_node_info(server, opts)
+    local name, uuid, id = get_node_identity(server)
+    local is_ephemeral = opts and opts.is_ephemeral or false
+    local addr = is_ephemeral and 'unix/:(socket)' or
+        'unix/:' .. server.net_box_uri
+    return format_node(name or uuid, id, addr)
+end
+
+local function get_local_node_info(server)
+    local name, uuid, id = get_node_identity(server)
+    return format_node(name or uuid, id)
+end
+
+g.test_raft_messages_contain_extended_node_info = function(g)
+    local local_b_info = get_local_node_info(g.server_b)
+    t.assert(g.server_b:grep_log(string.format(
+        'RAFT: vote for %s', local_b_info)))
+
+    re_promote_server(g.server_a)
+    local local_a_info = get_local_node_info(g.server_a)
+    local remote_a_info = get_remote_node_info(g.server_a)
+    local remote_b_info = get_remote_node_info(g.server_b)
+
+    t.assert(g.server_b:grep_log(string.format(
+             'RAFT: vote for %s', remote_a_info)))
+    t.assert(g.server_a:grep_log(string.format(
+             'RAFT: vote for %s', local_a_info)))
+    t.assert(g.server_a:grep_log(string.format(
+        'RAFT: message.*from %s', remote_b_info)))
+    t.assert(g.server_b:grep_log(string.format(
+        'RAFT: leader is %s', remote_a_info)))
+    t.assert(g.server_a:grep_log('RAFT: enter leader state'))
+end
+
+g.test_server_info_prefers_name_over_uuid = function(g)
+    local remote_a_info = get_remote_node_info(g.server_a)
+    -- Now the remote_a_info contains uuid.
+    t.assert(g.server_b:grep_log(string.format(
+        'RAFT: vote for %s', remote_a_info)))
+
+    g.server_a:exec(function() box.cfg{instance_name = 'server_a'} end)
+    re_promote_server(g.server_a)
+
+    -- After setting the instance_name the remote_a_info will contain name,
+    -- because name is more readable than uuid.
+    local remote_a_info_with_name = get_remote_node_info(g.server_a)
+    t.assert_not_equals(remote_a_info, remote_a_info_with_name)
+    t.assert(g.server_b:grep_log(string.format(
+        'RAFT: vote for %s', remote_a_info_with_name)))
+end

--- a/test/replication-luatest/gh_12697_improve_logs_verbosity_test.lua
+++ b/test/replication-luatest/gh_12697_improve_logs_verbosity_test.lua
@@ -110,3 +110,43 @@ g.test_server_info_prefers_name_over_uuid = function(g)
     t.assert(g.server_b:grep_log(string.format(
         'RAFT: vote for %s', remote_a_info_with_name)))
 end
+
+local APPLIER_NET_ERR = 'Applier to %s.*disconnected. Self: %s'
+
+g.test_relay_applier_net_errors_has_extended_node_info = function(g)
+    local remote_a_eph_info = get_remote_node_info(
+        g.server_a, {is_ephemeral = true})
+    local remote_b_info = get_remote_node_info(
+        g.server_b, {is_ephemeral = false})
+
+    g.server_b:stop()
+    t.assert(g.server_a:grep_log(string.format(
+        APPLIER_NET_ERR, remote_b_info, 'server_a')))
+    g.server_b:start()
+end
+
+g.test_anon_replica_applier_net_error_has_extended_node_info = function(g)
+    g.anon_server = g.replica_set:build_and_add_server{
+        alias = 'anon_replica',
+        box_cfg = {
+            replication = {
+                server.build_listen_uri('server_a', g.replica_set.id),
+                server.build_listen_uri('server_b', g.replica_set.id),
+            },
+            replication_anon = true,
+            read_only = true,
+        },
+    }
+    g.anon_server:start()
+    g.anon_server:wait_until_ready()
+
+    local remote_a_info = get_remote_node_info(
+        g.server_a, {is_ephemeral = false})
+    g.server_a:stop()
+
+    local anon_server_uuid = g.anon_server:get_instance_uuid():gsub(
+        '([%-%(%)])', '%%%1')
+    t.assert(g.anon_server:grep_log(string.format(
+        APPLIER_NET_ERR, remote_a_info, anon_server_uuid)))
+    g.server_a:start()
+end

--- a/test/unit/raft_test_utils.c
+++ b/test/unit/raft_test_utils.c
@@ -32,6 +32,7 @@
 #include "raft/raft_ev.h"
 #include "raft_test_utils.h"
 #include "random.h"
+#include "tt_static.h"
 
 #include <fcntl.h>
 
@@ -75,10 +76,14 @@ raft_node_write_f(struct raft *raft, const struct raft_msg *msg);
 static void
 raft_node_schedule_async_f(struct raft *raft);
 
+static const char *
+raft_node_to_string_f(uint32_t node_id);
+
 static struct raft_vtab raft_vtab = {
 	.broadcast = raft_node_broadcast_f,
 	.write = raft_node_write_f,
 	.schedule_async = raft_node_schedule_async_f,
+	.node_to_string = raft_node_to_string_f,
 };
 
 static int
@@ -590,6 +595,12 @@ raft_node_schedule_async_f(struct raft *raft)
 	struct raft_node *node = container_of(raft, struct raft_node, raft);
 	node->has_work = true;
 	fiber_wakeup(node->worker);
+}
+
+static const char *
+raft_node_to_string_f(uint32_t node_id)
+{
+	return tt_sprintf("%u", node_id);
 }
 
 static int


### PR DESCRIPTION
  box: enhance applier/relay net errors with extended node information
  
  Previously, network errors like SocketError contained only the IP and port
  of the local and remote nodes. Identifying specific nodes within a replica
  set based on this information was difficult, forcing clients and support
  teams to spend significant time matching IP:port pairs with node names or
  UUIDs.
  
  This patch adds `self` and `remote` parameters to SocketError instances.
  These parameters contain an extended string representation of the node,
  including its name or UUID, ID, and URI.
  
  Closes #12697
  
  NO_DOC=feature