### PR TITLE
[backport/release/3.7] luajit: bump new version

### DIFF
--- a/changelogs/unreleased/gh-12480-luajit-fixes.md
+++ b/changelogs/unreleased/gh-12480-luajit-fixes.md
@@ -1,0 +1,12 @@
+## bugfix/luajit
+
+Backported patches from the vanilla LuaJIT trunk (gh-12480). The following
+issues were fixed as part of this activity:
+
+* Fixed incorrect JIT behavior for vararg FFI functions on the macOS AArch64
+  platform (gh-6097).
+* Fixed various FFI ABI and calling convention issues for x64/AArch64
+  architectures.
+* Fixed `ipairs_aux()` to match JIT backend behavior on x86/x64.
+* Fixed `os.time()` returning `-1`.
+* Fixed UBSan warnings for `table.new()`.


### PR DESCRIPTION
* test: introduce tests for debugging extensions
* lldb: refactor extension
* dbg: sort initialization of commands
* lldb: support full-range 64-bit lightuserdata
* dbg: generalize extension
* ci: introduce workflow to test debugger extension
* FFI: Unify stack setup for C calls in interpreter.
* FFI/ARM64/OSX: Handle non-standard OSX C calling conventions.
* ARM64: Fix pass-by-value struct calling conventions.
* FFI: Various ABI and calling convention fixes.
* FFI/MacOS: Fix calling convention for enums.
* test: fix libfficcall compilation for old GCC
* x86/x64: Change ipairs_aux to match JIT backend behavior.
* dbg: fix lj-stack command for LLDB
* dbg: fix DUALNUM detection for LLDB
* dbg: update help for the lj-arch command
* dbg: introduce lj-gco command
* dbg: introduce lj-bc, lj-func and lj-proto dumpers
* Fix corner case of os.time().
* Make check in os.time() consistent.
* dbg: introduce lj-ir, lj-jslots, lj-trace dumpers
* dbg: introduce lj-ctype command, extend cdata dump
* test: add verbose mode for debug extension tests
* Prevent sanitizer warnings for lj_tab_new*() and table.new().
* FFI/MacOS: Fix calling convention for on-stack varargs.
* test: skip lj-1470 test for unconfigured timezones

Closes #12480
Closes #6097
Closes #6068
Part of #4808

NO_DOC=LuaJIT submodule bump
NO_TEST=LuaJIT submodule bump