### PR TITLE
config: add metric enabled helper

### DIFF
--- a/changelogs/unreleased/gh-12841-config-is-metric-enabled.md
+++ b/changelogs/unreleased/gh-12841-config-is-metric-enabled.md
@@ -1,0 +1,5 @@
+## feature/config
+
+* Added `config:is_metric_enabled()` to check whether a metric group or
+  selector is enabled by the applied `metrics.include` / `metrics.exclude`
+  configuration (gh-12841).

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -120,6 +120,130 @@ local function normalize_waited_statuses(statuses)
     return res
 end
 
+-- The metrics filter helpers below mirror the logic from `metrics.cfg()`
+-- (see third_party/metrics/metrics/cfg.lua).
+local metrics_tarantool
+
+local function is_default_metric(name)
+    if name == 'all' then
+        return true
+    end
+
+    if metrics_tarantool == nil then
+        metrics_tarantool = require('metrics.tarantool')
+    end
+    return metrics_tarantool.is_default_metric(name)
+end
+
+local metrics_filter_cache = {
+    configdata = nil,
+}
+
+local function split_metric_groups_and_selectors(values, default_value,
+                                                 empty_default,
+                                                 empty_selectors)
+    values = values or default_value
+
+    if type(values) == 'string' then
+        return values, values
+    end
+
+    assert(type(values) == 'table')
+
+    local default_metrics = {}
+    local custom_selectors = {}
+    for _, value in ipairs(values) do
+        if value == 'all' then
+            table.insert(default_metrics, value)
+            return default_metrics, 'all'
+        elseif is_default_metric(value) then
+            table.insert(default_metrics, value)
+        else
+            table.insert(custom_selectors, value)
+        end
+    end
+
+    if next(default_metrics) == nil then
+        default_metrics = empty_default
+    end
+
+    if next(custom_selectors) == nil then
+        custom_selectors = empty_selectors
+    end
+
+    return default_metrics, custom_selectors
+end
+
+local function metrics_filter(self)
+    local configdata = self._configdata_applied
+    if rawequal(metrics_filter_cache.configdata, configdata) then
+        return metrics_filter_cache
+    end
+
+    local default_include, selector_include =
+        split_metric_groups_and_selectors(self:get('metrics.include'), 'all',
+                                          'none', 'all')
+    local default_exclude, selector_exclude =
+        split_metric_groups_and_selectors(self:get('metrics.exclude'), {}, {},
+                                          {})
+
+    metrics_filter_cache = {
+        configdata = configdata,
+        default_include = default_include,
+        selector_include = selector_include,
+        default_exclude = default_exclude,
+        selector_exclude = selector_exclude,
+    }
+    return metrics_filter_cache
+end
+
+local function metric_group_matches(name, rules)
+    if rules == 'all' then
+        return true
+    elseif rules == 'none' then
+        return false
+    end
+
+    for _, rule in ipairs(rules) do
+        if rule == 'all' or name == rule then
+            return true
+        end
+    end
+
+    return false
+end
+
+local function metric_selector_matches(name, rules)
+    if rules == 'all' then
+        return true
+    elseif rules == 'none' then
+        return false
+    end
+
+    for _, rule in ipairs(rules) do
+        if name == rule or name:startswith(rule .. '.') then
+            return true
+        end
+    end
+
+    return false
+end
+
+local function metric_is_enabled(name, filter)
+    if is_default_metric(name) then
+        if metric_group_matches(name, filter.default_exclude) then
+            return false
+        end
+        return metric_group_matches(name, filter.default_include)
+    end
+
+    if metric_selector_matches(name, filter.selector_exclude) then
+        return false
+    end
+
+    return metric_selector_matches(name, filter.selector_include)
+end
+
 function methods._meta(self, source_name, key, value)
     local data = self._metadata[source_name] or {}
     data[key] = value
@@ -748,6 +872,24 @@ function methods.has_role(self, role, opts)
         end
     end
     return false
+end
+
+-- Check the effective metrics filter from the applied configuration.
+-- This method answers whether a metric group or selector is enabled by
+-- metrics.include / metrics.exclude, not whether a collector exists in the
+-- metrics registry at the moment.
+function methods.is_metric_enabled(self, name)
+    selfcheck(self, 'is_metric_enabled')
+    initcheck(self, 'is_metric_enabled', 'instance')
+
+    if type(name) ~= 'string' then
+        error(('Expected string, got %s'):format(type(name)), 0)
+    end
+    if name == '' then
+        error('Expected non-empty metric name', 0)
+    end
+
+    return metric_is_enabled(name, metrics_filter(self))
 end
 
 -- Cluster configuration.

--- a/test/config-luatest/config_test.lua
+++ b/test/config-luatest/config_test.lua
@@ -1053,6 +1053,125 @@ g.test_metrics_1_3_0_options = function()
     end)
 end
 
+local function start_server_with_metrics_config(metrics_config)
+    local dir = treegen.prepare_directory({}, {})
+    local config = ([[
+        credentials:
+          users:
+            guest:
+              roles:
+              - super
+
+        iproto:
+          listen:
+            - uri: unix/:./{{ instance_name }}.iproto
+
+%s
+
+        groups:
+          group-001:
+            replicasets:
+              replicaset-001:
+                instances:
+                  instance-001: {}
+    ]]):format(metrics_config or '')
+
+    local config_file = treegen.write_file(dir, 'base_config.yaml', config)
+    local opts = {
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = dir,
+    }
+    g.server = server:new(opts)
+    g.server:start()
+end
+
+g.test_is_metric_enabled_default = function()
+    start_server_with_metrics_config()
+    g.server:exec(function()
+        local config = require('config')
+
+        t.assert_equals(config:is_metric_enabled('info'), true)
+        t.assert_equals(config:is_metric_enabled('cpu_extended'), true)
+        t.assert_equals(config:is_metric_enabled('roles.crud-router'), true)
+    end)
+end
+
+g.test_is_metric_enabled_include_with_exclude_all = function()
+    start_server_with_metrics_config([[
+        metrics:
+          include: [cpu]
+          exclude: [all]
+    ]])
+    g.server:exec(function()
+        local config = require('config')
+
+        t.assert_equals(config:is_metric_enabled('cpu'), false)
+        t.assert_equals(config:is_metric_enabled('info'), false)
+        t.assert_equals(config:is_metric_enabled('roles.crud-router'), false)
+    end)
+end
+
+g.test_is_metric_enabled_include_all_with_exclude_all = function()
+    start_server_with_metrics_config([[
+        metrics:
+          include: [all]
+          exclude: [all]
+    ]])
+    g.server:exec(function()
+        local config = require('config')
+
+        t.assert_equals(config:is_metric_enabled('info'), false)
+        t.assert_equals(config:is_metric_enabled('cpu_extended'), false)
+        t.assert_equals(config:is_metric_enabled('roles.crud-router'), false)
+    end)
+end
+
+g.test_is_metric_enabled_exclude_has_priority = function()
+    start_server_with_metrics_config([[
+        metrics:
+          include: [all]
+          exclude: [cpu_extended]
+    ]])
+    g.server:exec(function()
+        local config = require('config')
+
+        t.assert_equals(config:is_metric_enabled('info'), true)
+        t.assert_equals(config:is_metric_enabled('cpu_extended'), false)
+    end)
+end
+
+g.test_is_metric_enabled_custom_selectors = function()
+    start_server_with_metrics_config([[
+        metrics:
+          include:
+            - roles.crud-router
+          exclude:
+            - roles.crud-router.crud_errors
+    ]])
+    g.server:exec(function()
+        local config = require('config')
+
+        t.assert_equals(config:is_metric_enabled(
+            'roles.crud-router.crud_requests'), true)
+        t.assert_equals(config:is_metric_enabled(
+            'roles.crud-router.crud_errors'), false)
+        t.assert_equals(config:is_metric_enabled('roles.queue'), false)
+    end)
+end
+
+g.test_is_metric_enabled_argument_validation = function()
+    start_server_with_metrics_config()
+    g.server:exec(function()
+        local config = require('config')
+
+        t.assert_error_msg_equals('Expected string, got number',
+            config.is_metric_enabled, config, 1)
+        t.assert_error_msg_equals('Expected non-empty metric name',
+            config.is_metric_enabled, config, '')
+    end)
+end
+
 g.test_audit_options = function()
     t.tarantool.skip_if_not_enterprise()
     local dir = treegen.prepare_directory({}, {})


### PR DESCRIPTION
This patch adds `config:is_metric_enabled()` to query whether a built-in metric group or custom selector is enabled by the applied `metrics.include/metrics.exclude` configuration.

Closes #12841