### PR TITLE
[backport 3.6] memtx: fix stmt tuple clarifying when MVCC enabled

### DIFF
--- a/changelogs/unreleased/gh-12260-memtx-mvcc-wrong-stmt-tuple-clarifying.md
+++ b/changelogs/unreleased/gh-12260-memtx-mvcc-wrong-stmt-tuple-clarifying.md
@@ -1,0 +1,4 @@
+## bugfix/memtx
+
+* Fixed a bug in MVCC `read-confirmed` isolation where `delete` and `update`
+  could see an incorrect tuple (gh-12260).

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -187,6 +187,7 @@ set(box_sources
     index_def.c
     index_weak_ref.c
     iterator_type.c
+    memtx_index.c
     memtx_hash.cc
     memtx_tree.cc
     memtx_rtree.cc

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -1180,20 +1180,6 @@ generic_index_get(struct index *index, const char *key,
 	return -1;
 }
 
-int
-generic_index_replace(struct index *index, struct tuple *old_tuple,
-		      struct tuple *new_tuple, enum dup_replace_mode mode,
-		      struct tuple **result, struct tuple **successor)
-{
-	(void)old_tuple;
-	(void)new_tuple;
-	(void)mode;
-	(void)result;
-	(void)successor;
-	diag_set(UnsupportedIndexFeature, index->def, "replace()");
-	return -1;
-}
-
 struct iterator *
 generic_index_create_iterator(struct index *base, enum iterator_type type,
 			      const char *key, uint32_t part_count,
@@ -1323,55 +1309,6 @@ void
 generic_index_reset_stat(struct index *index)
 {
 	(void)index;
-}
-
-void
-generic_index_begin_build(struct index *)
-{
-}
-
-int
-generic_index_reserve(struct index *, uint32_t)
-{
-	return 0;
-}
-
-int
-generic_index_build_next(struct index *index, struct tuple *tuple)
-{
-	struct tuple *unused;
-	/*
-	 * Note this is not no-op call in case of rtee index:
-	 * reserving 0 bytes is required during rtree recovery.
-	 * For details see memtx_rtree_index_reserve().
-	 */
-	if (index_reserve(index, 0) != 0)
-		return -1;
-	return index_replace(index, NULL, tuple, DUP_INSERT, &unused, &unused);
-}
-
-void
-generic_index_end_build(struct index *)
-{
-}
-
-int
-disabled_index_build_next(struct index *index, struct tuple *tuple)
-{
-	(void) index; (void) tuple;
-	return 0;
-}
-
-int
-disabled_index_replace(struct index *index, struct tuple *old_tuple,
-		       struct tuple *new_tuple, enum dup_replace_mode mode,
-		       struct tuple **result, struct tuple **successor)
-{
-	(void) old_tuple; (void) new_tuple; (void) mode;
-	(void) index;
-	*result = NULL;
-	*successor = NULL;
-	return 0;
 }
 
 int

--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -1159,17 +1159,6 @@ generic_index_read_view_count(struct index_read_view *rv,
 }
 
 int
-generic_index_get_internal(struct index *index, const char *key,
-			   uint32_t part_count, struct tuple **result)
-{
-	(void)key;
-	(void)part_count;
-	(void)result;
-	diag_set(UnsupportedIndexFeature, index->def, "get_internal()");
-	return -1;
-}
-
-int
 generic_index_get(struct index *index, const char *key,
 		  uint32_t part_count, struct tuple **result)
 {

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -640,13 +640,6 @@ struct index_vtab {
 	int (*random)(struct index *index, uint32_t rnd, struct tuple **result);
 	ssize_t (*count)(struct index *index, enum iterator_type type,
 			 const char *key, uint32_t part_count);
-	/*
-	 * Same as get(), but returns a tuple as it is stored in the index,
-	 * without any transformations. Used internally by engines. For
-	 * example, memtx returns a tuple without decompression.
-	 */
-	int (*get_internal)(struct index *index, const char *key,
-			    uint32_t part_count, struct tuple **result);
 	int (*get)(struct index *index, const char *key,
 		   uint32_t part_count, struct tuple **result);
 	/**
@@ -1014,13 +1007,6 @@ index_count(struct index *index, enum iterator_type type,
 }
 
 static inline int
-index_get_internal(struct index *index, const char *key,
-		   uint32_t part_count, struct tuple **result)
-{
-	return index->vtab->get_internal(index, key, part_count, result);
-}
-
-static inline int
 index_get(struct index *index, const char *key,
 	   uint32_t part_count, struct tuple **result)
 {
@@ -1241,9 +1227,6 @@ ssize_t
 generic_index_read_view_count(struct index_read_view *rv,
 			      enum iterator_type type, const char *key,
 			      uint32_t part_count);
-int
-generic_index_get_internal(struct index *index, const char *key,
-			   uint32_t part_count, struct tuple **result);
 int generic_index_get(struct index *, const char *, uint32_t, struct tuple **);
 struct index_read_view *
 generic_index_create_read_view(struct index *index);

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -516,7 +516,6 @@ static const struct index_vtab memtx_bitset_index_vtab_base = {
 	/* .max = */ generic_index_max,
 	/* .random = */ generic_index_random,
 	/* .count = */ memtx_bitset_index_count,
-	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ generic_index_get,
 	/* .create_iterator = */ memtx_bitset_index_create_iterator,
 	/* .create_iterator_with_offset = */
@@ -530,6 +529,7 @@ static const struct index_vtab memtx_bitset_index_vtab_base = {
 
 static const struct memtx_index_vtab memtx_bitset_index_vtab = {
 	/* .base = */ memtx_bitset_index_vtab_base,
+	/* .get_internal = */ generic_memtx_index_get_internal,
 	/* .replace = */ memtx_bitset_index_replace,
 	/* .begin_build = */ generic_memtx_index_begin_build,
 	/* .reserve = */ generic_memtx_index_reserve,

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -62,6 +62,7 @@
 #include "memtx_space.h"
 #include "memtx_space_upgrade.h"
 #include "memtx_sort_data.h"
+#include "memtx_index.h"
 #include "tt_sort.h"
 #include "assoc.h"
 #include "scoped_guard.h"
@@ -141,7 +142,7 @@ memtx_end_build_primary_key(struct space *space, struct memtx_engine *memtx)
 	    memtx_space->replace == memtx_space_replace_all_keys)
 		return 0;
 
-	index_end_build(space->index[0]);
+	memtx_index_end_build(space->index[0]);
 	return 0;
 }
 
@@ -176,8 +177,8 @@ memtx_build_secondary_index_using_tt_sort(struct index *index, struct index *pk)
 		return -1;
 	uint32_t estimated_tuples = n_tuples * 1.2;
 
-	index_begin_build(index);
-	if (index_reserve(index, estimated_tuples) < 0)
+	memtx_index_begin_build(index);
+	if (memtx_index_reserve(index, estimated_tuples) < 0)
 		return -1;
 
 	if (n_tuples > 0) {
@@ -198,7 +199,7 @@ memtx_build_secondary_index_using_tt_sort(struct index *index, struct index *pk)
 			break;
 		if (tuple == NULL)
 			break;
-		rc = index_build_next(index, tuple);
+		rc = memtx_index_build_next(index, tuple);
 		if (rc != 0)
 			break;
 	}
@@ -206,7 +207,7 @@ memtx_build_secondary_index_using_tt_sort(struct index *index, struct index *pk)
 	if (rc != 0)
 		return -1;
 
-	index_end_build(index);
+	memtx_index_end_build(index);
 	return 0;
 }
 
@@ -889,8 +890,8 @@ memtx_engine_rollback_statement(struct engine *engine, struct txn *txn,
 		struct tuple *unused;
 		struct index *index = space->index[i];
 		/* Rollback must not fail. */
-		if (index_replace(index, new_tuple, old_tuple,
-				  DUP_INSERT, &unused, &unused) != 0) {
+		if (memtx_index_replace(index, new_tuple, old_tuple, DUP_INSERT,
+					&unused, &unused) != 0) {
 			diag_log();
 			unreachable();
 			panic("failed to rollback change");

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -2568,7 +2568,8 @@ memtx_index_get(struct index *index, const char *key, uint32_t part_count,
 		struct tuple **result)
 {
 	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
-	if (vtab->get_internal(index, key, part_count, result) != 0)
+	if (vtab->get_internal(index, key, part_count, result,
+			       /*is_rw=*/false) != 0)
 		return -1;
 	struct space *space = space_by_id(index->def->space_id);
 	return memtx_prepare_result_tuple(space, result);

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -2567,7 +2567,8 @@ int
 memtx_index_get(struct index *index, const char *key, uint32_t part_count,
 		struct tuple **result)
 {
-	if (index->vtab->get_internal(index, key, part_count, result) != 0)
+	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
+	if (vtab->get_internal(index, key, part_count, result) != 0)
 		return -1;
 	struct space *space = space_by_id(index->def->space_id);
 	return memtx_prepare_result_tuple(space, result);

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -730,7 +730,6 @@ static const struct index_vtab memtx_hash_index_vtab_base = {
 	/* .max = */ generic_index_max,
 	/* .random = */ memtx_hash_index_random,
 	/* .count = */ memtx_hash_index_count,
-	/* .get_internal = */ memtx_hash_index_get_internal,
 	/* .get = */ memtx_index_get,
 	/* .create_iterator = */ memtx_hash_index_create_iterator,
 	/* .create_iterator_with_offset = */
@@ -744,6 +743,7 @@ static const struct index_vtab memtx_hash_index_vtab_base = {
 
 static const struct memtx_index_vtab memtx_hash_index_vtab = {
 	/* .base = */ memtx_hash_index_vtab_base,
+	/* .get_internal = */ memtx_hash_index_get_internal,
 	/* .replace = */ memtx_hash_index_replace,
 	/* .begin_build = */ generic_memtx_index_begin_build,
 	/* .reserve = */ generic_memtx_index_reserve,

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -322,7 +322,8 @@ memtx_hash_index_count(struct index *base, enum iterator_type type,
 
 static int
 memtx_hash_index_get_internal(struct index *base, const char *key,
-			      uint32_t part_count, struct tuple **result)
+			      uint32_t part_count, struct tuple **result,
+			      bool is_rw)
 {
 	struct memtx_hash_index *index = (struct memtx_hash_index *)base;
 
@@ -337,7 +338,9 @@ memtx_hash_index_get_internal(struct index *base, const char *key,
 	uint32_t k = light_index_find_key(&index->hash_table, h, key);
 	if (k != light_index_end) {
 		struct tuple *tuple = light_index_get(&index->hash_table, k);
-		*result = memtx_tx_tuple_clarify(txn, space, tuple, base, 0);
+		*result = is_rw ?
+			memtx_tx_tuple_clarify_rw(txn, space, tuple, base, 0) :
+			memtx_tx_tuple_clarify(txn, space, tuple, base, 0);
 	} else {
 		memtx_tx_track_point(txn, space, base, key);
 	}

--- a/src/box/memtx_index.c
+++ b/src/box/memtx_index.c
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2025, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "memtx_index.h"
+
+void
+generic_memtx_index_begin_build(struct index *index)
+{
+	(void)index;
+}
+
+int
+generic_memtx_index_reserve(struct index *index, uint32_t size_hint)
+{
+	(void)index;
+	(void)size_hint;
+	return 0;
+}
+
+int
+generic_memtx_index_build_next(struct index *index, struct tuple *tuple)
+{
+	struct tuple *unused;
+	/*
+	 * Note this is not no-op call in case of rtee index:
+	 * reserving 0 bytes is required during rtree recovery.
+	 * For details see memtx_rtree_index_reserve().
+	 */
+	if (memtx_index_reserve(index, 0) != 0)
+		return -1;
+	return memtx_index_replace(index, NULL, tuple, DUP_INSERT, &unused,
+				   &unused);
+}
+
+void
+generic_memtx_index_end_build(struct index *index)
+{
+	(void)index;
+}

--- a/src/box/memtx_index.c
+++ b/src/box/memtx_index.c
@@ -7,11 +7,13 @@
 
 int
 generic_memtx_index_get_internal(struct index *index, const char *key,
-				 uint32_t part_count, struct tuple **result)
+				 uint32_t part_count, struct tuple **result,
+				 bool is_rw)
 {
 	(void)key;
 	(void)part_count;
 	(void)result;
+	(void)is_rw;
 	diag_set(UnsupportedIndexFeature, index->def, "get_internal()");
 	return -1;
 }

--- a/src/box/memtx_index.c
+++ b/src/box/memtx_index.c
@@ -5,6 +5,17 @@
  */
 #include "memtx_index.h"
 
+int
+generic_memtx_index_get_internal(struct index *index, const char *key,
+				 uint32_t part_count, struct tuple **result)
+{
+	(void)key;
+	(void)part_count;
+	(void)result;
+	diag_set(UnsupportedIndexFeature, index->def, "get_internal()");
+	return -1;
+}
+
 void
 generic_memtx_index_begin_build(struct index *index)
 {

--- a/src/box/memtx_index.h
+++ b/src/box/memtx_index.h
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2025, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include "index.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+/** Virtual function table for memtx-specific index operations. */
+struct memtx_index_vtab {
+	/** Base index virtual table for common index operations. */
+	struct index_vtab base;
+	/**
+	 * Main entrance point for changing data in index. Once built and
+	 * before deletion this is the only way to insert, replace and delete
+	 * data from the index.
+	 * @param mode - @sa dup_replace_mode description
+	 * @param result - here the replaced or deleted tuple is placed.
+	 * @param successor - if the index supports ordering, then in case of
+	 *  insert (!) here the successor tuple is returned. In other words,
+	 *  here will be stored the tuple, before which new tuple is inserted.
+	 *
+	 * NB: do not use the same object for @a result and @a successor - they
+	 *     are different returned values and implementation can rely on it.
+	 */
+	int (*replace)(struct index *index, struct tuple *old_tuple,
+		       struct tuple *new_tuple, enum dup_replace_mode mode,
+		       struct tuple **result, struct tuple **successor);
+	/**
+	 * Two-phase index creation: begin building, add tuples, finish.
+	 */
+	void (*begin_build)(struct index *index);
+	/**
+	 * Optional hint, given to the index, about
+	 * the total size of the index. Called after
+	 * begin_build().
+	 */
+	int (*reserve)(struct index *index, uint32_t size_hint);
+	/** Add one tuple for index build. */
+	int (*build_next)(struct index *index, struct tuple *tuple);
+	/** Finish index build. */
+	void (*end_build)(struct index *index);
+};
+
+static inline int
+memtx_index_replace(struct index *index, struct tuple *old_tuple,
+		    struct tuple *new_tuple, enum dup_replace_mode mode,
+		    struct tuple **result, struct tuple **successor)
+{
+	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
+	return vtab->replace(index, old_tuple, new_tuple, mode, result,
+			     successor);
+}
+
+static inline void
+memtx_index_begin_build(struct index *index)
+{
+	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
+	vtab->begin_build(index);
+}
+
+static inline int
+memtx_index_reserve(struct index *index, uint32_t size_hint)
+{
+	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
+	return vtab->reserve(index, size_hint);
+}
+
+static inline int
+memtx_index_build_next(struct index *index, struct tuple *tuple)
+{
+	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
+	return vtab->build_next(index, tuple);
+}
+
+static inline void
+memtx_index_end_build(struct index *index)
+{
+	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
+	vtab->end_build(index);
+}
+
+/** No-op stub for the `begin_build` operation. */
+void
+generic_memtx_index_begin_build(struct index *index);
+
+/** No-op stub for the `reserve` operation. */
+int
+generic_memtx_index_reserve(struct index *index, uint32_t size_hint);
+
+/**
+ * Generic implementation of the `build_next` operation: reserves space in the
+ * index and inserts the tuple into the index.
+ */
+int
+generic_memtx_index_build_next(struct index *index, struct tuple *tuple);
+
+/** No-op stub for the `end_build` operation. */
+void
+generic_memtx_index_end_build(struct index *index);
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/src/box/memtx_index.h
+++ b/src/box/memtx_index.h
@@ -15,6 +15,12 @@ extern "C" {
 struct memtx_index_vtab {
 	/** Base index virtual table for common index operations. */
 	struct index_vtab base;
+	/*
+	 * Same as get(), but returns a tuple as it is stored in the index,
+	 * without decompression, blessing, or space upgrade.
+	 */
+	int (*get_internal)(struct index *index, const char *key,
+			    uint32_t part_count, struct tuple **result);
 	/**
 	 * Main entrance point for changing data in index. Once built and
 	 * before deletion this is the only way to insert, replace and delete
@@ -46,6 +52,14 @@ struct memtx_index_vtab {
 	/** Finish index build. */
 	void (*end_build)(struct index *index);
 };
+
+static inline int
+memtx_index_get_internal(struct index *index, const char *key,
+			 uint32_t part_count, struct tuple **result)
+{
+	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
+	return vtab->get_internal(index, key, part_count, result);
+}
 
 static inline int
 memtx_index_replace(struct index *index, struct tuple *old_tuple,
@@ -84,6 +98,10 @@ memtx_index_end_build(struct index *index)
 	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
 	vtab->end_build(index);
 }
+
+int
+generic_memtx_index_get_internal(struct index *index, const char *key,
+				 uint32_t part_count, struct tuple **result);
 
 /** No-op stub for the `begin_build` operation. */
 void

--- a/src/box/memtx_index.h
+++ b/src/box/memtx_index.h
@@ -15,12 +15,18 @@ extern "C" {
 struct memtx_index_vtab {
 	/** Base index virtual table for common index operations. */
 	struct index_vtab base;
-	/*
+	/**
 	 * Same as get(), but returns a tuple as it is stored in the index,
 	 * without decompression, blessing, or space upgrade.
+	 *
+	 * @param is_rw - if true, the call is for a write statement and MVCC
+	 *  clarification uses read-write semantics (sees prepared statements
+	 *  regardless of isolation level), otherwise clarification respects
+	 *  the read transaction's isolation level.
 	 */
 	int (*get_internal)(struct index *index, const char *key,
-			    uint32_t part_count, struct tuple **result);
+			    uint32_t part_count, struct tuple **result,
+			    bool is_rw);
 	/**
 	 * Main entrance point for changing data in index. Once built and
 	 * before deletion this is the only way to insert, replace and delete
@@ -55,10 +61,11 @@ struct memtx_index_vtab {
 
 static inline int
 memtx_index_get_internal(struct index *index, const char *key,
-			 uint32_t part_count, struct tuple **result)
+			 uint32_t part_count, struct tuple **result,
+			 bool is_rw)
 {
 	struct memtx_index_vtab *vtab = (struct memtx_index_vtab *)index->vtab;
-	return vtab->get_internal(index, key, part_count, result);
+	return vtab->get_internal(index, key, part_count, result, is_rw);
 }
 
 static inline int
@@ -101,7 +108,8 @@ memtx_index_end_build(struct index *index)
 
 int
 generic_memtx_index_get_internal(struct index *index, const char *key,
-				 uint32_t part_count, struct tuple **result);
+				 uint32_t part_count, struct tuple **result,
+				 bool is_rw);
 
 /** No-op stub for the `begin_build` operation. */
 void

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -232,7 +232,8 @@ memtx_rtree_index_count(struct index *base, enum iterator_type type,
 
 static int
 memtx_rtree_index_get_internal(struct index *base, const char *key,
-			       uint32_t part_count, struct tuple **result)
+			       uint32_t part_count, struct tuple **result,
+			       bool is_rw)
 {
 	struct memtx_rtree_index *index = (struct memtx_rtree_index *)base;
 	struct rtree_iterator iterator;
@@ -254,7 +255,9 @@ memtx_rtree_index_get_internal(struct index *base, const char *key,
 			break;
 		struct txn *txn = in_txn();
 		struct space *space = space_by_id(base->def->space_id);
-		*result = memtx_tx_tuple_clarify(txn, space, tuple, base, 0);
+		*result = is_rw ?
+			memtx_tx_tuple_clarify_rw(txn, space, tuple, base, 0) :
+			memtx_tx_tuple_clarify(txn, space, tuple, base, 0);
 	} while (*result == NULL);
 	rtree_iterator_destroy(&iterator);
 	return 0;

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -411,7 +411,6 @@ static const struct index_vtab memtx_rtree_index_vtab_base = {
 	/* .max = */ generic_index_max,
 	/* .random = */ generic_index_random,
 	/* .count = */ memtx_rtree_index_count,
-	/* .get_internal = */ memtx_rtree_index_get_internal,
 	/* .get = */ memtx_index_get,
 	/* .create_iterator = */ memtx_rtree_index_create_iterator,
 	/* .create_iterator_with_offset = */
@@ -425,6 +424,7 @@ static const struct index_vtab memtx_rtree_index_vtab_base = {
 
 static const struct memtx_index_vtab memtx_rtree_index_vtab = {
 	/* .base = */ memtx_rtree_index_vtab_base,
+	/* .get_internal = */ memtx_rtree_index_get_internal,
 	/* .replace = */ memtx_rtree_index_replace,
 	/* .begin_build = */ generic_memtx_index_begin_build,
 	/* .reserve = */ memtx_rtree_index_reserve,

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -419,7 +419,7 @@ memtx_space_execute_delete(struct space *space, struct txn *txn,
 		return -1;
 	struct tuple *old_index_tuple;
 	if (memtx_index_get_internal(pk, key, part_count,
-				     &old_index_tuple) != 0)
+				     &old_index_tuple, /*is_rw=*/true) != 0)
 		return -1;
 	if (old_index_tuple == NULL) {
 		*result = NULL;
@@ -459,7 +459,7 @@ memtx_space_execute_update(struct space *space, struct txn *txn,
 		return -1;
 	struct tuple *old_index_tuple;
 	if (memtx_index_get_internal(pk, key, part_count,
-				     &old_index_tuple) != 0)
+				     &old_index_tuple, /*is_rw=*/true) != 0)
 		return -1;
 
 	if (old_index_tuple == NULL) {
@@ -552,7 +552,7 @@ memtx_space_execute_upsert(struct space *space, struct txn *txn,
 	/* Try to find the tuple by primary key. */
 	struct tuple *old_index_tuple;
 	int rc = memtx_index_get_internal(index, key, part_count,
-					  &old_index_tuple);
+					  &old_index_tuple, /*is_rw=*/true);
 	region_truncate(&fiber()->gc, region_svp);
 	if (rc != 0)
 		return -1;

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -418,7 +418,8 @@ memtx_space_execute_delete(struct space *space, struct txn *txn,
 	if (exact_key_validate(pk->def, key, part_count) != 0)
 		return -1;
 	struct tuple *old_index_tuple;
-	if (index_get_internal(pk, key, part_count, &old_index_tuple) != 0)
+	if (memtx_index_get_internal(pk, key, part_count,
+				     &old_index_tuple) != 0)
 		return -1;
 	if (old_index_tuple == NULL) {
 		*result = NULL;
@@ -457,7 +458,8 @@ memtx_space_execute_update(struct space *space, struct txn *txn,
 	if (exact_key_validate(pk->def, key, part_count) != 0)
 		return -1;
 	struct tuple *old_index_tuple;
-	if (index_get_internal(pk, key, part_count, &old_index_tuple) != 0)
+	if (memtx_index_get_internal(pk, key, part_count,
+				     &old_index_tuple) != 0)
 		return -1;
 
 	if (old_index_tuple == NULL) {
@@ -549,7 +551,8 @@ memtx_space_execute_upsert(struct space *space, struct txn *txn,
 
 	/* Try to find the tuple by primary key. */
 	struct tuple *old_index_tuple;
-	int rc = index_get_internal(index, key, part_count, &old_index_tuple);
+	int rc = memtx_index_get_internal(index, key, part_count,
+					  &old_index_tuple);
 	region_truncate(&fiber()->gc, region_svp);
 	if (rc != 0)
 		return -1;

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -47,6 +47,7 @@
 #include "memtx_space_upgrade.h"
 #include "memtx_tuple_compression.h"
 #include "memtx_sort_data.h"
+#include "memtx_index.h"
 #include "schema.h"
 #include "small/region.h"
 
@@ -167,7 +168,7 @@ memtx_space_replace_build_next(struct space *space, struct tuple *old_tuple,
 			return -1;
 
 		/* Start building the new space's PK. */
-		index_begin_build(space->index[0]);
+		memtx_index_begin_build(space->index[0]);
 
 		memtx->recovery.last_space_id = space->def->id;
 	}
@@ -199,7 +200,7 @@ memtx_space_replace_build_next(struct space *space, struct tuple *old_tuple,
 		return -1;
 
 	/* Add the tuple to the PK to be built. */
-	if (index_build_next(space->index[0], new_tuple) != 0)
+	if (memtx_index_build_next(space->index[0], new_tuple) != 0)
 		return -1;
 	memtx_space_update_tuple_stat(space, NULL, new_tuple);
 	tuple_ref(new_tuple);
@@ -217,8 +218,8 @@ memtx_space_replace_primary_key(struct space *space, struct tuple *old_tuple,
 				struct tuple **result)
 {
 	struct tuple *successor;
-	if (index_replace(space->index[0], old_tuple,
-			  new_tuple, mode, &old_tuple, &successor) != 0)
+	if (memtx_index_replace(space->index[0], old_tuple, new_tuple, mode,
+				&old_tuple, &successor) != 0)
 		return -1;
 	memtx_space_update_tuple_stat(space, old_tuple, new_tuple);
 	if (new_tuple != NULL)
@@ -957,15 +958,15 @@ sequence_data_index_new(struct memtx_engine *memtx, struct index_def *def)
 	if (index == NULL)
 		return NULL;
 
-	static struct index_vtab vtab;
+	static struct memtx_index_vtab vtab;
 	static bool vtab_initialized;
 	if (!vtab_initialized) {
-		vtab = *index->vtab;
-		vtab.create_read_view = sequence_data_read_view_create;
+		vtab = *(struct memtx_index_vtab *)index->vtab;
+		vtab.base.create_read_view = sequence_data_read_view_create;
 		vtab_initialized = true;
 	}
 
-	index->vtab = &vtab;
+	index->vtab = (struct index_vtab *)&vtab;
 	return index;
 }
 
@@ -1234,9 +1235,9 @@ memtx_build_on_replace_rollback(struct trigger *base, void *event)
 	 * Use DUP_REPLACE_OR_INSERT mode because if we tried to replace a tuple
 	 * with a duplicate at a unique index, this trigger would not be called.
 	 */
-	state->rc = index_replace(state->index, stmt->new_tuple,
-				  stmt->old_tuple, DUP_REPLACE_OR_INSERT,
-				  &delete, &successor);
+	state->rc = memtx_index_replace(state->index, stmt->new_tuple,
+					stmt->old_tuple, DUP_REPLACE_OR_INSERT,
+					&delete, &successor);
 	if (state->rc != 0) {
 		diag_move(diag_get(), &state->diag);
 		return 0;
@@ -1298,8 +1299,9 @@ memtx_build_on_replace(struct trigger *trigger, void *event)
 		state->index->def->opts.is_unique ? DUP_INSERT :
 						    DUP_REPLACE_OR_INSERT;
 	struct tuple *successor;
-	state->rc = index_replace(state->index, stmt->old_tuple,
-				  stmt->new_tuple, mode, &delete, &successor);
+	state->rc = memtx_index_replace(state->index, stmt->old_tuple,
+					stmt->new_tuple, mode, &delete,
+					&successor);
 	if (state->rc != 0) {
 		diag_move(diag_get(), &state->diag);
 		return 0;
@@ -1446,8 +1448,8 @@ memtx_space_build_index(struct space *src_space, struct index *new_index,
 		 */
 		struct tuple *old_tuple;
 		struct tuple *successor;
-		rc = index_replace(new_index, NULL, tuple,
-				   DUP_INSERT, &old_tuple, &successor);
+		rc = memtx_index_replace(new_index, NULL, tuple, DUP_INSERT,
+					 &old_tuple, &successor);
 		if (rc != 0)
 			break;
 		assert(old_tuple == NULL); /* Guaranteed by DUP_INSERT. */

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -2677,7 +2677,6 @@ static const struct index_vtab memtx_tree_disabled_index_vtab_base = {
 	/* .max = */ generic_index_max,
 	/* .random = */ generic_index_random,
 	/* .count = */ generic_index_count,
-	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ generic_index_get,
 	/* .create_iterator = */ generic_index_create_iterator,
 	/* .create_iterator_with_offset = */
@@ -2691,6 +2690,7 @@ static const struct index_vtab memtx_tree_disabled_index_vtab_base = {
 
 static const struct memtx_index_vtab memtx_tree_disabled_index_vtab = {
 	/* .base = */ memtx_tree_disabled_index_vtab_base,
+	/* .get_internal = */ generic_memtx_index_get_internal,
 	/* .replace = */ memtx_tree_disabled_index_replace,
 	/* .begin_build = */ generic_memtx_index_begin_build,
 	/* .reserve = */ generic_memtx_index_reserve,
@@ -2745,7 +2745,6 @@ get_memtx_tree_index_vtab(void)
 		/* .max = */ generic_index_max,
 		/* .random = */ memtx_tree_index_random<USE_HINT>,
 		/* .count = */ memtx_tree_index_count<USE_HINT>,
-		/* .get_internal */ memtx_tree_index_get_internal<USE_HINT>,
 		/* .get = */ memtx_index_get,
 		/* .create_iterator = */
 			memtx_tree_index_create_iterator<USE_HINT>,
@@ -2760,6 +2759,7 @@ get_memtx_tree_index_vtab(void)
 	};
 	static const struct memtx_index_vtab vtab = {
 		/* .base = */ vtab_base,
+		/* .get_internal = */ memtx_tree_index_get_internal<USE_HINT>,
 		/* .replace = */ is_mk ? memtx_tree_index_replace_multikey :
 				 is_func ? memtx_tree_func_index_replace :
 				 memtx_tree_index_replace<USE_HINT>,

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -1316,7 +1316,8 @@ memtx_tree_index_count(struct index *base, enum iterator_type type,
 template <bool USE_HINT>
 static int
 memtx_tree_index_get_internal(struct index *base, const char *key,
-			      uint32_t part_count, struct tuple **result)
+			      uint32_t part_count, struct tuple **result,
+			      bool is_rw)
 {
 	assert(base->def->opts.is_unique &&
 	       part_count == base->def->key_def->part_count);
@@ -1340,8 +1341,11 @@ memtx_tree_index_get_internal(struct index *base, const char *key,
 	}
 	bool is_multikey = base->def->key_def->is_multikey;
 	uint32_t mk_index = is_multikey ? (uint32_t)res->hint : 0;
-	*result = memtx_tx_tuple_clarify(txn, space, res->tuple, base,
-					 mk_index);
+	*result = is_rw ?
+		memtx_tx_tuple_clarify_rw(txn, space, res->tuple,
+					  base, mk_index) :
+		memtx_tx_tuple_clarify(txn, space, res->tuple,
+				       base, mk_index);
 	return 0;
 }
 

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -3311,13 +3311,14 @@ detect_whether_prepared_ok(struct txn *txn, struct space *space)
 struct tuple *
 memtx_tx_tuple_clarify_slow(struct txn *txn, struct space *space,
 			    struct tuple *tuple, struct index *index,
-			    uint32_t mk_index)
+			    uint32_t mk_index, bool force_read_prepared)
 {
 	if (!tuple_has_flag(tuple, TUPLE_IS_DIRTY)) {
 		memtx_tx_track_read(txn, space, tuple);
 		return tuple;
 	}
-	bool is_prepared_ok = detect_whether_prepared_ok(txn, space);
+	bool is_prepared_ok = force_read_prepared ||
+		detect_whether_prepared_ok(txn, space);
 	struct tuple *res =
 		memtx_tx_tuple_clarify_impl(txn, space, tuple, index, mk_index,
 					    is_prepared_ok);

--- a/src/box/memtx_tx.h
+++ b/src/box/memtx_tx.h
@@ -273,7 +273,7 @@ memtx_tx_history_commit_stmt(struct txn_stmt *stmt);
 struct tuple *
 memtx_tx_tuple_clarify_slow(struct txn *txn, struct space *space,
 			    struct tuple *tuples, struct index *index,
-			    uint32_t mk_index);
+			    uint32_t mk_index, bool force_read_prepared);
 
 /** Helper of memtx_tx_track_point */
 void
@@ -419,8 +419,7 @@ memtx_tx_track_full_scan(struct txn *txn, struct space *space,
  * @param space - space in which the tuple was found.
  * @param tuple - tuple to clean.
  * @param index - index in which the tuple was found.
- * @param mk_index - multikey index (iа the index is multikey).
- * @param is_prepared_ok - allow to return prepared tuples.
+ * @param mk_index - multikey index (if the index is multikey).
  * @return clean tuple (can be NULL).
  */
 static inline struct tuple *
@@ -430,7 +429,30 @@ memtx_tx_tuple_clarify(struct txn *txn, struct space *space,
 {
 	if (!memtx_tx_manager_use_mvcc_engine)
 		return tuple;
-	return memtx_tx_tuple_clarify_slow(txn, space, tuple, index, mk_index);
+	return memtx_tx_tuple_clarify_slow(txn, space, tuple, index, mk_index,
+					   /*force_read_prepared=*/false);
+}
+
+/**
+ * Same as the previous function, but for writing statements -
+ * regardless of the isolation level, it always sees prepared statements.
+ *
+ * @param txn - current transactions.
+ * @param space - space in which the tuple was found.
+ * @param tuple - tuple to clean.
+ * @param index - index in which the tuple was found.
+ * @param mk_index - multikey index (if the index is multikey).
+ * @return clean tuple (can be NULL).
+ */
+static inline struct tuple *
+memtx_tx_tuple_clarify_rw(struct txn *txn, struct space *space,
+			  struct tuple *tuple, struct index *index,
+			  uint32_t mk_index)
+{
+	if (!memtx_tx_manager_use_mvcc_engine)
+		return tuple;
+	return memtx_tx_tuple_clarify_slow(txn, space, tuple, index, mk_index,
+					   /*force_read_prepared=*/true);
 }
 
 /**

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -281,7 +281,6 @@ static const struct index_vtab session_settings_index_vtab = {
 	/* .count = */ generic_index_count,
 	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ session_settings_index_get,
-	/* .replace = */ generic_index_replace,
 	/* .create_iterator = */ session_settings_index_create_iterator,
 	/* .create_iterator_with_offset = */
 	generic_index_create_iterator_with_offset,
@@ -290,10 +289,6 @@ static const struct index_vtab session_settings_index_vtab = {
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,
 	/* .reset_stat = */ generic_index_reset_stat,
-	/* .begin_build = */ generic_index_begin_build,
-	/* .reserve = */ generic_index_reserve,
-	/* .build_next = */ generic_index_build_next,
-	/* .end_build = */ generic_index_end_build,
 };
 
 static void

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -279,7 +279,6 @@ static const struct index_vtab session_settings_index_vtab = {
 	/* .max = */ generic_index_max,
 	/* .random = */ generic_index_random,
 	/* .count = */ generic_index_count,
-	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ session_settings_index_get,
 	/* .create_iterator = */ session_settings_index_create_iterator,
 	/* .create_iterator_with_offset = */

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -206,7 +206,6 @@ static const struct index_vtab sysview_index_vtab = {
 	/* .count = */ generic_index_count,
 	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ sysview_index_get,
-	/* .replace = */ generic_index_replace,
 	/* .create_iterator = */ sysview_index_create_iterator,
 	/* .create_iterator_with_offset = */
 	generic_index_create_iterator_with_offset,
@@ -215,10 +214,6 @@ static const struct index_vtab sysview_index_vtab = {
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,
 	/* .reset_stat = */ generic_index_reset_stat,
-	/* .begin_build = */ generic_index_begin_build,
-	/* .reserve = */ generic_index_reserve,
-	/* .build_next = */ generic_index_build_next,
-	/* .end_build = */ generic_index_end_build,
 };
 
 static void

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -204,7 +204,6 @@ static const struct index_vtab sysview_index_vtab = {
 	/* .max = */ generic_index_max,
 	/* .random = */ generic_index_random,
 	/* .count = */ generic_index_count,
-	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ sysview_index_get,
 	/* .create_iterator = */ sysview_index_create_iterator,
 	/* .create_iterator_with_offset = */

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4848,7 +4848,6 @@ static const struct index_vtab vinyl_index_vtab = {
 	/* .max = */ generic_index_max,
 	/* .random = */ generic_index_random,
 	/* .count = */ generic_index_count,
-	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ vinyl_index_get,
 	/* .create_iterator = */ vinyl_index_create_iterator,
 	/* .create_iterator_with_offset = */

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4850,7 +4850,6 @@ static const struct index_vtab vinyl_index_vtab = {
 	/* .count = */ generic_index_count,
 	/* .get_internal = */ generic_index_get_internal,
 	/* .get = */ vinyl_index_get,
-	/* .replace = */ generic_index_replace,
 	/* .create_iterator = */ vinyl_index_create_iterator,
 	/* .create_iterator_with_offset = */
 	generic_index_create_iterator_with_offset,
@@ -4859,8 +4858,4 @@ static const struct index_vtab vinyl_index_vtab = {
 	/* .stat = */ vinyl_index_stat,
 	/* .compact = */ vinyl_index_compact,
 	/* .reset_stat = */ vinyl_index_reset_stat,
-	/* .begin_build = */ generic_index_begin_build,
-	/* .reserve = */ generic_index_reserve,
-	/* .build_next = */ generic_index_build_next,
-	/* .end_build = */ generic_index_end_build,
 };

--- a/test/box-luatest/gh_12260_memtx_mvcc_wrong_stmt_tuple_clarifying_test.lua
+++ b/test/box-luatest/gh_12260_memtx_mvcc_wrong_stmt_tuple_clarifying_test.lua
@@ -1,0 +1,80 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group('gh-12260-memtx-mvcc-wrong-stmt-tuple-clarifying')
+
+g.before_all(function()
+    t.tarantool.skip_if_not_debug()
+    g.server = server:new({
+        box_cfg = {
+            memtx_use_mvcc_engine = true,
+            txn_isolation = 'read-confirmed',
+        },
+    })
+    g.server:start()
+
+    g.server:exec(function()
+        box.schema.space.create('test')
+        box.space.test:create_index('pk')
+    end)
+end)
+
+g.after_each(function()
+    g.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        box.space.test:truncate()
+    end)
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+local cases = {
+    {
+        name = 'delete',
+        stmt = 'box.space.test:delete{1}',
+        result = {},
+    },
+    {
+        name = 'update',
+        stmt = "box.space.test:update({1}, {{'=', 2, 3}})",
+        result = {{1, 3}},
+    },
+}
+
+for _, case in ipairs(cases) do
+    g['test_wrong_' .. case.name .. '_tuple_clarifying'] = function()
+        g.server:exec(function(stmt, result)
+            local fiber = require('fiber')
+
+            box.space.test:insert{1, 1}
+
+            box.error.injection.set('ERRINJ_WAL_DELAY', true)
+            local f1 = fiber.create(function()
+                return box.space.test:replace{1, 2}
+            end)
+            f1:set_joinable(true)
+
+            local cond = fiber.cond()
+            local f2 = fiber.create(function()
+                box.begin()
+                loadstring(stmt)()
+                cond:wait()
+                box.commit()
+            end)
+            f2:set_joinable(true)
+
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+            t.assert_equals(f1:join(), true)
+
+            cond:signal()
+            t.assert_equals(f2:join(), true)
+            -- f2 must be serialized after f1, so here select must see the
+            -- tuple {1, 2} updated by f1 (nil in case of DELETE, {1, 3} in
+            -- case of UPDATE). If f2 had been serialized before f1, the
+            -- select would have returned {1, 2}.
+            t.assert_equals(box.space.test:select{}, result)
+        end, {case.stmt, case.result})
+    end
+end


### PR DESCRIPTION
*(This PR is a backport of #12607 to `release/3.6` to a future `3.6.4` release.)*

----

DELETE, UPDATE, and UPSERT need to see prepared, but unconfirmed tuples while building a statement, otherwise they may clarify a wrong tuple under read-confirmed isolation. Split point lookup paths so write
statements use prepared-visible lookup, while read-only lookups keep normal read visibility.

Closes https://github.com/tarantool/tarantool/issues/12260

NO_DOC=bugfix