### PR TITLE
box: fix crash on box.snapshot during box.cfg

### DIFF
--- a/changelogs/unreleased/gh-12879-box-snapshot-crash-on-unconfigured.md
+++ b/changelogs/unreleased/gh-12879-box-snapshot-crash-on-unconfigured.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed a crash on calling `box.snapshot()` during initial database
+  configuration. Now it raises the `ER_UNCONFIGURED` error in such case
+  (gh-12879).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -5987,7 +5987,8 @@ box_cfg(void)
 int
 box_checkpoint(void)
 {
-	assert(is_box_configured);
+	if (box_check_configured() != 0)
+		return -1;
 	return gc_checkpoint();
 }
 

--- a/test/box-luatest/gh_12879_box_snapshot_unconfigured_test.lua
+++ b/test/box-luatest/gh_12879_box_snapshot_unconfigured_test.lua
@@ -1,0 +1,30 @@
+local t = require('luatest')
+local treegen = require('luatest.treegen')
+local justrun = require('luatest.justrun')
+
+local g = t.group()
+
+g.test_snapshot_before_box_cfg = function()
+    t.assert_error_msg_equals('Please call box.cfg{} first',
+                              -- The box.snapshot function object itself is
+                              -- guarded by a metatable on box, so we have to
+                              -- access it through a pcall-protected
+                              -- `function() ... end`.
+                              function() box.snapshot() end)
+end
+
+g.test_snapshot_during_box_cfg = function()
+    local dir = treegen.prepare_directory({}, {})
+    treegen.write_file(dir, 'main.lua', [[
+        local t = require('luatest')
+        local fiber = require('fiber')
+        fiber.create(function() box.cfg{} end)
+        t.assert_error_msg_equals('Please call box.cfg{} first',
+                                  box.snapshot)
+        box.ctl.wait_rw()
+        os.exit(0)
+    ]])
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
+    t.assert_equals(res.exit_code, 0, {res.stdout, res.stderr})
+end


### PR DESCRIPTION
box: fix crash on box.snapshot during box.cfg

load_cfg.lua sets a metatable on box table, which throws an
ER_UNCONFIGURED error on access to guarded members, including
box.snapshot(). But the metatable is reset right on load_cfg() call,
even before the C-side box_cfg_xc() gets called. So during the whole
execution time of box_cfg_xc() box.snapshot() is callable and unguarded.

Calling box.snapshot() from cfg-triggered Lua code (on_schema_init,
recovery triggers, on_recovery_state) or simply from a separate fiber
during one of box.cfg() yields leads to a crash in gc_checkpoint() due
to an uninitialized checkpoint callback.

Replace the debug-only assert with a proper box_check_configured().

Closes #12879
NO_DOC=bugfix