### PR TITLE
popen: quote empty arguments in .command

### DIFF
--- a/changelogs/unreleased/gh-4914-popen-quote-empty-args.md
+++ b/changelogs/unreleased/gh-4914-popen-quote-empty-args.md
@@ -1,0 +1,4 @@
+## bugfix/lua/popen
+
+* Quote empty arguments in `<popen handle>.command` so they are visible in the
+  rendered command string (gh-4914).

--- a/src/lib/core/popen.c
+++ b/src/lib/core/popen.c
@@ -221,12 +221,15 @@ handle_new(struct popen_opts *opts)
 	for (i = 0; i < opts->nr_argv-1; i++) {
 		if (opts->argv[i] == NULL)
 			continue;
+		size_t len = strlen(opts->argv[i]);
 		bool is_multiword = strchr(opts->argv[i], ' ') != NULL;
-		if (is_multiword)
+		/* Quote empty and multiword arguments. */
+		bool use_quotes = len == 0 || is_multiword;
+		if (use_quotes)
 			*pos++ = '\'';
 		strlcpy(pos, opts->argv[i], pos_max - pos);
-		pos += strlen(opts->argv[i]);
-		if (is_multiword)
+		pos += len;
+		if (use_quotes)
 			*pos++ = '\'';
 		*pos++ = ' ';
 	}

--- a/test/app-luatest/popen_test.lua
+++ b/test/app-luatest/popen_test.lua
@@ -112,3 +112,34 @@ g.test_new_no_command = function()
     }
     t.assert_error_covers(exp_err, popen.new, {})
 end
+
+-- gh-4914: popen's .command must quote empty arguments, not just
+-- multiword ones, so that they stay visible in the rendered
+-- command line.
+g.test_command_quote_empty_args = function()
+    local cases = {
+        -- Empty arguments are quoted.
+        {
+            argv = {'/usr/bin/printf', '%s', ''},
+            exp_command = "/usr/bin/printf %s ''",
+        },
+        -- Non-empty single-word arguments stay unquoted.
+        {
+            argv = {'/usr/bin/printf', '%s', 'foo'},
+            exp_command = '/usr/bin/printf %s foo',
+        },
+        -- Multiword arguments are still quoted.
+        {
+            argv = {'/usr/bin/printf', '%s', 'a b'},
+            exp_command = "/usr/bin/printf %s 'a b'",
+        },
+    }
+
+    for _, case in ipairs(cases) do
+        local ph = popen.new(case.argv, {
+            stdout = popen.opts.DEVNULL,
+            stderr = popen.opts.DEVNULL,
+        })
+        t.assert_equals(ph.command, case.exp_command)
+    end
+end


### PR DESCRIPTION
A `<popen handle>.command` field renders the argument list as a shell-like command line. It quoted multiword arguments (those with a space) so they read as a single token, but left empty arguments unquoted, rendering them as nothing. Let's quote empty arguments too.

Fixes #4914