### PR TITLE
box: use fake txn_stmt in space_before_replace

### DIFF
--- a/changelogs/unreleased/gh-12779-space-before-replace-yield-use-after-free-fix.md
+++ b/changelogs/unreleased/gh-12779-space-before-replace-yield-use-after-free-fix.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a heap-use-after-free bug when a `space.before_replace` trigger yielded
+  with disabled MVCC (gh-12779).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -2132,13 +2132,12 @@ space_check_alter(struct space *old_space, struct space_def *new_space_def)
  * this replica.
  */
 static int
-filter_temporary_ddl_stmt(struct txn *txn, const struct space_def *def)
+filter_temporary_ddl_stmt(struct txn_stmt *stmt, const struct space_def *def)
 {
 	if (def == NULL)
 		return 0;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
 	if (space_opts_is_temporary(&def->opts)) {
-		txn_stmt_mark_as_temporary(txn, stmt);
+		txn_stmt_mark_as_temporary(stmt);
 		return 0;
 	}
 	if (stmt->row->replica_id == 0 && recovery_state != INITIAL_RECOVERY)
@@ -2173,8 +2172,7 @@ filter_temporary_ddl_stmt(struct txn *txn, const struct space_def *def)
 static int
 before_replace_dd_space_index(struct trigger *trigger, void *event)
 {
-	struct txn *txn = (struct txn *)event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 	uint32_t id;
@@ -2257,8 +2255,7 @@ before_replace_dd_space_index(struct trigger *trigger, void *event)
 static int
 on_replace_dd_space(struct trigger * /* trigger */, void *event)
 {
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 	struct region *region = &fiber()->gc;
@@ -2294,7 +2291,7 @@ on_replace_dd_space(struct trigger * /* trigger */, void *event)
 		if (def != NULL)
 			space_def_delete(def);
 	});
-	if (filter_temporary_ddl_stmt(txn, old_space != NULL ?
+	if (filter_temporary_ddl_stmt(stmt, old_space != NULL ?
 				      old_space->def : def) != 0)
 		return -1;
 	if (new_tuple != NULL && old_space == NULL) { /* INSERT */
@@ -2618,8 +2615,7 @@ on_replace_dd_space(struct trigger * /* trigger */, void *event)
 static int
 on_replace_dd_index(struct trigger * /* trigger */, void *event)
 {
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 	uint32_t id, iid;
@@ -2635,7 +2631,7 @@ on_replace_dd_index(struct trigger * /* trigger */, void *event)
 	struct space *old_space = space_cache_find(id);
 	if (old_space == NULL)
 		return -1;
-	if (filter_temporary_ddl_stmt(txn, old_space->def) != 0)
+	if (filter_temporary_ddl_stmt(stmt, old_space->def) != 0)
 		return -1;
 	if (old_space->def->opts.is_view) {
 		diag_set(ClientError, ER_ALTER_SPACE, space_name(old_space),
@@ -2855,8 +2851,7 @@ on_replace_dd_index(struct trigger * /* trigger */, void *event)
 static int
 on_replace_dd_truncate(struct trigger * /* trigger */, void *event)
 {
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *new_tuple = stmt->new_tuple;
 
 	if (recovery_state == INITIAL_RECOVERY) {
@@ -2875,7 +2870,7 @@ on_replace_dd_truncate(struct trigger * /* trigger */, void *event)
 	if (old_space == NULL)
 		return -1;
 	if (space_is_temporary(old_space))
-		txn_stmt_mark_as_temporary(txn, stmt);
+		txn_stmt_mark_as_temporary(stmt);
 
 	if (new_tuple == NULL) {
 		/* Space drop - nothing else to do. */
@@ -2936,7 +2931,7 @@ on_replace_dd_truncate(struct trigger * /* trigger */, void *event)
 		 * The trigger is invoked after txn->n_local_rows
 		 * is counted, so don't forget to update it here.
 		 */
-		++txn->n_local_rows;
+		++stmt->txn->n_local_rows;
 	}
 
 	try {
@@ -3155,8 +3150,7 @@ user_cache_alter_user(struct trigger *trigger, void * /* event */)
 static int
 on_replace_dd_user(struct trigger * /* trigger */, void *event)
 {
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 
@@ -3564,8 +3558,7 @@ on_drop_func_rollback(struct trigger *trigger, void * /* event */)
 static int
 on_replace_dd_func(struct trigger * /* trigger */, void *event)
 {
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 
@@ -3828,8 +3821,7 @@ on_drop_collation_rollback(struct trigger *trigger, void *event)
 static int
 on_replace_dd_collation(struct trigger * /* trigger */, void *event)
 {
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 	if (new_tuple == NULL && old_tuple != NULL) {
@@ -4212,8 +4204,7 @@ modify_priv(struct trigger *trigger, void *event)
 static int
 on_replace_dd_priv(struct trigger * /* trigger */, void *event)
 {
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 	struct priv_def priv;
@@ -4345,8 +4336,7 @@ on_commit_cluster_name(struct trigger *trigger, void * /* event */)
 static int
 before_replace_dd_schema(struct trigger * /* trigger */, void *event)
 {
-	struct txn *txn = (struct txn *)event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 	const char *key = tuple_field_cstr(new_tuple != NULL ?
@@ -4442,8 +4432,8 @@ on_commit_schema_set_bootstrap_leader_uuid(struct trigger *trigger, void *event)
 static int
 on_replace_dd_schema(struct trigger * /* trigger */, void *event)
 {
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
+	struct txn *txn = stmt->txn;
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 	const char *key = tuple_field_cstr(new_tuple ? new_tuple : old_tuple,
@@ -4732,10 +4722,9 @@ on_replace_cluster_set_name(struct trigger *trigger, void * /* event */)
 
 /** Set instance name on _cluster update. */
 static int
-on_replace_dd_cluster_set_name(struct replica *replica,
-			       const char *new_name)
+on_replace_dd_cluster_set_name(struct replica *replica, const char *new_name,
+			       struct txn_stmt *stmt)
 {
-	struct txn_stmt *stmt = txn_current_stmt(in_txn());
 	assert(replica->id != REPLICA_ID_NIL);
 	if (strcmp(replica->name, new_name) == 0)
 		return 0;
@@ -4776,7 +4765,8 @@ on_replace_dd_cluster_set_name(struct replica *replica,
 /** Set instance UUID on _cluster update. */
 static int
 on_replace_dd_cluster_set_uuid(struct replica *replica,
-			       const struct replica_def *new_def)
+			       const struct replica_def *new_def,
+			       struct txn_stmt *stmt)
 {
 	struct replica *old_replica = replica;
 	if (replica_has_connections(old_replica)) {
@@ -4823,7 +4813,6 @@ on_replace_dd_cluster_set_uuid(struct replica *replica,
 	replica_set_name(new_replica, old_def->name);
 	on_rollback_drop_new->data = new_replica;
 	on_rollback_add_old->data = old_def;
-	struct txn_stmt *stmt = txn_current_stmt(in_txn());
 	txn_stmt_on_rollback(stmt, on_rollback_drop_new);
 	txn_stmt_on_rollback(stmt, on_rollback_add_old);
 	return 0;
@@ -4832,7 +4821,8 @@ on_replace_dd_cluster_set_uuid(struct replica *replica,
 /** _cluster update - both old and new tuples are present. */
 static int
 on_replace_dd_cluster_update(const struct replica_def *old_def,
-			     const struct replica_def *new_def)
+			     const struct replica_def *new_def,
+			     struct txn_stmt *stmt)
 {
 	assert(new_def->id == old_def->id);
 	struct replica *replica = replica_by_id(new_def->id);
@@ -4852,19 +4842,19 @@ on_replace_dd_cluster_update(const struct replica_def *old_def,
 		if (recovery_state == FINISHED_RECOVERY &&
 		    gc_erase_consumer(&replica->uuid) != 0)
 			return -1;
-		if (on_replace_dd_cluster_set_uuid(replica, new_def) != 0)
+		if (on_replace_dd_cluster_set_uuid(replica, new_def, stmt) != 0)
 			return -1;
 		/* The replica was re-created. */
 		replica = replica_by_id(new_def->id);
 	}
-	return on_replace_dd_cluster_set_name(replica, new_def->name);
+	return on_replace_dd_cluster_set_name(replica, new_def->name, stmt);
 }
 
 /** _cluster insert - only a new tuple is present. */
 static int
-on_replace_dd_cluster_insert(const struct replica_def *new_def)
+on_replace_dd_cluster_insert(const struct replica_def *new_def,
+			     struct txn_stmt *stmt)
 {
-	struct txn_stmt *stmt = txn_current_stmt(in_txn());
 	struct replica *replica = replica_by_id(new_def->id);
 	/*
 	 * With read-views enabled there might be already a replica whose
@@ -4912,14 +4902,14 @@ on_replace_dd_cluster_insert(const struct replica_def *new_def)
 		replica = replicaset_add(new_def->id, &new_def->uuid);
 	on_rollback->data = replica;
 	txn_stmt_on_rollback(stmt, on_rollback);
-	return on_replace_dd_cluster_set_name(replica, new_def->name);
+	return on_replace_dd_cluster_set_name(replica, new_def->name, stmt);
 }
 
 /** _cluster delete - only the old tuple is present. */
 static int
-on_replace_dd_cluster_delete(const struct replica_def *old_def)
+on_replace_dd_cluster_delete(const struct replica_def *old_def,
+			     struct txn_stmt *stmt)
 {
-	struct txn_stmt *stmt = txn_current_stmt(in_txn());
 	/*
 	 * It's okay to delete the instance id when the deletion is coming from
 	 * the master or doing recovery (i.e., after we already applied the
@@ -4981,29 +4971,29 @@ static int
 on_replace_dd_cluster(struct trigger *trigger, void *event)
 {
 	(void) trigger;
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct replica_def *new_def = NULL;
 	struct replica_def *old_def = NULL;
 	if (stmt->new_tuple != NULL) {
 		new_def = replica_def_new_from_tuple(stmt->new_tuple,
-						     &txn->region);
+						     &stmt->txn->region);
 		if (new_def == NULL)
 			return -1;
 	}
 	if (stmt->old_tuple != NULL) {
 		old_def = replica_def_new_from_tuple(stmt->old_tuple,
-						     &txn->region);
+						     &stmt->txn->region);
 		if (old_def == NULL)
 			return -1;
 	}
 	if (new_def != NULL) {
 		if (old_def != NULL)
-			return on_replace_dd_cluster_update(old_def, new_def);
-		return on_replace_dd_cluster_insert(new_def);
+			return on_replace_dd_cluster_update(old_def, new_def,
+							    stmt);
+		return on_replace_dd_cluster_insert(new_def, stmt);
 	}
 	assert(old_def != NULL);
-	return on_replace_dd_cluster_delete(old_def);
+	return on_replace_dd_cluster_delete(old_def, stmt);
 }
 
 /* }}} cluster configuration */
@@ -5134,8 +5124,7 @@ on_alter_sequence_rollback(struct trigger *trigger, void * /* event */)
 static int
 on_replace_dd_sequence(struct trigger * /* trigger */, void *event)
 {
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 
@@ -5252,8 +5241,7 @@ on_drop_sequence_data_rollback(struct trigger *trigger, void * /* event */)
 static int
 on_replace_dd_sequence_data(struct trigger * /* trigger */, void *event)
 {
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 
@@ -5401,8 +5389,7 @@ clear_space_sequence(struct trigger *trigger, void * /* event */)
 static int
 on_replace_dd_space_sequence(struct trigger * /* trigger */, void *event)
 {
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *tuple = stmt->new_tuple ? stmt->new_tuple : stmt->old_tuple;
 	uint32_t space_id;
 	if (tuple_field_u32(tuple, BOX_SPACE_SEQUENCE_FIELD_ID, &space_id) != 0)
@@ -5582,8 +5569,7 @@ on_replace_trigger_commit(struct trigger *trigger, void * /* event */)
 static int
 on_replace_dd_trigger(struct trigger * /* trigger */, void *event)
 {
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 
@@ -5703,8 +5689,7 @@ static int
 on_replace_dd_func_index(struct trigger *trigger, void *event)
 {
 	(void) trigger;
-	struct txn *txn = (struct txn *) event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 	struct tuple *old_tuple = stmt->old_tuple;
 	struct tuple *new_tuple = stmt->new_tuple;
 

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -1072,9 +1072,8 @@ struct memtx_ddl_state {
 static int
 memtx_check_on_replace(struct trigger *trigger, void *event)
 {
-	struct txn *txn = event;
 	struct memtx_ddl_state *state = trigger->data;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 
 	/* Nothing to check on DELETE. */
 	if (stmt->new_tuple == NULL)
@@ -1283,9 +1282,8 @@ memtx_build_on_replace_commit(struct trigger *base, void *event)
 static int
 memtx_build_on_replace(struct trigger *trigger, void *event)
 {
-	struct txn *txn = event;
 	struct memtx_ddl_state *state = trigger->data;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
 
 	struct tuple *cmp_tuple = stmt->new_tuple != NULL ? stmt->new_tuple :
 							    stmt->old_tuple;

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -202,7 +202,8 @@ static int
 on_replace_dd_system_space(struct trigger *trigger, void *event)
 {
 	(void) trigger;
-	struct txn *txn = (struct txn *) event;
+	struct txn_stmt *stmt = (struct txn_stmt *)event;
+	struct txn *txn = stmt->txn;
 	if (txn->space_on_replace_triggers_depth > 1) {
 		diag_set(ClientError, ER_UNSUPPORTED,
 			 "Space on_replace trigger", "DDL operations");

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -880,12 +880,8 @@ space_index_def(struct space *space, int n)
  * to port_c. Transaction mustn't be aborted.
  */
 static void
-space_push_replace_trigger_arguments(struct port *args, struct txn *txn)
+space_push_replace_trigger_arguments(struct port *args, struct txn_stmt *stmt)
 {
-	assert(txn_check_can_continue(txn) == 0);
-	struct txn_stmt *stmt = txn_current_stmt(txn);
-	assert(stmt != NULL);
-
 	if (stmt->old_tuple != NULL)
 		port_c_add_tuple(args, stmt->old_tuple);
 	else
@@ -924,7 +920,7 @@ space_push_replace_trigger_arguments(struct port *args, struct txn *txn)
  * Updated tuple is validated against the space format.
  */
 static int
-space_run_replace_triggers(struct event *event, struct txn *txn,
+space_run_replace_triggers(struct event *event, struct txn_stmt *stmt,
 			   bool update_tuple)
 {
 	if (!space_events_enabled)
@@ -932,11 +928,9 @@ space_run_replace_triggers(struct event *event, struct txn *txn,
 	/** Return early if event has no triggers or if txn can't continue. */
 	if (!event_has_triggers(event))
 		return 0;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
-	assert(stmt != NULL);
 	if (stmt->space->run_recovery_triggers)
 		say_warn_once("space on recovery triggers are deprecated");
-	int rc = txn_check_can_continue(txn);
+	int rc = txn_check_can_continue(stmt->txn);
 	if (rc != 0)
 		return -1;
 
@@ -948,7 +942,7 @@ space_run_replace_triggers(struct event *event, struct txn *txn,
 	/* Don't pass port for returned values if we don't update tuple. */
 	struct port *ret_ptr = update_tuple ? &ret : NULL;
 	port_c_create(&args);
-	space_push_replace_trigger_arguments(&args, txn);
+	space_push_replace_trigger_arguments(&args, stmt);
 	while (rc == 0 && event_trigger_iterator_next(&it, &trigger, &name)) {
 		bool has_ret = false;
 		uint32_t region_svp = region_used(&fiber()->gc);
@@ -956,7 +950,7 @@ space_run_replace_triggers(struct event *event, struct txn *txn,
 		 * The transaction could be aborted while the previous trigger
 		 * was running (e.g. if the trigger callback yielded).
 		 */
-		rc = txn_check_can_continue(txn);
+		rc = txn_check_can_continue(stmt->txn);
 		if (rc != 0)
 			goto out;
 		rc = func_adapter_call(trigger, &args, ret_ptr);
@@ -972,7 +966,7 @@ space_run_replace_triggers(struct event *event, struct txn *txn,
 		 * The transaction could be aborted while the trigger was
 		 * running (e.g. if the trigger callback yielded).
 		 */
-		rc = txn_check_can_continue(txn);
+		rc = txn_check_can_continue(stmt->txn);
 		if (rc != 0)
 			goto out;
 		/*
@@ -1016,7 +1010,7 @@ space_run_replace_triggers(struct event *event, struct txn *txn,
 		/* Can't update values in port - destroy it and create again. */
 		port_destroy(&args);
 		port_c_create(&args);
-		space_push_replace_trigger_arguments(&args, txn);
+		space_push_replace_trigger_arguments(&args, stmt);
 out:
 		if (has_ret)
 			port_destroy(&ret);
@@ -1028,7 +1022,7 @@ out:
 }
 
 int
-space_on_replace(struct space *space, struct txn *txn)
+space_on_replace(struct space *space, struct txn_stmt *stmt)
 {
 	/*
 	 * Since the triggers can yield, a space can be dropped
@@ -1041,9 +1035,9 @@ space_on_replace(struct space *space, struct txn *txn)
 	};
 	for (size_t i = 0; i < lengthof(events); ++i)
 		event_ref(events[i]);
-	int rc = trigger_run(&space->on_replace, txn);
+	int rc = trigger_run(&space->on_replace, stmt);
 	for (size_t i = 0; i < lengthof(events) && rc == 0; ++i)
-		rc = space_run_replace_triggers(events[i], txn, false);
+		rc = space_run_replace_triggers(events[i], stmt, false);
 	for (size_t i = 0; i < lengthof(events); ++i)
 		event_unref(events[i]);
 	return rc;
@@ -1295,9 +1289,9 @@ after_old_tuple_lookup:;
 	 */
 	for (size_t i = 0; i < lengthof(events); ++i)
 		event_ref(events[i]);
-	int rc = trigger_run(&space->before_replace, txn);
+	int rc = trigger_run(&space->before_replace, stmt);
 	for (size_t i = 0; i < lengthof(events) && rc == 0; ++i)
-		rc = space_run_replace_triggers(events[i], txn, true);
+		rc = space_run_replace_triggers(events[i], stmt, true);
 	for (size_t i = 0; i < lengthof(events); ++i)
 		event_unref(events[i]);
 

--- a/src/box/space.c
+++ b/src/box/space.c
@@ -1264,19 +1264,20 @@ after_old_tuple_lookup:;
 	 * Execute all registered BEFORE triggers.
 	 *
 	 * We pass the log row, old and new tuples to the triggers
-	 * in txn_current_stmt(), which should be empty, because
-	 * the engine method (execute_replace or similar) has not
-	 * been called yet. Triggers may update new_tuple in place
-	 * so the next trigger sees the result of the previous one.
-	 * After we are done, we clear row, old_tuple and new_tuple
-	 * in txn_current_stmt() to be set by the engine.
+	 * in a fake statement allocated on stack so as not to mess
+	 * with txn_current_stmt(), which may be updated internally
+	 * by the transaction manager, for example, if the trigger
+	 * yields.
 	 */
-	struct txn_stmt *stmt = txn_current_stmt(txn);
-	assert(stmt->old_tuple == NULL && stmt->new_tuple == NULL);
-	assert(stmt->row == NULL);
-	stmt->old_tuple = old_tuple;
-	stmt->new_tuple = new_tuple;
-	stmt->row = request->header;
+	struct txn_stmt fake_stmt = {
+		.txn = txn,
+		.space = space,
+		.old_tuple = old_tuple,
+		.new_tuple = new_tuple,
+		.row = request->header,
+		.type = type,
+	};
+	struct txn_stmt *stmt = &fake_stmt;
 
 	struct event *events[] = {
 		space->before_replace_event.by_id,
@@ -1302,9 +1303,6 @@ after_old_tuple_lookup:;
 	bool request_changed = (stmt->new_tuple != new_tuple);
 	new_tuple = stmt->new_tuple;
 	assert(stmt->old_tuple == old_tuple);
-	stmt->old_tuple = NULL;
-	stmt->new_tuple = NULL;
-	stmt->row = NULL;
 
 	if (rc != 0)
 		goto out;

--- a/src/box/space.h
+++ b/src/box/space.h
@@ -51,6 +51,7 @@ struct space;
 struct engine;
 struct sequence;
 struct txn;
+struct txn_stmt;
 struct request;
 struct port;
 struct tuple;
@@ -582,7 +583,7 @@ space_has_before_replace_event_triggers(struct space *space)
  * Run on_replace triggers registered for a space.
  */
 int
-space_on_replace(struct space *space, struct txn *txn);
+space_on_replace(struct space *space, struct txn_stmt *stmt);
 
 /**
  * Execute a DML request on the given space.

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -724,7 +724,7 @@ txn_commit_stmt(struct txn *txn, struct request *request)
 	    (stmt->old_tuple || stmt->new_tuple)) {
 		if (space_has_on_replace_triggers(stmt->space)) {
 			txn->space_on_replace_triggers_depth++;
-			int rc = space_on_replace(stmt->space, txn);
+			int rc = space_on_replace(stmt->space, stmt);
 			txn->space_on_replace_triggers_depth--;
 			if (rc != 0)
 				goto fail;
@@ -1805,10 +1805,10 @@ txn_attach(struct txn *txn)
 }
 
 void
-txn_stmt_mark_as_temporary(struct txn *txn, struct txn_stmt *stmt)
+txn_stmt_mark_as_temporary(struct txn_stmt *stmt)
 {
 	assert(stmt->row != NULL);
 	/* Revert row counter increases. */
-	txn_update_row_counts(txn, stmt, -1);
+	txn_update_row_counts(stmt->txn, stmt, -1);
 	stmt->row = NULL;
 }

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -980,7 +980,7 @@ txn_is_nop(const struct txn *txn)
  * The downside of confusing control flow is outweighed by the efficiency.
  */
 void
-txn_stmt_mark_as_temporary(struct txn *txn, struct txn_stmt *stmt);
+txn_stmt_mark_as_temporary(struct txn_stmt *stmt);
 
 /**
  * End a statement. In autocommit mode, end

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -1076,8 +1076,7 @@ struct vy_check_format_ctx {
 static int
 vy_check_format_on_replace(struct trigger *trigger, void *event)
 {
-	struct txn *txn = event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = event;
 	struct vy_check_format_ctx *ctx = trigger->data;
 
 	if (stmt->new_tuple == NULL)
@@ -4080,12 +4079,11 @@ struct vy_build_ctx {
 static int
 vy_build_on_replace(struct trigger *trigger, void *event)
 {
-	struct txn *txn = event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = event;
 	struct vy_build_ctx *ctx = trigger->data;
 	struct tuple_format *format = ctx->format;
 	struct vy_lsm *lsm = ctx->lsm;
-	struct vy_tx *tx = txn->engines_tx[lsm->base.engine->id];
+	struct vy_tx *tx = stmt->txn->engines_tx[lsm->base.engine->id];
 
 	if (ctx->is_failed)
 		return 0; /* already failed, nothing to do */
@@ -4607,8 +4605,8 @@ vy_deferred_delete_on_replace(struct trigger *trigger, void *event)
 {
 	(void)trigger;
 
-	struct txn *txn = event;
-	struct txn_stmt *stmt = txn_current_stmt(txn);
+	struct txn_stmt *stmt = event;
+	struct txn *txn = stmt->txn;
 	bool is_first_statement = txn_is_first_statement(txn);
 
 	if (stmt->new_tuple == NULL)


### PR DESCRIPTION
The test box-luatest/gh_8027_txn_handle_abort_in_trigger_test.lua fails
with an assertion failure:

```
./src/box/tuple.h:1508: tuple_unref: Assertion `tuple->local_refs >= 1' failed.
```

This happens because a before_replace trigger callback yields with
disabled memtx MVCC, which causes the transaction manager to rollback
the current statement in txn_on_yield screwing our assumptions about
stmt->new_tuple reference counting in space_before_replace.

We could take another reference to stmt->new_tuple to avoid that,
but modifying txn_current_stmt before it's initialized, as we do in
space_before_replace, looks unsafe so instead let's allocate a fake
statement on stack so as not to mess with the transaction manager
internals.

Closes #12779