### PR TITLE
box: fix rejection of decimals with large scale and zero value

### DIFF
--- a/changelogs/unreleased/gh_12808_didnt_reject_demical_with_value_zero.md
+++ b/changelogs/unreleased/gh_12808_didnt_reject_demical_with_value_zero.md
@@ -1,0 +1,5 @@
+## bugfix/box
+
+* Fixed an issue where zero values were incorrectly rejected by fixed-point
+  decimal fields when their scale was greater than or equal to their precision
+  (gh-12808).

--- a/src/lib/core/decimal.c
+++ b/src/lib/core/decimal.c
@@ -98,6 +98,8 @@ bool
 decimal_fits_fixed_point(decimal_t *dec, int precision, int scale)
 {
 	decimal_t tmp = *dec;
+	if (decNumberIsZero(&tmp))
+		return true;
 	decNumberReduce(&tmp, dec, &decimal_context);
 	VERIFY(decimal_check_status(&tmp, &decimal_context) != NULL);
 	int d = tmp.exponent + scale;

--- a/test/box-luatest/fixed_point_decimal_test.lua
+++ b/test/box-luatest/fixed_point_decimal_test.lua
@@ -412,3 +412,32 @@ g.test_mp_null_values = function(cg)
         t.assert_equals(s.index.sk:select({box.NULL}), {{2, box.NULL}})
     end)
 end
+
+g.test_decimal_zero_fits_fixed_point = function(cg)
+    cg.server:exec(function()
+        local decimal = require('decimal')
+        local cases = {
+            decimal32  = {-9, -5, -1, 0, 1, 5, 9},
+            decimal64  = {-18, -15, -1, 0, 1, 15, 18},
+            decimal128 = {-38, -30, -1, 0, 1, 30, 38},
+            decimal256 = {-76, -68, -1, 0, 1, 68, 76},
+        }
+        for decimal_type, scales in pairs(cases) do
+            for _, scale in pairs(scales) do
+                local s = box.schema.space.create('test', {
+                    format = {
+                        {name = 'a', type = 'unsigned'},
+                        {name = 'b', type = decimal_type, scale = scale},
+                    },
+                })
+                s:create_index('pk')
+                s:replace{1, decimal.new('0')}
+                s:replace{1, decimal.new(0)}
+                s:replace{1, decimal.new('0.' .. string.rep('0', scale))}
+                s:replace{1, decimal.new('-0.' .. string.rep('0', 1000))}
+                s:replace{1, decimal.new('0.' .. string.rep('0', 1000))}
+                s:drop()
+            end
+        end
+    end)
+end


### PR DESCRIPTION
The `decimal_fits_fixed_point` function does not check if the decimal value is exactly zero. Because of this, in `decNumberReduce` the exponent becomes negative. As a result, 'd' becomes negative and hits 'if (d < 0) return false'.

After adding a call to `decNumberIsZero`, if the decimal value is zero it returns 'true' without checking 'd < 0'.

Closes #12808