### PR TITLE
test: fix flaky tests

### DIFF
--- a/test/box-luatest/gh_7930_memtx_mvcc_loss_of_committed_tuple_after_prepared_tx_rollback_test.lua
+++ b/test/box-luatest/gh_7930_memtx_mvcc_loss_of_committed_tuple_after_prepared_tx_rollback_test.lua
@@ -9,7 +9,6 @@ g.before_all(function(cg)
         box_cfg = {
             memtx_use_mvcc_engine = true,
             replication_synchro_quorum = 2,
-            replication_synchro_timeout = 0.0001,
         }
     }
     cg.server:start()
@@ -19,7 +18,9 @@ g.before_all(function(cg)
         local as = box.schema.space.create("as")
         as:create_index("pk")
 
+        box.cfg{replication_synchro_timeout = 10}
         box.ctl.promote()
+        box.cfg{replication_synchro_timeout = 0.0001}
     end)
 end)
 

--- a/test/replication/gh-5874-qsync-txn-recovery.result
+++ b/test/replication/gh-5874-qsync-txn-recovery.result
@@ -13,7 +13,7 @@ old_synchro_quorum = box.cfg.replication_synchro_quorum
 old_synchro_timeout = box.cfg.replication_synchro_timeout
  | ---
  | ...
-box.cfg{replication_synchro_quorum = 2, replication_synchro_timeout = 0.001}
+box.cfg{replication_synchro_quorum = 2, replication_synchro_timeout = 10}
  | ---
  | ...
 engine = test_run:get_cfg('engine')
@@ -32,6 +32,9 @@ _ = sync:create_index('pk')
  | ---
  | ...
 box.ctl.promote()
+ | ---
+ | ...
+box.cfg{replication_synchro_timeout = 0.001}
  | ---
  | ...
 

--- a/test/replication/gh-5874-qsync-txn-recovery.test.lua
+++ b/test/replication/gh-5874-qsync-txn-recovery.test.lua
@@ -6,13 +6,14 @@ test_run = require('test_run').new()
 --
 old_synchro_quorum = box.cfg.replication_synchro_quorum
 old_synchro_timeout = box.cfg.replication_synchro_timeout
-box.cfg{replication_synchro_quorum = 2, replication_synchro_timeout = 0.001}
+box.cfg{replication_synchro_quorum = 2, replication_synchro_timeout = 10}
 engine = test_run:get_cfg('engine')
 async = box.schema.create_space('async', {engine = engine})
 _ = async:create_index('pk')
 sync = box.schema.create_space('sync', {is_sync = true, engine = engine})
 _ = sync:create_index('pk')
 box.ctl.promote()
+box.cfg{replication_synchro_timeout = 0.001}
 
 -- The transaction fails, but is written to the log anyway.
 box.begin() async:insert{1} sync:insert{1} box.commit()


### PR DESCRIPTION
This patch fixes flaky tests
box-luatest/gh_7930_memtx_mvcc_loss_of_committed_tuple_after_prepared_tx_rollback_test.lua replication/gh-5874-qsync-txn-recovery.test.lua

Closes #12821
Closes #12822

NO_DOC=flaky test fix
NO_CHANGELOG=flaky test fix