### PR TITLE
Do not use pthread_atfork to reset signals

### DIFF
--- a/changelogs/unreleased/gh-12846-app-threads-fiber-signal-reset-assertion-fix.md
+++ b/changelogs/unreleased/gh-12846-app-threads-fiber-signal-reset-assertion-fix.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed an assertion failure in `fiber_signal_reset()` that occurred during
+  application threads initialization on CentOS 7 based systems (gh-12846).

--- a/src/lib/core/clock_lowres.c
+++ b/src/lib/core/clock_lowres.c
@@ -51,18 +51,3 @@ clock_lowres_signal_init(void)
 	if (setitimer(ITIMER_REAL, &timer, NULL) == -1)
 		panic_syserror("cannot set low resolution clock timer");
 }
-
-void
-clock_lowres_signal_reset(void)
-{
-	struct itimerval timer;
-	memset(&timer, 0, sizeof(timer));
-	if (setitimer(ITIMER_REAL, &timer, NULL) == -1)
-		say_syserror("cannot reset low resolution clock timer");
-
-	struct sigaction sa;
-	memset(&sa, 0, sizeof(sa));
-	sa.sa_handler = SIG_DFL;
-	if (sigaction(SIGALRM, &sa, NULL) == -1)
-		say_syserror("cannot reset low resolution clock timer signal");
-}

--- a/src/lib/core/clock_lowres.h
+++ b/src/lib/core/clock_lowres.h
@@ -34,10 +34,6 @@ clock_lowres_monotonic(void)
 void
 clock_lowres_signal_init(void);
 
-/** Reset signal handler and interval timer. */
-void
-clock_lowres_signal_reset(void);
-
 #if __cplusplus
 }
 #endif

--- a/src/lib/core/crash.c
+++ b/src/lib/core/crash.c
@@ -210,21 +210,6 @@ crash_signal_cb(int signo, siginfo_t *siginfo, void *context)
 static const int crash_signals[] = { SIGILL, SIGBUS, SIGFPE, SIGSEGV };
 
 void
-crash_signal_reset(void)
-{
-	struct sigaction sa = {
-		.sa_handler = SIG_DFL,
-	};
-	sigemptyset(&sa.sa_mask);
-
-	for (size_t i = 0; i < lengthof(crash_signals); i++) {
-		if (sigaction(crash_signals[i], &sa, NULL) == 0)
-			continue;
-		say_syserror("reset sigaction %d", crash_signals[i]);
-	}
-}
-
-void
 crash_signal_init(void)
 {
 	/*

--- a/src/lib/core/crash.h
+++ b/src/lib/core/crash.h
@@ -150,12 +150,6 @@ crash_signal_init(void);
 void
 crash_report_stderr(struct crash_info *cinfo);
 
-/**
- * Reset crash signal handlers.
- */
-void
-crash_signal_reset(void);
-
 #if defined(__cplusplus)
 }
 #endif /* defined(__cplusplus) */

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -2277,7 +2277,6 @@ fiber_init(int (*invoke)(fiber_func f, va_list ap))
 	if (main_cord.loop == NULL)
 		panic("can't init event loop");
 	cord_create(&main_cord, "main");
-	fiber_signal_init();
 }
 
 void
@@ -2296,12 +2295,6 @@ fiber_wakeup_trigger_cb(struct trigger *trigger, void *event)
 	return 0;
 }
 
-/**
- * True if fiber_signal_init was called.
- * Needed for re-entrancy of fiber signal initialization.
- */
-static bool signal_initialized;
-
 /** Reset current slice on SIGURG. */
 static void
 signal_sigurg_cb(int signum)
@@ -2315,9 +2308,6 @@ void
 fiber_signal_init(void)
 {
 	assert(cord_is_main());
-	if (signal_initialized)
-		return;
-	signal_initialized = true;
 	clock_lowres_signal_init();
 
 	struct sigaction sa;
@@ -2325,21 +2315,6 @@ fiber_signal_init(void)
 	sa.sa_handler = signal_sigurg_cb;
 	if (tt_sigaction(SIGURG, &sa, NULL) == -1)
 		panic_syserror("cannot set fiber sigurg handler");
-}
-
-void
-fiber_signal_reset(void)
-{
-	assert(cord_is_main());
-	assert(signal_initialized);
-	signal_initialized = false;
-	clock_lowres_signal_reset();
-
-	struct sigaction sa;
-	memset(&sa, 0, sizeof(sa));
-	sa.sa_handler = SIG_DFL;
-	if (tt_sigaction(SIGURG, &sa, NULL) == -1)
-		say_syserror("cannot reset fiber sigurg handler");
 }
 
 int fiber_stat(fiber_stat_cb cb, void *cb_ctx)

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -1028,21 +1028,10 @@ void
 fiber_free(void);
 
 /**
- * Manually init signals needed for fiber module.
- * This function is re-entrant.
- * All needed signals are initialized in fiber_init,
- * but you may need this functions to init signals
- * after they have been reset before fork.
+ * Init signals needed for fiber module.
  */
 void
 fiber_signal_init(void);
-
-/**
- * Reset signals needed for fiber module.
- * See fiber_signal_init description.
- */
-void
-fiber_signal_reset(void);
 
 /**
  * A trigger callback which just wakes up the fiber stored in the

--- a/src/lib/core/say.c
+++ b/src/lib/core/say.c
@@ -515,6 +515,8 @@ log_pipe_init(struct log *log, const char *init_str)
 	}
 
 	if (log->pid == 0) {
+		/* Unblock all signals in the child process. */
+		sigfillset(&mask);
 		pthread_sigmask(SIG_UNBLOCK, &mask, NULL);
 
 		close(pipefd[1]);

--- a/src/main.cc
+++ b/src/main.cc
@@ -272,37 +272,6 @@ signal_free(void)
 		ev_signal_stop(loop(), &ev_sigs[i]);
 }
 
-/** Make sure the child has a default signal disposition. */
-static void
-signal_reset(void)
-{
-	for (int i = 0; i < ev_sig_count; i++)
-		ev_signal_stop(loop(), &ev_sigs[i]);
-
-	struct sigaction sa;
-
-	/* Reset all signals to their defaults. */
-	memset(&sa, 0, sizeof(sa));
-	sigemptyset(&sa.sa_mask);
-	sa.sa_handler = SIG_DFL;
-
-	if (sigaction(SIGUSR1, &sa, NULL) == -1 ||
-	    sigaction(SIGINT, &sa, NULL) == -1 ||
-	    sigaction(SIGTERM, &sa, NULL) == -1 ||
-	    sigaction(SIGHUP, &sa, NULL) == -1 ||
-	    sigaction(SIGWINCH, &sa, NULL) == -1)
-		say_syserror("sigaction");
-
-	fiber_signal_reset();
-	crash_signal_reset();
-
-	/* Unblock any signals blocked by libev. */
-	sigset_t sigset;
-	sigfillset(&sigset);
-	if (pthread_sigmask(SIG_UNBLOCK, &sigset, NULL) == -1)
-		say_syserror("pthread_sigmask");
-}
-
 /**
  * Adjust the process signal mask and add handlers for signals.
  */
@@ -329,8 +298,6 @@ signal_init(void)
 	ev_signal_init(&ev_sigs[5], broadcast_sigusr2, SIGUSR2);
 	for (int i = 0; i < ev_sig_count; i++)
 		ev_signal_start(loop(), &ev_sigs[i]);
-
-	tt_pthread_atfork(NULL, NULL, signal_reset);
 }
 
 /** Run in the background. */
@@ -367,12 +334,6 @@ daemonize(void)
 	 * kqueue on FreeBSD.
 	 */
 	ev_loop_fork(cord()->loop);
-
-	/*
-	 * reinit signals after fork, because fork() implicitly calls
-	 * signal_reset() via pthread_atfork() hook installed by signal_init().
-	 */
-	signal_init();
 
 	/* redirect stdin; stdout and stderr handled in say_logger_init */
 	fd = open("/dev/null", O_RDONLY);

--- a/src/tt_pthread.h
+++ b/src/tt_pthread.h
@@ -259,11 +259,6 @@
 	tt_pthread_error(e__);			\
 })
 
-#define tt_pthread_atfork(prepare, parent, child)\
-({	int e__ = pthread_atfork(prepare, parent, child);\
-	tt_pthread_error(e__);			\
-})
-
 /**
  * Make sure the created thread blocks all signals, they are handled in the main
  * thread. Except SIGILL, SIGBUS, SIGFPE and SIGSEGV, that cannot be blocked and

--- a/test/unit/clock_lowres.c
+++ b/test/unit/clock_lowres.c
@@ -39,6 +39,5 @@ main(void)
 	ok(success, "Check that monotonic lowres clock does not diverge "
 		    "too much from monotonic clock");
 
-	clock_lowres_signal_reset();
 	return check_plan();
 }

--- a/test/unit/memtx_allocator.cc
+++ b/test/unit/memtx_allocator.cc
@@ -674,7 +674,6 @@ main()
 	tuple_free();
 	fiber_free();
 	memory_free();
-	clock_lowres_signal_reset();
 	say_logger_free();
 	return rc;
 }


### PR DESCRIPTION
When Tarantool is forked, its signal configuration is reset using the signal_reset() callback installed with pthread_atfork(). This leads to an assertion failure on CentOS 7 based systems when application threads are configured:

```
./tarantool/src/lib/core/fiber.c:2338: fiber_signal_reset: Assertion `cord_is_main()' failed.
```

The problem is that the built-in metrics.tarantool.memory Lua module calls io.popen() on load, which executes pthread_atfork() handlers on older glibc versions, the details are below, but first let's dive into the history of signal_reset().

Its initial intention was to make the checkpoint process interruptible back when checkpointing was done using fork(), see commit d6572f074a899 ("A fix for https://bugs.launchpad.net/tarantool/+bug/992171"). Now, it doesn't make sense because we do checkpointing in a separate thread using our own CoW mechanism so do we really need to reset signals?

We fork the Tarantool process in the following scenarios:

 1. To daemonize the process when run in the background mode, see daemonize(). Here we call fork() directly.
 2. To start a logger process, see log_pipe_init(). Here fork() is followed by execv().
 3. To start a user-defined command with our implementation of popen(). Here we use vfork() + execve().
 4. Tarantool can also be forked by the built-in Lua functions os.execute() and io.popen().

Calling signal_reset() in scenario no.1 is obviously pointless because we don't want to reset signal handlers in this case and have to cancel its effect with signal_init().

To figure out if we need to call signal_reset() in scenario no.2, let's recap what signal_reset() actually does:

 1. Resets all custom signal handlers to defaults with sigaction().
 2. Unsets the interval timer used to update the low-resolution monotonic clock with setitimer().
 3. Unblocks all signals with pthread_sigmask().

Action no.1 is useless because custom signal handlers are reset to defaults by execve() anyway. Action no.2 is useless as well, because interval timers are not inherited by a child process. Action no.3 can be performed directly by log_pipe_init(), no need to install a callback for that.

Scenario no.3 resets signals directly because pthread_atfork() callbacks are not invoked when vfork() is called.

As for scenario no.4, the behavior depends on the glibc version. On older glibc versions, shipped with CentOS 7 based systems in particular, system() and popen(), which are called by os.execute() and io.popen(), use fork() under the hood so pthread_atfork() callbacks are invoked. However, starting from glibc 2.24 system() and popen() are implemented using posix_spawn(), which doesn't invoke pthread_atfork() callbacks. That's why we experience the assertion failure we started this commit message with only on CentOS 7 based systems.

To fix the assertion failure, let's remove signal_reset() completely because, as we figured out, it isn't called on modern systems and actually does nothing useful.

Closes #12846