### PR TITLE
test/fuzz: add missed fuzzing test for xrow

### DIFF
--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -128,8 +128,11 @@ mp_decode_vclock(const char **data, struct vclock *vclock)
 		int64_t lsn = mp_decode_uint(data);
 		if (lsn < 0 || id >= VCLOCK_MAX)
 			return -1;
-		if (lsn > 0)
+		if (lsn > 0) {
+			if (lsn <= vclock_get(vclock, id))
+				return -1;
 			vclock_follow(vclock, id, lsn);
+		}
 	}
 	return 0;
 }
@@ -2078,11 +2081,14 @@ mp_decode_ballot(const char *data, const char *end,
 		}
 		if (mp_decode_uint(&data) == IPROTO_BALLOT)
 			break;
+		mp_next(&data); /* skip value */
 	}
 	if (data == end)
 		return 0;
 
 	/* Decode BALLOT map. */
+	if (mp_typeof(*data) != MP_MAP)
+		return -1;
 	map_size = mp_decode_map(&data);
 	for (uint32_t i = 0; i < map_size; i++) {
 		if (mp_typeof(*data) != MP_UINT) {

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -211,6 +211,66 @@ create_fuzz_test(PREFIX xrow_decode_error
                          ${PROJECT_SOURCE_DIR}/test/unit/core_test_utils.c
                  LIBRARIES xrow fuzzer_config)
 
+create_fuzz_test(PREFIX xrow_decode_ballot
+                 SOURCES xrow_decode_ballot_fuzzer.c
+                         ${PROJECT_SOURCE_DIR}/test/unit/core_test_utils.c
+                 LIBRARIES xrow fuzzer_config)
+
+create_fuzz_test(PREFIX xrow_decode_subscribe
+                 SOURCES xrow_decode_subscribe_fuzzer.c
+                         ${PROJECT_SOURCE_DIR}/test/unit/core_test_utils.c
+                 LIBRARIES xrow fuzzer_config)
+
+create_fuzz_test(PREFIX xrow_decode_synchro
+                 SOURCES xrow_decode_synchro_fuzzer.c
+                         ${PROJECT_SOURCE_DIR}/test/unit/core_test_utils.c
+                 LIBRARIES xrow fuzzer_config)
+
+create_fuzz_test(PREFIX xrow_decode_register
+                 SOURCES xrow_decode_register_fuzzer.c
+                         ${PROJECT_SOURCE_DIR}/test/unit/core_test_utils.c
+                 LIBRARIES xrow fuzzer_config)
+
+create_fuzz_test(PREFIX xrow_decode_subscribe_response
+                 SOURCES xrow_decode_subscribe_response_fuzzer.c
+                         ${PROJECT_SOURCE_DIR}/test/unit/core_test_utils.c
+                 LIBRARIES xrow fuzzer_config)
+
+create_fuzz_test(PREFIX xrow_decode_join
+                 SOURCES xrow_decode_join_fuzzer.c
+                         ${PROJECT_SOURCE_DIR}/test/unit/core_test_utils.c
+                 LIBRARIES xrow fuzzer_config)
+
+create_fuzz_test(PREFIX xrow_decode_fetch_snapshot
+                 SOURCES xrow_decode_fetch_snapshot_fuzzer.c
+                         ${PROJECT_SOURCE_DIR}/test/unit/core_test_utils.c
+                 LIBRARIES xrow fuzzer_config)
+
+create_fuzz_test(PREFIX xrow_decode_relay_heartbeat
+                 SOURCES xrow_decode_relay_heartbeat_fuzzer.c
+                         ${PROJECT_SOURCE_DIR}/test/unit/core_test_utils.c
+                 LIBRARIES xrow fuzzer_config)
+
+create_fuzz_test(PREFIX xrow_decode_applier_heartbeat
+                 SOURCES xrow_decode_applier_heartbeat_fuzzer.c
+                         ${PROJECT_SOURCE_DIR}/test/unit/core_test_utils.c
+                 LIBRARIES xrow fuzzer_config)
+
+create_fuzz_test(PREFIX xrow_decode_vclock_ignore0
+                 SOURCES xrow_decode_vclock_ignore0_fuzzer.c
+                         ${PROJECT_SOURCE_DIR}/test/unit/core_test_utils.c
+                 LIBRARIES xrow fuzzer_config)
+
+create_fuzz_test(PREFIX xrow_decode_commit
+                 SOURCES xrow_decode_commit_fuzzer.c
+                         ${PROJECT_SOURCE_DIR}/test/unit/core_test_utils.c
+                 LIBRARIES xrow fuzzer_config)
+
+create_fuzz_test(PREFIX xrow_decode_ballot_event
+                 SOURCES xrow_decode_ballot_event_fuzzer.c
+                         ${PROJECT_SOURCE_DIR}/test/unit/core_test_utils.c
+                 LIBRARIES xrow fuzzer_config)
+
 # Blocked by https://github.com/tarantool/tarantool/issues/8948.
 if (NOT ENABLE_UB_SANITIZER)
   create_fuzz_test(PREFIX decimal_to_int64

--- a/test/fuzz/xrow_decode_applier_heartbeat_fuzzer.c
+++ b/test/fuzz/xrow_decode_applier_heartbeat_fuzzer.c
@@ -1,0 +1,43 @@
+#include "box/xrow.h"
+#include "box/iproto_constants.h"
+#include "fiber.h"
+#include "memory.h"
+
+__attribute__((constructor))
+static void
+setup(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+}
+
+__attribute__((destructor))
+static void
+teardown(void)
+{
+	fiber_free();
+	memory_free();
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	const char *d = (const char *)data;
+	const char *end = (const char *)data + size;
+	if (mp_check_exact(&d, end) != 0)
+		return -1;
+
+	struct iovec body = {0};
+	body.iov_base = (void *)data;
+	body.iov_len = size;
+
+	struct xrow_header row = {0};
+	row.body[0] = body;
+	row.bodycnt = 1;
+
+	struct applier_heartbeat req = {0};
+	if (xrow_decode_applier_heartbeat(&row, &req) == -1)
+		return -1;
+
+	return 0;
+}

--- a/test/fuzz/xrow_decode_ballot_event_fuzzer.c
+++ b/test/fuzz/xrow_decode_ballot_event_fuzzer.c
@@ -1,0 +1,41 @@
+#include "box/xrow.h"
+#include "box/iproto_constants.h"
+#include "fiber.h"
+#include "memory.h"
+#include "msgpuck.h"
+
+__attribute__((constructor))
+static void
+setup(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+}
+
+__attribute__((destructor))
+static void
+teardown(void)
+{
+	fiber_free();
+	memory_free();
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	const char *d = (const char *)data;
+	const char *end = (const char *)data + size;
+	if (mp_check_exact(&d, end) != 0)
+		return -1;
+
+	struct watch_request req = {0};
+	req.data = (const char *)data;
+	req.data_end = (const char *)data + size;
+
+	struct ballot ballot = {0};
+	bool is_empty = false;
+	if (xrow_decode_ballot_event(&req, &ballot, &is_empty) == -1)
+		return -1;
+
+	return 0;
+}

--- a/test/fuzz/xrow_decode_ballot_fuzzer.c
+++ b/test/fuzz/xrow_decode_ballot_fuzzer.c
@@ -1,0 +1,42 @@
+#include "box/xrow.h"
+#include "box/iproto_constants.h"
+#include "fiber.h"
+#include "memory.h"
+
+__attribute__((constructor))
+static void
+setup(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+}
+
+__attribute__((destructor))
+static void
+teardown(void)
+{
+	fiber_free();
+	memory_free();
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	const char *d = (const char *)data;
+	const char *end = (const char *)data + size;
+	if (mp_check_exact(&d, end) != 0 || mp_typeof(*data) != MP_MAP)
+		return -1;
+
+	struct iovec body = {0};
+	body.iov_base = (void *)data;
+	body.iov_len = size;
+
+	struct xrow_header row = {0};
+	row.body[0] = body;
+	row.bodycnt = 1;
+
+	struct ballot request = {0};
+	xrow_decode_ballot(&row, &request);
+
+	return 0;
+}

--- a/test/fuzz/xrow_decode_commit_fuzzer.c
+++ b/test/fuzz/xrow_decode_commit_fuzzer.c
@@ -1,0 +1,44 @@
+#include "box/xrow.h"
+#include "box/iproto_constants.h"
+#include "fiber.h"
+#include "memory.h"
+
+__attribute__((constructor))
+static void
+setup(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+}
+
+__attribute__((destructor))
+static void
+teardown(void)
+{
+	fiber_free();
+	memory_free();
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	const char *d = (const char *)data;
+	const char *end = (const char *)data + size;
+	if (mp_check_exact(&d, end) != 0)
+		return -1;
+
+	struct iovec body = {0};
+	body.iov_base = (void *)data;
+	body.iov_len = size;
+
+	struct xrow_header row = {0};
+	row.body[0] = body;
+	row.bodycnt = 1;
+	row.type = IPROTO_COMMIT;
+
+	struct commit_request req = {0};
+	if (xrow_decode_commit(&row, &req) == -1)
+		return -1;
+
+	return 0;
+}

--- a/test/fuzz/xrow_decode_fetch_snapshot_fuzzer.c
+++ b/test/fuzz/xrow_decode_fetch_snapshot_fuzzer.c
@@ -1,0 +1,43 @@
+#include "box/xrow.h"
+#include "box/iproto_constants.h"
+#include "fiber.h"
+#include "memory.h"
+
+__attribute__((constructor))
+static void
+setup(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+}
+
+__attribute__((destructor))
+static void
+teardown(void)
+{
+	fiber_free();
+	memory_free();
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	const char *d = (const char *)data;
+	const char *end = (const char *)data + size;
+	if (mp_check_exact(&d, end) != 0)
+		return -1;
+
+	struct iovec body = {0};
+	body.iov_base = (void *)data;
+	body.iov_len = size;
+
+	struct xrow_header row = {0};
+	row.body[0] = body;
+	row.bodycnt = 1;
+
+	struct fetch_snapshot_request req = {0};
+	if (xrow_decode_fetch_snapshot(&row, &req) == -1)
+		return -1;
+
+	return 0;
+}

--- a/test/fuzz/xrow_decode_join_fuzzer.c
+++ b/test/fuzz/xrow_decode_join_fuzzer.c
@@ -1,0 +1,43 @@
+#include "box/xrow.h"
+#include "box/iproto_constants.h"
+#include "fiber.h"
+#include "memory.h"
+
+__attribute__((constructor))
+static void
+setup(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+}
+
+__attribute__((destructor))
+static void
+teardown(void)
+{
+	fiber_free();
+	memory_free();
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	const char *d = (const char *)data;
+	const char *end = (const char *)data + size;
+	if (mp_check_exact(&d, end) != 0)
+		return -1;
+
+	struct iovec body = {0};
+	body.iov_base = (void *)data;
+	body.iov_len = size;
+
+	struct xrow_header row = {0};
+	row.body[0] = body;
+	row.bodycnt = 1;
+
+	struct join_request req = {0};
+	if (xrow_decode_join(&row, &req) == -1)
+		return -1;
+
+	return 0;
+}

--- a/test/fuzz/xrow_decode_register_fuzzer.c
+++ b/test/fuzz/xrow_decode_register_fuzzer.c
@@ -1,0 +1,43 @@
+#include "box/xrow.h"
+#include "box/iproto_constants.h"
+#include "fiber.h"
+#include "memory.h"
+
+__attribute__((constructor))
+static void
+setup(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+}
+
+__attribute__((destructor))
+static void
+teardown(void)
+{
+	fiber_free();
+	memory_free();
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	const char *d = (const char *)data;
+	const char *end = (const char *)data + size;
+	if (mp_check_exact(&d, end) != 0)
+		return -1;
+
+	struct iovec body = {0};
+	body.iov_base = (void *)data;
+	body.iov_len = size;
+
+	struct xrow_header row = {0};
+	row.body[0] = body;
+	row.bodycnt = 1;
+
+	struct register_request req = {0};
+	if (xrow_decode_register(&row, &req) == -1)
+		return -1;
+
+	return 0;
+}

--- a/test/fuzz/xrow_decode_relay_heartbeat_fuzzer.c
+++ b/test/fuzz/xrow_decode_relay_heartbeat_fuzzer.c
@@ -1,0 +1,43 @@
+#include "box/xrow.h"
+#include "box/iproto_constants.h"
+#include "fiber.h"
+#include "memory.h"
+
+__attribute__((constructor))
+static void
+setup(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+}
+
+__attribute__((destructor))
+static void
+teardown(void)
+{
+	fiber_free();
+	memory_free();
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	const char *d = (const char *)data;
+	const char *end = (const char *)data + size;
+	if (mp_check_exact(&d, end) != 0)
+		return -1;
+
+	struct iovec body = {0};
+	body.iov_base = (void *)data;
+	body.iov_len = size;
+
+	struct xrow_header row = {0};
+	row.body[0] = body;
+	row.bodycnt = 1;
+
+	struct relay_heartbeat req = {0};
+	if (xrow_decode_relay_heartbeat(&row, &req) == -1)
+		return -1;
+
+	return 0;
+}

--- a/test/fuzz/xrow_decode_subscribe_fuzzer.c
+++ b/test/fuzz/xrow_decode_subscribe_fuzzer.c
@@ -1,0 +1,44 @@
+#include "box/xrow.h"
+#include "box/iproto_constants.h"
+#include "fiber.h"
+#include "memory.h"
+
+__attribute__((constructor))
+static void
+setup(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+}
+
+__attribute__((destructor))
+static void
+teardown(void)
+{
+	fiber_free();
+	memory_free();
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	const char *d = (const char *)data;
+	const char *end = (const char *)data + size;
+	if (mp_check_exact(&d, end) != 0)
+		return -1;
+
+	struct iovec body = {0};
+	body.iov_base = (void *)data;
+	body.iov_len = size;
+
+	struct xrow_header row = {0};
+	row.body[0] = body;
+	row.bodycnt = 1;
+
+	struct subscribe_request req = {0};
+
+	if (xrow_decode_subscribe(&row, &req) == -1)
+		return -1;
+
+	return 0;
+}

--- a/test/fuzz/xrow_decode_subscribe_response_fuzzer.c
+++ b/test/fuzz/xrow_decode_subscribe_response_fuzzer.c
@@ -1,0 +1,43 @@
+#include "box/xrow.h"
+#include "box/iproto_constants.h"
+#include "fiber.h"
+#include "memory.h"
+
+__attribute__((constructor))
+static void
+setup(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+}
+
+__attribute__((destructor))
+static void
+teardown(void)
+{
+	fiber_free();
+	memory_free();
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	const char *d = (const char *)data;
+	const char *end = (const char *)data + size;
+	if (mp_check_exact(&d, end) != 0)
+		return -1;
+
+	struct iovec body = {0};
+	body.iov_base = (void *)data;
+	body.iov_len = size;
+
+	struct xrow_header row = {0};
+	row.body[0] = body;
+	row.bodycnt = 1;
+
+	struct subscribe_response req = {0};
+	if (xrow_decode_subscribe_response(&row, &req) == -1)
+		return -1;
+
+	return 0;
+}

--- a/test/fuzz/xrow_decode_synchro_fuzzer.c
+++ b/test/fuzz/xrow_decode_synchro_fuzzer.c
@@ -1,0 +1,44 @@
+#include "box/xrow.h"
+#include "box/iproto_constants.h"
+#include "fiber.h"
+#include "memory.h"
+
+__attribute__((constructor))
+static void
+setup(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+}
+
+__attribute__((destructor))
+static void
+teardown(void)
+{
+	fiber_free();
+	memory_free();
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	const char *d = (const char *)data;
+	const char *end = (const char *)data + size;
+	if (mp_check_exact(&d, end) != 0)
+		return -1;
+
+	struct iovec body = {0};
+	body.iov_base = (void *)data;
+	body.iov_len = size;
+
+	struct xrow_header row = {0};
+	row.body[0] = body;
+	row.bodycnt = 1;
+
+	struct synchro_request req = {0};
+
+	if (xrow_decode_synchro(&row, &req) == -1)
+		return -1;
+
+	return 0;
+}

--- a/test/fuzz/xrow_decode_vclock_ignore0_fuzzer.c
+++ b/test/fuzz/xrow_decode_vclock_ignore0_fuzzer.c
@@ -1,0 +1,43 @@
+#include "box/xrow.h"
+#include "box/iproto_constants.h"
+#include "fiber.h"
+#include "memory.h"
+
+__attribute__((constructor))
+static void
+setup(void)
+{
+	memory_init();
+	fiber_init(fiber_c_invoke);
+}
+
+__attribute__((destructor))
+static void
+teardown(void)
+{
+	fiber_free();
+	memory_free();
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	const char *d = (const char *)data;
+	const char *end = (const char *)data + size;
+	if (mp_check_exact(&d, end) != 0)
+		return -1;
+
+	struct iovec body = {0};
+	body.iov_base = (void *)data;
+	body.iov_len = size;
+
+	struct xrow_header row = {0};
+	row.body[0] = body;
+	row.bodycnt = 1;
+
+	struct vclock vclock;
+	if (xrow_decode_vclock_ignore0(&row, &vclock) == -1)
+		return -1;
+
+	return 0;
+}


### PR DESCRIPTION
The patch adds fuzzing tests for IPROTO decoding functions: xrow_decode_synchro(), xrow_decode_ballot(), xrow_decode_subscribe(), xrow_decode_applier_heartbeat(), xrow_decode_ballot_event(), xrow_decode_commit(), xrow_decode_fetch_snapshot(), xrow_decode_join(), xrow_decode_register(),
xrow_decode_relay_heartbeat(), xrow_decode_subscribe_response() and xrow_decode_vclock_ignore0().

The patch also fixes the implementation,
otherwise the tests are failed with reachable assertions.

NO_CHANGELOG=testing
NO_DOC=testing