### PR TITLE
box: fix wal_sync crash when box is not configured

### DIFF
--- a/changelogs/unreleased/gh-12556-wal-sync-before-cfg.md
+++ b/changelogs/unreleased/gh-12556-wal-sync-before-cfg.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a crash on calling `box.ctl.wal_sync()` before `box.cfg{}`.
+  Now it raises an `ER_UNCONFIGURED` error in this case (gh-12556).

--- a/src/box/lua/ctl.c
+++ b/src/box/lua/ctl.c
@@ -196,6 +196,8 @@ lbox_ctl_set_iproto_lockdown(struct lua_State *L)
 static int
 lbox_ctl_wal_sync(struct lua_State *L)
 {
+	if (box_check_configured() != 0)
+		return luaT_error(L);
 	if (journal_sync(NULL))
 		return luaT_error(L);
 	return 0;

--- a/test/box-luatest/gh_12556_wal_sync_before_cfg_test.lua
+++ b/test/box-luatest/gh_12556_wal_sync_before_cfg_test.lua
@@ -1,0 +1,37 @@
+local t = require('luatest')
+local treegen = require('luatest.treegen')
+local justrun = require('luatest.justrun')
+
+local g = t.group()
+
+g.test_wal_sync_before_cfg = function()
+    t.assert_error_msg_equals(
+        'Please call box.cfg{} first',
+        box.ctl.wal_sync
+    )
+end
+
+g.test_wal_sync_during_cfg = function()
+    local dir = treegen.prepare_directory({}, {})
+
+    treegen.write_file(dir, 'main.lua', [[
+        local t = require('luatest')
+        local fiber = require('fiber')
+
+        fiber.create(function()
+            box.cfg{}
+        end)
+
+        t.assert_error_msg_equals(
+            'Please call box.cfg{} first',
+            box.ctl.wal_sync
+        )
+
+        box.ctl.wait_rw()
+        os.exit(0)
+    ]])
+
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, {}, {'main.lua'}, opts)
+    t.assert_equals(res.exit_code, 0, {res.stdout, res.stderr})
+end


### PR DESCRIPTION
Calling box.ctl.wal_sync() before box.cfg{} caused a segfault because the WAL journal was not initialized yet (NULL pointer).

Add a check so it returns a proper error instead of crashing.

Closes #12556

NO_DOC=bugfix