### PR TITLE
lua: bump metrics module

### DIFF
--- a/changelogs/unreleased/bump-metrics-to-1.8.1.md
+++ b/changelogs/unreleased/bump-metrics-to-1.8.1.md
@@ -1,0 +1,10 @@
+## feature/metrics
+
+* Updated the metrics submodule to 1.8.1.
+
+  Changes in 1.8.1:
+
+  * Fixed `metrics.cfg{exclude = {'all'}}` so it excludes custom metric
+    selectors in addition to built-in metric groups ([gh-548][mgh-548]).
+
+[mgh-548]: https://github.com/tarantool/metrics/pull/548


### PR DESCRIPTION
Bump metric package submodule to 1.8.1. Commits from PR[1] fixes bugs.

1. tarantool/metrics#548

NO_TEST=metrics submodule bump
NO_DOC=bugfix