### PR TITLE
config: add sharding.rebalancer_bucket_send_timeout

### DIFF
--- a/changelogs/unreleased/config-sharding-rebalancer-bucket-send-timeout.md
+++ b/changelogs/unreleased/config-sharding-rebalancer-bucket-send-timeout.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* Added the `sharding.rebalancer_bucket_send_timeout` configuration option.
+  Supported since vshard 0.1.41. The default value is infinity.

--- a/changelogs/unreleased/config-sharding-vshard-version-validation.md
+++ b/changelogs/unreleased/config-sharding-vshard-version-validation.md
@@ -1,0 +1,6 @@
+## bugfix/config
+
+* An unsupported (too old) or missing vshard version required by the sharding
+  configuration is now detected at the configuration validation stage, rather
+  than during application. This ensures that invalid configurations are rejected
+  before any changes are applied.

--- a/src/box/lua/config/applier/credentials.lua
+++ b/src/box/lua/config/applier/credentials.lua
@@ -1,4 +1,3 @@
-local expression = require('internal.config.utils.expression')
 local log = require('internal.config.utils.log')
 local textutils = require('internal.config.utils.textutils')
 local loaders = require('internal.loaders')
@@ -327,19 +326,15 @@ local function sharding_role(configdata)
         return {}
     end
 
+    -- VShard availability and its minimum version are ensured by the sharding
+    -- configuration validation (the `vshard_since` schema annotation).
     local funcs = {}
-    --
-    -- The error will be thrown later, in sharding.lua. Here we are simply
-    -- trying to avoid the "module not found" error.
-    --
-    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
-    if ok and expression.eval('v >= 0.1.25', {v = vshard.consts.VERSION}) then
-        local vexports = loaders.require_first('vshard-ee.storage.exports',
-            'vshard.storage.exports')
-        local exports = vexports.compile(vexports.log[#vexports.log])
-        for name in pairs(exports.funcs) do
-            table.insert(funcs, name)
-        end
+    local vexports = loaders.require_first('vshard-ee.storage.exports',
+        'vshard.storage.exports')
+    assert(vexports)
+    local exports = vexports.compile(vexports.log[#vexports.log])
+    for name in pairs(exports.funcs) do
+        table.insert(funcs, name)
     end
     return {
         privileges = {{

--- a/src/box/lua/config/applier/sharding.lua
+++ b/src/box/lua/config/applier/sharding.lua
@@ -1,4 +1,3 @@
-local expression = require('internal.config.utils.expression')
 local log = require('internal.config.utils.log')
 local loaders = require('internal.loaders')
 _G.vshard = nil
@@ -12,17 +11,10 @@ local function apply(config)
     if roles == nil then
         return
     end
-    -- Make sure vshard is available and its version is not too old.
-    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
-    if not ok then
-        error('The vshard-ee/vshard module is not available', 0)
-    end
-    if expression.eval('v < 0.1.25', {v = vshard.consts.VERSION}) then
-        error('The vshard module is too old: the minimum supported version ' ..
-              'is 0.1.25.', 0)
-    end
-
-    _G.vshard = vshard
+    -- VShard availability and its minimum version are ensured by the sharding
+    -- configuration validation (the `vshard_since` schema annotation).
+    _G.vshard = loaders.require_first('vshard-ee', 'vshard')
+    assert(_G.vshard)
     local is_storage = false
     local is_router = false
     for _, role in pairs(roles) do

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -271,6 +271,7 @@ function methods.sharding(self)
         'discovery_mode',
         'sched_ref_quota',
         'sched_move_quota',
+        'rebalancer_bucket_send_timeout',
     }
     for _, v in pairs(vshard_global_options) do
         cfg[v] = instance_config:get(self._iconfig_def, 'sharding.'..v)

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -2734,6 +2734,11 @@ I['sharding.lock'] = format_text([[
     buckets nor migrate its own buckets.
 ]])
 
+I['sharding.rebalancer_bucket_send_timeout'] = format_text([[
+    The timeout (in seconds) for sending a single bucket during rebalancing.
+    Requires vshard 0.1.41 or newer.
+]])
+
 I['sharding.rebalancer_disbalance_threshold'] = format_text([[
     The maximum bucket disbalance threshold (in percent). The disbalance
     is calculated for each replica set using the following formula:

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -11,6 +11,8 @@ local network = require('internal.config.utils.network')
 local loaders = require('internal.loaders')
 local expression = require('internal.config.utils.expression')
 
+local TIMEOUT_INFINITY = 500 * 365 * 86400
+
 -- List of annotations:
 --
 -- * enterprise_edition (boolean)
@@ -1973,6 +1975,11 @@ return schema.new('instance_config', schema.record({
             default = 1,
             validate = validators['sharding.sched_move_quota'],
         }),
+        rebalancer_bucket_send_timeout = vshard_since('0.1.41', schema.scalar({
+            type = 'number',
+            default = TIMEOUT_INFINITY,
+            validate = validators['sharding.rebalancer_bucket_send_timeout'],
+        })),
     })),
     audit_log = enterprise_edition(schema.record({
         -- The same as the destination for the logger, audit logger destination

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -8,12 +8,19 @@ local validators = require('internal.config.validators')
 local discriminators = require('internal.config.discriminators')
 local funcutils = require('internal.config.utils.funcutils')
 local network = require('internal.config.utils.network')
+local loaders = require('internal.loaders')
+local expression = require('internal.config.utils.expression')
 
 -- List of annotations:
 --
 -- * enterprise_edition (boolean)
 --
 --   Available only in Tarantool Enterprise Edition.
+--
+-- * vshard_since (string)
+--
+--   The minimum vshard version that accepts this sharding option.
+--   Enforced in configdata's sharding() method.
 --
 -- * default (any)
 --
@@ -104,6 +111,52 @@ end
 
 local function sensitive_ee(schema_node)
     return sensitive(enterprise_edition(schema_node))
+end
+
+local function vshard_since_validate(data, w)
+    -- OK if the option is not set.
+    if data == nil then
+        return
+    end
+
+    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
+    if not ok then
+        w.error('The vshard-ee/vshard module is not available')
+    end
+
+    if expression.eval('v < '..w.schema.vshard_since,
+                       {v = vshard.consts.VERSION}) then
+        w.error('The vshard module is too old: the minimum supported ' ..
+                'version is %s', w.schema.vshard_since)
+    end
+end
+
+local function vshard_since_apply_default_if(_data, w)
+    -- Apply the default only when the installed vshard accepts the option.
+    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
+    if not ok then
+        return false
+    end
+    return not expression.eval('v < '..w.schema.vshard_since,
+                               {v = vshard.consts.VERSION})
+end
+
+-- Accepted by vshard only since the given version. Configuring the annotated
+-- node (an option or the whole sharding section) with an older vshard is a
+-- configuration error.
+local function vshard_since(version, schema_node)
+    schema_node.vshard_since = version
+
+    -- Perform a domain specific validation first and only then check the
+    -- vshard version, consistent with the data type validation order.
+    schema_node.validate = funcutils.chain2(
+        schema_node.validate,
+        vshard_since_validate)
+    schema_node.apply_default_if = funcutils.chain2(
+        schema_node.apply_default_if,
+        vshard_since_apply_default_if)
+
+    return schema_node
 end
 
 -- Accept a value of 'iproto.listen' option and return the first URI
@@ -1834,7 +1887,7 @@ return schema.new('instance_config', schema.record({
             value = schema.scalar({type = 'string'}),
         }),
     }),
-    sharding = schema.record({
+    sharding = vshard_since('0.1.25', schema.record({
         -- Instance vshard options.
         zone = schema.scalar({type = 'integer'}),
         -- Replicaset vshard options.
@@ -1920,7 +1973,7 @@ return schema.new('instance_config', schema.record({
             default = 1,
             validate = validators['sharding.sched_move_quota'],
         }),
-    }),
+    })),
     audit_log = enterprise_edition(schema.record({
         -- The same as the destination for the logger, audit logger destination
         -- is handled separately in the box_cfg applier, so there are no

--- a/src/box/lua/config/validators.lua
+++ b/src/box/lua/config/validators.lua
@@ -451,6 +451,10 @@ M['sharding.rebalancer_max_sending'] = function(_data, w)
     validate_scope(w, {'global'})
 end
 
+M['sharding.rebalancer_bucket_send_timeout'] = function(_data, w)
+    validate_scope(w, {'global'})
+end
+
 M['sharding.rebalancer_mode'] = function(_data, w)
     validate_scope(w, {'global'})
 end

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -3,6 +3,7 @@ local fio = require('fio')
 local t = require('luatest')
 local instance_config = require('internal.config.instance_config')
 local cluster_config = require('internal.config.cluster_config')
+local helpers = require('test.config-luatest.helpers')
 
 local g = t.group()
 
@@ -528,18 +529,23 @@ g.test_defaults = function()
 end
 
 local examples = {
-    single = 'single.yaml',
-    upgrade = 'upgrade.yaml',
-    sharding = 'sharding.yaml',
-    replicaset = 'replicaset.yaml',
-    replicaset_manual_failover = 'replicaset_manual_failover.yaml',
-    replicaset_election_failover = 'replicaset_election_failover.yaml',
+    single = {path = 'single.yaml'},
+    upgrade = {path = 'upgrade.yaml'},
+    sharding = {path = 'sharding.yaml', vshard_since = '0.1.25'},
+    replicaset = {path = 'replicaset.yaml'},
+    replicaset_manual_failover = {path = 'replicaset_manual_failover.yaml'},
+    replicaset_election_failover = {path = 'replicaset_election_failover.yaml'},
 }
 
-for case, path in pairs(examples) do
+for case, example in pairs(examples) do
     local test_name = ('test_example_%s'):format(case)
-    local config_path = ('test/config-luatest/examples/config/%s'):format(path)
+    local config_path = ('test/config-luatest/examples/config/%s'):format(
+        example.path)
     g[test_name] = function()
+        if example.vshard_since ~= nil then
+            t.skip_if(not helpers.has_vshard_since(example.vshard_since),
+                      'Module "vshard-ee/vshard" is not available')
+        end
         local config_file = fio.abspath(config_path)
         local fh = fio.open(config_file, {'O_RDONLY'})
         local config = yaml.decode(fh:read())
@@ -854,6 +860,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.bucket_count',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     bucket_count = 30000,
@@ -866,6 +873,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.connection_outdate_delay',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     connection_outdate_delay = 10,
@@ -878,6 +886,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.discovery_mode',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     discovery_mode = 'off',
@@ -890,6 +899,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.failover_ping_timeout',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     failover_ping_timeout = 10,
@@ -902,6 +912,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.lock',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     lock = true,
@@ -914,6 +925,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.rebalancer_disbalance_threshold',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     rebalancer_disbalance_threshold = 7,
@@ -926,6 +938,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.rebalancer_max_receiving',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     rebalancer_max_receiving = 1000,
@@ -938,6 +951,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.rebalancer_max_sending',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     rebalancer_max_sending = 10,
@@ -950,6 +964,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.rebalancer_mode',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     rebalancer_mode = 'off',
@@ -962,6 +977,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.sched_move_quota',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     sched_move_quota = 10,
@@ -974,6 +990,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.sched_ref_quota',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     sched_ref_quota = 1000,
@@ -986,6 +1003,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.shard_index',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     shard_index = 'my_bucket_id',
@@ -998,6 +1016,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.sync_timeout',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     sync_timeout = 10,
@@ -1010,6 +1029,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.weight',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     weight = 10,
@@ -1022,6 +1042,7 @@ g.test_scope = function()
         },
         {
             name = 'sharding.roles',
+            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     roles = {'storage'},
@@ -1035,6 +1056,13 @@ g.test_scope = function()
     }
 
     for _, case in ipairs(cases) do
+        -- The sharding section is validated only with a vshard module that
+        -- accepts the option, so its scope cannot be checked otherwise.
+        if case.vshard_since ~= nil and
+           not helpers.has_vshard_since(case.vshard_since) then
+            goto continue
+        end
+
         -- Global level.
         local global_data = case.data
         if case.global then
@@ -1107,6 +1135,7 @@ g.test_scope = function()
         -- Validation against the instance config: accepted for
         -- all the options.
         instance_config:validate(case.data)
+    ::continue::
     end
 end
 

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -393,6 +393,8 @@ g.test_defaults = function()
             bucket_count = 3000,
             discovery_mode = "on",
             failover_ping_timeout = 5,
+            rebalancer_bucket_send_timeout = helpers.has_vshard_since('0.1.41')
+                                             and 500 * 365 * 86400,
             rebalancer_disbalance_threshold = 1,
             rebalancer_max_receiving = 100,
             rebalancer_max_sending = 1,
@@ -921,6 +923,19 @@ g.test_scope = function()
             global = true,
             group = true,
             replicaset = true,
+            instance = false,
+        },
+        {
+            name = 'sharding.rebalancer_bucket_send_timeout',
+            vshard_since = '0.1.41',
+            data = {
+                sharding = {
+                    rebalancer_bucket_send_timeout = 42,
+                },
+            },
+            global = true,
+            group = false,
+            replicaset = false,
             instance = false,
         },
         {

--- a/test/config-luatest/helpers.lua
+++ b/test/config-luatest/helpers.lua
@@ -2,10 +2,33 @@ local fun = require('fun')
 local yaml = require('yaml')
 local fio = require('fio')
 local cluster_config = require('internal.config.cluster_config')
+local expression = require('internal.config.utils.expression')
 local t = require('luatest')
 local treegen = require('luatest.treegen')
 local justrun = require('luatest.justrun')
 local server = require('luatest.server')
+
+--
+-- Returns true if the available vshard module is recent enough to accept the
+-- sharding options annotated with the vshard_since version, nil otherwise.
+--
+local function has_vshard_since(version)
+    local ok, vshard = pcall(require, 'vshard-ee')
+    if not ok then
+        ok, vshard = pcall(require, 'vshard')
+    end
+    if not ok then
+        return nil
+    end
+    if expression.eval('v < ' .. version, {v = vshard.consts.VERSION}) then
+        return nil
+    end
+    return true
+end
+
+local function has_vshard()
+    return has_vshard_since('0.1.25')
+end
 
 local function group(name, params)
     local g = t.group(name, params)
@@ -370,6 +393,11 @@ return {
     -- Use require('myluatest') instead of require('luatest')
     -- inside the test case to get better diagnostics at failure.
     run_as_script = run_as_script,
+
+    -- Whether the available vshard module accepts the sharding options
+    -- annotated with the given vshard_since version.
+    has_vshard_since = has_vshard_since,
+    has_vshard = has_vshard,
 
     -- Start a three instance replicaset with the given config
     -- file.

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -33,6 +33,12 @@ local function validate_fields(config, record)
 
     local record_fields = {}
     for k, v in pairs(record.fields) do
+        -- An option accepted only by a newer vshard is not expected in the
+        -- config when the available vshard is too old.
+        if v.vshard_since ~= nil and
+           not helpers.has_vshard_since(v.vshard_since) then
+            goto continue
+        end
         if v.type == 'record' then
             validate_fields(config[k], v)
         elseif v.type == 'map' and v.value.type == 'record' then
@@ -47,6 +53,7 @@ local function validate_fields(config, record)
         if not v.enterprise_edition or is_enterprise then
             table.insert(record_fields, k)
         end
+        ::continue::
     end
 
     t.assert_items_equals(config_fields, record_fields)
@@ -1795,6 +1802,8 @@ g.test_sharding = function()
             discovery_mode = 'once',
             bucket_count = 5,
             shard_index = 'six',
+            rebalancer_bucket_send_timeout = helpers.has_vshard_since('0.1.41')
+                                             and 12,
             rebalancer_disbalance_threshold = 7,
             rebalancer_max_receiving = 8,
             rebalancer_max_sending = 9,
@@ -1821,6 +1830,8 @@ g.test_sharding = function()
         bucket_count = 3000,
         discovery_mode = "on",
         failover_ping_timeout = 5,
+        rebalancer_bucket_send_timeout = helpers.has_vshard_since('0.1.41')
+                                         and 500 * 365 * 86400,
         rebalancer_disbalance_threshold = 1,
         rebalancer_max_receiving = 100,
         rebalancer_max_sending = 1,

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -2,6 +2,7 @@ local fun = require('fun')
 local log = require('log')
 local t = require('luatest')
 local instance_config = require('internal.config.instance_config')
+local helpers = require('test.config-luatest.helpers')
 
 local g = t.group()
 
@@ -1779,6 +1780,9 @@ g.test_metrics = function()
 end
 
 g.test_sharding = function()
+    -- The sharding section is validated only with the vshard module available.
+    t.skip_if(not helpers.has_vshard(),
+              'vshard module is required to validate sharding')
     local iconfig = {
         sharding = {
             roles = {'router', 'storage'},

--- a/test/config-luatest/rpc_test.lua
+++ b/test/config-luatest/rpc_test.lua
@@ -12,13 +12,9 @@ local helpers = require('test.config-luatest.helpers')
 
 local g = helpers.group()
 
-local has_vshard = pcall(require, 'vshard-ee')
-if not has_vshard then
-    has_vshard = pcall(require, 'vshard')
-end
-
 local function skip_if_no_vshard()
-    t.skip_if(not has_vshard, 'Module "vshard-ee/vshard" is not available')
+    t.skip_if(not helpers.has_vshard(),
+              'Module "vshard-ee/vshard" is not available')
 end
 
 local function start_stub_servers(g, dir, instances)

--- a/test/config-luatest/rpc_test.lua
+++ b/test/config-luatest/rpc_test.lua
@@ -1057,11 +1057,22 @@ g.test_call_picks_any = function(g)
         -- Connect to the local instance to avoid possible race
         -- conditions when connecting to non-local instance could
         -- be faster than connecting to a local one.
-        connpool.connect('instance-001')
+        local conn = connpool.connect('instance-001')
 
         -- The connection timeout for filter() and call() methods
         -- is hardcoded in connpool and equals 10 seconds.
         local CONNECT_TIMEOUT = 10
+
+        -- connpool.connect() returns as soon as the connection
+        -- becomes active, but the instance mode is fetched
+        -- asynchronously via a 'box.status' watcher. Until the mode
+        -- is known, call() doesn't consider the local instance a
+        -- ready candidate (the 'no wait' filter skips it), falls back
+        -- to waiting for any instance and may pick a non-local one.
+        -- Wait for the local mode to be fetched.
+        t.helpers.retrying({timeout = CONNECT_TIMEOUT}, function()
+            t.assert_not_equals(conn:mode(), nil)
+        end)
 
         -- call() should wait for any available instance matching
         -- the requirements and not wait for the unavailable instance

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -9,13 +9,9 @@ local cluster = require('luatest.cluster')
 
 local g = helpers.group()
 
-local has_vshard = pcall(require, 'vshard-ee')
-if not has_vshard then
-    has_vshard = pcall(require, 'vshard')
-end
-
 local function skip_if_no_vshard()
-    t.skip_if(not has_vshard, 'Module "vshard-ee/vshard" is not available')
+    t.skip_if(not helpers.has_vshard(),
+              'Module "vshard-ee/vshard" is not available')
 end
 
 g.test_fixed_masters = function(g)
@@ -909,5 +905,71 @@ g.test_has_sharding_role = function()
         t.assert(config:is_router({instance = 'r-001'}))
         t.assert(config:is_storage({instance = 'rs-001'}))
         t.assert(config:is_router({instance = 'rs-001'}))
+    end)
+end
+
+--
+-- The whole sharding section is annotated with vshard_since('0.1.25'), so
+-- configuring sharding with an older vshard must be rejected at the
+-- configuration validation stage.
+--
+g.test_vshard_too_old = function(g)
+    skip_if_no_vshard()
+    local dir = treegen.prepare_directory({}, {})
+    -- Note, that none of the nodes has `sharding.roles` set, the error will
+    -- still be thrown, since it's now checked on config validation stage.
+    local config = [[
+    credentials:
+      users:
+        guest:
+          roles: [super]
+        storage:
+          roles: [sharding]
+          password: "storage"
+
+    iproto:
+      listen:
+        - uri: 'unix/:./{{ instance_name }}.iproto'
+      advertise:
+        sharding:
+          login: 'storage'
+
+    sharding:
+      bucket_count: 1234
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            instances:
+              instance-001: {}
+    ]]
+    local config_file = treegen.write_file(dir, 'config.yaml', config)
+    local opts = {
+        env = {LUA_PATH = os.environ()['LUA_PATH']},
+        config_file = config_file,
+        alias = 'instance-001',
+        chdir = dir,
+    }
+    g.server = server:new(opts)
+    g.server:start()
+
+    g.server:exec(function()
+        local loaders = require('internal.loaders')
+        local config = require('config')
+        local vshard = loaders.require_first('vshard-ee', 'vshard')
+
+        local saved = vshard.consts.VERSION
+        vshard.consts.VERSION = '0.1.20'
+        local ok, err = pcall(config.reload, config)
+        vshard.consts.VERSION = saved
+
+        t.assert_not(ok)
+        -- The error must come from the configuration validation stage: it
+        -- carries the schema path prefix ("...sharding:"). This distinguishes
+        -- it from any apply-stage check producing a bare message.
+        t.assert_str_contains(tostring(err),
+            'sharding: The vshard module is too old: the minimum supported ' ..
+            'version is 0.1.25')
     end)
 end

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -973,3 +973,120 @@ g.test_vshard_too_old = function(g)
             'version is 0.1.25')
     end)
 end
+
+--
+-- Make sure the sharding.rebalancer_bucket_send_timeout configuration
+-- parameter is forwarded to vshard.
+--
+g.test_rebalancer_bucket_send_timeout = function(g)
+    t.skip_if(not helpers.has_vshard_since('0.1.41'),
+              'vshard module accepting rebalancer_bucket_send_timeout ' ..
+              'is required')
+    local dir = treegen.prepare_directory({}, {})
+    local config = [[
+    credentials:
+      users:
+        guest:
+          roles: [super]
+        storage:
+          roles: [sharding]
+          password: "storage"
+
+    iproto:
+      listen:
+        - uri: 'unix/:./{{ instance_name }}.iproto'
+      advertise:
+        sharding:
+          login: 'storage'
+
+    sharding:
+      rebalancer_bucket_send_timeout: 42
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            sharding:
+              roles: [storage, rebalancer, router]
+            instances:
+              instance-001: {}
+    ]]
+    local config_file = treegen.write_file(dir, 'config.yaml', config)
+    local opts = {
+        env = {LUA_PATH = os.environ()['LUA_PATH']},
+        config_file = config_file,
+        chdir = dir,
+        alias = 'instance-001',
+    }
+    g.server = server:new(opts)
+    g.server:start()
+
+    local res = g.server:eval('return vshard.storage.internal.current_cfg')
+    t.assert_equals(res.rebalancer_bucket_send_timeout, 42)
+end
+
+--
+-- sharding.rebalancer_bucket_send_timeout requires vshard 0.1.41. A vshard
+-- that is new enough for sharding in general (>= 0.1.25) but older than
+-- 0.1.41 must reject the option at the configuration validation stage.
+--
+g.test_rebalancer_bucket_send_timeout_vshard_too_old = function(g)
+    t.skip_if(not helpers.has_vshard_since('0.1.41'),
+              'vshard module accepting rebalancer_bucket_send_timeout ' ..
+              'is required')
+    local dir = treegen.prepare_directory({}, {})
+    local config = [[
+    credentials:
+      users:
+        guest:
+          roles: [super]
+        storage:
+          roles: [sharding]
+          password: "storage"
+
+    iproto:
+      listen:
+        - uri: 'unix/:./{{ instance_name }}.iproto'
+      advertise:
+        sharding:
+          login: 'storage'
+
+    sharding:
+      rebalancer_bucket_send_timeout: 42
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            sharding:
+              roles: [storage, rebalancer, router]
+            instances:
+              instance-001: {}
+    ]]
+    local config_file = treegen.write_file(dir, 'config.yaml', config)
+    local opts = {
+        env = {LUA_PATH = os.environ()['LUA_PATH']},
+        config_file = config_file,
+        chdir = dir,
+        alias = 'instance-001',
+    }
+    g.server = server:new(opts)
+    g.server:start()
+
+    g.server:exec(function()
+        local loaders = require('internal.loaders')
+        local config = require('config')
+        local vshard = loaders.require_first('vshard-ee', 'vshard')
+
+        -- New enough for sharding (0.1.25), too old for the option (0.1.41).
+        local saved = vshard.consts.VERSION
+        vshard.consts.VERSION = '0.1.30'
+        local ok, err = pcall(config.reload, config)
+        vshard.consts.VERSION = saved
+
+        t.assert_not(ok)
+        t.assert_str_contains(tostring(err),
+            'rebalancer_bucket_send_timeout: The vshard module is too old: ' ..
+            'the minimum supported version is 0.1.41')
+    end)
+end

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -186,19 +186,14 @@ g.test_fixed_masters = function(g)
 
     -- Storages.
     local exec = 'return vshard.storage.internal.current_cfg'
-    local res = g.server_1:eval(exec)
-    t.assert_equals(res, exp)
-    res = g.server_2:eval(exec)
-    t.assert_equals(res, exp)
-    res = g.server_3:eval(exec)
-    t.assert_equals(res, exp)
-    res = g.server_4:eval(exec)
-    t.assert_equals(res, exp)
+    t.assert_covers(g.server_1:eval(exec), exp)
+    t.assert_covers(g.server_2:eval(exec), exp)
+    t.assert_covers(g.server_3:eval(exec), exp)
+    t.assert_covers(g.server_4:eval(exec), exp)
 
     -- Router.
     exec = 'return vshard.router.internal.static_router.current_cfg'
-    res = g.server_5:eval(exec)
-    t.assert_equals(res, exp)
+    t.assert_covers(g.server_5:eval(exec), exp)
 
     -- Check that basic sharding works.
     exec = [[

--- a/test/config-luatest/vshard_upgrade_test.lua
+++ b/test/config-luatest/vshard_upgrade_test.lua
@@ -4,13 +4,9 @@ local server = require('luatest.server')
 local yaml = require('yaml')
 local fun = require('fun')
 local fio = require('fio')
+local helpers = require('test.config-luatest.helpers')
 
 local g = t.group()
-
-local has_vshard = pcall(require, 'vshard-ee')
-if not has_vshard then
-    has_vshard = pcall(require, 'vshard')
-end
 
 --
 -- Test, that Tarantool upgrade with vshard happens without downtime:
@@ -23,7 +19,8 @@ end
 --     6. Vshard works after all names are applied.
 --
 g.before_all(function(g)
-    t.skip_if(not has_vshard, 'Module "vshard-ee/vshard" is not available')
+    t.skip_if(not helpers.has_vshard(),
+              'Module "vshard-ee/vshard" is not available')
     local uuids = {
         ['rs-001'] = 'cbf06940-0790-498b-948d-042b62cf3d29',
         ['rs-002'] = 'ac522f65-aa94-4134-9f64-51ee384f1a54',


### PR DESCRIPTION
Needed for https://github.com/tarantool/tarantool/issues/12865

Note, vshard tests are not launched under out CI (because it's unbelievably difficult to install master vshard before building the tarantool and installing it just for one workflow looks crutchy). So, it's better, if vshard itself will launch integration tests with core, which should be done in the scope of https://github.com/tarantool/vshard/issues/582  