### PR TITLE
config: introduce integrity check audit filters

### DIFF
--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1968,6 +1968,8 @@ return schema.new('instance_config', schema.record({
             "space_insert",
             "space_replace",
             "space_delete",
+            "integrity_check_ok",
+            "integrity_check_fail",
             -- Groups of events.
             "none",
             "all",
@@ -1978,6 +1980,7 @@ return schema.new('instance_config', schema.record({
             "dml",
             "data_operations",
             "compatibility",
+            "integrity_check",
         }),
         spaces = enterprise_edition(schema.union({
             variants = {

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -996,8 +996,9 @@ g.test_audit_options = function()
         'role_grant_rights', 'role_revoke_rights', 'password_change',
         'access_denied', 'eval', 'call', 'space_select', 'space_create',
         'space_alter', 'space_drop', 'space_insert', 'space_replace',
-        'space_delete', 'none', 'all', 'audit', 'auth', 'priv', 'ddl', 'dml',
-        'data_operations', 'compatibility'
+        'space_delete', 'integrity_check_ok', 'integrity_check_fail',
+        'none', 'all', 'audit', 'auth', 'priv', 'ddl', 'dml',
+        'data_operations', 'compatibility', 'integrity_check'
     }
 
     local verify = function(events, audit_spaces)


### PR DESCRIPTION
The filters allow to control audit logging of integrity check results in the config.

Needed-for tarantool/tarantool-ee#1761

NO_DOC=ee
NO_TEST=ee
NO_CHANGELOG=ee