### PR TITLE
config: log effective config on startup failure

### DIFF
--- a/changelogs/unreleased/gh-11117-startup-failure-config.md
+++ b/changelogs/unreleased/gh-11117-startup-failure-config.md
@@ -1,0 +1,6 @@
+## feature/config
+
+* Added logging of the collected instance configuration when declarative
+  configuration startup fails after the configuration has been collected
+  and `TT_CONFIG_DEBUG=1` is set. Sensitive values are masked
+  (gh-11117).

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -65,6 +65,16 @@ function methods.filter(self, f, opts)
     return instance_config:filter(data, f)
 end
 
+function methods.masked_iconfig(self, opts)
+    local data = table.deepcopy(choose_iconfig(self, opts))
+    self:filter(function(w)
+        return w.schema.computed.annotations.sensitive
+    end, opts):each(function(w)
+        instance_config:set(data, w.path, '<hidden>')
+    end)
+    return data
+end
+
 -- List of names of the instances in the same replicaset.
 --
 -- The names are useful to pass to other methods as opts.peer.

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -1,5 +1,6 @@
 local fiber = require('fiber')
 local fio = require('fio')
+local yaml = require('yaml')
 local instance_config = require('internal.config.instance_config')
 local cluster_config = require('internal.config.cluster_config')
 local configdata = require('internal.config.configdata')
@@ -477,6 +478,17 @@ end
 function methods._startup(self, instance_name, config_file)
     local ok, err = pcall(self._startup_impl, self, instance_name, config_file)
     if not ok then
+        if self._configdata ~= nil then
+            local ok, iconfig = pcall(self._configdata.masked_iconfig,
+                                      self._configdata)
+            if ok then
+                log.debug('Instance configuration at startup failure:\n%s',
+                          yaml.encode(iconfig))
+            else
+                log.debug('Unable to prepare instance configuration for ' ..
+                          'startup failure report: %s', iconfig)
+            end
+        end
         log.error(err)
         os.exit(1)
     end

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -44,6 +44,10 @@ local network = require('internal.config.utils.network')
 -- * mk_parent_dir (boolean)
 --
 --   Create a parent directory for the given file before box.cfg().
+--
+-- * sensitive (boolean)
+--
+--   Hide the value from diagnostic configuration dumps.
 
 local function enterprise_edition_validate(data, w)
     -- OK if we're on Tarantool EE.
@@ -91,6 +95,15 @@ local function enterprise_edition(schema_node)
         enterprise_edition_apply_default_if)
 
     return schema_node
+end
+
+local function sensitive(schema_node)
+    schema_node.sensitive = true
+    return schema_node
+end
+
+local function sensitive_ee(schema_node)
+    return sensitive(enterprise_edition(schema_node))
 end
 
 -- Accept a value of 'iproto.listen' option and return the first URI
@@ -328,9 +341,9 @@ return schema.new('instance_config', schema.record({
             username = schema.scalar({
                 type = 'string',
             }),
-            password = schema.scalar({
+            password = sensitive(schema.scalar({
                 type = 'string',
-            }),
+            })),
             http = schema.record({
                 request = schema.record({
                     timeout = schema.scalar({
@@ -400,9 +413,9 @@ return schema.new('instance_config', schema.record({
                     login = schema.scalar({
                         type = 'string',
                     }),
-                    password = schema.scalar({
+                    password = sensitive(schema.scalar({
                         type = 'string',
-                    }),
+                    })),
                     params = schema.record({
                         transport = schema.enum({
                             'plain',
@@ -420,10 +433,10 @@ return schema.new('instance_config', schema.record({
                         ssl_ciphers = enterprise_edition(schema.scalar({
                             type = 'string',
                         })),
-                        ssl_password = enterprise_edition(schema.scalar({
+                        ssl_password = sensitive_ee(schema.scalar({
                             type = 'string',
                         })),
-                        ssl_password_file = enterprise_edition(schema.scalar({
+                        ssl_password_file = sensitive_ee(schema.scalar({
                             type = 'string',
                         })),
                     }),
@@ -702,10 +715,10 @@ return schema.new('instance_config', schema.record({
                     ssl_ciphers = enterprise_edition(schema.scalar({
                         type = 'string',
                     })),
-                    ssl_password = enterprise_edition(schema.scalar({
+                    ssl_password = sensitive_ee(schema.scalar({
                         type = 'string',
                     })),
-                    ssl_password_file = enterprise_edition(schema.scalar({
+                    ssl_password_file = sensitive_ee(schema.scalar({
                         type = 'string',
                     })),
                 }),
@@ -782,9 +795,9 @@ return schema.new('instance_config', schema.record({
                 login = schema.scalar({
                     type = 'string',
                 }),
-                password = schema.scalar({
+                password = sensitive(schema.scalar({
                     type = 'string',
-                }),
+                })),
                 uri = schema.scalar({
                     type = 'string',
                     validate = validators['iproto.advertise.peer.uri'],
@@ -806,10 +819,10 @@ return schema.new('instance_config', schema.record({
                     ssl_key_file = enterprise_edition(schema.scalar({
                         type = 'string',
                     })),
-                    ssl_password = enterprise_edition(schema.scalar({
+                    ssl_password = sensitive_ee(schema.scalar({
                         type = 'string',
                     })),
-                    ssl_password_file = enterprise_edition(schema.scalar({
+                    ssl_password_file = sensitive_ee(schema.scalar({
                         type = 'string',
                     })),
                 }),
@@ -820,9 +833,9 @@ return schema.new('instance_config', schema.record({
                 login = schema.scalar({
                     type = 'string',
                 }),
-                password = schema.scalar({
+                password = sensitive(schema.scalar({
                     type = 'string',
-                }),
+                })),
                 uri = schema.scalar({
                     type = 'string',
                     validate = validators['iproto.advertise.sharding.uri'],
@@ -844,10 +857,10 @@ return schema.new('instance_config', schema.record({
                     ssl_key_file = enterprise_edition(schema.scalar({
                         type = 'string',
                     })),
-                    ssl_password = enterprise_edition(schema.scalar({
+                    ssl_password = sensitive_ee(schema.scalar({
                         type = 'string',
                     })),
-                    ssl_password_file = enterprise_edition(schema.scalar({
+                    ssl_password_file = sensitive_ee(schema.scalar({
                         type = 'string',
                     })),
                 }),
@@ -884,12 +897,12 @@ return schema.new('instance_config', schema.record({
             ssl_key = schema.scalar({
                 type = 'string',
             }),
-            ssl_password = schema.scalar({
+            ssl_password = sensitive(schema.scalar({
                 type = 'string',
-            }),
-            ssl_password_file = schema.scalar({
+            })),
+            ssl_password_file = sensitive(schema.scalar({
                 type = 'string',
-            }),
+            })),
         })),
     }),
     database = schema.record({
@@ -1492,9 +1505,9 @@ return schema.new('instance_config', schema.record({
             }),
             -- Parameters of the user.
             value = schema.record({
-                password = schema.scalar({
+                password = sensitive(schema.scalar({
                     type = 'string',
-                }),
+                })),
                 privileges = schema.array({
                     items = schema.record({
                         permissions = schema.set({
@@ -2149,10 +2162,10 @@ return schema.new('instance_config', schema.record({
                         ssl_ciphers = enterprise_edition(schema.scalar({
                             type = 'string',
                         })),
-                        ssl_password = enterprise_edition(schema.scalar({
+                        ssl_password = sensitive_ee(schema.scalar({
                             type = 'string',
                         })),
-                        ssl_password_file = enterprise_edition(schema.scalar({
+                        ssl_password_file = sensitive_ee(schema.scalar({
                             type = 'string',
                         })),
                         ssl_verify_client = schema.enum({
@@ -2195,8 +2208,10 @@ return schema.new('instance_config', schema.record({
                 ssl_cert = schema.scalar({ type = 'string' }),
                 ssl_key = schema.scalar({ type = 'string' }),
                 ssl_ciphers = schema.scalar({ type = 'string' }),
-                ssl_password = schema.scalar({ type = 'string' }),
-                ssl_password_file = schema.scalar({ type = 'string' }),
+                ssl_password = sensitive(schema.scalar({ type = 'string' })),
+                ssl_password_file = sensitive(schema.scalar({
+                    type = 'string',
+                })),
             }),
         })),
     }, {

--- a/test/config-luatest/gh_11117_startup_failure_config_test.lua
+++ b/test/config-luatest/gh_11117_startup_failure_config_test.lua
@@ -1,0 +1,69 @@
+local t = require('luatest')
+local yaml = require('yaml')
+local treegen = require('luatest.treegen')
+local justrun = require('luatest.justrun')
+
+local g = t.group()
+
+g.test_report_instance_config_on_startup_failure = function()
+    local dir = treegen.prepare_directory({}, {})
+    treegen.write_file(dir, 'main.lua', [[
+        error('application startup failed', 0)
+    ]])
+    local config = {
+        credentials = {
+            users = {
+                guest = {
+                    roles = {'super'},
+                },
+                client = {
+                    password = 'topsecret',
+                    roles = {'super'},
+                },
+            },
+        },
+        app = {
+            file = 'main.lua',
+        },
+        iproto = {
+            listen = {{
+                uri = 'unix/:./{{ instance_name }}.iproto',
+            }},
+        },
+        replication = {
+            failover = 'manual',
+        },
+        groups = {
+            ['group-001'] = {
+                replicasets = {
+                    ['replicaset-001'] = {
+                        leader = 'instance-001',
+                        instances = {
+                            ['instance-001'] = {},
+                        },
+                    },
+                },
+            },
+        },
+    }
+    local config_file = treegen.write_file(dir, 'config.yaml',
+                                           yaml.encode(config))
+    local env = {TT_CONFIG_DEBUG = '1'}
+    local args = {'--name', 'instance-001', '--config', config_file}
+    local opts = {nojson = true, stderr = true}
+
+    local res = justrun.tarantool(dir, env, args, opts)
+
+    t.assert_equals(res.exit_code, 1)
+    t.assert_str_contains(res.stderr, 'application startup failed')
+    t.assert_str_contains(res.stderr,
+                          'Instance configuration at startup failure:')
+    t.assert_str_contains(res.stderr, 'replication:')
+    t.assert_str_contains(res.stderr, '  failover: manual')
+    t.assert_str_contains(res.stderr, 'iproto:')
+    t.assert_str_contains(res.stderr,
+                          '  - uri: unix/:./instance-001.iproto')
+    t.assert_str_contains(res.stderr, 'client:')
+    t.assert_str_contains(res.stderr, 'password: <hidden>')
+    t.assert_not_str_contains(res.stderr, 'topsecret')
+end

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -55,6 +55,46 @@ g.test_general = function()
     t.assert_equals(instance_config.name, 'instance_config')
 end
 
+g.test_sensitive_annotations = function()
+    local iconfig = {
+        credentials = {
+            users = {
+                client = {
+                    password = 'topsecret',
+                },
+            },
+        },
+        iproto = {
+            advertise = {
+                peer = {
+                    uri = 'localhost:3301',
+                    login = 'replicator',
+                    password = 'replication-secret',
+                },
+                sharding = {
+                    uri = 'localhost:3302',
+                    login = 'storage',
+                    password = 'sharding-secret',
+                },
+            },
+        },
+    }
+    instance_config:validate(iconfig)
+
+    local paths = instance_config:filter(iconfig, function(w)
+        return w.schema.computed.annotations.sensitive
+    end):map(function(w)
+        return table.concat(w.path, '.')
+    end):totable()
+    table.sort(paths)
+
+    t.assert_equals(paths, {
+        'credentials.users.client.password',
+        'iproto.advertise.peer.password',
+        'iproto.advertise.sharding.password',
+    })
+end
+
 g.test_config = function()
     t.tarantool.skip_if_enterprise()
     local iconfig = {


### PR DESCRIPTION
When declarative configuration startup fails after the instance configuration has been collected, the original configuration source may not be enough to understand what configuration was actually applied to the instance. Some values may come from instance-level overrides, environment variables, and template substitution.

This patch adds logging of the effective instance configuration in this case when `TT_CONFIG_DEBUG=1` is set (sensitive values are hidden).

Example log output:

```yaml
2026-06-19 14:05:34.882 [88442] main/104/interactive/tarantool.config log.lua:74 I> D> Instance configuration at startup failure:
---
app:
  file: main.lua
credentials:
  roles: []
  users:
    client:
      password: <hidden>
      roles:
      - super
    guest:
      roles:
      - super
iproto:
  listen:
  - uri: unix/:./instance-001.iproto
replication:
  failover: manual
...

2026-06-19 14:05:34.882 [88442] main/104/interactive/tarantool.config log.lua:74 I> E> application startup failed
2026-06-19 14:05:34.882 [88442] main/127/iproto.shutdown evio.c:605 I> tx_binary: stopped
```

Closes #11117