### PR TITLE
popen: reject a run with no command

### DIFF
--- a/changelogs/unreleased/gh-4913-popen-reject-no-command.md
+++ b/changelogs/unreleased/gh-4913-popen-reject-no-command.md
@@ -1,0 +1,4 @@
+## bugfix/lua/popen
+
+* `popen.new({})` now fails instantly and reports an appropriate error
+  (gh-4913).

--- a/src/lib/core/popen.c
+++ b/src/lib/core/popen.c
@@ -195,6 +195,18 @@ handle_new(struct popen_opts *opts)
 		return NULL;
 	}
 
+	/*
+	 * Reject empty argv earlier (it has no sense to run
+	 * anyway).
+	 *
+	 * This way we don't have to take this case into account
+	 * in size/pointer calculations below.
+	 */
+	if (opts->argv[0] == NULL) {
+		diag_set(IllegalParams, "popen: no command to run");
+		return NULL;
+	}
+
 	for (i = 0; i < opts->nr_argv; i++) {
 		if (opts->argv[i] == NULL)
 			continue;

--- a/test/app-luatest/popen_test.lua
+++ b/test/app-luatest/popen_test.lua
@@ -103,3 +103,12 @@ g.test_popen_is_closed = function()
     }
     t.assert_error_covers(exp_err, ph.info, ph)
 end
+
+-- popen.new({}) fails with a proper diagnostic (gh-4913).
+g.test_new_no_command = function()
+    local exp_err = {
+        type = 'IllegalParams',
+        message = 'popen: no command to run',
+    }
+    t.assert_error_covers(exp_err, popen.new, {})
+end

--- a/test/app-tap/popen.test.lua
+++ b/test/app-tap/popen.test.lua
@@ -430,8 +430,8 @@ local function test_new_invalid_args(test)
         [{false}]                            = argerr('argv', 'boolean'),
         [{0}]                                = argerr('argv', 'number'),
         [{''}]                               = argerr('argv', 'string'),
-        -- FIXME: A table is ok, but not an empty one.
-        [{{}}]                               = nil,
+        -- A table is ok, but not an empty one.
+        [{{}}]                               = 'popen: no command to run',
         [{popen.shell}]                      = argerr('argv', 'function'),
         [{io.stdin}]                         = argerr('argv', 'userdata'),
         [{coroutine.create(function() end)}] = argerr('argv', 'thread'),


### PR DESCRIPTION
`popen.new({})` has no program to run, so there is no sense to accept such an input. This commit forbids it with a clear `IllegalParams` diagnostics.

The motivation is described in the linked issue. In short, if we allow it, we have to handle uninitialized read in `<popen handle>.command`. But there is no much sense to complicate the code, since this input is anyway broken. Let's explicitly forbid it instead.

Fixes #4913