### PR TITLE
config: support named role health checks

### DIFF
--- a/changelogs/unreleased/gh-12914-application-role-health-checks.md
+++ b/changelogs/unreleased/gh-12914-application-role-health-checks.md
@@ -1,0 +1,5 @@
+## feature/config
+
+* Application role health checks may now return a map of named check results.
+  Each result is reported as a separate readiness check and may have an
+  independent status, reason, and alert code (gh-12914).

--- a/src/box/lua/config/applier/roles.lua
+++ b/src/box/lua/config/applier/roles.lua
@@ -308,7 +308,7 @@ local function register_role_health_check(role_name, role, cfg)
     health.remove_health_check(check_name, {if_exists = true})
     local ok, err = health.add_health_check(check_name, function()
         return role.health_check(cfg)
-    end)
+    end, {multi_result = true})
     if not ok then
         error(('Failed to register health check for the role %s: %s'):format(
             role_name, err), 0)

--- a/src/box/lua/healthcheck.lua
+++ b/src/box/lua/healthcheck.lua
@@ -35,8 +35,17 @@ local health_checks = {
 
 -- {{{ Alert helpers
 
-local function alert_key(alert_code)
-    return alert_code:gsub(':', '.')
+local function sorted_keys(tbl)
+    local keys = {}
+    for key, _ in pairs(tbl) do
+        table.insert(keys, key)
+    end
+    table.sort(keys)
+    return keys
+end
+
+local function alert_key(alert_code, name)
+    return ('%s:%s'):format(alert_code, name):gsub(':', '.')
 end
 
 local function alert_message(kind, name, check)
@@ -57,7 +66,7 @@ local function set_alert(kind, name, message, code)
         return
     end
 
-    local key = alert_key(code)
+    local key = alert_key(code, name)
     local issued = health_checks[kind].alerts[name]
 
     if issued ~= nil and issued.message == message and issued.key == key then
@@ -94,12 +103,29 @@ local function unset_alert(kind, name)
     health_checks[kind].alerts[name] = nil
 end
 
+local function unset_alerts_by_prefix(kind, prefix)
+    assert(health_checks[kind] ~= nil)
+
+    local subchecks_prefix = prefix .. '.'
+    local alerts_to_unset = {}
+    for name, _ in pairs(health_checks[kind].alerts) do
+        if name == prefix or name:sub(1, #subchecks_prefix) ==
+           subchecks_prefix then
+            table.insert(alerts_to_unset, name)
+        end
+    end
+    for _, name in ipairs(alerts_to_unset) do
+        unset_alert(kind, name)
+    end
+end
+
 local function sync_alerts(kind, results, ok_status)
     assert(health_checks[kind] ~= nil)
 
     local failed = {}
 
-    for name, check in pairs(results) do
+    for _, name in ipairs(sorted_keys(results)) do
+        local check = results[name]
         if check.status ~= ok_status then
             failed[name] = true
             if check.alert_code ~= nil then
@@ -109,7 +135,7 @@ local function sync_alerts(kind, results, ok_status)
         end
     end
 
-    for name, _ in pairs(health_checks[kind].alerts) do
+    for _, name in ipairs(sorted_keys(health_checks[kind].alerts)) do
         if not failed[name] then
             unset_alert(kind, name)
         end
@@ -149,6 +175,7 @@ local HEALTHCHECK_OPTION_TYPES = {
     if_not_exists = 'boolean',
     alert = 'boolean',
     alert_code = 'string',
+    multi_result = 'boolean',
 }
 
 local LIVENESS_PROBE_TYPES = {
@@ -172,13 +199,16 @@ local function add_check(kind, name, fn, opts)
 
     if registry[name] == nil then
         local alert_code
-        if opts.alert ~= false then
+        local alert = opts.alert ~= false
+        if alert then
             alert_code = opts.alert_code or default_alert_code(kind, name)
         end
         registry[name] = {
             fn = fn,
+            alert = alert,
             alert_code = alert_code,
-            status = nil,
+            multi_result = opts.multi_result,
+            statuses = {},
         }
     end
 
@@ -196,26 +226,105 @@ local function remove_check(kind, name, opts)
         return false, ('health check %q does not exist'):format(name)
     end
 
-    unset_alert(kind, name)
+    unset_alerts_by_prefix(kind, name)
     registry[name] = nil
 
     return true
 end
 
-local function evaluate(check, ok_status, fail_status, use_degraded)
-    local fn = check.fn
-    local alert_code = check.alert_code
-    local function fail(reason)
-        local status = fail_status
-        if use_degraded and
-           (check.status == ok_status or check.status == 'degraded') then
-            status = 'degraded'
+local function full_check_name(name, subname)
+    return ('%s.%s'):format(name, subname)
+end
+
+local function check_alert_code(check, kind, name, item)
+    if not check.alert then
+        return nil
+    end
+    if type(item) == 'table' and type(item.alert_code) == 'string' then
+        return item.alert_code
+    end
+    if type(item) == 'table' then
+        return default_alert_code(kind, name)
+    end
+    return check.alert_code
+end
+
+local function check_fail_status(check, name, ok_status, fail_status,
+                                 use_degraded)
+    local status = fail_status
+    if use_degraded and
+       (check.statuses[name] == ok_status or check.statuses[name] ==
+        'degraded') then
+        status = 'degraded'
+    end
+    check.statuses[name] = status
+    return status
+end
+
+local function cleanup_check_statuses(check, prefix, active)
+    local subchecks_prefix = prefix .. '.'
+    for name, _ in pairs(check.statuses) do
+        if (name == prefix or name:sub(1, #subchecks_prefix) ==
+            subchecks_prefix) and not active[name] then
+            check.statuses[name] = nil
         end
-        check.status = status
+    end
+end
+
+local function validate_check_result_item(subname, item, ok_status,
+                                          fail_status, use_degraded)
+    if type(subname) ~= 'string' or subname == '' then
+        return 'health check result key must be a non-empty string'
+    end
+    if type(item) ~= 'table' then
+        return ('health check result %q must be a table'):format(subname)
+    end
+    if item.status ~= ok_status and item.status ~= fail_status and
+       (not use_degraded or item.status ~= 'degraded') then
+        return ('health check result %q must have status %q or %q'):
+               format(subname, ok_status, fail_status)
+    end
+    if item.reason ~= nil and type(item.reason) ~= 'string' then
+        return ('health check result %q reason must be a string'):
+               format(subname)
+    end
+    if item.alert_code ~= nil and type(item.alert_code) ~= 'string' then
+        return ('health check result %q alert_code must be a string'):
+               format(subname)
+    end
+    return nil
+end
+
+local function evaluate_check_result_item(check, kind, fullname, item,
+                                          ok_status, fail_status,
+                                          use_degraded, reason)
+    if reason ~= nil then
+        local status = check_fail_status(check, fullname, ok_status,
+                                         fail_status, use_degraded)
         return {
             status = status,
             reason = reason,
-            alert_code = alert_code,
+            alert_code = check_alert_code(check, kind, fullname, item),
+        }
+    end
+    check.statuses[fullname] = item.status
+    return {
+        status = item.status,
+        reason = item.reason,
+        alert_code = item.status ~= ok_status and
+                     check_alert_code(check, kind, fullname, item) or nil,
+    }
+end
+
+local function evaluate(check, kind, name, ok_status, fail_status, use_degraded)
+    local fn = check.fn
+    local function fail(reason)
+        local status = check_fail_status(check, name, ok_status, fail_status,
+                                         use_degraded)
+        return {
+            status = status,
+            reason = reason,
+            alert_code = check_alert_code(check, kind, name),
         }
     end
     local csw = fiber.self():csw()
@@ -230,12 +339,41 @@ local function evaluate(check, ok_status, fail_status, use_degraded)
     end
 
     if res == true then
-        check.status = ok_status
+        check.statuses[name] = ok_status
         return { status = ok_status }
     end
 
     if (res == false or res == nil) and type(reason) == 'string' then
         return fail(reason)
+    end
+
+    if type(res) == 'table' and check.multi_result then
+        local results = {}
+        local active = {}
+        if next(res) == nil then
+            check.statuses[name] = ok_status
+            active[name] = true
+            cleanup_check_statuses(check, name, active)
+            return {
+                [name] = { status = ok_status },
+            }
+        end
+        for subname, item in pairs(res) do
+            local fullname = name
+            if type(subname) == 'string' and subname ~= '' then
+                fullname = full_check_name(name, subname)
+            end
+            active[fullname] = true
+            local err = validate_check_result_item(subname, item, ok_status,
+                                                   fail_status, use_degraded)
+            results[fullname] = evaluate_check_result_item(check, kind,
+                                                           fullname, item,
+                                                           ok_status,
+                                                           fail_status,
+                                                           use_degraded, err)
+        end
+        cleanup_check_statuses(check, name, active)
+        return results
     end
 
     return fail('health check must return true or false, <string>')
@@ -246,7 +384,15 @@ local function evaluate_registry(kind, ok_status, fail_status, skip)
     local use_degraded = kind == 'readiness'
     for name, check in pairs(checks[kind]) do
         if skip == nil or not skip[name] then
-            res[name] = evaluate(check, ok_status, fail_status, use_degraded)
+            local check_res = evaluate(check, kind, name, ok_status,
+                                       fail_status, use_degraded)
+            if check_res.status ~= nil then
+                res[name] = check_res
+            else
+                for check_name, item in pairs(check_res) do
+                    res[check_name] = item
+                end
+            end
         end
     end
     return res

--- a/test/box-luatest/box_info_health_test.lua
+++ b/test/box-luatest/box_info_health_test.lua
@@ -384,5 +384,24 @@ g.test_invalid_check_result = function(cg)
         })
 
         t.assert_equals(health.remove_health_check('invalid'), true)
+
+        t.assert_equals(health.add_health_check('invalid', function()
+            return {
+                app = {
+                    status = 'not_ready',
+                    reason = 'failed',
+                },
+            }
+        end), true)
+
+        info = box.info.health.readiness
+        t.assert_equals(info.status, false)
+        t.assert_equals(info.checks.invalid, {
+            status = 'not_ready',
+            reason = 'health check must return true or false, <string>',
+            alert_code = 'health.readiness.invalid',
+        })
+
+        t.assert_equals(health.remove_health_check('invalid'), true)
     end)
 end

--- a/test/config-luatest/roles_test.lua
+++ b/test/config-luatest/roles_test.lua
@@ -82,6 +82,164 @@ g.test_role_health_check = function(g)
     })
 end
 
+g.test_role_health_check_result_map = function(g)
+    local one = [[
+        return {
+            validate = function() end,
+            apply = function() end,
+            stop = function() end,
+            health_check = function()
+                return {
+                    ['manager.main'] = rawget(_G, 'check_manager_main'),
+                    ['manager.archive'] = rawget(_G, 'check_manager_archive'),
+                }
+            end,
+        }
+    ]]
+    local verify = function()
+        local function set_manager(name, check)
+            rawset(_G, ('check_manager_%s'):format(name), check)
+        end
+
+        local function check_name(name)
+            return ('role.one.manager.%s'):format(name)
+        end
+
+        local function assert_alert(alert, name, reason, code)
+            t.assert_items_include(alert, {
+                type = 'warn',
+                message = ('Readiness health check %q failed: %s'):
+                          format(check_name(name), reason),
+                alert_code = code,
+            })
+        end
+
+        set_manager('main', {status = 'ready'})
+        set_manager('archive', {
+            status = 'not_ready',
+            reason = 'last backup is too old',
+            alert_code = 'backup.manager.archive.stale',
+        })
+
+        local health = box.info.health.readiness
+        t.assert_equals(health.checks[check_name('main')], {
+            status = 'ready',
+        })
+        t.assert_equals(health.checks[check_name('archive')], {
+            status = 'not_ready',
+            reason = 'last backup is too old',
+            alert_code = 'backup.manager.archive.stale',
+        })
+        t.assert_equals(health.status, false)
+        t.assert_equals(#box.info.config.alerts, 1)
+        assert_alert(box.info.config.alerts[1], 'archive',
+                     'last backup is too old',
+                     'backup.manager.archive.stale')
+
+        set_manager('main', {
+            status = 'not_ready',
+            reason = 'backup target is unavailable',
+            alert_code = 'backup.manager.unavailable',
+        })
+        set_manager('archive', {
+            status = 'not_ready',
+            reason = 'backup target is unavailable',
+            alert_code = 'backup.manager.unavailable',
+        })
+        t.assert_equals(#box.info.config.alerts, 2)
+
+        set_manager('main', {status = 'ready'})
+        health = box.info.health.readiness
+        t.assert_equals(health.checks[check_name('main')], {
+            status = 'ready',
+        })
+        t.assert_equals(health.checks[check_name('archive')], {
+            status = 'not_ready',
+            reason = 'backup target is unavailable',
+            alert_code = 'backup.manager.unavailable',
+        })
+        t.assert_equals(health.status, false)
+        t.assert_equals(#box.info.config.alerts, 1)
+        assert_alert(box.info.config.alerts[1], 'archive',
+                     'backup target is unavailable',
+                     'backup.manager.unavailable')
+
+        set_manager('archive', nil)
+        health = box.info.health.readiness
+        t.assert_equals(health.checks[check_name('archive')], nil)
+        t.assert_equals(box.info.health.readiness.status, true)
+        t.assert_equals(box.info.config.alerts, {})
+
+        set_manager('archive', {
+            status = 'not_ready',
+            reason = 'last backup is too old',
+            alert_code = 'backup.manager.archive.stale',
+        })
+        health = box.info.health.readiness
+        t.assert_equals(health.checks[check_name('archive')], {
+            status = 'not_ready',
+            reason = 'last backup is too old',
+            alert_code = 'backup.manager.archive.stale',
+        })
+        t.assert_equals(health.status, false)
+        t.assert_equals(#box.info.config.alerts, 1)
+    end
+
+    helpers.success_case(g, {
+        roles = {one = one},
+        options = {
+            ['roles'] = {'one'},
+        },
+        verify = verify,
+    })
+end
+
+g.test_role_health_check_invalid_result_item = function(g)
+    local one = [[
+        return {
+            validate = function() end,
+            apply = function() end,
+            stop = function() end,
+            health_check = function()
+                return {
+                    ['manager.main'] = {
+                        status = 'bad',
+                        alert_code = 'backup.manager.main.bad',
+                    },
+                    [42] = {
+                        status = 'not_ready',
+                        reason = 'nameless',
+                    },
+                }
+            end,
+        }
+    ]]
+    local verify = function()
+        local checks = box.info.health.readiness.checks
+        t.assert_equals(checks['role.one.manager.main'], {
+            status = 'not_ready',
+            reason = 'health check result "manager.main" must have ' ..
+                     'status "ready" or "not_ready"',
+            alert_code = 'backup.manager.main.bad',
+        })
+        t.assert_equals(checks['role.one'], {
+            status = 'not_ready',
+            reason = 'health check result key must be a non-empty string',
+            alert_code = 'health.readiness.role.one',
+        })
+        t.assert_equals(box.info.health.readiness.status, false)
+        t.assert_equals(#box.info.config.alerts, 2)
+    end
+
+    helpers.success_case(g, {
+        roles = {one = one},
+        options = {
+            ['roles'] = {'one'},
+        },
+        verify = verify,
+    })
+end
+
 -- Make sure the role is loaded only once during each run.
 g.test_role_repeat_success = function(g)
     local one = [[


### PR DESCRIPTION
This patch allows an application role `health_check()` callback to return a map of named readiness check results. Each returned item is reported as a separate role readiness check and may define its own status, reason, and alert code.

The old callback contract is kept unchanged: returning true reports the role as ready, while returning false or nil with a reason reports one failed role check.

Closes #12914

---

Doc Request: tarantool/doc#5702 _(TODO: update the doc request to reflect the new feature)_
