### PR TITLE
[backport 3.7] sql: fix duplicate column error for a select

### DIFF
--- a/changelogs/unreleased/gh-12337-throw-duplicate-column-error-select-test.md
+++ b/changelogs/unreleased/gh-12337-throw-duplicate-column-error-select-test.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* An error now occurs if a column appears more than once in a subquery of
+  a SELECT statement (gh-12337).

--- a/src/box/sql/resolve.c
+++ b/src/box/sql/resolve.c
@@ -195,6 +195,27 @@ sql_find_column_expr(const struct ExprList *list, const char *tab_name,
 	return -1;
 }
 
+/**
+ * This function counts the number of occurrences of name in space.
+ */
+static int
+sql_count_column_in_space_def(const struct space_def *space_def,
+			      const char *name, const char *old_name)
+{
+	int count = 0;
+	for (uint32_t i = 0; i < space_def->field_count; ++i) {
+		if (strcmp(space_def->fields[i].name, name) == 0)
+			count++;
+	}
+	if (count == 0 && old_name != NULL) {
+		for (uint32_t i = 0; i < space_def->field_count; ++i) {
+			if (strcmp(space_def->fields[i].name, old_name) == 0)
+				count++;
+		}
+	}
+	return count;
+}
+
 /*
  * Given the name of a column of the form X.Y.Z or Y.Z or just Z, look up
  * that name in the set of source tables in pSrcList and make the pExpr
@@ -320,7 +341,11 @@ lookupName(struct Parse *pParse, struct Expr *pExpr, struct NameContext *pNC)
 				     nameInUsingClause(pItem->pUsing, zCol,
 						       old_col)))
 					continue;
-				cnt++;
+				int count =
+					sql_count_column_in_space_def(space_def,
+								      zCol,
+								      old_col);
+				cnt = cnt + count;
 				pMatch = pItem;
 				pExpr->iColumn = (i16) j;
 			}

--- a/test/sql-luatest/select_test.lua
+++ b/test/sql-luatest/select_test.lua
@@ -1,0 +1,37 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group("dup")
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--
+-- No duplicate column error for a select
+g.test_12337_throw_duplicate_from_select = function(cg)
+    cg.server:exec(function()
+        local sql = [[SELECT * FROM (SELECT 1 as a, 2 as a, 3 as c);]]
+        local _, err = box.execute(sql)
+        local exp_err = "ambiguous column name: a"
+        t.assert_equals(tostring(err), exp_err)
+
+        _, err = box.execute([[SELECT a FROM (SELECT 1 as a, 2 as a, 3 as c);]])
+        t.assert_equals(tostring(err), exp_err)
+
+        sql = [[SELECT c FROM (SELECT 1 as a, 2 as a, 3 as c);]]
+        local res = box.execute(sql)
+        t.assert_equals(res.rows, {{3}})
+
+        _, err = box.execute([[SELECT a FROM (SELECT 1 as A, 2 as A, 3 as c);]])
+        t.assert_equals(tostring(err), exp_err)
+
+        res = box.execute([[SELECT * FROM (SELECT 1 as a, 2 as A, 3 as c);]])
+        t.assert_equals(res.rows, {{1, 2, 3}})
+    end)
+end

--- a/test/sql-tap/tkt-7a31705a7e6.test.lua
+++ b/test/sql-tap/tkt-7a31705a7e6.test.lua
@@ -23,10 +23,10 @@ test:plan(1)
 test:do_execsql_test(
     "tkt-7a31705a7e6-1.1",
     [[
-        CREATE TABLE t1 (a INTEGER PRIMARY KEY);
-        CREATE TABLE t2 (a INTEGER PRIMARY KEY, b INTEGER);
-        CREATE TABLE t2x (b INTEGER PRIMARY KEY);
-        SELECT t1.a FROM ((t1 JOIN t2 ON t1.a=t2.a) AS x JOIN t2x ON x.b=t2x.b) as y;
+        CREATE TABLE t1 (a1 INTEGER PRIMARY KEY);
+        CREATE TABLE t2 (a2 INTEGER PRIMARY KEY, b2 INTEGER);
+        CREATE TABLE t2x (b2x INTEGER PRIMARY KEY);
+        SELECT t1.a1 FROM ((t1 JOIN t2 ON t1.a1=t2.a2) AS x JOIN t2x ON x.b2=t2x.b2x) as y;
     ]], {
         -- <tkt-7a31705a7e6-1.1>
 

--- a/test/sql/boolean.result
+++ b/test/sql/boolean.result
@@ -592,11 +592,11 @@ SELECT cast('TRUE' AS BOOLEAN), cast('FALSE' AS BOOLEAN);
  | ...
 
 -- Check usage in trigger.
-CREATE TABLE t4 (i INT PRIMARY KEY, a BOOLEAN);
+CREATE TABLE t4 (i4 INT PRIMARY KEY, a BOOLEAN);
  | ---
  | - row_count: 1
  | ...
-CREATE TABLE t5 (i INT PRIMARY KEY AUTOINCREMENT, b BOOLEAN);
+CREATE TABLE t5 (i5 INT PRIMARY KEY AUTOINCREMENT, b BOOLEAN);
  | ---
  | - row_count: 1
  | ...
@@ -615,7 +615,7 @@ DROP TRIGGER r;
 SELECT * FROM t4;
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i4
  |     type: integer
  |   - name: a
  |     type: boolean
@@ -625,7 +625,7 @@ SELECT * FROM t4;
 SELECT * FROM t5;
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i5
  |     type: integer
  |   - name: b
  |     type: boolean
@@ -641,7 +641,7 @@ INSERT INTO t5 VALUES (100, false);
 SELECT * FROM t4 UNION SELECT * FROM t5;
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i4
  |     type: integer
  |   - name: a
  |     type: boolean
@@ -652,7 +652,7 @@ SELECT * FROM t4 UNION SELECT * FROM t5;
 SELECT * FROM t4 UNION ALL SELECT * FROM t5;
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i4
  |     type: integer
  |   - name: a
  |     type: boolean
@@ -664,7 +664,7 @@ SELECT * FROM t4 UNION ALL SELECT * FROM t5;
 SELECT * FROM t4 INTERSECT SELECT * FROM t5;
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i4
  |     type: integer
  |   - name: a
  |     type: boolean
@@ -682,7 +682,7 @@ INSERT INTO t5(b) SELECT a FROM t4;
 SELECT * FROM t5;
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i5
  |     type: integer
  |   - name: b
  |     type: boolean
@@ -692,21 +692,21 @@ SELECT * FROM t5;
  |   - [101, false]
  | ...
 
-SELECT * FROM (SELECT t4.i, t5.i, a, b FROM t4, t5 WHERE a = false OR b = true);
+SELECT * FROM (SELECT t4.i4, t5.i5, a, b FROM t4, t5 WHERE a = false OR b = true);
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i4
  |     type: integer
- |   - name: i
+ |   - name: i5
  |     type: integer
  |   - name: a
  |     type: boolean
  |   - name: b
  |     type: boolean
  |   rows:
- |   - [100, 100, false, true]
+ |   - [100, 1, false, true]
  |   - [100, 100, false, false]
- |   - [100, 100, false, false]
+ |   - [100, 101, false, false]
  | ...
 
 -- Check VIEW.
@@ -745,7 +745,7 @@ INSERT INTO t4 SELECT * from temp;
 SELECT * FROM t4;
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i4
  |     type: integer
  |   - name: a
  |     type: boolean
@@ -781,11 +781,11 @@ SELECT x, y FROM cnt;
 SELECT * FROM t4 JOIN t5 ON t4.a = t5.b;
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i4
  |     type: integer
  |   - name: a
  |     type: boolean
- |   - name: i
+ |   - name: i5
  |     type: integer
  |   - name: b
  |     type: boolean
@@ -799,11 +799,11 @@ SELECT * FROM t4 JOIN t5 ON t4.a = t5.b;
 SELECT * FROM t4 LEFT JOIN t5 ON t4.a = t5.b;
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i4
  |     type: integer
  |   - name: a
  |     type: boolean
- |   - name: i
+ |   - name: i5
  |     type: integer
  |   - name: b
  |     type: boolean
@@ -817,11 +817,11 @@ SELECT * FROM t4 LEFT JOIN t5 ON t4.a = t5.b;
 SELECT * FROM t4 INNER JOIN t5 ON t4.a = t5.b;
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i4
  |     type: integer
  |   - name: a
  |     type: boolean
- |   - name: i
+ |   - name: i5
  |     type: integer
  |   - name: b
  |     type: boolean
@@ -841,7 +841,7 @@ UPDATE t4 SET a = NOT a;
 SELECT * FROM t4;
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i4
  |     type: integer
  |   - name: a
  |     type: boolean
@@ -852,16 +852,16 @@ SELECT * FROM t4;
  | ...
 
 -- Check SWITCH-CASE.
-SELECT i, \
+SELECT i4, \
 CASE \
-	WHEN a == true AND i % 2 == 1 THEN false \
-	WHEN a == true and i % 2 == 0 THEN true \
+    WHEN a == true AND i4 % 2 == 1 THEN false \
+    WHEN a == true and i4 % 2 == 0 THEN true \
 	WHEN a != true then false \
 END AS a0 \
 FROM t4;
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i4
  |     type: integer
  |   - name: a0
  |     type: boolean
@@ -872,10 +872,10 @@ FROM t4;
  | ...
 
 -- Check ORDER BY.
-SELECT * FROM t4 UNION SELECT * FROM t5 ORDER BY a, i;
+SELECT * FROM t4 UNION SELECT * FROM t5 ORDER BY a, i4;
  | ---
  | - metadata:
- |   - name: i
+ |   - name: i4
  |     type: integer
  |   - name: a
  |     type: boolean

--- a/test/sql/boolean.test.sql
+++ b/test/sql/boolean.test.sql
@@ -150,8 +150,8 @@ SELECT cast('true' AS BOOLEAN), cast('false' AS BOOLEAN);
 SELECT cast('TRUE' AS BOOLEAN), cast('FALSE' AS BOOLEAN);
 
 -- Check usage in trigger.
-CREATE TABLE t4 (i INT PRIMARY KEY, a BOOLEAN);
-CREATE TABLE t5 (i INT PRIMARY KEY AUTOINCREMENT, b BOOLEAN);
+CREATE TABLE t4 (i4 INT PRIMARY KEY, a BOOLEAN);
+CREATE TABLE t5 (i5 INT PRIMARY KEY AUTOINCREMENT, b BOOLEAN);
 CREATE TRIGGER r AFTER INSERT ON t4 FOR EACH ROW BEGIN INSERT INTO t5(b) VALUES(true); END;
 INSERT INTO t4 VALUES (100, false);
 DROP TRIGGER r;
@@ -168,7 +168,7 @@ SELECT * FROM t4 INTERSECT SELECT * FROM t5;
 INSERT INTO t5(b) SELECT a FROM t4;
 SELECT * FROM t5;
 
-SELECT * FROM (SELECT t4.i, t5.i, a, b FROM t4, t5 WHERE a = false OR b = true);
+SELECT * FROM (SELECT t4.i4, t5.i5, a, b FROM t4, t5 WHERE a = false OR b = true);
 
 -- Check VIEW.
 CREATE VIEW v AS SELECT b FROM t5;
@@ -196,16 +196,16 @@ UPDATE t4 SET a = NOT a;
 SELECT * FROM t4;
 
 -- Check SWITCH-CASE.
-SELECT i, \
+SELECT i4, \
 CASE \
-	WHEN a == true AND i % 2 == 1 THEN false \
-	WHEN a == true and i % 2 == 0 THEN true \
+    WHEN a == true AND i4 % 2 == 1 THEN false \
+    WHEN a == true and i4 % 2 == 0 THEN true \
 	WHEN a != true then false \
 END AS a0 \
 FROM t4;
 
 -- Check ORDER BY.
-SELECT * FROM t4 UNION SELECT * FROM t5 ORDER BY a, i;
+SELECT * FROM t4 UNION SELECT * FROM t5 ORDER BY a, i4;
 
 -- Check GROUP BY.
 SELECT a, COUNT(*) FROM (SELECT * FROM t4 UNION SELECT * FROM t5) GROUP BY a;


### PR DESCRIPTION
This patch fixes duplicate column error for a SELECT.

Prior to this patch:
```
tarantool> box.execute([[SELECT * FROM (SELECT 1 as a, 2 as a);]])
---
- metadata:
  - name: a
    type: integer
  - name: a
    type: integer
  rows:
  - [1, 1]
...
```
After this patch:
```
tarantool> box.execute([[SELECT * FROM (SELECT 1 as a, 2 as a);]])
---
- null
- 'ambiguous column name: a'
...
```
Closes #12337

NO_DOC=bugfix

(cherry picked from commit fd205ac6a73a9587eb64d703df23e7ad6f808a8c)