### PR TITLE
misc: make fiber_new non-failing

### DIFF
--- a/changelogs/unreleased/gh-12338-non-failing-fiber-new.md
+++ b/changelogs/unreleased/gh-12338-non-failing-fiber-new.md
@@ -1,0 +1,3 @@
+## feature/core
+
+* `fiber_new()` and `fiber_new_ex()` are now non-failing (gh-12338).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -4526,14 +4526,10 @@ on_replace_dd_schema(struct trigger * /* trigger */, void *event)
 		    recovery_state == FINISHED_RECOVERY) {
 			fiber = fiber_new_system("synchro_filter_enabler",
 						 start_synchro_filtering);
-			if (fiber == NULL)
-				return -1;
 		} else if (version <= version_id(2, 10, 1) &&
 			   recovery_state == FINISHED_RECOVERY) {
 			fiber = fiber_new_system("synchro_filter_disabler",
 						 stop_synchro_filtering);
-			if (fiber == NULL)
-				return -1;
 		}
 		data->fiber = fiber;
 		/*

--- a/src/box/applier.cc
+++ b/src/box/applier.cc
@@ -155,7 +155,7 @@ applier_check_sync(struct applier *applier)
 
 /**
  * A helper function to create an applier fiber. Basically, it's a wrapper
- * around fiber_new_system_xc(), which appends the applier URI to the fiber name
+ * around fiber_new_system(), which appends the applier URI to the fiber name
  * and makes the new fiber joinable. Note, this function creates a new fiber,
  * but doesn't start it.
  */
@@ -166,7 +166,7 @@ applier_fiber_new(struct applier *applier, const char *name, fiber_func func,
 	char buf[FIBER_NAME_MAX];
 	int pos = snprintf(buf, sizeof(buf), "%s/", name);
 	uri_format(buf + pos, sizeof(buf) - pos, &applier->uri, false);
-	struct fiber *f = fiber_new_system_xc(buf, func);
+	struct fiber *f = fiber_new_system(buf, func);
 	fiber_set_joinable(f, is_joinable);
 	return f;
 }

--- a/src/box/gc.c
+++ b/src/box/gc.c
@@ -139,20 +139,14 @@ gc_init(on_garbage_collection_f on_garbage_collection)
 	checkpoint_schedule_cfg(&gc.checkpoint_schedule, 0, 0, 0);
 
 	gc.cleanup_fiber = fiber_new_system("gc", gc_cleanup_fiber_f);
-	if (gc.cleanup_fiber == NULL)
-		panic("failed to start garbage collection fiber");
 	fiber_set_joinable(gc.cleanup_fiber, true);
 
 	gc.checkpoint_fiber = fiber_new_system("checkpoint_daemon",
 					       gc_checkpoint_fiber_f);
-	if (gc.checkpoint_fiber == NULL)
-		panic("failed to start checkpoint daemon fiber");
 	fiber_set_joinable(gc.checkpoint_fiber, true);
 
 	gc.sync_fiber = fiber_new_system("gc_sync",
 					 gc_sync_fiber_f);
-	if (gc.sync_fiber == NULL)
-		panic("failed to start gc sync fiber");
 	fiber_set_joinable(gc.sync_fiber, true);
 
 	gc.on_garbage_collection = on_garbage_collection;

--- a/src/box/lua/connpool.lua
+++ b/src/box/lua/connpool.lua
@@ -94,6 +94,7 @@ function pool_methods._failed_connection_watchdog_step(self)
             if until_reconnect <= 0 then
                 table.insert(instance_names_to_reconnect, name)
             elseif until_reconnect < until_next_reconnect then
+
                 until_next_reconnect = until_reconnect
             end
         end

--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -3203,13 +3203,6 @@ luaT_netbox_transport_start(struct lua_State *L)
 		name = tt_sprintf("fd=%d (net.box)", transport->opts.fd);
 	}
 	transport->worker = fiber_new_system(name, netbox_worker_f);
-	if (transport->worker == NULL) {
-		luaL_unref(L, LUA_REGISTRYINDEX, transport->coro_ref);
-		transport->coro_ref = LUA_NOREF;
-		luaL_unref(L, LUA_REGISTRYINDEX, transport->self_ref);
-		transport->self_ref = LUA_NOREF;
-		return luaT_error(L);
-	}
 	fiber_set_managed_shutdown(transport->worker);
 	transport->worker->f_arg = transport;
 	/*

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1971,8 +1971,6 @@ memtx_engine_new(const char *snap_dirname, bool force_recovery,
 
 	stailq_create(&memtx->gc_queue);
 	memtx->gc_fiber = fiber_new_system("memtx.gc", memtx_engine_gc_f);
-	if (memtx->gc_fiber == NULL)
-		goto fail;
 	fiber_set_joinable(memtx->gc_fiber, true);
 
 	/*

--- a/src/box/raft.c
+++ b/src/box/raft.c
@@ -176,21 +176,6 @@ box_raft_schedule_async(struct raft *raft)
 	if (box_raft_worker == NULL) {
 		box_raft_worker = fiber_new_system("raft_worker",
 						   box_raft_worker_f);
-		if (box_raft_worker == NULL) {
-			/*
-			 * XXX: should be handled properly, no need to panic.
-			 * The issue though is that most of the Raft state
-			 * machine functions are not supposed to fail, and also
-			 * they usually wakeup the fiber when their work is
-			 * finished. So it is too late to fail. On the other
-			 * hand it looks not so good to create the fiber when
-			 * Raft is initialized. Because then it will occupy
-			 * memory even if Raft is not used.
-			 */
-			diag_log();
-			panic("Could't create Raft worker fiber");
-			return;
-		}
 		box_raft_worker->f_arg = raft;
 		fiber_set_joinable(box_raft_worker, true);
 	}

--- a/src/box/recovery.cc
+++ b/src/box/recovery.cc
@@ -555,8 +555,6 @@ recovery_follow_local(struct recovery *r, struct xstream *stream,
 	 */
 	assert(r->watcher == NULL);
 	r->watcher = fiber_new_system(name, hot_standby_f);
-	if (r->watcher == NULL)
-		diag_raise();
 	fiber_set_joinable(r->watcher, true);
 	fiber_start(r->watcher, r, stream, wal_dir_rescan_delay);
 }

--- a/src/box/relay.cc
+++ b/src/box/relay.cc
@@ -1093,7 +1093,7 @@ relay_subscribe_f(va_list ap)
 	/* Start fiber for receiving replica acks. */
 	char name[FIBER_NAME_MAX];
 	snprintf(name, sizeof(name), "%s:%s", fiber()->name, "reader");
-	struct fiber *reader = fiber_new_xc(name, relay_reader_f);
+	struct fiber *reader = fiber_new(name, relay_reader_f);
 	fiber_set_joinable(reader, true);
 	fiber_start(reader, relay, fiber());
 

--- a/src/box/replication.cc
+++ b/src/box/replication.cc
@@ -440,8 +440,6 @@ replication_anon_gc_init(void)
 	replication_anon_gc_fiber =
 		fiber_new_system("replication_anon_gc",
 				 replication_anon_gc_fiber_f);
-	if (replication_anon_gc_fiber == NULL)
-		panic("Cannot init replication submodule");
 	fiber_set_joinable(replication_anon_gc_fiber, true);
 	fiber_start(replication_anon_gc_fiber);
 }

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -292,8 +292,6 @@ txn_limbo_create(struct txn_limbo *limbo, struct raft *raft)
 	limbo->term = 1;
 	limbo->worker = fiber_new_system("txn_limbo_worker",
 					 txn_limbo_worker_f);
-	if (limbo->worker == NULL)
-		panic("failed to allocate synchronous queue worker fiber");
 	limbo->worker->f_arg = limbo;
 	fiber_set_joinable(limbo->worker, true);
 	trigger_create(&limbo->on_ack, txn_limbo_on_ack_f, limbo, NULL);

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -3676,8 +3676,6 @@ vy_squash_schedule(struct vy_lsm *lsm, struct vy_entry entry, void *arg)
 	if (sq->fiber == NULL) {
 		sq->fiber = fiber_new_system("vinyl.squash_queue",
 					     vy_squash_queue_f);
-		if (sq->fiber == NULL)
-			goto fail;
 		fiber_set_joinable(sq->fiber, true);
 		fiber_start(sq->fiber, sq);
 	}

--- a/src/box/vy_log.c
+++ b/src/box/vy_log.c
@@ -723,8 +723,6 @@ vy_log_init(const char *dir)
 	fiber_cond_create(&vy_log.flusher_cond);
 	vy_log.flusher = fiber_new_system("vinyl.vylog_flusher",
 					  vy_log_flusher_f);
-	if (vy_log.flusher == NULL)
-		panic("failed to allocate vylog flusher fiber");
 	fiber_set_joinable(vy_log.flusher, true);
 	fiber_wakeup(vy_log.flusher);
 }

--- a/src/box/vy_scheduler.c
+++ b/src/box/vy_scheduler.c
@@ -464,8 +464,6 @@ vy_scheduler_create(struct vy_scheduler *scheduler, int write_threads,
 
 	scheduler->scheduler_fiber = fiber_new_system("vinyl.scheduler",
 						      vy_scheduler_f);
-	if (scheduler->scheduler_fiber == NULL)
-		panic("failed to allocate vinyl scheduler fiber");
 	fiber_set_joinable(scheduler->scheduler_fiber, true);
 
 	fiber_cond_create(&scheduler->scheduler_cond);
@@ -1862,15 +1860,8 @@ vy_task_execute_f(struct cmsg *cmsg)
 	assert(&worker->cord == cord());
 
 	task->fiber = fiber_new("task", vy_task_f);
-	if (task->fiber == NULL) {
-		task->is_failed = true;
-		diag_move(diag_get(), &task->diag);
-		cmsg_init(&task->cmsg, vy_task_complete_route);
-		cpipe_push(&worker->tx_pipe, &task->cmsg);
-	} else {
-		worker->task = task;
-		fiber_start(task->fiber, task);
-	}
+	worker->task = task;
+	fiber_start(task->fiber, task);
 }
 
 /**

--- a/src/box/watcher.c
+++ b/src/box/watcher.c
@@ -141,10 +141,6 @@ watchable_wakeup_worker(struct watchable *watchable)
 	if (watchable->worker == NULL) {
 		watchable->worker = fiber_new_system("box.watchable",
 						     watchable_worker_f);
-		if (watchable->worker == NULL) {
-			diag_log();
-			panic("failed to start box.watchable worker fiber");
-		}
 		fiber_set_joinable(watchable->worker, true);
 		watchable->worker->f_arg = watchable;
 	}
@@ -320,11 +316,8 @@ watcher_run(struct watcher *watcher)
 	if ((watcher->flags & WATCHER_RUN_ASYNC) != 0) {
 		struct fiber *fiber = fiber_new("box.watcher",
 						watcher_run_async_f);
-		if (fiber != NULL) {
-			fiber_start(fiber, watcher);
-			return;
-		}
-		diag_log();
+		fiber_start(fiber, watcher);
+		return;
 	}
 	watcher_do_run(watcher);
 }

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1187,10 +1187,15 @@ fiber_loop(MAYBE_UNUSED void *data)
 		if (!(fiber->flags & FIBER_IS_SYSTEM)) {
 			assert(cord()->client_fiber_count > 0);
 			cord()->client_fiber_count--;
-			if (cord()->shutdown_fiber != NULL &&
-			    cord()->client_fiber_count == 0)
-				fiber_wakeup(cord()->shutdown_fiber);
 		}
+		if (fiber->flags & FIBER_MANAGED_SHUTDOWN) {
+			assert(cord()->managed_shutdown_fiber_count > 0);
+			cord()->managed_shutdown_fiber_count--;
+		}
+		if (unlikely(cord()->shutdown_fiber != NULL) &&
+		    cord()->client_fiber_count == 0 &&
+		    cord()->managed_shutdown_fiber_count == 0)
+			fiber_wakeup(cord()->shutdown_fiber);
 		fiber_on_stop(fiber);
 		/* reset pending wakeups */
 		rlist_del(&fiber->state);
@@ -1906,6 +1911,7 @@ cord_create(struct cord *cord, const char *name)
 	signal_stack_init();
 	cord->shutdown_fiber = NULL;
 	cord->client_fiber_count = 0;
+	cord->managed_shutdown_fiber_count = 0;
 	cord->is_shutdown = false;
 }
 
@@ -2345,7 +2351,8 @@ fiber_set_system(struct fiber *f, bool yesno)
 			assert(cord()->client_fiber_count > 0);
 			cord()->client_fiber_count--;
 			if (cord()->shutdown_fiber != NULL &&
-			    cord()->client_fiber_count == 0)
+			    cord()->client_fiber_count == 0 &&
+			    cord()->managed_shutdown_fiber_count == 0)
 				fiber_wakeup(cord()->shutdown_fiber);
 		}
 	} else {
@@ -2359,7 +2366,10 @@ fiber_set_system(struct fiber *f, bool yesno)
 void
 fiber_set_managed_shutdown(struct fiber *f)
 {
-	f->flags |= FIBER_MANAGED_SHUTDOWN;
+	if (!(f->flags & FIBER_MANAGED_SHUTDOWN)) {
+		f->flags |= FIBER_MANAGED_SHUTDOWN;
+		cord()->managed_shutdown_fiber_count++;
+	}
 }
 
 int
@@ -2369,19 +2379,22 @@ fiber_shutdown(double timeout)
 	cord()->is_shutdown = true;
 	struct fiber *fiber;
 	rlist_foreach_entry(fiber, &cord()->alive, link) {
-		if (fiber->flags & FIBER_MANAGED_SHUTDOWN)
-			fiber_set_system(fiber, false);
-		if (!(fiber->flags & FIBER_IS_SYSTEM))
+		if (!(fiber->flags & FIBER_IS_SYSTEM) ||
+		    (fiber->flags & FIBER_MANAGED_SHUTDOWN))
 			fiber_cancel(fiber);
 	}
 	cord()->shutdown_fiber = fiber();
 	double deadline = ev_monotonic_now(loop()) + timeout;
-	while (cord()->client_fiber_count != 0) {
+	while (cord()->client_fiber_count != 0 ||
+	       cord()->managed_shutdown_fiber_count != 0) {
 		if (fiber_yield_deadline(deadline)) {
 			diag_set(TimedOut);
 			break;
 		}
 	}
 	cord()->shutdown_fiber = NULL;
-	return cord()->client_fiber_count == 0 ? 0 : -1;
+	if (cord()->client_fiber_count != 0 ||
+	    cord()->managed_shutdown_fiber_count != 0)
+		return -1;
+	return 0;
 }

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -851,6 +851,12 @@ fiber_yield_impl(MAYBE_UNUSED bool will_switch_back)
 	assert((callee->flags & FIBER_IS_RUNNING) == 0);
 
 	caller->flags &= ~FIBER_IS_RUNNING;
+	if (unlikely(cord->is_shutdown) &&
+	    !(caller->flags & (FIBER_IS_CANCELLED |
+			       FIBER_IS_DEAD)) &&
+	    (!(caller->flags & FIBER_IS_SYSTEM) ||
+	     (caller->flags & FIBER_MANAGED_SHUTDOWN)))
+		fiber_cancel(caller);
 	cord->fiber = callee;
 	callee->flags = (callee->flags & ~FIBER_IS_READY) | FIBER_IS_RUNNING;
 
@@ -1553,11 +1559,6 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 	struct fiber *fiber = NULL;
 	assert(fiber_attr != NULL);
 	cord_collect_garbage(cord);
-
-	if (cord->is_shutdown && !(fiber_attr->flags & FIBER_IS_SYSTEM)) {
-		diag_set(FiberIsCancelled);
-		return NULL;
-	}
 
 	if (fiber_is_reusable(fiber_attr->flags) && !rlist_empty(&cord->dead)) {
 		fiber = rlist_first_entry(&cord->dead, struct fiber, link);

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -197,25 +197,16 @@ fiber_madvise(void *addr, size_t len, int advice)
 	return 0;
 }
 
-static inline int
+static int
 fiber_mprotect(void *addr, size_t len, int prot)
 {
-	(void)addr;
-	(void)len;
-	(void)prot;
 	struct errinj *inj = errinj(ERRINJ_FIBER_MPROTECT, ERRINJ_INT);
 	if (inj != NULL && inj->iparam == prot) {
 		errno = ENOMEM;
 		goto error;
 	}
-/*
- * If we panic then fiber stacks remain protected which cause leak sanitizer
- * failures. Disable memory protection under ASAN.
- */
-#ifndef ENABLE_ASAN
 	if (mprotect(addr, len, prot) != 0)
 		goto error;
-#endif
 	return 0;
 error:
 	diag_set(SystemError, "fiber mprotect failed");
@@ -1440,7 +1431,8 @@ fiber_stack_destroy(struct fiber *fiber, struct slab_cache *slabc)
 		else
 			guard = page_align_up(fiber->stack + fiber->stack_size);
 
-		if (fiber_mprotect(guard, page_size, mprotect_flags) != 0) {
+		if (fiber->has_guard &&
+		    fiber_mprotect(guard, page_size, mprotect_flags) != 0) {
 			/*
 			 * FIXME: We need some intelligent handling:
 			 * say put this slab into a queue and retry
@@ -1474,18 +1466,12 @@ fiber_stack_destroy(struct fiber *fiber, struct slab_cache *slabc)
 	}
 }
 
-static int
+static void
 fiber_stack_create(struct fiber *fiber, const struct fiber_attr *fiber_attr,
 		   struct slab_cache *slabc)
 {
 	size_t stack_size = fiber_attr->stack_size - slab_sizeof();
-	fiber->stack_slab = slab_get(slabc, stack_size);
-
-	if (fiber->stack_slab == NULL) {
-		diag_set(OutOfMemory, stack_size,
-			 "runtime arena", "fiber stack");
-		return -1;
-	}
+	fiber->stack_slab = xslab_get(slabc, stack_size);
 	void *guard;
 	/* Adjust begin and size for stack memory chunk. */
 	if (stack_direction < 0) {
@@ -1515,18 +1501,19 @@ fiber_stack_create(struct fiber *fiber, const struct fiber_attr *fiber_attr,
 						  (char *)fiber->stack +
 						  fiber->stack_size);
 
-	if (fiber_mprotect(guard, page_size, PROT_NONE)) {
-		/*
-		 * Write an error into the log since a guard
-		 * page is critical for functionality.
-		 */
-		diag_log();
-		fiber_stack_destroy(fiber, slabc);
-		return -1;
-	}
+#ifndef ENABLE_ASAN
+	fiber->has_guard = fiber_mprotect(guard, page_size, PROT_NONE) == 0;
+	if (!fiber->has_guard)
+		say_syserror("can't create guard page");
+#else
+	/*
+	 * If we panic then fiber stacks remain protected which cause leak
+	 * sanitizer failures. Disable memory protection under ASAN.
+	 */
+	fiber->has_guard = false;
+#endif
 
 	fiber_stack_watermark_create(fiber, fiber_attr);
-	return 0;
 }
 
 static void
@@ -1565,21 +1552,12 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 		rlist_move_entry(&cord->alive, fiber, link);
 		assert(fiber_is_dead(fiber));
 	} else {
-		fiber = (struct fiber *)
-			mempool_alloc(&cord->fiber_mempool);
-		if (fiber == NULL) {
-			diag_set(OutOfMemory, sizeof(struct fiber),
-				 "fiber pool", "fiber");
-			return NULL;
-		}
+		fiber = xmempool_alloc(&cord->fiber_mempool);
 		memset(fiber, 0, sizeof(struct fiber));
 		fiber->storage.lua.storage_ref = FIBER_LUA_NOREF;
 		fiber->storage.lua.fid_ref = FIBER_LUA_NOREF;
 
-		if (fiber_stack_create(fiber, fiber_attr, &cord()->slabc)) {
-			mempool_free(&cord->fiber_mempool, fiber);
-			return NULL;
-		}
+		fiber_stack_create(fiber, fiber_attr, &cord()->slabc);
 		coro_create(&fiber->ctx, fiber_loop, NULL,
 			    fiber->stack, fiber->stack_size);
 
@@ -1612,30 +1590,12 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 
 }
 
-/**
- * Create a new fiber.
- *
- * Takes a fiber from fiber cache, if it's not empty.
- * Can fail only if there is not enough memory for
- * the fiber structure or fiber stack.
- *
- * The created fiber automatically returns itself
- * to the fiber cache when its "main" function
- * completes.
- */
 struct fiber *
 fiber_new(const char *name, fiber_func f)
 {
 	return fiber_new_ex(name, &fiber_attr_default, f);
 }
 
-/**
- * Create a new system fiber.
- *
- * Works the same way as fiber_new(), but uses fiber_attr_default
- * supplemented by the FIBER_IS_SYSTEM flag in order to create a
- * fiber.
- */
 struct fiber *
 fiber_new_system(const char *name, fiber_func f)
 {
@@ -2200,8 +2160,6 @@ cord_costart_thread_func(void *arg)
 	free(arg);
 
 	struct fiber *f = fiber_new("main", ctx.run);
-	if (f == NULL)
-		return NULL;
 	cord()->main_fiber = f;
 
 	TRIGGER(break_ev_loop, break_ev_loop_f);

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -176,8 +176,10 @@ enum {
 	 */
 	FIBER_JOIN_BEEN_INVOKED = 1 << 9,
 	/**
-	 * Makes sense only for system fibers. If flag is set then fiber
-	 * will be finished on fiber_shutdown().
+	 * If the flag is set, then the fiber will be cancelled and awaited to
+	 * finish on fiber_shutdown(), just like non-system fibers. Note that
+	 * this flag can be set for non-system fibers too, although one doesn't
+	 * need to.
 	 */
 	FIBER_MANAGED_SHUTDOWN = 1 << 10,
 	FIBER_DEFAULT_FLAGS	= 0
@@ -866,6 +868,8 @@ struct cord {
 	ev_async cancel_event;
 	/** Number of alive client (non system) fibers. */
 	int client_fiber_count;
+	/** Number of alive fibers with managed shutdown. */
+	int managed_shutdown_fiber_count;
 	/** Fiber calling fiber_shutdown. NULL if there is no such. */
 	struct fiber *shutdown_fiber;
 	/** Whether shutdown is started. */
@@ -1261,11 +1265,7 @@ fiber_lua_state(struct fiber *f);
 void
 fiber_set_system(struct fiber *f, bool yesno);
 
-/**
- * Turn managed shutdown on for system fiber. See FIBER_MANAGED_SHUTDOWN.
- * It is should be used after fiber creation. Using it during shutdown does not
- * work.
- */
+/** Turn managed shutdown on. See FIBER_MANAGED_SHUTDOWN. */
 void
 fiber_set_managed_shutdown(struct fiber *f);
 

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -245,8 +245,7 @@ fiber_self(void);
  * Create a new fiber.
  *
  * Takes a fiber from fiber cache, if it's not empty.
- * Can fail only if there is not enough memory for
- * the fiber structure or fiber stack.
+ * Never fails (never returns NULL).
  *
  * The created fiber automatically returns itself
  * to the fiber cache when its "main" function
@@ -263,8 +262,7 @@ fiber_new(const char *name, fiber_func f);
 /**
  * Create a new fiber with defined attributes.
  *
- * Can fail only if there is not enough memory for
- * the fiber structure or fiber stack.
+ * Never fails (never returns NULL).
  *
  * The created fiber automatically returns itself
  * to the fiber cache if has default stack size
@@ -630,6 +628,12 @@ struct fiber {
 	struct slab *stack_slab;
 	/** Coro stack addr. */
 	void *stack;
+	/**
+	 * Whether fiber stack guard page is protected with mprotect().
+	 * Can be false in case of mprotect() failure or under ASAN
+	 * when we turn this feature off.
+	 */
+	bool has_guard;
 #ifdef HAVE_MADV_DONTNEED
 	/**
 	 * We want to keep total stack memory usage low while still
@@ -1017,7 +1021,7 @@ cord_slab_cache(void)
  * @details
  * Works the same way as fiber_new(), but uses fiber_attr_default
  * supplemented by the FIBER_IS_SYSTEM flag in order to create a
- * fiber.
+ * fiber. Never fails (never returns NULL).
  *
  * @param name       string with fiber name
  * @param f          func for run inside fiber
@@ -1301,31 +1305,6 @@ fiber_testcancel(void)
 	 */
 	if (fiber_is_cancelled())
 		tnt_raise(FiberIsCancelled);
-}
-
-static inline struct fiber *
-fiber_new_xc(const char *name, fiber_func func)
-{
-	struct fiber *f = fiber_new(name, func);
-	if (f == NULL) {
-		diag_raise();
-		unreachable();
-	}
-	return f;
-}
-
-/**
- * The same as fiber_new_system(), but throws an exception
- */
-static inline struct fiber *
-fiber_new_system_xc(const char *name, fiber_func func)
-{
-	struct fiber *f = fiber_new_system(name, func);
-	if (f == NULL) {
-		diag_raise();
-		unreachable();
-	}
-	return f;
 }
 
 static inline int

--- a/src/lib/core/fiber_pool.c
+++ b/src/lib/core/fiber_pool.c
@@ -144,10 +144,6 @@ fiber_pool_cb(ev_loop *loop, struct ev_watcher *watcher, int events)
 			 * it's execution.
 			 */
 			f = fiber_new_system("pool", fiber_pool_f);
-			if (f == NULL) {
-				diag_log();
-				break;
-			}
 			fiber_start(f, pool);
 		} else {
 			/**

--- a/src/lib/swim/swim.c
+++ b/src/lib/swim/swim.c
@@ -1901,11 +1901,7 @@ swim_event_handler_f(va_list va)
 struct swim *
 swim_new(uint64_t generation)
 {
-	struct swim *swim = (struct swim *) calloc(1, sizeof(*swim));
-	if (swim == NULL) {
-		diag_set(OutOfMemory, sizeof(*swim), "calloc", "swim");
-		return NULL;
-	}
+	struct swim *swim = xcalloc(1, sizeof(*swim));
 	swim->initial_generation = generation;
 	swim->members = mh_swim_table_new();
 	rlist_create(&swim->round_queue);
@@ -1929,10 +1925,6 @@ swim_new(uint64_t generation)
 	stailq_create(&swim->event_queue);
 	swim->event_handler = fiber_new_system("SWIM event handler",
 					       swim_event_handler_f);
-	if (swim->event_handler == NULL) {
-		swim_delete(swim);
-		return NULL;
-	}
 	fiber_set_joinable(swim->event_handler, true);
 	fiber_set_managed_shutdown(swim->event_handler);
 	fiber_start(swim->event_handler, swim);

--- a/src/lib/swim/swim.h
+++ b/src/lib/swim/swim.h
@@ -65,7 +65,7 @@ enum swim_gc_mode {
 /**
  * Create a new SWIM instance. Do not bind to a port or set any
  * parameters. Allocation and initialization only. The function
- * yields.
+ * yields. Never fails (never returns NULL).
  */
 struct swim *
 swim_new(uint64_t generation);

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -475,10 +475,6 @@ fiber_create(struct lua_State *L)
 	int coro_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
 	struct fiber *f = fiber_new("lua", lua_fiber_run_f);
-	if (f == NULL) {
-		luaL_unref(L, LUA_REGISTRYINDEX, coro_ref);
-		luaT_error(L);
-	}
 #ifdef ENABLE_BACKTRACE
 	if (fiber_parent_backtrace_is_enabled()) {
 		struct fiber *parent = fiber();

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -1237,8 +1237,6 @@ tarantool_lua_run_script(char *path, struct instance_state *instance,
 	 */
 
 	script_fiber = fiber_new(title, run_script_f);
-	if (script_fiber == NULL)
-		panic("%s", diag_last_error(diag_get())->errmsg);
 	script_fiber->storage.lua.stack = tarantool_L;
 	/*
 	 * Create a new diag on the stack. Don't pass fiber's diag, because it

--- a/src/lua/swim.c
+++ b/src/lua/swim.c
@@ -119,8 +119,6 @@ lua_swim_new(struct lua_State *L)
 {
 	uint64_t generation = luaL_checkuint64(L, 1);
 	struct swim *s = swim_new(generation);
-	if (s == NULL)
-		return luaT_push_nil_and_error(L);
 	*(struct swim **) luaL_pushcdata(L, ctid_swim_ptr) = s;
 	return 1;
 }

--- a/src/lua/swim.lua
+++ b/src/lua/swim.lua
@@ -1003,9 +1003,6 @@ local function swim_new(cfg)
         generation = fiber.time64()
     end
     local ptr = internal.swim_new(generation)
-    if ptr == nil then
-        return nil, box.error.last()
-    end
     ffi.gc(ptr, internal.swim_gc)
     local s = setmetatable({
         ptr = ptr,

--- a/src/main.cc
+++ b/src/main.cc
@@ -1047,9 +1047,6 @@ main(int argc, char **argv)
 		 */
 		on_shutdown_fiber = fiber_new_system("on_shutdown",
 						     on_shutdown_f);
-		if (on_shutdown_fiber == NULL)
-			diag_raise();
-
 		/*
 		 * The call to tarantool_free() below, thanks to
 		 * on_shutdown triggers, works all the time

--- a/src/on_shutdown.c
+++ b/src/on_shutdown.c
@@ -213,16 +213,11 @@ on_shutdown_run_triggers(void)
 		trigger = rlist_shift_entry(&triggers, struct trigger, link);
 		snprintf(name, FIBER_NAME_INLINE,
 			 "trigger_fiber%d", current_fiber);
-		fibers[current_fiber] =
+		struct fiber *fiber =
 			fiber_new(name, on_shutdown_trigger_fiber_f);
-		if (fibers[current_fiber] != NULL) {
-			fiber_set_joinable(fibers[current_fiber], true);
-			fiber_start(fibers[current_fiber], trigger);
-			current_fiber++;
-		} else {
-			rc = -1;
-			goto out;
-		}
+		fiber_set_joinable(fiber, true);
+		fiber_start(fiber, trigger);
+		fibers[current_fiber++] = fiber;
 	}
 
 	/*
@@ -243,16 +238,11 @@ on_shutdown_run_triggers(void)
 	       current_fiber < trigger_count) {
 		snprintf(name, FIBER_NAME_INLINE,
 			 "trigger_fiber_%s", trigger_name);
-		fibers[current_fiber] =
+		struct fiber *fiber =
 			fiber_new(name, on_shutdown_event_trigger_fiber_f);
-		if (fibers[current_fiber] != NULL) {
-			fiber_set_joinable(fibers[current_fiber], true);
-			fiber_start(fibers[current_fiber], func);
-			current_fiber++;
-		} else {
-			rc = -1;
-			goto out;
-		}
+		fiber_set_joinable(fiber, true);
+		fiber_start(fiber, func);
+		fibers[current_fiber++] = fiber;
 	}
 	event_trigger_iterator_destroy(&it);
 

--- a/src/trivia/util.h
+++ b/src/trivia/util.h
@@ -177,6 +177,8 @@ alloc_failure(const char *filename, int line, size_t size)
 			alloc_failure(__FILE__, __LINE__, (size));		\
 	})
 
+#define xslab_get(p, size)	xalloc_impl((size), slab_get, (p), (size))
+
 /** \cond public */
 
 /**

--- a/test/app/on_shutdownlib.c
+++ b/test/app/on_shutdownlib.c
@@ -107,7 +107,6 @@ cfg(lua_State *L)
 				    on_shutdown_module_stop_func,
 				    on_shutdown_module_bad_func) == 0);
 	module.fiber = fiber_new("fiber", module_fiber_f);
-	fail_unless(module.fiber != NULL);
 	fiber_set_joinable(module.fiber, true);
 	fiber_start(module.fiber);
 	return 0;

--- a/test/unit/cbus.c
+++ b/test/unit/cbus.c
@@ -311,7 +311,6 @@ main(void)
 	fiber_init(fiber_c_invoke);
 	cbus_init();
 	struct fiber *main_fiber = fiber_new("main", cbus_test_suite_f);
-	assert(main_fiber != NULL);
 	fiber_wakeup(main_fiber);
 	ev_run(loop(), 0);
 

--- a/test/unit/cbus_call.c
+++ b/test/unit/cbus_call.c
@@ -122,7 +122,6 @@ static void
 test_cbus_call_cancel(void)
 {
 	struct fiber *canceler_fiber = fiber_new("canceler", canceler_fn);
-	fail_if(canceler_fiber == NULL);
 	fiber_wakeup(canceler_fiber);
 
 	struct cbus_call_msg msg;
@@ -194,7 +193,6 @@ main(void)
 	callee_start(&callee_cord);
 
 	caller_fiber = fiber_new("caller", caller_fn);
-	fail_if(caller_fiber == NULL);
 	fiber_wakeup(caller_fiber);
 
 	ev_run(loop(), 0);

--- a/test/unit/cbus_stress.c
+++ b/test/unit/cbus_stress.c
@@ -139,7 +139,6 @@ thread_start_test_cb(struct cmsg *cmsg)
 {
 	struct thread *t = container_of(cmsg, struct thread, cmsg);
 	struct fiber *test_fiber = fiber_new("test", test_func);
-	assert(test_fiber != NULL);
 	fiber_start(test_fiber, t);
 }
 
@@ -375,7 +374,6 @@ main()
 	header();
 
 	struct fiber *main_fiber = fiber_new("main", main_func);
-	assert(main_fiber != NULL);
 	fiber_wakeup(main_fiber);
 	ev_run(loop(), 0);
 

--- a/test/unit/coio.cc
+++ b/test/unit/coio.cc
@@ -32,7 +32,7 @@ stat_notify_test(FILE *f, const char *filename)
 {
 	header();
 
-	struct fiber *touch = fiber_new_xc("touch", touch_f);
+	struct fiber *touch = fiber_new("touch", touch_f);
 	fiber_start(touch, f);
 	ev_stat stat;
 	note("filename: %s", filename);
@@ -260,7 +260,7 @@ read_write_test(void)
 			/* Make the fd non-writable. */
 			fill_pipe(fds[1]);
 		}
-		struct fiber *f = fiber_new_xc("rw_test", test_funcs[i]);
+		struct fiber *f = fiber_new("rw_test", test_funcs[i]);
 		fiber_set_joinable(f, true);
 		fiber_start(f, &io);
 		fiber_wakeup(f);
@@ -294,7 +294,7 @@ main_f(va_list ap)
 
 	coio_init();
 	coio_enable();
-	struct fiber *call_fiber = fiber_new_xc("coio_call wakeup", test_call_f);
+	struct fiber *call_fiber = fiber_new("coio_call wakeup", test_call_f);
 	fiber_set_joinable(call_fiber, true);
 	fiber_start(call_fiber);
 	fiber_wakeup(call_fiber);
@@ -314,7 +314,7 @@ int main()
 {
 	memory_init();
 	fiber_init(fiber_cxx_invoke);
-	struct fiber *test = fiber_new_xc("coio_stat", main_f);
+	struct fiber *test = fiber_new("coio_stat", main_f);
 	fiber_wakeup(test);
 	ev_run(loop(), 0);
 	fiber_free();

--- a/test/unit/ev_signal_pid.cc
+++ b/test/unit/ev_signal_pid.cc
@@ -103,7 +103,7 @@ main(void)
 	memory_init();
 	fiber_init(fiber_cxx_invoke);
 
-	struct fiber *main = fiber_new_xc("main", main_f);
+	struct fiber *main = fiber_new("main", main_f);
 	fiber_wakeup(main);
 	ev_run(loop(), 0);
 

--- a/test/unit/fiber.cc
+++ b/test/unit/fiber.cc
@@ -734,17 +734,17 @@ new_fiber_on_shudown_f(va_list ap)
 {
 	while (!fiber_is_cancelled())
 		fiber_yield();
+	/*
+	 * New client fiber spawned during fiber shutdown is cancelled
+	 * immediately.
+	 */
 	struct fiber *fiber = fiber_new("fiber_on_shutdown", wait_cancel_f);
-	fail_unless(fiber == NULL);
-	fail_unless(!diag_is_empty(diag_get()));
-	fail_unless(strcmp(diag_last_error(diag_get())->errmsg,
-			   "fiber is cancelled") == 0);
-	struct fiber *system_fiber =
-			fiber_new_system("system_fiber_on_shutdown", noop_f);
-	fail_unless(system_fiber != NULL);
-	fiber_set_joinable(system_fiber, true);
-	fiber_start(system_fiber);
-	fiber_join(system_fiber);
+	fail_unless(fiber != NULL);
+	fiber_set_joinable(fiber, true);
+	fiber_start(fiber);
+	fiber_sleep(0);
+	fail_unless((fiber->flags & FIBER_IS_DEAD) != 0);
+	fiber_join(fiber);
 	return 0;
 }
 
@@ -756,17 +756,22 @@ fiber_test_shutdown(void)
 	struct fiber *fiber1 = fiber_new("fiber1", wait_cancel_f);
 	fail_unless(fiber1 != NULL);
 	fiber_set_joinable(fiber1, true);
+	fiber_start(fiber1);
 	struct fiber *fiber2 = fiber_new_system("fiber2", wait_cancel_f);
 	fail_unless(fiber2 != NULL);
+	fiber_start(fiber2);
 	struct fiber *fiber3 = fiber_new("fiber3", hang_on_cancel_f);
 	fail_unless(fiber3 != NULL);
+	fiber_start(fiber3);
 	struct fiber *fiber4 = fiber_new("fiber4", new_fiber_on_shudown_f);
 	fail_unless(fiber4 != NULL);
 	fiber_set_joinable(fiber4, true);
+	fiber_start(fiber4);
 	struct fiber *fiber6 = fiber_new_system("fiber6", wait_cancel_f);
 	fail_unless(fiber6 != NULL);
 	fiber_set_managed_shutdown(fiber6);
 	fiber_set_joinable(fiber6, true);
+	fiber_start(fiber6);
 
 	int rc = fiber_shutdown(1000.0);
 	fail_unless(rc == 0);
@@ -785,11 +790,48 @@ fiber_test_shutdown(void)
 	fiber_cancel(fiber2);
 	fiber_join(fiber2);
 
+	/*
+	 * New client fiber spawned after fiber shutdown is cancelled
+	 * immediately.
+	 */
 	struct fiber *fiber5 = fiber_new("fiber5", wait_cancel_f);
-	fail_unless(fiber5 == NULL);
-	fail_unless(!diag_is_empty(diag_get()));
-	fail_unless(strcmp(diag_last_error(diag_get())->errmsg,
-			   "fiber is cancelled") == 0);
+	fail_unless(fiber5 != NULL);
+	fiber_set_joinable(fiber5, true);
+	fiber_start(fiber5);
+	fiber_sleep(0);
+	fail_unless((fiber5->flags & FIBER_IS_DEAD) != 0);
+	fail_unless(fiber_join(fiber5) == 0);
+
+	/* New system fiber spawned after fiber shutdown is NOT cancelled. */
+	struct fiber *fiber7 = fiber_new_system("fiber7", wait_cancel_f);
+	fail_unless(fiber7 != NULL);
+	fiber_set_joinable(fiber7, true);
+	fiber_start(fiber7);
+	fiber_sleep(0);
+	fail_unless((fiber7->flags & FIBER_IS_DEAD) == 0);
+	fiber_cancel(fiber7);
+	fail_unless(fiber_join(fiber7) == 0);
+
+	/*
+	 * New system fiber with managed shutdown spawned after fiber shutdown
+	 * is cancelled immediately.
+	 */
+	struct fiber *fiber8 = fiber_new_system("fiber8", wait_cancel_f);
+	fail_unless(fiber8 != NULL);
+	fiber_set_joinable(fiber8, true);
+	fiber_set_managed_shutdown(fiber8);
+	fiber_start(fiber8);
+	fiber_sleep(0);
+	fail_unless((fiber8->flags & FIBER_IS_DEAD) != 0);
+	fail_unless(fiber_join(fiber8) == 0);
+
+	/**
+	 * Test that we don't try to cancel dead non-joinable fiber (this
+	 * will lead to panic.
+	 */
+	struct fiber *fiber9 = fiber_new("fiber9", noop_f);
+	fail_unless(fiber9 != NULL);
+	fiber_start(fiber9);
 
 	header();
 }

--- a/test/unit/fiber.cc
+++ b/test/unit/fiber.cc
@@ -157,19 +157,19 @@ fiber_join_test()
 {
 	header();
 
-	struct fiber *fiber = fiber_new_xc("join", noop_f);
+	struct fiber *fiber = fiber_new("join", noop_f);
 	fiber_set_joinable(fiber, true);
 	fiber_wakeup(fiber);
 	fiber_join(fiber);
 
-	fiber = fiber_new_xc("cancel", cancel_f);
+	fiber = fiber_new("cancel", cancel_f);
 	fiber_set_joinable(fiber, true);
 	fiber_wakeup(fiber);
 	fiber_sleep(0);
 	fiber_cancel(fiber);
 	fiber_join(fiber);
 
-	fiber = fiber_new_xc("exception", exception_f);
+	fiber = fiber_new("exception", exception_f);
 	fiber_set_joinable(fiber, true);
 	fiber_wakeup(fiber);
 	try {
@@ -188,7 +188,7 @@ fiber_join_test()
 	unlink(path);
 	fail_unless(f != NULL);
 
-	fiber = fiber_new_xc("exception", exception_f);
+	fiber = fiber_new("exception", exception_f);
 	fiber_wakeup(fiber);
 	fiber_sleep(0);
 	char buf[1024];
@@ -204,7 +204,7 @@ fiber_join_test()
 	 * A fiber which is using exception should not
 	 * push them up the stack.
 	 */
-	fiber = fiber_new_xc("no_exception", no_exception_f);
+	fiber = fiber_new("no_exception", no_exception_f);
 	fiber_set_joinable(fiber, true);
 	fiber_wakeup(fiber);
 	fiber_join(fiber);
@@ -212,7 +212,7 @@ fiber_join_test()
 	 * Trying to cancel a dead joinable cancellable fiber lead to
 	 * a crash, because cancel would try to schedule it.
 	 */
-	fiber = fiber_new_xc("cancel_dead", cancel_dead_f);
+	fiber = fiber_new("cancel_dead", cancel_dead_f);
 	fiber_set_joinable(fiber, true);
 	fiber_wakeup(fiber);
 	/** Let the fiber schedule */
@@ -222,7 +222,7 @@ fiber_join_test()
 	fiber_join(fiber);
 
 	note("Can change the joinability in safe cases.");
-	fiber = fiber_new_xc("alive_not_joinable", noop_f);
+	fiber = fiber_new("alive_not_joinable", noop_f);
 	/* Non-joinable not dead fiber.  */
 	fiber_set_joinable(fiber, true);
 	fail_unless((fiber->flags & FIBER_IS_JOINABLE) != 0);
@@ -251,7 +251,7 @@ fiber_stack_test()
 	 * Test a fiber with the default stack size.
 	 */
 	stack_expand_limit = default_attr.stack_size * 3 / 4;
-	fiber = fiber_new_xc("test_stack", test_stack_f);
+	fiber = fiber_new("test_stack", test_stack_f);
 	fiber_wakeup(fiber);
 	fiber_sleep(0);
 	note("normal-stack fiber not crashed");
@@ -322,7 +322,7 @@ fiber_wakeup_self_test()
 	 * Wakeup + start of a new fiber. This is different from yield but
 	 * works without crashes too.
 	 */
-	struct fiber *newf = fiber_new_xc("nop", noop_f);
+	struct fiber *newf = fiber_new("nop", noop_f);
 	fiber_wakeup(f);
 	fiber_start(newf);
 
@@ -334,7 +334,7 @@ fiber_wakeup_dead_test()
 {
 	header();
 
-	struct fiber *fiber = fiber_new_xc("wakeup_dead", noop_f);
+	struct fiber *fiber = fiber_new("wakeup_dead", noop_f);
 	fiber_set_joinable(fiber, true);
 	fiber_start(fiber);
 	fiber_wakeup(fiber);
@@ -349,7 +349,7 @@ fiber_dead_while_in_cache_test(void)
 {
 	header();
 
-	struct fiber *f = fiber_new_xc("nop", noop_f);
+	struct fiber *f = fiber_new("nop", noop_f);
 	int fiber_count = fiber_count_total();
 	fiber_start(f);
 	/* The fiber remains in the cache of recycled fibers. */
@@ -365,7 +365,7 @@ fiber_flags_respect_test(void)
 	header();
 
 	/* Make sure the cache has at least one fiber. */
-	struct fiber *f = fiber_new_xc("nop", noop_f);
+	struct fiber *f = fiber_new("nop", noop_f);
 	fiber_start(f);
 
 	/* Fibers taken from the cache need to respect the passed flags. */
@@ -387,7 +387,7 @@ fiber_wait_on_deadline_test()
 {
 	header();
 
-	struct fiber *fiber = fiber_new_xc("noop", noop_f);
+	struct fiber *fiber = fiber_new("noop", noop_f);
 	fiber_set_joinable(fiber, true);
 	fiber_wakeup(fiber);
 	bool exceeded = fiber_wait_on_deadline(fiber, fiber_clock() + 100.0);
@@ -395,7 +395,7 @@ fiber_wait_on_deadline_test()
 	fail_if(!fiber_is_dead(fiber));
 	fiber_join(fiber);
 
-	fiber = fiber_new_xc("cancel", cancel_f);
+	fiber = fiber_new("cancel", cancel_f);
 	fiber_set_joinable(fiber, true);
 	fiber_wakeup(fiber);
 	exceeded = fiber_wait_on_deadline(fiber, fiber_clock() + 0.001);
@@ -418,7 +418,6 @@ cord_cojoin_test(void)
 
 	/* Check that cord_cojoin is not interrupted by fiber_wakeup. */
 	struct fiber *waker_fiber = fiber_new("waker", waker_f);
-	fail_if(waker_fiber == NULL);
 	waker_fiber->f_arg = fiber();
 	fiber_wakeup(waker_fiber);
 
@@ -438,12 +437,10 @@ cord_cojoin_cancel_test(void)
 	fail_if(cord_costart(&cord, "cord", wait_cancel_f, NULL) != 0);
 
 	struct fiber *canceller_fiber = fiber_new("canceller", canceller_f);
-	fail_if(canceller_fiber == NULL);
 	canceller_fiber->f_arg = fiber();
 	fiber_wakeup(canceller_fiber);
 
 	struct fiber *watcher_fiber = fiber_new("watcher", watcher_f);
-	fail_if(watcher_fiber == NULL);
 	fiber_set_joinable(watcher_fiber, true);
 	fiber_wakeup(watcher_fiber);
 
@@ -525,7 +522,7 @@ fiber_test_leak(bool backtrace_enabled)
 	int rc = lseek(fd, 0, SEEK_END);
 	fail_if(rc == -1);
 
-	struct fiber *fiber = fiber_new_xc("leak", leaker_f);
+	struct fiber *fiber = fiber_new("leak", leaker_f);
 	fiber_set_joinable(fiber, true);
 	fiber_wakeup(fiber);
 	fiber_join(fiber);
@@ -601,19 +598,15 @@ fiber_test_client_fiber_count(void)
 	int count = cord()->client_fiber_count;
 
 	struct fiber *fiber1 = fiber_new("fiber1", wait_cancel_f);
-	fail_unless(fiber1 != NULL);
 	fail_unless(++count == cord()->client_fiber_count);
 
 	struct fiber *fiber2 = fiber_new("fiber2", wait_cancel_f);
-	fail_unless(fiber2 != NULL);
 	fail_unless(++count == cord()->client_fiber_count);
 
 	struct fiber *fiber3 = fiber_new_system("fiber3", wait_cancel_f);
-	fail_unless(fiber3 != NULL);
 	fail_unless(count == cord()->client_fiber_count);
 
 	struct fiber *fiber4 = fiber_new_system("fiber4", wait_cancel_f);
-	fail_unless(fiber4 != NULL);
 	fail_unless(count == cord()->client_fiber_count);
 
 	fiber_set_joinable(fiber1, true);
@@ -645,7 +638,6 @@ fiber_test_set_system(void)
 	header();
 
 	struct fiber *fiber1 = fiber_new("fiber1", wait_cancel_f);
-	fail_unless(fiber1 != NULL);
 	int count = cord()->client_fiber_count;
 
 	fiber_set_system(fiber1, true);
@@ -665,7 +657,6 @@ fiber_test_set_system(void)
 	fail_unless((fiber1->flags & FIBER_IS_SYSTEM) == 0);
 
 	struct fiber *fiber2 = fiber_new_system("fiber2", wait_cancel_f);
-	fail_unless(fiber2 != NULL);
 	count = cord()->client_fiber_count;
 
 	fiber_set_system(fiber2, false);
@@ -700,7 +691,6 @@ fiber_test_set_managed_shutdown(void)
 	header();
 
 	struct fiber *fiber1 = fiber_new_system("fiber1", wait_cancel_f);
-	fail_unless(fiber1 != NULL);
 	int count = cord()->managed_shutdown_fiber_count;
 
 	fiber_set_managed_shutdown(fiber1);
@@ -739,7 +729,6 @@ new_fiber_on_shudown_f(va_list ap)
 	 * immediately.
 	 */
 	struct fiber *fiber = fiber_new("fiber_on_shutdown", wait_cancel_f);
-	fail_unless(fiber != NULL);
 	fiber_set_joinable(fiber, true);
 	fiber_start(fiber);
 	fiber_sleep(0);
@@ -754,21 +743,16 @@ fiber_test_shutdown(void)
 	footer();
 
 	struct fiber *fiber1 = fiber_new("fiber1", wait_cancel_f);
-	fail_unless(fiber1 != NULL);
 	fiber_set_joinable(fiber1, true);
 	fiber_start(fiber1);
 	struct fiber *fiber2 = fiber_new_system("fiber2", wait_cancel_f);
-	fail_unless(fiber2 != NULL);
 	fiber_start(fiber2);
 	struct fiber *fiber3 = fiber_new("fiber3", hang_on_cancel_f);
-	fail_unless(fiber3 != NULL);
 	fiber_start(fiber3);
 	struct fiber *fiber4 = fiber_new("fiber4", new_fiber_on_shudown_f);
-	fail_unless(fiber4 != NULL);
 	fiber_set_joinable(fiber4, true);
 	fiber_start(fiber4);
 	struct fiber *fiber6 = fiber_new_system("fiber6", wait_cancel_f);
-	fail_unless(fiber6 != NULL);
 	fiber_set_managed_shutdown(fiber6);
 	fiber_set_joinable(fiber6, true);
 	fiber_start(fiber6);
@@ -795,7 +779,6 @@ fiber_test_shutdown(void)
 	 * immediately.
 	 */
 	struct fiber *fiber5 = fiber_new("fiber5", wait_cancel_f);
-	fail_unless(fiber5 != NULL);
 	fiber_set_joinable(fiber5, true);
 	fiber_start(fiber5);
 	fiber_sleep(0);
@@ -804,7 +787,6 @@ fiber_test_shutdown(void)
 
 	/* New system fiber spawned after fiber shutdown is NOT cancelled. */
 	struct fiber *fiber7 = fiber_new_system("fiber7", wait_cancel_f);
-	fail_unless(fiber7 != NULL);
 	fiber_set_joinable(fiber7, true);
 	fiber_start(fiber7);
 	fiber_sleep(0);
@@ -817,7 +799,6 @@ fiber_test_shutdown(void)
 	 * is cancelled immediately.
 	 */
 	struct fiber *fiber8 = fiber_new_system("fiber8", wait_cancel_f);
-	fail_unless(fiber8 != NULL);
 	fiber_set_joinable(fiber8, true);
 	fiber_set_managed_shutdown(fiber8);
 	fiber_start(fiber8);
@@ -830,7 +811,6 @@ fiber_test_shutdown(void)
 	 * will lead to panic.
 	 */
 	struct fiber *fiber9 = fiber_new("fiber9", noop_f);
-	fail_unless(fiber9 != NULL);
 	fiber_start(fiber9);
 
 	header();
@@ -902,7 +882,7 @@ int main()
 	memory_init();
 	fiber_init(fiber_cxx_invoke);
 	fiber_attr_create(&default_attr);
-	struct fiber *main = fiber_new_system_xc("main", main_f);
+	struct fiber *main = fiber_new_system("main", main_f);
 	fiber_wakeup(main);
 	ev_run(loop(), 0);
 	fiber_free();

--- a/test/unit/fiber.cc
+++ b/test/unit/fiber.cc
@@ -694,6 +694,30 @@ fiber_test_set_system(void)
 	footer();
 }
 
+static void
+fiber_test_set_managed_shutdown(void)
+{
+	header();
+
+	struct fiber *fiber1 = fiber_new_system("fiber1", wait_cancel_f);
+	fail_unless(fiber1 != NULL);
+	int count = cord()->managed_shutdown_fiber_count;
+
+	fiber_set_managed_shutdown(fiber1);
+	fail_unless(++count == cord()->managed_shutdown_fiber_count);
+	fail_unless((fiber1->flags & FIBER_MANAGED_SHUTDOWN) != 0);
+
+	fiber_set_managed_shutdown(fiber1);
+	fail_unless(count == cord()->managed_shutdown_fiber_count);
+	fail_unless((fiber1->flags & FIBER_MANAGED_SHUTDOWN) != 0);
+
+	fiber_set_joinable(fiber1, true);
+	fiber_cancel(fiber1);
+	fiber_join(fiber1);
+
+	footer();
+}
+
 static int
 hang_on_cancel_f(va_list ap)
 {
@@ -819,6 +843,7 @@ main_f(va_list ap)
 	fiber_test_leak_modes();
 	fiber_test_client_fiber_count();
 	fiber_test_set_system();
+	fiber_test_set_managed_shutdown();
 	fiber_test_shutdown();
 	cord_no_user_thread_rename();
 	ev_break(loop(), EVBREAK_ALL);

--- a/test/unit/fiber.result
+++ b/test/unit/fiber.result
@@ -42,6 +42,8 @@
 	*** fiber_test_client_fiber_count: done ***
 	*** fiber_test_set_system ***
 	*** fiber_test_set_system: done ***
+	*** fiber_test_set_managed_shutdown ***
+	*** fiber_test_set_managed_shutdown: done ***
 	*** fiber_test_shutdown: done ***
 	*** fiber_test_shutdown ***
 	*** cord_no_user_thread_rename ***

--- a/test/unit/fiber_channel.cc
+++ b/test/unit/fiber_channel.cc
@@ -151,7 +151,6 @@ fiber_channel_close_reader(enum fiber_channel_close_mode mode)
 
 	struct fiber_channel *channel = fiber_channel_new(0);
 	struct fiber *reader = fiber_new("reader", reader_f);
-	fail_if(reader == NULL);
 	fiber_set_ctx(reader, channel);
 	fiber_set_joinable(reader, true);
 	fiber_wakeup(reader);
@@ -197,7 +196,6 @@ fiber_channel_close_writer(enum fiber_channel_close_mode mode)
 
 	struct fiber_channel *channel = fiber_channel_new(0);
 	struct fiber *writer = fiber_new("writer", writer_f);
-	fail_if(writer == NULL);
 	fiber_set_ctx(writer, channel);
 	fiber_set_joinable(writer, true);
 	fiber_wakeup(writer);
@@ -246,7 +244,7 @@ int main()
 {
 	memory_init();
 	fiber_init(fiber_c_invoke);
-	struct fiber *main= fiber_new_xc("main", main_f);
+	struct fiber *main = fiber_new("main", main_f);
 	fiber_wakeup(main);
 	ev_run(loop(), 0);
 	fiber_free();

--- a/test/unit/fiber_channel_stress.cc
+++ b/test/unit/fiber_channel_stress.cc
@@ -33,9 +33,9 @@ static int
 main_f(va_list ap)
 {
 	header();
-	struct fiber *push = fiber_new_xc("push_f", push_f);
+	struct fiber *push = fiber_new("push_f", push_f);
 	fiber_set_joinable(push, true);
-	struct fiber *pop = fiber_new_xc("pop_f", pop_f);
+	struct fiber *pop = fiber_new("pop_f", pop_f);
 	fiber_set_joinable(pop, true);
 	struct fiber_channel *channel = fiber_channel_new(1);
 	fiber_start(push, channel);
@@ -52,7 +52,7 @@ int main()
 {
 	memory_init();
 	fiber_init(fiber_c_invoke);
-	struct fiber *main= fiber_new_xc("main", main_f);
+	struct fiber *main = fiber_new("main", main_f);
 	fiber_wakeup(main);
 	ev_run(loop(), 0);
 	fiber_free();

--- a/test/unit/fiber_cond.c
+++ b/test/unit/fiber_cond.c
@@ -34,12 +34,10 @@ fiber_cond_basic()
 	int check = 0;
 
 	struct fiber *f1 = fiber_new("f1", fiber_cond_basic_f);
-	assert(f1 != NULL);
 	fiber_start(f1, cond, &check);
 	fiber_set_joinable(f1, true);
 
 	struct fiber *f2 = fiber_new("f2", fiber_cond_basic_f);
-	assert(f2 != NULL);
 	fiber_start(f2, cond, &check);
 	fiber_set_joinable(f2, true);
 

--- a/test/unit/fiber_stack.c
+++ b/test/unit/fiber_stack.c
@@ -37,7 +37,7 @@ main_f(va_list ap)
 #ifdef NDEBUG
 	plan(1);
 #else
-	plan(11);
+	plan(10);
 #endif
 
 	/*
@@ -83,8 +83,10 @@ main_f(va_list ap)
 	fiber = fiber_new_ex("test_mprotect", fiber_attr, noop_f);
 	inj->iparam = -1;
 
-	ok(fiber == NULL, "mprotect: failed to setup fiber guard page");
-	ok(diag_get() != NULL, "mprotect: diag is armed after error");
+	ok(fiber != NULL, "mprotect: fiber guard page setup failure ignored");
+	fiber_set_joinable(fiber, true);
+	fiber_start(fiber);
+	fiber_join(fiber);
 
 	/*
 	 * Check madvise error on fiber creation.
@@ -131,7 +133,11 @@ main_f(va_list ap)
 	inj->iparam = -1;
 
 	used_after = slab_cache_used(slabc);
+#ifndef ENABLE_ASAN
 	ok(used_after > used_before, "expected leak detected");
+#else
+	ok(used_after == used_before, "no leak under ASAN");
+#endif
 
 	cord_collect_garbage(cord());
 	ok(fiber_count_total() == fiber_count, "fiber is deleted");

--- a/test/unit/fiber_stress.cc
+++ b/test/unit/fiber_stress.cc
@@ -19,7 +19,7 @@ benchmark_f(va_list ap)
 {
 	struct fiber *fibers[FIBERS];
 	for (int i = 0; i < FIBERS; i++) {
-		fibers[i] = fiber_new_xc("yield-wielder", yield_f);
+		fibers[i] = fiber_new("yield-wielder", yield_f);
 		fiber_wakeup(fibers[i]);
 	}
 	/** Wait for fibers to die. */
@@ -35,7 +35,7 @@ int main()
 {
 	memory_init();
 	fiber_init(fiber_cxx_invoke);
-	struct fiber *benchmark = fiber_new_xc("benchmark", benchmark_f);
+	struct fiber *benchmark = fiber_new("benchmark", benchmark_f);
 	fiber_wakeup(benchmark);
 	ev_run(loop(), 0);
 	fiber_free();

--- a/test/unit/guard.cc
+++ b/test/unit/guard.cc
@@ -64,7 +64,7 @@ int main()
 	memory_init();
 	fiber_init(fiber_cxx_invoke);
 	fiber_attr_create(&default_attr);
-	struct fiber *fmain = fiber_new_xc("main", main_f);
+	struct fiber *fmain = fiber_new("main", main_f);
 	fiber_wakeup(fmain);
 	ev_run(loop(), 0);
 	fiber_free();

--- a/test/unit/latch.c
+++ b/test/unit/latch.c
@@ -47,7 +47,6 @@ latch_order_test(bool wakeup_before_unlock)
 	struct fiber *fibers[num_fibers];
 	for (size_t i = 0; i < num_fibers; i++) {
 		fibers[i] = fiber_new("ordered", order_f);
-		fail_if(fibers[i] == NULL);
 		fiber_set_joinable(fibers[i], true);
 		fiber_start(fibers[i], &i, &check, &latch);
 	}
@@ -75,7 +74,6 @@ latch_timeout_test(void)
 	latch_create(&latch);
 
 	struct fiber *fiber = fiber_new("sleeping", sleep_f);
-	fail_if(fiber == NULL);
 	fiber_set_joinable(fiber, true);
 	fiber_start(fiber, &latch);
 

--- a/test/unit/port.cc
+++ b/test/unit/port.cc
@@ -1219,7 +1219,7 @@ main(void)
 			L, "mp = require('msgpack')") == 0);
 
 	/* XXX: session cleanup tied to fiber stop (session_new_on_demand). */
-	struct fiber *main = fiber_new_system_xc("main", main_f);
+	struct fiber *main = fiber_new_system("main", main_f);
 	fiber_wakeup(main);
 	ev_run(loop(), 0);
 

--- a/test/unit/say.c
+++ b/test/unit/say.c
@@ -241,10 +241,6 @@ int main()
 	coio_enable();
 
 	struct fiber *test = fiber_new("loggers", main_f);
-	if (test == NULL) {
-		diag_log();
-		return check_plan();
-	}
 	fiber_wakeup(test);
 	ev_run(loop(), 0);
 

--- a/test/unit/tnt_thread.c
+++ b/test/unit/tnt_thread.c
@@ -365,7 +365,6 @@ main(void)
 	fiber_init(fiber_c_invoke);
 	cbus_init();
 	struct fiber *main_fiber = fiber_new("main", tnt_thread_test_suite_f);
-	assert(main_fiber != NULL);
 	fiber_wakeup(main_fiber);
 	ev_run(loop(), 0);
 	cbus_free();

--- a/test/unit/tt_sort.cc
+++ b/test/unit/tt_sort.cc
@@ -262,7 +262,7 @@ main(void)
 	memory_init();
 	fiber_init(fiber_cxx_invoke);
 
-	struct fiber *main = fiber_new_xc("main", main_f);
+	struct fiber *main = fiber_new("main", main_f);
 	fiber_wakeup(main);
 	ev_run(loop(), 0);
 


### PR DESCRIPTION
There are 2 cases when `fiber_new()` may fail:
1. stack allocation failure.
2. guard page protection with `mprotect()` failure.

Let's panic in the 1st case - we panic soon anyway as our policy is to panic on runtime memory allocation failures.

Let's just drop a line in log in the 2d case, checking stack overflow is not critical.

Closes #12338