### PR TITLE
config: report WAL_IO reload commit failure in credentials apply

### DIFF
--- a/changelogs/unreleased/gh-10359-config-wal-io-reload-commit-failure.md
+++ b/changelogs/unreleased/gh-10359-config-wal-io-reload-commit-failure.md
@@ -1,0 +1,4 @@
+## bugfix/config
+
+* Fixed credentials error reporting by adding the pending operation to WAL write
+  failure messages (gh-10359).

--- a/src/box/lua/config/applier/credentials.lua
+++ b/src/box/lua/config/applier/credentials.lua
@@ -477,6 +477,19 @@ end
 -- }}} Triggers for grants after obj creation
 
 -- {{{ Main sync logic
+local actions_applied = {}
+
+local function record_txn_action(action)
+    table.insert(actions_applied, action)
+end
+
+local function get_txn_actions_str()
+    return table.concat(actions_applied, ', ')
+end
+
+local function clear_txn_actions()
+    actions_applied = {}
+end
 
 -- Grant or revoke some user/role privileges for an object.
 local privileges_action_f = function(grant_or_revoke, role_or_user, name, privs,
@@ -491,9 +504,11 @@ local privileges_action_f = function(grant_or_revoke, role_or_user, name, privs,
                           {_origin = CONFIG_ORIGIN})
 
     if ok then
-        log.verbose('credentials.apply: box.schema.%s.%s(%q, %q, %q, %q)',
-                    role_or_user, grant_or_revoke, name, privs,
+        local action = ('box.schema.%s.%s(%q, %q, %q, %q)')
+            :format(role_or_user, grant_or_revoke, name, privs,
                     obj_type, obj_name)
+        log.verbose('credentials.apply: ' .. action)
+        record_txn_action(action)
         return
     end
     if err.code ~= box.error.NO_SUCH_SPACE and
@@ -690,6 +705,7 @@ local function create_role(role_name)
     else
         log.verbose('credentials.apply: create role %q', role_name)
         box.schema.role.create(role_name, {_origin = CONFIG_ORIGIN})
+        record_txn_action(('box.schema.role.create(%q)'):format(role_name))
     end
 end
 
@@ -711,6 +727,7 @@ local function create_user(user_name)
     else
         log.verbose('credentials.apply: create user %q', user_name)
         box.schema.user.create(user_name, {_origin = CONFIG_ORIGIN})
+        record_txn_action(('box.schema.user.create(%q)'):format(user_name))
     end
 end
 
@@ -731,6 +748,8 @@ local function set_password(user_name, password)
         end
 
         log.verbose('credentials.apply: remove password for user %q', user_name)
+        record_txn_action(('box.schema.user.passwd(%q, nil)')
+            :format(user_name))
         -- No password is set, so remove it for the user.
         -- There is no handy function for it, so remove it directly in
         -- system space _user. Users are described in the following way:
@@ -758,6 +777,8 @@ local function set_password(user_name, password)
         -- No password is currently set for the user, just set a new one.
         log.verbose('credentials.apply: set a password for user %q', user_name)
         box.schema.user.passwd(user_name, password)
+        record_txn_action(('box.schema.user.passwd(%q)')
+            :format(user_name))
         return
     end
 
@@ -796,11 +817,15 @@ local function set_password(user_name, password)
             log.verbose('credentials.apply: a password for user %q has ' ..
                         'different auth_type, resetting it', user_name)
             box.schema.user.passwd(user_name, password)
+            record_txn_action(('box.schema.user.passwd(%q)')
+                :format(user_name))
         end
     else
         log.verbose('credentials.apply: set a password for user %q',
                     user_name)
         box.schema.user.passwd(user_name, password)
+        record_txn_action(('box.schema.user.passwd(%q)')
+            :format(user_name))
     end
 
 end
@@ -837,6 +862,7 @@ local function drop_users_not_in_config(user_map)
     for _, name in ipairs(to_drop) do
         log.verbose('credentials.apply: drop user %q', name)
         box.schema.user.drop(name, {_origin = CONFIG_ORIGIN})
+        record_txn_action(('box.schema.user.drop(%q)'):format(name))
     end
 end
 
@@ -854,6 +880,7 @@ local function drop_roles_not_in_config(role_map)
     for _, name in ipairs(to_drop) do
         log.verbose('credentials.apply: drop role %q', name)
         box.schema.role.drop(name, {_origin = CONFIG_ORIGIN})
+        record_txn_action(('box.schema.role.drop(%q)'):format(name))
     end
 end
 
@@ -934,6 +961,30 @@ end
 -- of main fiber in case of 'BLOCKING_FULL_SYNC'.
 local wait_sync
 
+local function credentials_atomic(func, ...)
+    local func_called = false
+    clear_txn_actions()
+
+    local ok, err = pcall(box.atomic, function(...)
+        func(...)
+        func_called = true
+    end, ...)
+
+    if ok then
+        return
+    end
+
+    if func_called and #actions_applied > 0 then
+        local msg = 'credentials.apply: failed to commit credentials ' ..
+                    'transaction with pending operation(s): %s'
+        local actions = get_txn_actions_str()
+        local e = box.error.new(box.error.PROC_LUA, msg:format(actions))
+        e:set_prev(err)
+        error(e, 0)
+    end
+    error(err, 0)
+end
+
 local function sync_object(obj_to_sync)
     if obj_to_sync.type == 'BLOCKING_FULL_SYNC' or
         obj_to_sync.type == 'BACKGROUND_FULL_SYNC' then
@@ -962,7 +1013,7 @@ local function sync_object(obj_to_sync)
         register_objects(credentials.roles)
         register_objects(credentials.users)
 
-        box.atomic(function()
+        credentials_atomic(function()
             drop_roles_not_in_config(credentials.roles)
             drop_users_not_in_config(credentials.users)
             create_roles(credentials.roles)
@@ -974,7 +1025,7 @@ local function sync_object(obj_to_sync)
     else
         local credentials = get_credentials(config)
 
-        box.atomic(sync_privileges, credentials, obj_to_sync)
+        credentials_atomic(sync_privileges, credentials, obj_to_sync)
     end
     refresh_unmanaged_subjects_alert()
 end

--- a/test/config-luatest/gh_10359_credentials_reload_wal_injection_test.lua
+++ b/test/config-luatest/gh_10359_credentials_reload_wal_injection_test.lua
@@ -1,0 +1,313 @@
+local t = require('luatest')
+local treegen = require('luatest.treegen')
+local yaml = require('yaml')
+local server = require('luatest.server')
+
+local g_reload = t.group('reload')
+
+local errinj_role = [[
+    return {
+        validate = function(_cfg)
+            -- No-op.
+        end,
+        apply = function(_cfg)
+            box.error.injection.set('ERRINJ_WAL_IO', true)
+        end,
+        stop = function()
+            box.error.injection.set('ERRINJ_WAL_IO', false)
+        end,
+    }
+]]
+
+local base_config = {
+    credentials = {
+        users = {
+            guest = {
+                roles = {'super'},
+            },
+            user_to_drop = {
+                roles = {'super'},
+                password = 'secret',
+                privileges = {{
+                    permissions = {'read'},
+                    universe = true,
+                }}
+            },
+            user_with_space_priv = {
+                privileges = {{
+                    permissions = {'read'},
+                    spaces = {'_space'},
+                }}
+            },
+            user_with_role_to_drop = {
+                roles = {'role_granted_to_drop'},
+            },
+            myuser = {}
+        },
+        roles = {
+            role_to_drop = {},
+            role_granted_to_drop = {},
+        }
+    },
+    roles = {'errinj'},
+    iproto = {
+        listen = {{uri = 'unix/:./{{ instance_name }}.iproto'}},
+    },
+    groups = {
+        ['group-001'] = {
+            replicasets = {
+                ['replicaset-001'] = {
+                    instances = {
+                        ['instance-001'] = {},
+                    },
+                },
+            },
+        },
+    },
+}
+
+local function write_config(g, new_config)
+    return treegen.write_file(g.cfg_dir, 'config.yaml',
+                              yaml.encode(new_config))
+end
+
+g_reload.before_all(function(g)
+    t.tarantool.skip_if_not_debug()
+
+    g.cfg_dir = treegen.prepare_directory({}, {})
+    treegen.write_file(g.cfg_dir, 'errinj.lua', errinj_role)
+    local config_file = write_config(g, base_config)
+
+    g.server = server:new({
+        config_file = config_file,
+        chdir = g.cfg_dir,
+        alias = 'instance-001',
+    })
+    g.server:start()
+end)
+
+g_reload.after_all(function(g)
+    if g.server ~= nil then
+        g.server:drop()
+        g.server = nil
+    end
+end)
+
+-- The message of the ClientError raised by the WAL_IO error injection.
+local wal_io_err_msg = 'Failed to write to disk'
+
+local function commit_failure_msg(exp_operation)
+    return 'credentials.apply: failed to commit credentials ' ..
+        'transaction with pending operation(s): ' .. exp_operation
+end
+
+local function reload_with_wal_io_error(g, config_for_reload, exp_operation)
+    write_config(g, config_for_reload)
+
+    local exp_err = commit_failure_msg(exp_operation)
+
+    t.assert_error_msg_contains(exp_err, g.server.exec, g.server, function()
+        require('config'):reload()
+    end)
+
+    g.server:exec(function(exp_err, exp_cause)
+        local info = require('config'):info()
+        t.assert_equals(info.status, 'check_errors')
+        local found = false
+        for _, alert in ipairs(info.alerts) do
+            local message = tostring(alert.message)
+            if message:find(exp_err, 1, true) ~= nil then
+                found = true
+                -- The original WAL error must be chained as the cause, so
+                -- that it's not lost even though it's not a part of the
+                -- top-level error message.
+                t.assert(box.error.is(alert.message))
+                t.assert_is_not(alert.message.prev, nil)
+                t.assert_equals(alert.message.prev.message, exp_cause)
+            end
+        end
+        t.assert(found)
+    end, {exp_err, wal_io_err_msg})
+end
+
+g_reload.test_create_drop_user_error_context = function(g)
+    -- Add a user that is absent from the applied base config.
+    local config = table.deepcopy(base_config)
+    config.credentials.users.user_to_create = {}
+
+    reload_with_wal_io_error(g, config,
+                             'box.schema.user.create("user_to_create")')
+
+    -- Remove a config-managed user present in the applied base config.
+    config = table.deepcopy(base_config)
+    config.credentials.users.user_to_drop = nil
+
+    reload_with_wal_io_error(g, config,
+                             'box.schema.user.drop("user_to_drop")')
+end
+
+g_reload.test_create_drop_role_error_context = function(g)
+    -- Add a role that is absent from the applied base config.
+    local config = table.deepcopy(base_config)
+    config.credentials.roles.role_to_create = {}
+
+    reload_with_wal_io_error(g, config,
+                             'box.schema.role.create("role_to_create")')
+
+    -- Remove a config-managed role present in the applied base config.
+    config = table.deepcopy(base_config)
+    config.credentials.roles.role_to_drop = nil
+
+    reload_with_wal_io_error(g, config,
+                             'box.schema.role.drop("role_to_drop")')
+end
+
+g_reload.test_set_remove_password_error_context = function(g)
+    -- Change an existing user's password.
+    local config = table.deepcopy(base_config)
+    config.credentials.users.user_to_drop.password = 'new_pass'
+
+    reload_with_wal_io_error(g, config,
+                             'box.schema.user.passwd("user_to_drop")')
+
+    -- Remove an existing user's password.
+    config = table.deepcopy(base_config)
+    config.credentials.users.user_to_drop.password = nil
+
+    reload_with_wal_io_error(g, config,
+                             'box.schema.user.passwd("user_to_drop", nil)')
+end
+
+g_reload.test_grant_revoke_role_error_context = function(g)
+    -- Grant a configured role to an existing user.
+    local config = table.deepcopy(base_config)
+    config.credentials.users.myuser = {
+        roles = {'role_to_drop'},
+    }
+
+    reload_with_wal_io_error(g, config,
+        'box.schema.user.grant("myuser", "execute", "role", "role_to_drop")')
+
+    -- Revoke a configured role from an existing user.
+    config = table.deepcopy(base_config)
+    config.credentials.users.user_to_drop.roles = {}
+
+    reload_with_wal_io_error(g, config,
+        'box.schema.user.revoke("user_to_drop", "execute", "role", "super")')
+end
+
+g_reload.test_grant_revoke_privilege_error_context = function(g)
+    -- Grant a universe privilege to an existing user.
+    local config = table.deepcopy(base_config)
+    config.credentials.users.myuser = {
+        privileges = {{
+            permissions = {'read'},
+            universe = true,
+        }},
+    }
+
+    reload_with_wal_io_error(g, config,
+        'box.schema.user.grant("myuser", "read", "universe", "")')
+
+    -- Revoke a universe privilege from an existing user.
+    config = table.deepcopy(base_config)
+    config.credentials.users.user_to_drop.privileges = nil
+
+    reload_with_wal_io_error(g, config,
+        'box.schema.user.revoke("user_to_drop", "read", "universe", "")')
+end
+
+g_reload.test_revoke_space_privilege_error_context = function(g)
+    local config = table.deepcopy(base_config)
+    config.credentials.users.user_with_space_priv.privileges = nil
+
+    reload_with_wal_io_error(g, config,
+        'box.schema.user.revoke("user_with_space_priv", "read", "space", ' ..
+        '"_space")')
+end
+
+g_reload.test_drop_role_revoke_role_grant_error_context = function(g)
+    local config = table.deepcopy(base_config)
+    config.credentials.users.user_with_role_to_drop.roles = {}
+    config.credentials.roles.role_granted_to_drop = nil
+
+    reload_with_wal_io_error(g, config,
+        'box.schema.role.drop("role_granted_to_drop")')
+end
+
+-- Async per-object sync: late object creation applies a pending grant in the
+-- background; WAL failures are logged (not raised or alerted).
+local g_delayed = t.group('delayed')
+
+g_delayed.before_all(function(g)
+    t.tarantool.skip_if_not_debug()
+
+    g.cfg_dir = treegen.prepare_directory({}, {})
+
+    local config = table.deepcopy(base_config)
+    config.roles = nil
+    config.credentials.users.myuser = {
+        privileges = {{
+            permissions = {'read'},
+            spaces = {'late_space'},
+        }, {
+            permissions = {'execute'},
+            functions = {'late_func'},
+        }},
+    }
+    local config_file = write_config(g, config)
+
+    g.server = server:new({
+        config_file = config_file,
+        chdir = g.cfg_dir,
+        alias = 'instance-001',
+    })
+    g.server:start()
+end)
+
+g_delayed.after_all(function(g)
+    if g.server ~= nil then
+        g.server:drop()
+        g.server = nil
+    end
+end)
+
+g_delayed.after_each(function(g)
+    g.server:exec(function()
+        box.error.injection.set('ERRINJ_WAL_IO', false)
+    end)
+end)
+
+-- Create the object and enable the WAL error injection on its commit, so that
+-- the following pending grant transaction fails to write to disk.
+local function create_object_with_wal_io_error(g, create_fn, exp_operation)
+    g.server:exec(function(create_fn)
+        box.begin()
+        box.on_commit(function()
+            box.error.injection.set('ERRINJ_WAL_IO', true)
+        end)
+        loadstring(create_fn)()
+        box.commit()
+    end, {create_fn})
+
+    local exp_err = commit_failure_msg(exp_operation)
+
+    local exp_pattern = exp_err:gsub('[%(%)%.%%%+%-%*%?%[%]%^%$]', '%%%1')
+
+    t.helpers.retrying({timeout = 5}, function()
+        t.assert(g.server:grep_log(exp_pattern),
+                 'Expected error in log: ' .. exp_err)
+    end)
+end
+
+g_delayed.test_grant_space_privilege_on_create_error_context = function(g)
+    create_object_with_wal_io_error(g,
+        'box.schema.space.create("late_space")',
+        'box.schema.user.grant("myuser", "read", "space", "late_space")')
+end
+
+g_delayed.test_grant_function_privilege_on_create_error_context = function(g)
+    create_object_with_wal_io_error(g,
+        'box.schema.func.create("late_func")',
+        'box.schema.user.grant("myuser", "execute", "function", "late_func")')
+end


### PR DESCRIPTION
Add credentials_atomic() to detect WAL commit failures during reload. 
Report a clear error when changes were applied but commit failed. 
Cover the WAL_IO injection scenario with a new config-luatest. 

Closes #10359

NO_DOC=internal reload error handling; tests only 
NO_CHANGELOG=no user-visible change