### PR TITLE
cmake: bump lunapark to a new version

### DIFF
--- a/cmake/BuildLuaTests.cmake
+++ b/cmake/BuildLuaTests.cmake
@@ -36,7 +36,7 @@ list(APPEND LUA_TESTS_CMAKE_FLAGS
 
 include(ExternalProject)
 
-set(GIT_REF "854eba8e865ee1ac4c602fcb71836219c5d2f046")
+set(GIT_REF "533b7bd46c0a3e3543f97b8e0b69e056da52235d")
 # Git reference can be overridden with environment variable. It is
 # needed for checking build by project itself.
 if (DEFINED ENV{LUA_TESTS_GIT_REF})


### PR DESCRIPTION
~~Depends on https://github.com/ligurio/lunapark/pull/209~~
~~Depends on https://github.com/google/oss-fuzz/pull/15830~~

----

The patch bumps lunapark to a new version that contains fixes for Lua API tests and other changes [1]:

- luacheckrc: remove a global table.create
- tests/lapi: handle NaN and INF in math_log_test
- tests/lapi: fix math_log_test
- tests/lapi: fix table_foreach_test
- tests/lapi: fix table_remove_test
- tests/lapi: fix string_unpack_test
- tests/lapi: fix io_torture_test
- tests/lapi: fix string_match_test
- tests/lapi: check a number of arguments early
- ci: disable cflite_pr workflow
- ci: fix setup packages
- tests/capi: update LuaJIT metrics
- cmake: use fine-grained UBsan suppressions in Lua
- ci: disable oss-fuzz workflow
- ci: test changes in Lua API tests
- patches: update static linkage for PUC Rio Lua
- cfl: enable quiet mode for zip
- cfl: update luarock installation
- ci: bump actions/checkout version
- cmake: bump luzer to a new version
- cmake: enable debug in a bundled LuaJIT
- cmake: introduce DISABLE_LIBFUZZER_STATIC_LINKAGE
- cfl: bump pruning timeout
- infra: add shell.nix
- cmake: update presets
- cfl: fix "zip: Argument list too long"
- ci: bump actions/checkout version
- cmake: update code coverage module
- cmake: use AppendFlags in BuildLua and BuildLuaJIT
- cmake: update LUAJIT_BLACKLIST_TESTS
- cmake: rename project
- cmake: fix long line
- cmake: unset unused variables in ProtobufMutator
- cfl: support luzer-based tests
- cfl: bump Ubuntu to 24.04
- cmake: bump luzer to a new version
- ci: run testing on every push
- ci: introduce workflow for building proofs
- proofs: support code coverage using cbmc-viewer
- proofs: initial commit with infrastructure

These fixes stabilized PUC Rio Lua fuzzing in OSS-Fuzz - there are no test fails now. The proposed patch should fix the same test fails for Tarantool in OSS Fuzz.

1. https://github.com/ligurio/lunapark/compare/854eba8e865ee1ac4c602fcb71836219c5d2f046...4f341f63da9f8b11e74f04701959df4aa977a4ad

Follows up ligurio/lunapark#189
Follows up ligurio/lunapark#190
Follows up ligurio/lunapark#193
Follows up ligurio/lunapark#194
Follows up ligurio/lunapark#196
Follows up ligurio/lunapark#197
Follows up ligurio/lunapark#205
Related to #11250

NO_CHANGELOG=build
NO_DOC=build
NO_TEST=build


-----

Depends on https://github.com/google/oss-fuzz/pull/15830