### PR TITLE
config: extend aboard API with bool returns

### DIFF
--- a/changelogs/unreleased/aboard-api-extend.md
+++ b/changelogs/unreleased/aboard-api-extend.md
@@ -1,0 +1,6 @@
+## feature/config
+
+* Extended the alerts API: `set()`, `add()`, `unset()`, and `clear()` now return a
+  `bool` indicating whether a change was made. For example, `set()` returns
+  `false` if an alert with the same key and message already exists. Also added
+  `alerts_namespace:get(key)` to look up an alert by key.

--- a/src/box/lua/config/utils/aboard.lua
+++ b/src/box/lua/config/utils/aboard.lua
@@ -27,14 +27,12 @@ local log = require('internal.config.utils.log')
 --
 -- A timestamp is saved on the :set() method call to show it in
 -- an :alerts() result.
+--
+-- If `opts.key` is given and an alert with the same key and the
+-- same message already exists, the alert is not updated and
+-- `false` is returned. Otherwise `true` is returned.
 local function aboard_set(self, alert, opts)
     assert(alert.type == 'error' or alert.type == 'warn')
-    if alert.type == 'error' then
-        log.error(alert.message)
-    else
-        log.warn(alert.message)
-    end
-    alert.timestamp = datetime.now()
 
     local key
     if opts == nil or opts.key == nil then
@@ -42,9 +40,22 @@ local function aboard_set(self, alert, opts)
         self._next_key = self._next_key + 1
     else
         key = opts.key
+        local existing = self._alerts[key]
+        if existing ~= nil and existing.message == alert.message
+            and existing.type == alert.type then
+            return false
+        end
     end
 
+    if alert.type == 'error' then
+        log.error(alert.message)
+    else
+        log.warn(alert.message)
+    end
+    alert.timestamp = datetime.now()
+
     self._alerts[key] = alert
+    return true
 end
 
 -- Return an alert pointed by the given `key` or nil.
@@ -58,14 +69,18 @@ end
 --
 -- The `on_drop` callback (see the aboard.new() function) is
 -- called if the alert had existed.
+--
+-- Returns `true` if the alert was dropped, `false` if it didn't
+-- exist.
 local function aboard_drop(self, key)
     if self._alerts[key] == nil then
-        return
+        return false
     end
     self._alerts[key] = nil
     if self._on_drop ~= nil then
         self._on_drop(self, key)
     end
+    return true
 end
 
 -- Drop alerts that fit the given criteria.
@@ -79,6 +94,8 @@ end
 --
 -- The `on_drop` callback (see the aboard.new() function) is
 -- called for each of the dropped alert.
+--
+-- Returns `true` if any alert was dropped, `false` otherwise.
 local function aboard_drop_if(self, filter_f)
     local to_drop = {}
     for key, alert in pairs(self._alerts) do
@@ -90,6 +107,7 @@ local function aboard_drop_if(self, filter_f)
     for _, key in ipairs(to_drop) do
         self:drop(key)
     end
+    return #to_drop > 0
 end
 
 -- Traverse all alerts and apply the provided callback function to each of them.
@@ -102,9 +120,14 @@ end
 -- Drop all the alerts.
 --
 -- The `on_drop` callback is NOT called.
+--
+-- Returns `true` if any alert was dropped, `false` if the board
+-- was already empty.
 local function aboard_clean(self)
+    local was_empty = next(self._alerts) == nil
     self._alerts = {}
     self._next_key = 1
+    return not was_empty
 end
 
 -- Serialize the alerts to show them to a user.
@@ -208,23 +231,32 @@ end
 function namespace_methods.add(self, alert)
     namespace_selfcheck(self, 'add')
     local a = process_alert(self, alert)
-    self._aboard:set(a)
+    return self._aboard:set(a)
+end
+
+function namespace_methods.get(self, key)
+    namespace_selfcheck(self, 'get')
+    local alert = self._aboard:get(process_key(self, key))
+    if alert ~= nil then
+        alert = table.copy(alert)
+    end
+    return alert
 end
 
 function namespace_methods.set(self, key, alert)
     namespace_selfcheck(self, 'set')
     local a = process_alert(self, alert)
-    self._aboard:set(a, {key = process_key(self, key)})
+    return self._aboard:set(a, {key = process_key(self, key)})
 end
 
 function namespace_methods.unset(self, key)
     namespace_selfcheck(self, 'unset')
-    self._aboard:drop(process_key(self, key))
+    return self._aboard:drop(process_key(self, key))
 end
 
 function namespace_methods.clear(self)
     namespace_selfcheck(self, 'clear')
-    self._aboard:drop_if(function(_key, alert)
+    return self._aboard:drop_if(function(_key, alert)
         return alert._namespace == self._name
     end)
 end

--- a/test/config-luatest/alerts_test.lua
+++ b/test/config-luatest/alerts_test.lua
@@ -210,6 +210,110 @@ g.test_alerts_cleaned_by_aboard = function(g)
     })
 end
 
+g.test_alert_set_unset_clear_return_values = function(g)
+    local verify = function()
+        local alerts = require('config'):new_alerts_namespace('my_alerts')
+
+        t.assert_is(alerts:set('key1', {message = 'msg1'}), true)
+        t.assert_is(alerts:set('key1', {message = 'msg1'}), false)
+        t.assert_is(alerts:set('key1', {message = 'msg2'}), true)
+
+        t.assert_is(alerts:unset('key1'), true)
+        t.assert_is(alerts:unset('key1'), false)
+
+        t.assert_is(alerts:set('key2', {message = 'msg2'}), true)
+        t.assert_is(alerts:clear(), true)
+        t.assert_is(alerts:clear(), false)
+    end
+
+    helpers.success_case(g, {
+        verify = verify,
+    })
+end
+
+-- Ensure that add returns true, and that namespace:get() returns the alert
+-- by key or nil.
+g.test_alert_add_return_value_and_get = function(g)
+    local verify = function()
+        local alerts = require('config'):new_alerts_namespace('my_alerts')
+
+        t.assert_is(alerts:add({message = 'msg1'}), true)
+
+        alerts:set('key1', {message = 'msg2', my_field = 'val'})
+        local alert = alerts:get('key1')
+        t.assert_equals(alert.message, 'msg2')
+        t.assert_equals(alert.my_field, 'val')
+
+        t.assert_is(alerts:get('nonexistent'), nil)
+    end
+
+    helpers.success_case(g, {
+        verify = verify,
+    })
+end
+
+-- Ensure that aboard-level set, get, drop_if, and clean return bool
+-- (or alert/nil for :get()).
+g.test_aboard_set_get_drop_if_clean_return_values = function(g)
+    local verify = function()
+        local aboard = require('config')._aboard
+
+        t.assert_is(aboard:set({type = 'warn', message = 'msg1'},
+                               {key = 'key1'}), true)
+        t.assert_is(aboard:set({type = 'warn', message = 'msg1'},
+                               {key = 'key1'}), false)
+        t.assert_is(aboard:set({type = 'warn', message = 'msg2'},
+                               {key = 'key1'}), true)
+        t.assert_is(aboard:set({type = 'warn', message = 'msg3'},
+                               {key = 'key2'}), true)
+
+        -- Different type, same message: should update
+        t.assert_is(aboard:set({type = 'error', message = 'x'},
+                               {key = 'k'}), true)
+        t.assert_is(aboard:set({type = 'warn', message = 'x'},
+                               {key = 'k'}), true)
+
+        t.assert_equals(aboard:get('key1').message, 'msg2')
+        t.assert_is(aboard:get('nonexistent'), nil)
+
+        t.assert_is(aboard:drop('nonexistent'), false)
+        t.assert_is(aboard:drop('key1'), true)
+        t.assert_is(aboard:drop('key1'), false)
+
+        t.assert_is(aboard:drop_if(function() return false end), false)
+        t.assert_is(aboard:drop_if(function() return true end), true)
+        t.assert_is(aboard:drop_if(function() return true end), false)
+
+        aboard:set({type = 'warn', message = 'msg4'}, {key = 'key4'})
+        t.assert_is(aboard:clean(), true)
+        t.assert_is(aboard:clean(), false)
+    end
+
+    helpers.success_case(g, {
+        verify = verify,
+    })
+end
+
+-- Ensure that namespace:get() returns a copy.
+g.test_alert_get_returns_copy = function(g)
+    local verify = function()
+        local alerts = require('config'):new_alerts_namespace('my_alerts')
+
+        alerts:set('key1', {message = 'msg1', my_field = 'val'})
+        local alert = alerts:get('key1')
+        alert.message = 'modified'
+        alert.my_field = 'modified'
+
+        local stored = alerts:get('key1')
+        t.assert_equals(stored.message, 'msg1')
+        t.assert_equals(stored.my_field, 'val')
+    end
+
+    helpers.success_case(g, {
+        verify = verify,
+    })
+end
+
 -- Ensure that all faults are caught and reported correctly.
 g.test_alerts_assertions = function()
     local cases = {
@@ -297,6 +401,14 @@ g.test_alerts_assertions = function()
                 alerts:set("my:key", {message = 'Test alert'})
             ]],
             err = 'alert key cannot contain a colon',
+        },
+        {
+            script = [[
+                local config = require('config')
+                local alerts = config:new_alerts_namespace('my_alerts')
+                alerts.get("my_key")
+            ]],
+            err = 'Use alerts_namespace:get',
         },
         {
             script = [[


### PR DESCRIPTION
`aboard:set()` now returns false and skips the update if an alert with the same key and message already exists.

`drop`, `drop_if`, `clean`, `add`, `unset`, `clear` now return bool indicating whether a change was made.

Also add `namespace:get()` to look up an alert by key without accessing internal fields.