### PR TITLE
box: free formerly in-progress txns on tarantool exit

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6488,6 +6488,15 @@ box_storage_free(void)
 	wal_free();
 	iproto_free();
 	txn_limbo_free();
+
+	/*
+	 * We free the transactions from the limbo queue above.
+	 * Free the remained transactions here.
+	 */
+	struct txn *txn, *tmp;
+	rlist_foreach_entry_safe(txn, &txns, in_txns, tmp)
+		txn_free(txn);
+
 	replication_free();
 	gc_free();
 	engine_free();

--- a/test/engine-luatest/shutdown_test.lua
+++ b/test/engine-luatest/shutdown_test.lua
@@ -49,7 +49,11 @@ g.test_shutdown_secondary_index_build = function(cg)
 end
 
 -- Luatest server currently does not allow to check process exit code.
-local g_crash = t.group('crash', {{engine = 'memtx'}, {engine = 'vinyl'}})
+local g_crash = t.group('crash', {
+    {engine = 'memtx', memtx_use_mvcc_engine = true},
+    {engine = 'memtx', memtx_use_mvcc_engine = false},
+    {engine = 'vinyl'}
+})
 
 g_crash.before_each(function(cg)
     local id = ('%s-%s'):format('server', utils.generate_id())
@@ -60,7 +64,10 @@ end)
 -- Test shutdown when there is an active transaction.
 g_crash.test_shutdown_with_active_txn = function(cg)
     local script_base = [[
-        box.cfg{memtx_use_mvcc_engine = true}
+        box.cfg{
+            memtx_use_mvcc_engine = %s,
+            log_level = 'error',
+        }
 
         box.schema.space.create('test', {engine = '%s'})
         box.space.test:create_index('pk')
@@ -70,9 +77,11 @@ g_crash.test_shutdown_with_active_txn = function(cg)
         box.space.test:select()
         os.exit()
     ]]
-    local script = script_base:format(cg.params.engine)
+    local script = script_base:format(cg.params.memtx_use_mvcc_engine,
+                                      cg.params.engine)
 
     local result = justrun.tarantool(cg.workdir, {}, {'-e', script},
-                                    {nojson = true, quote_args = true})
-    t.assert_equals(result.exit_code, 0)
+                                     {nojson = true, quote_args = true,
+                                      stderr = true})
+    t.assert_covers(result, {exit_code = 0, stderr = ''})
 end


### PR DESCRIPTION
The fiber that calls the os.exit() after Tarantool Lua is initialized never dies (enters the infinite loop of yielding). But in case the fiber has an unfinished transaction, we usually roll it back using a registered `on_stop` trigger. During the process the txn's resources are also freed.

This is not important as we're going to die anyways, but let's free the remained transactions manually in `box_free` to make Tarantool finish more gracefully.

Closes #12887

NO_DOC=bugfix
NO_CHANGELOG=irrelevant for users as the leak happens on exit