### PR TITLE
doc: fix minor nits around agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,11 +87,19 @@ depending on what is being tested. The most widely used ones are listed below.
   `test/unit/`. They are fast, simple, and offer very low-level access to
   internals of Tarantool.
 
-- Lua Diff tests. These are legacy tests, their files all end with `.test.lua`.
-  Code in such Lua files is executed like in an interactive console, the correct
-  output is saved into `.result` files, and on each run the actual output is
-  compared to the `.result` file. They must match. New tests do not use this
-  method anymore.
+- Lua Diff tests. These are legacy tests, their files all end with `.test.lua`
+  or `.test.py`, test suite's `suite.ini` file has `core = tarantool`. Code in
+  such Lua and Python files is executed like in an interactive console, the
+  correct output is saved into `.result` files, and on each run the actual
+  output is compared to the `.result` file. They must match. New tests do not
+  use this method anymore.
+
+- Lua App tests. These are legacy tests, their files all end with `.test.lua`,
+  test suite's `suite.ini` file has `core = app`, located in `test/*-tap`
+  folders. The test file is passed as the script argument to tarantool's
+  command line. The result usually TAP13 compliant and doesn't require a
+  `.result` file, however, if it exists, test-run compares against it. New
+  tests do not use this method anymore.
 
 - Lua Luatest tests. These are the majority of all tests. They all end with
   `_test.lua`, and are usually located in folders `test/*-luatest`, grouped by

--- a/doc/agents/setup-dev.md
+++ b/doc/agents/setup-dev.md
@@ -4,8 +4,9 @@ The document explains how to set up Tarantool's sources for development: coding,
 building, running tests, installing or finding dependencies.
 
 The setup is very individual: some people prefer building in the sources, some
-make a `build/` folder, some usually compile in Debug while others in Release,
-some will run tests using raw `luatest`, others would use `test-run.py`.
+make a `build/` folder, some usually compile in Debug while others in
+RelWithDebInfo, some will run tests using raw `luatest`, others would use
+`test-run.py`.
 
 The user must be questioned about their local setup, their preferences, their
 ways of development.
@@ -21,14 +22,14 @@ the sources in there. Having all the artifacts in one folder allows to delete it
 easily if something goes wrong.
 
 The supported CMake options are all the usual ones, like
-`-DCMAKE_BUILD_TYPE=Debug` or `=Release`.
+`-DCMAKE_BUILD_TYPE=Debug` or `=RelWithDebInfo`.
 
 Once cmake is configured, you must avoid reconfiguration when possible, because
 it is expensive.
 
 Tarantool has external dependencies - for example, it needs a compiler at the
-very least. Also many other libraries like `libicu`, `libcurl`, and more. Their
-installation is very individual. Developers are using various Linux
+very least. Also many other libraries like `libicu`, `libreadline`, and more.
+Their installation is very individual. Developers are using various Linux
 distributions with different package managers. There is no one standard way of
 installing everything.
 
@@ -42,15 +43,16 @@ An example of usage is:
 python3 test-run.py --var <artifacts_dir> --builddir <build_dir> <param_i>...
 ```
 
-The `--var` argument is optional. But it might be convenient to control, if you
-want to see and analyze the artifacts in specific easily reachable location. It
-can also help to reduce the path length to the artifacts, which can be important
-because the servers in the tests will use Unix sockets. Their path is limited by
-approximately 128 chars.
+The `--var` argument is optional (unless several test-run invocations are
+working in parallel). But it might be convenient to control, if you want to see
+and analyze the artifacts in specific easily reachable location. It can also
+help to reduce the path length to the artifacts, which can be important because
+the servers in the tests will use Unix sockets. Their absolute path is limited
+by approximately 107 chars on Linux and 103 chars on Mac OS.
 
-The `--builddir` is optional, but it is necessary in practically all cases. It
-points to the directory where Tarantool sources were cmake-configured and
-compiled (from the **Build** step, for example).
+The `--builddir` is optional, but it is necessary in case of the out-of-source
+build. It points to the directory where Tarantool sources were cmake-configured
+and compiled (from the **Build** step, for example).
 
 The `<param_i>...` is what the test runner will be looking for in the folder and
 file names recursively in `./test`, and will run all the tests whose path


### PR DESCRIPTION
I've looked over agent documents and have minor corrections. The list is below.

A couple of corrections around test types:

* Clarified that diff based tests may be written using Python.
* Added `app` test type (missed in the original description).
* Mention `suite.ini` and its `core` property to give a formal way to differentiate test types.

Regarding building:

* Replaced `Release` with `RelWithDebInfo`, because the latter is the real production build that shipped in our packages. `Release` (without debug info) shouldn't be used, because `fiber.info` stacktraces are incomplete without the debug info (and splitdebug doesn't work here). Maybe there are other reasons (LuaJIT's stack unwinding?).
* Replaced `libcurl` as a build/runtime dependency with `libreadline`, because `libcurl` is bundled by default.

Redarding executing tests:

* Clarified that `--var` test-run's option is only optional if only one test-run's process works at the moment. Parallel ones need separate var directories.
* Clarified Unix socket path length statement: certain 107/103 symbols limit, path -> absolute path.
* `--builddir` is almost never needed if the in-source build is used, so replaced 'practically all cases' with 'in case of the out-of-source build'.