### PR TITLE
sql: rework parsing of DEFAULT

### DIFF
--- a/changelogs/unreleased/gh-12911-default-value-rule.md
+++ b/changelogs/unreleased/gh-12911-default-value-rule.md
@@ -1,0 +1,4 @@
+## feature/sql
+
+* The function that calculates a default value for a column can now be
+  specified without enclosing it in parentheses (gh-12911).

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -494,7 +494,7 @@ sql_expr_uint(const struct Expr *expr, uint64_t *res)
 	return errno == 0 ? 0 : -1;
 }
 
-void
+static void
 sql_add_term_default(struct Parse *parser, struct ExprSpan *expr_span)
 {
 	assert(parser->create_column_def.space != NULL);
@@ -533,9 +533,21 @@ sql_add_term_default(struct Parse *parser, struct ExprSpan *expr_span)
 		break;
 	}
 	case FIELD_TYPE_DOUBLE: {
+		const char *str;
+		if (expr->op == TK_UMINUS) {
+			assert(expr->pLeft != NULL &&
+			       expr->pLeft->op == TK_FLOAT);
+			str = tt_sprintf("-%s", expr->pLeft->u.zToken);
+		} else if (expr->op == TK_UPLUS) {
+			assert(expr->pLeft != NULL &&
+			       expr->pLeft->op == TK_FLOAT);
+			str = expr->pLeft->u.zToken;
+		} else {
+			assert(expr->op == TK_FLOAT);
+			str = expr->u.zToken;
+		}
 		double val;
-		sqlAtoF(expr_span->zStart, &val,
-			expr_span->zEnd - expr_span->zStart);
+		sqlAtoF(str, &val, strlen(str));
 		assert(!sqlIsNaN(val));
 		size = mp_sizeof_double(val);
 		buf = xregion_alloc(region, size);
@@ -543,8 +555,19 @@ sql_add_term_default(struct Parse *parser, struct ExprSpan *expr_span)
 		break;
 	}
 	case FIELD_TYPE_DECIMAL: {
-		const char *str = tt_cstr(expr_span->zStart,
-					  expr_span->zEnd - expr_span->zStart);
+		const char *str;
+		if (expr->op == TK_UMINUS) {
+			assert(expr->pLeft != NULL &&
+			       expr->pLeft->op == TK_DECIMAL);
+			str = tt_sprintf("-%s", expr->pLeft->u.zToken);
+		} else if (expr->op == TK_UPLUS) {
+			assert(expr->pLeft != NULL &&
+			       expr->pLeft->op == TK_DECIMAL);
+			str = expr->pLeft->u.zToken;
+		} else {
+			assert(expr->op == TK_DECIMAL);
+			str = expr->u.zToken;
+		}
 		decimal_t val;
 		if (decimal_from_string(&val, str) == NULL) {
 			diag_set(ClientError, ER_INVALID_DEC, str);
@@ -573,6 +596,11 @@ sql_add_term_default(struct Parse *parser, struct ExprSpan *expr_span)
 				 tt_sprintf("%s%s", "-", str));
 			parser->is_aborted = true;
 			break;
+		}
+		if (expr->op == TK_UPLUS) {
+			assert(expr->pLeft != NULL &&
+			       expr->pLeft->op == TK_INTEGER);
+			expr = expr->pLeft;
 		}
 		uint64_t val;
 		if (sql_expr_uint(expr, &val) == 0) {
@@ -1226,7 +1254,7 @@ vdbe_emit_ck_constraint_create(struct Parse *parser,
 	sqlVdbeCountChanges(v);
 }
 
-void
+static void
 sql_add_func_default(struct Parse *parser, struct ExprSpan *span)
 {
 	assert(parser->create_column_def.space != NULL);
@@ -1256,6 +1284,27 @@ sql_add_func_default(struct Parse *parser, struct ExprSpan *span)
 	parser->default_funcs = sql_xrealloc(parser->default_funcs, size);
 	parser->default_funcs[id].fieldno = fieldno;
 	parser->default_funcs[id].reg_func_id = reg_id;
+}
+
+static bool
+sql_expr_is_number_term(const struct Expr *expr)
+{
+	return expr->op == TK_INTEGER || expr->op == TK_FLOAT ||
+	       expr->op == TK_DECIMAL;
+}
+
+void
+sql_column_add_default(struct Parse *parser, struct ExprSpan *expr_span)
+{
+	struct Expr *expr = expr_span->pExpr;
+	if (sql_expr_is_term(expr))
+		sql_add_term_default(parser, expr_span);
+	else if (expr->op == TK_UPLUS && sql_expr_is_number_term(expr->pLeft))
+		sql_add_term_default(parser, expr_span);
+	else if (expr->op == TK_UMINUS && sql_expr_is_number_term(expr->pLeft))
+		sql_add_term_default(parser, expr_span);
+	else
+		sql_add_func_default(parser, expr_span);
 }
 
 /**

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -290,20 +290,17 @@ carglist ::= .
 %type cconsname { struct Token }
 cconsname(N) ::= CONSTRAINT nm(X). { N = X; }
 cconsname(N) ::= . { N = Token_nil; }
-ccons ::= DEFAULT term(X).            {sql_add_term_default(pParse, &X);}
-ccons ::= DEFAULT LP expr(X) RP.      {
-  if (sql_expr_is_term(X.pExpr))
-    sql_add_term_default(pParse, &X);
-  else
-    sql_add_func_default(pParse, &X);
-}
-ccons ::= DEFAULT PLUS number(X).     {sql_add_term_default(pParse, &X);}
-ccons ::= DEFAULT MINUS(A) number(X). {
-  ExprSpan v;
-  v.pExpr = sqlPExpr(pParse, TK_UMINUS, X.pExpr, 0);
-  v.zStart = A.z;
-  v.zEnd = X.zEnd;
-  sql_add_term_default(pParse, &v);
+
+/**
+ * Rule precedence [COLLATE] forces the parser to reduce this rule rather
+ * than shift a follow-up NOT or COLLATE token into the expression: the
+ * token NOT come earlier in the precedence table than COLLATE,
+ * and COLLATE itself is %left - so both shift-reduce conflicts
+ * with `expr NOT ...` / `expr COLLATE ...` resolve as reduce, and the
+ * tokens go to the next ccons instead.
+ */
+ccons ::= DEFAULT expr(X). [COLLATE] {
+  sql_column_add_default(pParse, &X);
 }
 
 // In addition to the type name, we also care about the primary key and
@@ -894,8 +891,6 @@ idlist(A) ::= nm(Y). {
 %destructor expr {sql_expr_delete($$.pExpr);}
 %type term {ExprSpan}
 %destructor term {sql_expr_delete($$.pExpr);}
-%type number {ExprSpan}
-%destructor number {sql_expr_delete($$.pExpr);}
 
 %include {
   /* This is a utility routine used to set the ExprSpan.zStart and
@@ -977,10 +972,9 @@ term(A) ::= STRING(X).     {spanExpr(&A, @X, X);/*A-overwrites-X*/}
 term(A) ::= FALSE(X) . {spanExpr(&A, @X, X);/*A-overwrites-X*/}
 term(A) ::= TRUE(X) . {spanExpr(&A, @X, X);/*A-overwrites-X*/}
 term(A) ::= UNKNOWN(X) . {spanExpr(&A, @X, X);/*A-overwrites-X*/}
-term(A) ::= number(A).
-number(A) ::= FLOAT(X). {spanExpr(&A, @X, X);/*A-overwrites-X*/}
-number(A) ::= DECIMAL(X) . {spanExpr(&A, @X, X);/*A-overwrites-X*/}
-number(A) ::= INTEGER(X). {
+term(A) ::= FLOAT(X). {spanExpr(&A, @X, X);/*A-overwrites-X*/}
+term(A) ::= DECIMAL(X) . {spanExpr(&A, @X, X);/*A-overwrites-X*/}
+term(A) ::= INTEGER(X). {
   A.pExpr = sql_expr_new_dequoted(TK_INTEGER, &X);
   A.pExpr->type = FIELD_TYPE_INTEGER;
   A.zStart = X.z;

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2736,13 +2736,9 @@ sqlAddPrimaryKey(struct Parse *parse);
 void
 sql_create_check_contraint(struct Parse *parser, bool is_field_ck);
 
-/** Add a default literal to the last created column. */
+/** Add a DEFAULT clause to the last created column. */
 void
-sql_add_term_default(struct Parse *parser, struct ExprSpan *expr_span);
-
-/** Add a default expression to the last created column. */
-void
-sql_add_func_default(struct Parse *parser, struct ExprSpan *span);
+sql_column_add_default(struct Parse *parser, struct ExprSpan *expr_span);
 
 void sqlAddCollateType(Parse *, Token *);
 

--- a/test/sql-luatest/defaults_test.lua
+++ b/test/sql-luatest/defaults_test.lua
@@ -104,132 +104,100 @@ g.test_sql_expr_default_func = function()
     end)
 end
 
-g.test_only_numbers_with_signs = function()
+-- Make sure that numeric values with sign are encoded as the literal defaults.
+g.test_numbers_with_signs = function()
     g.server:exec(function()
-        -- Make sure STRING literal with '-' before it cannot be the default.
-        local sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT -'a');]]
-        local res, err = box.execute(sql)
-        local exp = [[Syntax error at line 1 near ''a'']]
-        t.assert(res == nil);
-        t.assert_equals(err.message, exp)
-
-        -- Make sure STRING literal with '+' before it cannot be the default.
-        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT +'a');]]
-        res, err = box.execute(sql)
-        t.assert(res == nil);
-        t.assert_equals(err.message, exp)
-
-        -- Make sure NULL literal with '-' before it cannot be the default.
-        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT -NULL);]]
-        res, err = box.execute(sql)
-        exp = [[At line 1 at or near position 50: keyword 'NULL' is ]]..
-              [[reserved. Please use double quotes if 'NULL' is an identifier.]]
-        t.assert(res == nil);
-        t.assert_equals(err.message, exp)
-
-        -- Make sure NULL literal with '+' before it cannot be the default.
-        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT +NULL);]]
-        res, err = box.execute(sql)
-        t.assert(res == nil);
-        t.assert_equals(err.message, exp)
-
-        -- Make sure UNKNOWN literal with '-' before it cannot be the default.
-        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT -unknown);]]
-        res, err = box.execute(sql)
-        exp = [[At line 1 at or near position 50: keyword 'unknown' is ]]..
-              [[reserved. Please use double quotes if 'unknown' is an ]]..
-              [[identifier.]]
-        t.assert(res == nil);
-        t.assert_equals(err.message, exp)
-
-        -- Make sure UNKNOWN literal with '+' before it cannot be the default.
-        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT +unknown);]]
-        res, err = box.execute(sql)
-        t.assert(res == nil);
-        t.assert_equals(err.message, exp)
-
-        -- Make sure VARBINARY literal with '-' before it cannot be the default.
-        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT -x'aa');]]
-        res, err = box.execute(sql)
-        exp = [[Syntax error at line 1 near 'x'aa'']]
-        t.assert(res == nil);
-        t.assert_equals(err.message, exp)
-
-        -- Make sure VARBINARY literal with '+' before it cannot be the default.
-        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT +x'aa');]]
-        res, err = box.execute(sql)
-        t.assert(res == nil);
-        t.assert_equals(err.message, exp)
-
-        -- Make sure TRUE literal with '-' before it cannot be the default.
-        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT -true);]]
-        res, err = box.execute(sql)
-        exp = [[At line 1 at or near position 50: keyword 'true' is ]]..
-              [[reserved. Please use double quotes if 'true' is an identifier.]]
-        t.assert(res == nil);
-        t.assert_equals(err.message, exp)
-
-        -- Make sure TRUE literal with '+' before it cannot be the default.
-        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT +true);]]
-        res, err = box.execute(sql)
-        t.assert(res == nil);
-        t.assert_equals(err.message, exp)
-
-        -- Make sure FALSE literal with '-' before it cannot be the default.
-        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT -false);]]
-        res, err = box.execute(sql)
-        exp = [[At line 1 at or near position 50: keyword 'false' is ]]..
-              [[reserved. Please use double quotes if 'false' is an ]]..
-              [[identifier.]]
-        t.assert(res == nil);
-        t.assert_equals(err.message, exp)
-
-        -- Make sure FALSE literal with '+' before it cannot be the default.
-        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT +false);]]
-        res, err = box.execute(sql)
-        t.assert(res == nil);
-        t.assert_equals(err.message, exp)
-
-        -- Make sure INTEGER literal with '-' before it can be the default.
-        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT -1);]]
+        local decimal = require('decimal')
+        local sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT -1);]]
         t.assert_equals(box.execute(sql), {row_count = 1})
         box.execute([[INSERT INTO t(i) VALUES (1);]])
         t.assert_equals(box.execute([[SELECT a FROM t;]]).rows, {{-1}})
+        t.assert_equals(box.space.t:format()[2].default, -1)
         box.execute([[DROP TABLE t;]])
 
-        -- Make sure INTEGER literal with '+' before it can be the default.
+        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT (-1));]]
+        t.assert_equals(box.execute(sql), {row_count = 1})
+        box.execute([[INSERT INTO t(i) VALUES (1);]])
+        t.assert_equals(box.execute([[SELECT a FROM t;]]).rows, {{-1}})
+        t.assert_equals(box.space.t:format()[2].default, -1)
+        box.execute([[DROP TABLE t;]])
+
+        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT (+1));]]
+        t.assert_equals(box.execute(sql), {row_count = 1})
+        box.execute([[INSERT INTO t(i) VALUES (1);]])
+        t.assert_equals(box.execute([[SELECT a FROM t;]]).rows, {{1}})
+        t.assert_equals(box.space.t:format()[2].default, 1)
+        box.execute([[DROP TABLE t;]])
+
         sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT +1);]]
         t.assert_equals(box.execute(sql), {row_count = 1})
         box.execute([[INSERT INTO t(i) VALUES (1);]])
         t.assert_equals(box.execute([[SELECT a FROM t;]]).rows, {{1}})
+        t.assert_equals(box.space.t:format()[2].default, 1)
         box.execute([[DROP TABLE t;]])
 
-        -- Make sure DOUBLE literal with '-' before it can be the default.
         sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT -1.1e0);]]
         t.assert_equals(box.execute(sql), {row_count = 1})
         box.execute([[INSERT INTO t(i) VALUES (1);]])
         t.assert_equals(box.execute([[SELECT a FROM t;]]).rows, {{-1.1}})
+        t.assert_equals(box.space.t:format()[2].default, -1.1)
+        t.assert_equals(type(box.space.t:format()[2].default), 'number')
         box.execute([[DROP TABLE t;]])
 
-        -- Make sure DOUBLE literal with '+' before it can be the default.
+        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT (-1.1e0));]]
+        t.assert_equals(box.execute(sql), {row_count = 1})
+        box.execute([[INSERT INTO t(i) VALUES (1);]])
+        t.assert_equals(box.execute([[SELECT a FROM t;]]).rows, {{-1.1}})
+        t.assert_equals(box.space.t:format()[2].default, -1.1)
+        t.assert_equals(type(box.space.t:format()[2].default), 'number')
+        box.execute([[DROP TABLE t;]])
+
+        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT (+1.1e0));]]
+        t.assert_equals(box.execute(sql), {row_count = 1})
+        box.execute([[INSERT INTO t(i) VALUES (1);]])
+        t.assert_equals(box.execute([[SELECT a FROM t;]]).rows, {{1.1}})
+        t.assert_equals(box.space.t:format()[2].default, 1.1)
+        t.assert_equals(type(box.space.t:format()[2].default), 'number')
+        box.execute([[DROP TABLE t;]])
+
         sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT +1.1e0);]]
         t.assert_equals(box.execute(sql), {row_count = 1})
         box.execute([[INSERT INTO t(i) VALUES (1);]])
         t.assert_equals(box.execute([[SELECT a FROM t;]]).rows, {{1.1}})
+        t.assert_equals(box.space.t:format()[2].default, 1.1)
+        t.assert_equals(type(box.space.t:format()[2].default), 'number')
         box.execute([[DROP TABLE t;]])
 
-        -- Make sure DECIMAL literal with '-' before it can be the default.
         sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT -1.1);]]
         t.assert_equals(box.execute(sql), {row_count = 1})
         box.execute([[INSERT INTO t(i) VALUES (1);]])
         t.assert_equals(box.execute([[SELECT a FROM t;]]).rows, {{-1.1}})
+        t.assert_equals(box.space.t:format()[2].default, -1.1)
+        t.assert(decimal.is_decimal(box.space.t:format()[2].default))
         box.execute([[DROP TABLE t;]])
 
-        -- Make sure DECIMAL literal with '+' before it can be the default.
+        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT (-1.1));]]
+        t.assert_equals(box.execute(sql), {row_count = 1})
+        box.execute([[INSERT INTO t(i) VALUES (1);]])
+        t.assert_equals(box.execute([[SELECT a FROM t;]]).rows, {{-1.1}})
+        t.assert_equals(box.space.t:format()[2].default, -1.1)
+        t.assert(decimal.is_decimal(box.space.t:format()[2].default))
+        box.execute([[DROP TABLE t;]])
+
+        sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT (+1.1));]]
+        t.assert_equals(box.execute(sql), {row_count = 1})
+        box.execute([[INSERT INTO t(i) VALUES (1);]])
+        t.assert_equals(box.execute([[SELECT a FROM t;]]).rows, {{1.1}})
+        t.assert_equals(box.space.t:format()[2].default, 1.1)
+        t.assert(decimal.is_decimal(box.space.t:format()[2].default))
+        box.execute([[DROP TABLE t;]])
+
         sql = [[CREATE TABLE t(i INT PRIMARY KEY, a ANY DEFAULT +1.1);]]
         t.assert_equals(box.execute(sql), {row_count = 1})
         box.execute([[INSERT INTO t(i) VALUES (1);]])
         t.assert_equals(box.execute([[SELECT a FROM t;]]).rows, {{1.1}})
+        t.assert_equals(box.space.t:format()[2].default, 1.1)
+        t.assert(decimal.is_decimal(box.space.t:format()[2].default))
         box.execute([[DROP TABLE t;]])
     end)
 end
@@ -253,7 +221,7 @@ g.test_new_func_defaults = function()
         box.execute(sql)
         local s = box.space.T
         local func = box.func.default_T_A
-        t.assert_equals(func.body, '9 * 7')
+        t.assert_equals(func.body, '(9 * 7)')
         t.assert_equals(s:format()[2].default_func, func.id)
         s:insert({1})
         t.assert_equals(s:select(), {{1, 63}})
@@ -261,5 +229,59 @@ g.test_new_func_defaults = function()
         t.assert_equals(s:select(), {{1, 63}, {2, 63}})
         s:drop()
         func:drop()
+    end)
+end
+
+--
+-- Make sure that function expressions are processed correctly when specified
+-- in the DEFAULT clause without parentheses.
+--
+g.test_func_defaults_without_parentheses = function()
+    g.server:exec(function()
+        local sql = [[CREATE TABLE T(I INT PRIMARY KEY,
+                      A ANY DEFAULT 1 + 1, B ANY DEFAULT (1 + 1));]]
+        box.execute(sql)
+        local func_id_2 = box.space.T:format()[2].default_func
+        t.assert_equals(box.space._func:get{func_id_2}.body, '1 + 1')
+        local func_id_3 = box.space.T:format()[3].default_func
+        t.assert_equals(box.space._func:get{func_id_3}.body, '(1 + 1)')
+        box.space.T:drop()
+        box.schema.func.drop(func_id_2)
+        box.schema.func.drop(func_id_3)
+    end)
+end
+
+--
+-- Make sure that the NULL, NOT NULL, and COLLATE column properties do not cause
+-- an error when using the DEFAULT clause with these keywords.
+--
+g.test_func_defaults_with_null_and_collate = function()
+    g.server:exec(function()
+        local sql = [[CREATE TABLE T(I INT PRIMARY KEY,
+                      A ANY DEFAULT 'a' COLLATE "unicode" COLLATE "unicode_ci",
+                      B ANY DEFAULT NULL IS NULL NULL,
+                      C ANY DEFAULT NULL NULL,
+                      D ANY DEFAULT NULL NOT NULL);]]
+        box.execute(sql)
+
+        local exp = box.space._collation.index.name:get{'unicode_ci'}.id;
+        t.assert_equals(box.space.T:format()[2].collation, exp)
+        t.assert_equals(box.space.T:format()[2].default, 'a')
+
+        local func_id = box.space.T:format()[3].default_func
+        t.assert_equals(box.space._func:get{func_id}.body, 'NULL IS NULL')
+        t.assert_equals(box.space.T:format()[3].is_nullable, true)
+
+        t.assert_equals(box.space.T:format()[4].is_nullable, true)
+
+        t.assert_equals(box.space.T:format()[5].is_nullable, false)
+
+        local exp_err = "Failed to execute SQL statement: " ..
+                        "NOT NULL constraint failed: T.D"
+        local _, err = box.execute([[INSERT INTO T(I) VALUES(1);]])
+        t.assert_equals(err.message, exp_err)
+
+        box.space.T:drop()
+        box.schema.func.drop(func_id)
     end)
 end

--- a/test/sql-tap/default.test.lua
+++ b/test/sql-tap/default.test.lua
@@ -220,7 +220,8 @@ test:do_catchsql_test(
         CREATE TABLE t6(id INTEGER PRIMARY KEY, b TEXT DEFAULT id);
     ]], {
     -- <default-5.2>
-    1, "Syntax error at line 1 near 'id'"
+    1, "Failed to create space 't6': default value of column 'b' "..
+       "is not constant"
     -- </default-5.2>
 })
 
@@ -230,7 +231,8 @@ test:do_catchsql_test(
         CREATE TABLE t6(id INTEGER PRIMARY KEY, b TEXT DEFAULT "id");
     ]], {
     -- <default-5.3>
-    1, "Syntax error at line 1 near '\"id\"'"
+    1, "Failed to create space 't6': default value of column 'b' "..
+       "is not constant"
     -- </default-5.3>
 })
 


### PR DESCRIPTION
Before this patch, the expression following the default value had to be literal unless enclosed in parentheses. This restriction has now been lifted.

Closes #12911

@TarantoolBot document
Title: column default value in SQL

The default value for a column in SQL is set using the DEFAULT keyword. The expression following this keyword will be evaluated as the default value or a function that evaluates to that value. If the expression is a literal, it will be evaluated as a value. Also, if the expression is a unary `+` or `-` and the following literal is of type INTEGER, DOUBLE, or DECIMAL, it will also be evaluated as a value. Otherwise, it will be evaluated as a function.