### PR TITLE
http: bundle HTTP server and metrics export role

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -67,3 +67,6 @@
 [submodule "luatest"]
 	path = luatest
 	url = https://github.com/tarantool/luatest.git
+[submodule "third_party/http"]
+	path = third_party/http
+	url = https://github.com/tarantool/http.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,6 @@
 [submodule "third_party/http"]
 	path = third_party/http
 	url = https://github.com/tarantool/http.git
+[submodule "third_party/metrics-export-role"]
+	path = third_party/metrics-export-role
+	url = https://github.com/tarantool/metrics-export-role.git

--- a/changelogs/unreleased/builtin-http-server.md
+++ b/changelogs/unreleased/builtin-http-server.md
@@ -1,0 +1,3 @@
+## feature/http
+
+* Bundled the `http` module and the `roles.httpd` role.

--- a/changelogs/unreleased/metrics-export-role.md
+++ b/changelogs/unreleased/metrics-export-role.md
@@ -1,0 +1,4 @@
+## feature/metrics
+
+* Bundled `metrics-export-role`. Metrics export can be configured using the
+  declarative `metrics.export` section or the `roles.metrics-export` role.

--- a/extra/exports_openssl
+++ b/extra/exports_openssl
@@ -1,0 +1,24 @@
+# OpenSSL symbols used by the built-in HTTP server through LuaJIT FFI.
+# Keep the symbols sorted by name using `LC_COLLATE="C" sort -f`.
+
+ERR_clear_error
+ERR_error_string
+ERR_peek_last_error
+SSL_CTX_free
+SSL_CTX_load_verify_locations
+SSL_CTX_new
+SSL_CTX_set_cipher_list
+SSL_CTX_set_default_passwd_cb
+SSL_CTX_set_default_passwd_cb_userdata
+SSL_CTX_set_verify
+SSL_CTX_use_certificate_file
+SSL_CTX_use_PrivateKey_file
+SSL_free
+SSL_get_error
+SSL_new
+SSL_pending
+SSL_read
+SSL_set_accept_state
+SSL_set_fd
+SSL_write
+TLS_server_method

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -136,6 +136,9 @@ lua_source(lua_sources ../third_party/http/http/sslsocket.lua
 lua_source(lua_sources ../third_party/http/http/server.lua http_server_lua)
 lua_source(lua_sources ../third_party/http/http/version.lua http_version_lua)
 lua_source(lua_sources ../third_party/http/roles/httpd.lua httpd_role_lua)
+lua_source(lua_sources
+           ../third_party/metrics-export-role/roles/metrics-export.lua
+           metrics_export_role_lua)
 
 # LuaJIT jit.* library
 lua_source(lua_sources ${LUAJIT_SOURCE_ROOT}/src/jit/bc.lua jit_bc_lua)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,6 +128,14 @@ lua_source(lua_sources ../third_party/metrics/metrics/tarantool/vinyl.lua metric
 lua_source(lua_sources ../third_party/metrics/metrics/tarantool.lua metrics_tarantool_lua)
 lua_source(lua_sources ../third_party/metrics/metrics/utils.lua metrics_utils_lua)
 lua_source(lua_sources ../third_party/metrics/metrics/version.lua metrics_version_lua)
+lua_source(lua_sources ../third_party/http/http/codes.lua http_codes_lua)
+lua_source(lua_sources ../third_party/http/http/mime_types.lua
+           http_mime_types_lua)
+lua_source(lua_sources ../third_party/http/http/sslsocket.lua
+           http_sslsocket_lua)
+lua_source(lua_sources ../third_party/http/http/server.lua http_server_lua)
+lua_source(lua_sources ../third_party/http/http/version.lua http_version_lua)
+lua_source(lua_sources ../third_party/http/roles/httpd.lua httpd_role_lua)
 
 # LuaJIT jit.* library
 lua_source(lua_sources ${LUAJIT_SOURCE_ROOT}/src/jit/bc.lua jit_bc_lua)
@@ -214,6 +222,7 @@ set (server_sources
      lua/builtin_modcache.c
      lua/tweaks.c
      lua/xml.c
+     ${PROJECT_SOURCE_DIR}/third_party/http/http/lib.c
      ${lua_sources}
      ${PROJECT_SOURCE_DIR}/third_party/lua-yaml/lyaml.cc
      ${PROJECT_SOURCE_DIR}/third_party/lua-cjson/lua_cjson.c
@@ -281,6 +290,11 @@ if (NOT TARGET_OS_DEBIAN_FREEBSD)
 endif()
 
 set_source_files_compile_flags(${server_sources})
+if (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
+    set_source_files_properties(
+        ${PROJECT_SOURCE_DIR}/third_party/http/http/lib.c
+        PROPERTIES COMPILE_FLAGS "-Wno-error")
+endif()
 add_library(server STATIC ${server_sources})
 add_dependencies(server build_bundled_libs)
 target_link_libraries(server core coll digest http_parser bit uri swim swim_udp
@@ -301,6 +315,11 @@ set (reexport_libraries server core misc bitset csv swim swim_udp swim_ev
      shutdown tzcode ${LUAJIT_LIBRARIES} ${MSGPUCK_LIBRARIES} ${ICU_LIBRARIES}
      ${CURL_LIBRARIES} ${XXHASH_LIBRARIES} ${LIBCDT_LIBRARIES}
      ${EXTRA_REEXPORT_LIBRARIES})
+
+if (OPENSSL_USE_STATIC_LIBS)
+    set (reexport_libraries ${reexport_libraries}
+         ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
+endif()
 
 set (common_libraries
     ${reexport_libraries}
@@ -353,6 +372,11 @@ set(TARANTOOL_CXX_FLAGS ${TARANTOOL_CXX_FLAGS} PARENT_SCOPE)
 set(exports_file_sources
     ${PROJECT_SOURCE_DIR}/extra/exports
     ${EXTRA_EXPORTS_FILE_SOURCES})
+if (OPENSSL_USE_STATIC_LIBS)
+    set(exports_file_sources ${exports_file_sources}
+        ${PROJECT_SOURCE_DIR}/extra/exports_openssl)
+endif()
+
 if (EXPORT_LIBCURL_SYMBOLS)
     set(exports_file_sources ${exports_file_sources}
         ${PROJECT_SOURCE_DIR}/extra/exports_libcurl)

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -43,6 +43,8 @@ lua_source(lua_sources lua/config/applier/connpool.lua     config_applier_connpo
 lua_source(lua_sources lua/config/applier/console.lua      config_applier_console_lua)
 lua_source(lua_sources lua/config/applier/credentials.lua  config_applier_credentials_lua)
 lua_source(lua_sources lua/config/applier/fiber.lua        config_applier_fiber_lua)
+lua_source(lua_sources lua/config/applier/metrics_export.lua
+           config_applier_metrics_export_lua)
 lua_source(lua_sources lua/config/applier/lua.lua          config_applier_lua_lua)
 lua_source(lua_sources lua/config/applier/mkdir.lua        config_applier_mkdir_lua)
 lua_source(lua_sources lua/config/applier/roles.lua        config_applier_roles_lua)

--- a/src/box/lua/config/applier/metrics_export.lua
+++ b/src/box/lua/config/applier/metrics_export.lua
@@ -1,0 +1,63 @@
+local role
+local is_applied = false
+
+local function get_role()
+    if role == nil then
+        role = require('roles.metrics-export')
+    end
+    return role
+end
+
+local function is_role_configured(configdata)
+    local roles = configdata:get('roles', {use_default = true}) or {}
+    for _, role_name in pairs(roles) do
+        if role_name == 'roles.metrics-export' then
+            return true
+        end
+    end
+    return false
+end
+
+local function apply(config)
+    local configdata = config._configdata
+    if not is_role_configured(configdata) then
+        return
+    end
+    local export_cfg = configdata:get('metrics.export', {
+        use_default = true,
+    }) or {}
+    if next(export_cfg) ~= nil then
+        error('metrics.export cannot be used together with role ' ..
+              '"roles.metrics-export"', 0)
+    end
+end
+
+local function post_apply(config)
+    local configdata = config._configdata
+    -- The role applier runs first and owns the module when it is configured
+    -- as a generic role for backward compatibility.
+    if is_role_configured(configdata) then
+        is_applied = false
+        return
+    end
+
+    local export_cfg = configdata:get('metrics.export', {
+        use_default = true,
+    }) or {}
+
+    if next(export_cfg) == nil then
+        if is_applied then
+            get_role().stop()
+            is_applied = false
+        end
+    else
+        get_role().apply(export_cfg)
+        is_applied = true
+    end
+end
+
+return {
+    name = 'metrics.export',
+    apply = apply,
+    post_apply = post_apply,
+}

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -2199,6 +2199,13 @@ I['metrics.labels'] = 'Global labels to be added to every observation.'
 
 I['metrics.labels.*'] = 'Label value.'
 
+I['metrics.export'] = format_text([[
+    Configuration for exporting metrics using the `metrics-export-role` module.
+    The export target (for example, `http`) maps to the role configuration.
+]])
+
+I['metrics.export.*'] = 'Configuration options for a specific export target.'
+
 -- }}} metrics configuration
 
 -- {{{ process configuration

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -301,6 +301,7 @@ function methods._initialize(self)
     self:_register_applier(require('internal.config.applier.connpool'))
     self:_register_applier(require('internal.config.applier.roles').stage_2)
     self:_register_applier(require('internal.config.applier.app').stage_2)
+    self:_register_applier(require('internal.config.applier.metrics_export'))
 
     if extras ~= nil then
         extras.initialize(self)

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -1882,6 +1882,10 @@ return schema.new('instance_config', schema.record({
             key = schema.scalar({type = 'string'}),
             value = schema.scalar({type = 'string'}),
         }),
+        export = schema.map({
+            key = schema.scalar({type = 'string'}),
+            value = schema.scalar({type = 'any'}),
+        }),
     }),
     sharding = vshard_since('0.1.25', schema.record({
         -- Instance vshard options.

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -165,6 +165,7 @@ extern char session_lua[],
 	metrics_utils_lua[],
 	metrics_version_lua[],
 	httpd_role_lua[],
+	metrics_export_role_lua[],
 	/* {{{ config */
 	config_applier_app_lua[],
 	config_applier_autoexpel_lua[],
@@ -176,6 +177,7 @@ extern char session_lua[],
 	config_applier_console_lua[],
 	config_applier_credentials_lua[],
 	config_applier_fiber_lua[],
+	config_applier_metrics_export_lua[],
 	config_applier_lua_lua[],
 	config_applier_mkdir_lua[],
 	config_applier_roles_lua[],
@@ -361,6 +363,8 @@ static const char * const lua_sources_main[] = {
 	"box/console", "console", console_lua,
 	"box/backup", NULL, backup_lua,
 	"third_party/http/roles/httpd", "roles.httpd", httpd_role_lua,
+	"third_party/metrics-export-role/roles/metrics-export",
+	"roles.metrics-export", metrics_export_role_lua,
 
 	/* {{{ config */
 
@@ -498,6 +502,10 @@ static const char * const lua_sources_main[] = {
 	"config/applier/fiber",
 	"internal.config.applier.fiber",
 	config_applier_fiber_lua,
+
+	"config/applier/metrics_export",
+	"internal.config.applier.metrics_export",
+	config_applier_metrics_export_lua,
 
 	"config/applier/lua",
 	"internal.config.applier.lua",

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -164,6 +164,7 @@ extern char session_lua[],
 	metrics_tarantool_lua[],
 	metrics_utils_lua[],
 	metrics_version_lua[],
+	httpd_role_lua[],
 	/* {{{ config */
 	config_applier_app_lua[],
 	config_applier_autoexpel_lua[],
@@ -359,6 +360,7 @@ static const char * const lua_sources_main[] = {
 	"box/upgrade", NULL, upgrade_lua,
 	"box/console", "console", console_lua,
 	"box/backup", NULL, backup_lua,
+	"third_party/http/roles/httpd", "roles.httpd", httpd_role_lua,
 
 	/* {{{ config */
 

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -108,6 +108,10 @@ LUALIB_API int
 luaopen_zip(lua_State *L);
 #endif
 
+/** Initialize the built-in HTTP server C module. */
+LUALIB_API int
+luaopen_http_lib(lua_State *L);
+
 #define MAX_MODNAME 64
 
 /**
@@ -139,6 +143,11 @@ extern char minifio_lua[],
 	errno_lua[],
 	fiber_lua[],
 	httpc_lua[],
+	http_codes_lua[],
+	http_mime_types_lua[],
+	http_sslsocket_lua[],
+	http_server_lua[],
+	http_version_lua[],
 	log_lua[],
 	uri_lua[],
 	socket_lua[],
@@ -223,6 +232,11 @@ static const char * const lua_modules_minimal[] = {
 	"datetime", datetime_lua,
 	"msgpackffi", msgpackffi_lua,
 	"http.client", httpc_lua,
+	"http.codes", http_codes_lua,
+	"http.mime_types", http_mime_types_lua,
+	"http.sslsocket", http_sslsocket_lua,
+	"http.version", http_version_lua,
+	"http.server", http_server_lua,
 	NULL
 };
 
@@ -805,6 +819,8 @@ tarantool_lua_init_minimal_impl(lua_State *L)
 	lua_pop(L, 1);
 	luaopen_http_client_driver(L);
 	lua_pop(L, 1);
+	luaopen_http_lib(L);
+	luaT_setmodule(L, "http.lib");
 
 	luaopen_tarantool(L);
 	for (const char * const *s = lua_modules_minimal; *s; s += 2) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,6 +102,7 @@ add_subdirectory(engine-luatest)
 add_subdirectory(engine-tap)
 add_subdirectory(http-luatest)
 add_subdirectory(metrics-luatest)
+add_subdirectory(metrics-export-role-luatest)
 add_subdirectory(replication-luatest)
 add_subdirectory(sql-tap)
 add_subdirectory(sql-luatest)
@@ -195,6 +196,7 @@ list(APPEND EXECUTED_WITHOUT_TEST_RUN
     engine-tap
     http-luatest
     metrics-luatest
+    metrics-export-role-luatest
     replication-luatest
     sql-luatest
     sql-tap

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -100,6 +100,7 @@ add_subdirectory(box-luatest)
 add_subdirectory(config-luatest)
 add_subdirectory(engine-luatest)
 add_subdirectory(engine-tap)
+add_subdirectory(http-luatest)
 add_subdirectory(metrics-luatest)
 add_subdirectory(replication-luatest)
 add_subdirectory(sql-tap)
@@ -192,6 +193,7 @@ list(APPEND EXECUTED_WITHOUT_TEST_RUN
     config-luatest
     engine-luatest
     engine-tap
+    http-luatest
     metrics-luatest
     replication-luatest
     sql-luatest

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1796,6 +1796,18 @@ g.test_metrics = function()
             include = {'network', 'info', 'cpu', 'roles.crud-router'},
             exclude = {'info', 'roles.crud-storage.custom_metric'},
             labels = {foo = 'bar'},
+            export = {
+                http = {{
+                    listen = 3301,
+                    endpoints = {{
+                        path = '/metrics/json',
+                        format = 'json',
+                        metrics = {
+                            enabled = true,
+                        },
+                    }},
+                }},
+            },
         }
     }
 

--- a/test/config-luatest/metrics_export_test.lua
+++ b/test/config-luatest/metrics_export_test.lua
@@ -1,0 +1,373 @@
+local t = require('luatest')
+local socket = require('socket')
+local json = require('json')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('luatest.cluster')
+local fio = require('fio')
+
+local http_client = require('http.client').new()
+
+local g = t.group()
+
+local function http_get(uri, opts)
+    local request_opts = {no_proxy = '*'}
+    if opts ~= nil then
+        for k, v in pairs(opts) do
+            request_opts[k] = v
+        end
+    end
+    return http_client:get(uri, request_opts)
+end
+
+local function get_free_port()
+    local srv = socket.tcp_server('127.0.0.1', 0, function() end)
+    t.assert(srv ~= nil)
+    local addr = srv:name()
+    srv:close()
+    if type(addr) == 'table' then
+        return addr.port
+    end
+    return tonumber(tostring(addr):match(':(%d+)$'))
+end
+
+local function register_metric(srv)
+    srv:exec(function()
+        local metrics = require('metrics')
+        local counter = metrics.counter('some_counter')
+        counter:inc(1, {label = 'ANY'})
+    end)
+end
+
+local function assert_none(uri)
+    t.helpers.retrying({timeout = 2}, function()
+        local response = http_get(uri)
+        t.assert_not_equals(response.status, 200)
+        t.assert_not(response.body)
+    end)
+end
+
+local function assert_json(uri)
+    t.helpers.retrying({timeout = 2}, function()
+        local response = http_get(uri)
+        t.assert(response.body)
+
+        local decoded = json.decode(response.body)
+        for _, node in ipairs(decoded) do
+            node.timestamp = nil
+        end
+        t.assert_equals(decoded, {
+            {
+                label_pairs = {alias = "i-001", label = "ANY"},
+                metric_name = "some_counter",
+                value = 1,
+            },
+        })
+    end)
+end
+
+local function assert_prometheus(uri)
+    t.helpers.retrying({timeout = 2}, function()
+        local response = http_get(uri)
+        t.assert(response.body)
+
+        local expected_prometheus =
+            '# HELP some_counter \n' ..
+            '# TYPE some_counter counter\n' ..
+            'some_counter{label="ANY",alias="i-001"} 1\n'
+        t.assert_equals(response.body, expected_prometheus)
+    end)
+end
+
+local base_config = cbuilder:new()
+    :use_group('g-001')
+    :use_replicaset('r-001')
+    :add_instance('i-001', {
+        database = {
+            mode = 'rw',
+        },
+    })
+    :config()
+
+g.test_http_export_listen_smoke = function()
+    local port = get_free_port()
+    local listen = ('127.0.0.1:%d'):format(port)
+
+    local config = cbuilder:new(base_config)
+        :set_instance_option('i-001', 'metrics', {
+            include = {'some_counter'},
+            export = {
+                http = {
+                    {
+                        listen = listen,
+                        endpoints = {
+                            { path = '/metrics/json', format = 'json' },
+                            { path = '/metrics/prom', format = 'prometheus' },
+                        },
+                    },
+                },
+            },
+        })
+        :config()
+
+    local c = cluster:new(config)
+    c:start()
+    register_metric(c['i-001'])
+
+    assert_json(('http://127.0.0.1:%d/metrics/json'):format(port))
+    assert_prometheus(('http://127.0.0.1:%d/metrics/prom'):format(port))
+    assert_none(('http://127.0.0.1:%d/metrics/absent'):format(port))
+end
+
+g.test_http_export_reload_add_endpoint = function()
+    local port = get_free_port()
+    local listen = ('127.0.0.1:%d'):format(port)
+
+    local config = cbuilder:new(base_config)
+        :set_instance_option('i-001', 'metrics', {
+            include = {'some_counter'},
+            export = {
+                http = {
+                    {
+                        listen = listen,
+                        endpoints = {
+                            { path = '/metrics/one', format = 'json' },
+                        },
+                    },
+                },
+            },
+        }):config()
+
+    local c = cluster:new(config)
+    c:start()
+    register_metric(c['i-001'])
+
+    assert_json(('http://127.0.0.1:%d/metrics/one'):format(port))
+    assert_none(('http://127.0.0.1:%d/metrics/two'):format(port))
+
+    c:modify_config():set_instance_option('i-001', 'metrics', {
+        include = {'some_counter'},
+        export = {
+            http = {
+                {
+                    listen = listen,
+                    endpoints = {
+                        { path = '/metrics/one', format = 'json' },
+                        { path = '/metrics/two', format = 'prometheus' },
+                    },
+                },
+            },
+        },
+    })
+    c:apply_config_changes()
+    c:reload()
+
+    assert_json(('http://127.0.0.1:%d/metrics/one'):format(port))
+    assert_prometheus(('http://127.0.0.1:%d/metrics/two'):format(port))
+end
+
+g.test_switch_to_metrics_export_role = function()
+    local port = get_free_port()
+    local listen = ('127.0.0.1:%d'):format(port)
+    local builtin_export = {
+        http = {
+            {
+                listen = listen,
+                endpoints = {
+                    { path = '/metrics/builtin', format = 'json' },
+                },
+            },
+        },
+    }
+    local role_export = {
+        http = {
+            {
+                listen = listen,
+                endpoints = {
+                    { path = '/metrics/role', format = 'json' },
+                },
+            },
+        },
+    }
+    local config = cbuilder:new(base_config)
+        :set_instance_option('i-001', 'metrics', {
+            include = {'some_counter'},
+            export = builtin_export,
+        }):config()
+    local c = cluster:new(config)
+    c:start()
+    register_metric(c['i-001'])
+    local builtin_uri = ('http://127.0.0.1:%d/metrics/builtin'):format(port)
+    local role_uri = ('http://127.0.0.1:%d/metrics/role'):format(port)
+    assert_json(builtin_uri)
+
+    c:modify_config()
+        :set_instance_option('i-001', 'roles', {'roles.metrics-export'})
+        :set_instance_option('i-001', 'roles_cfg', {
+            ['roles.metrics-export'] = role_export,
+        })
+    c:apply_config_changes()
+    local ok, err = c['i-001']:exec(function()
+        local config = require('config')
+        return pcall(config.reload, config)
+    end)
+    t.assert_not(ok)
+    t.assert_str_contains(err, 'metrics.export cannot be used together with ' ..
+                               'role "roles.metrics-export"')
+    assert_json(builtin_uri)
+
+    c:modify_config()
+        :set_instance_option('i-001', 'metrics.export', nil)
+    c:apply_config_changes()
+    c:reload()
+    assert_json(role_uri)
+    assert_none(builtin_uri)
+
+    c:modify_config()
+        :set_instance_option('i-001', 'metrics.export', builtin_export)
+        :set_instance_option('i-001', 'roles', nil)
+        :set_instance_option('i-001', 'roles_cfg', nil)
+    c:apply_config_changes()
+    c:reload()
+    assert_json(builtin_uri)
+    assert_none(role_uri)
+
+    c:modify_config()
+        :set_instance_option('i-001', 'metrics.export', nil)
+    c:apply_config_changes()
+    c:reload()
+    assert_none(builtin_uri)
+end
+
+g.test_http_export_disable_when_http_is_empty = function()
+    local port = get_free_port()
+    local listen = ('127.0.0.1:%d'):format(port)
+
+    local config = cbuilder:new(base_config)
+        :set_instance_option('i-001', 'metrics', {
+            include = {'some_counter'},
+            export = {
+                http = {
+                    {
+                        listen = listen,
+                        endpoints = {
+                            { path = '/metrics/one', format = 'json' },
+                        },
+                    },
+                },
+            },
+        }):config()
+
+    local c = cluster:new(config)
+    c:start()
+    register_metric(c['i-001'])
+
+    local uri = ('http://127.0.0.1:%d/metrics/one'):format(port)
+    assert_json(uri)
+
+    c:modify_config():set_instance_option('i-001', 'metrics', {
+        include = {'some_counter'},
+        export = {
+            http = {},
+        },
+    })
+    c:apply_config_changes()
+    c:reload()
+
+    assert_none(uri)
+end
+
+g.test_http_export_stop_disables_endpoints = function()
+    local port = get_free_port()
+    local listen = ('127.0.0.1:%d'):format(port)
+    local uri = ('http://127.0.0.1:%d/metrics/one'):format(port)
+
+    local config = cbuilder:new(base_config)
+        :set_instance_option('i-001', 'metrics', {
+            include = {'some_counter'},
+            export = {
+                http = {
+                    {
+                        listen = listen,
+                        endpoints = {
+                            { path = '/metrics/one', format = 'json' },
+                        },
+                    },
+                },
+            },
+        }):config()
+
+    local c = cluster:new(config)
+    c:start()
+    register_metric(c['i-001'])
+
+    assert_json(uri)
+
+    c:stop()
+
+    assert_none(uri)
+end
+
+g.test_http_export_default_httpd_server = function()
+    local httpd_port = get_free_port()
+
+    local config = cbuilder:new(base_config)
+        :set_instance_option('i-001', 'roles', { 'roles.httpd' })
+        :set_instance_option('i-001', 'roles_cfg', {
+            ['roles.httpd'] = {
+                default = { listen = httpd_port },
+            },
+        })
+        :set_instance_option('i-001', 'metrics', {
+            include = {'some_counter'},
+            export = {
+                http = {
+                    {
+                        endpoints = {
+                            { path = '/metrics/one', format = 'json' },
+                        },
+                    },
+                },
+            },
+        })
+        :config()
+
+    local c = cluster:new(config)
+    c:start()
+    register_metric(c['i-001'])
+
+    assert_json(('http://127.0.0.1:%d/metrics/one'):format(httpd_port))
+end
+
+g.test_http_export_server_requires_roles_httpd = function()
+    local log_path = fio.pathjoin(fio.tempdir(), 'log.txt')
+
+    local config = cbuilder:new(base_config)
+        :set_instance_option('i-001', 'log', {
+            to = 'file',
+            file = log_path,
+        })
+        :set_instance_option('i-001', 'metrics', {
+            include = {'some_counter'},
+            export = {
+                http = {
+                    {
+                        server = 'additional',
+                        endpoints = {
+                            { path = '/metrics/one', format = 'json' },
+                        },
+                    },
+                },
+            },
+        }):config()
+
+    local c = cluster:new(config)
+
+    t.assert_error(c.start, c)
+
+    local fh = fio.open(log_path, { 'O_RDONLY' })
+    t.assert(fh ~= nil)
+    local data = fh:read()
+    fh:close()
+
+    t.assert_str_contains(data, 'there is no configuration for httpd role')
+end

--- a/test/http-luatest/CMakeLists.txt
+++ b/test/http-luatest/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(TEST_SUITE_NAME "http-luatest")
+
+message(STATUS "Add test suite ${TEST_SUITE_NAME}")
+
+_add_test_suite_target(${TEST_SUITE_NAME}
+  LABELS "${TEST_SUITE_NAME};regression;"
+)
+
+list(APPEND TEST_ENV
+  "LUA_PATH=${LUATEST_LUA_PATH}"
+  "VARDIR=${VARDIR}"
+)
+
+file(GLOB tests ${CMAKE_CURRENT_SOURCE_DIR} *_test.lua)
+foreach(test_path ${tests})
+  get_filename_component(test_name ${test_path} NAME)
+  if(${test_name} STREQUAL ${TEST_SUITE_NAME})
+    continue()
+  endif()
+  add_luatest_test(${TEST_SUITE_NAME} ${test_name} "${TEST_ENV}" TRUE)
+endforeach()

--- a/test/http-luatest/helper.lua
+++ b/test/http-luatest/helper.lua
@@ -1,0 +1,98 @@
+local fio = require('fio')
+local fun = require('fun')
+
+os.setenv('http_proxy', '')
+os.setenv('https_proxy', '')
+os.setenv('HTTP_PROXY', '')
+os.setenv('HTTPS_PROXY', '')
+os.setenv('no_proxy', '*')
+os.setenv('NO_PROXY', '*')
+
+local repo_root = fio.cwd()
+local http_root = fio.pathjoin(repo_root, 'third_party', 'http')
+os.setenv('LUA_SOURCE_DIR', http_root)
+
+local function glob_recursive(path)
+    local pattern = path
+    local result = {}
+    repeat
+        pattern = pattern .. '/*'
+        local last_result = fio.glob(pattern)
+        for _, item in ipairs(last_result) do
+            result[#result + 1] = item
+        end
+    until #last_result == 0
+    return result
+end
+
+local function get_test_modules_list(path)
+    local files
+    if path:endswith('.lua') then
+        files = fun.iter({path})
+    else
+        local list = glob_recursive(path)
+        table.sort(list)
+        files = fun.iter(list):filter(
+            function(x) return x:endswith('_test.lua') end
+        )
+    end
+    return files:
+        map(function(x) return x:gsub('%.lua$', '') end):
+        map(function(x) return x:gsub('/+', '.') end):
+        totable()
+end
+
+local function array_to_map(array)
+    local result = {}
+    for _, value in ipairs(array) do
+        result[value] = true
+    end
+    return result
+end
+
+local third_party_tests = get_test_modules_list('third_party/http/test')
+local core_tests = get_test_modules_list('test/http-luatest')
+
+core_tests = array_to_map(core_tests)
+third_party_tests = array_to_map(third_party_tests)
+
+for third_party_test in pairs(third_party_tests) do
+    local name = third_party_test:gsub('^third_party.http.test.', '')
+                                 :gsub('%.', '_')
+    local core_test = 'test.http-luatest.' .. name
+    assert(core_tests[core_test],
+           'Expected ' .. core_test .. ' test, but it was not provided')
+end
+
+local function preload_from_file(module_name, path, transform)
+    local abs_path = fio.pathjoin(repo_root, path)
+    package.preload[module_name] = function()
+        local module = dofile(abs_path)
+        if transform ~= nil then
+            module = transform(module)
+        end
+        return module
+    end
+end
+
+preload_from_file('test.helpers', 'third_party/http/test/helpers.lua',
+                  function(helpers)
+    helpers.update_lua_env_variables = function(server)
+        server.env.LUA_PATH = http_root .. '/?.lua;' ..
+                              repo_root .. '/?.lua;' ..
+                              repo_root .. '/?/init.lua;' ..
+                              (server.env.LUA_PATH or '')
+    end
+    return helpers
+end)
+preload_from_file('test.mocks.mock_role',
+                  'third_party/http/test/mocks/mock_role.lua')
+
+for _, path in ipairs(glob_recursive('third_party/http/test')) do
+    if path:endswith('_test.lua') then
+        local module_name = path:gsub('%.lua$', ''):gsub('/+', '.')
+        preload_from_file(module_name, path)
+    end
+end
+
+return {}

--- a/test/http-luatest/integration_http_log_requests_test.lua
+++ b/test/http-luatest/integration_http_log_requests_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.integration.http_log_requests_test')

--- a/test/http-luatest/integration_http_server_delete_test.lua
+++ b/test/http-luatest/integration_http_server_delete_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.integration.http_server_delete_test')

--- a/test/http-luatest/integration_http_server_options_test.lua
+++ b/test/http-luatest/integration_http_server_options_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.integration.http_server_options_test')

--- a/test/http-luatest/integration_http_server_requests_test.lua
+++ b/test/http-luatest/integration_http_server_requests_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.integration.http_server_requests_test')

--- a/test/http-luatest/integration_http_server_url_for_test.lua
+++ b/test/http-luatest/integration_http_server_url_for_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.integration.http_server_url_for_test')

--- a/test/http-luatest/integration_http_server_url_match_test.lua
+++ b/test/http-luatest/integration_http_server_url_match_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.integration.http_server_url_match_test')

--- a/test/http-luatest/integration_http_tls_enabled_test.lua
+++ b/test/http-luatest/integration_http_tls_enabled_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.integration.http_tls_enabled_test')

--- a/test/http-luatest/integration_http_tls_enabled_validate_test.lua
+++ b/test/http-luatest/integration_http_tls_enabled_validate_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.integration.http_tls_enabled_validate_test')

--- a/test/http-luatest/integration_httpd_role_test.lua
+++ b/test/http-luatest/integration_httpd_role_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.integration.httpd_role_test')

--- a/test/http-luatest/openssl_symbols_test.lua
+++ b/test/http-luatest/openssl_symbols_test.lua
@@ -1,0 +1,9 @@
+local t = require('luatest')
+local ffi = require('ffi')
+
+local g = t.group()
+
+g.test_tls_server_method = function()
+    local method = ffi.C.TLS_server_method()
+    t.assert_not_equals(method, nil)
+end

--- a/test/http-luatest/suite.ini
+++ b/test/http-luatest/suite.ini
@@ -1,0 +1,4 @@
+[default]
+core = luatest
+description = http module tests on luatest
+is_parallel = False

--- a/test/http-luatest/unit_http_custom_socket_test.lua
+++ b/test/http-luatest/unit_http_custom_socket_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.unit.http_custom_socket_test')

--- a/test/http-luatest/unit_http_params_test.lua
+++ b/test/http-luatest/unit_http_params_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.unit.http_params_test')

--- a/test/http-luatest/unit_http_parse_request_test.lua
+++ b/test/http-luatest/unit_http_parse_request_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.unit.http_parse_request_test')

--- a/test/http-luatest/unit_http_setcookie_test.lua
+++ b/test/http-luatest/unit_http_setcookie_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.unit.http_setcookie_test')

--- a/test/http-luatest/unit_http_split_uri_test.lua
+++ b/test/http-luatest/unit_http_split_uri_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.unit.http_split_uri_test')

--- a/test/http-luatest/unit_http_template_test.lua
+++ b/test/http-luatest/unit_http_template_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.unit.http_template_test')

--- a/test/http-luatest/unit_httpd_role_test.lua
+++ b/test/http-luatest/unit_httpd_role_test.lua
@@ -1,0 +1,3 @@
+require('test.http-luatest.helper')
+
+require('third_party.http.test.unit.httpd_role_test')

--- a/test/metrics-export-role-luatest/CMakeLists.txt
+++ b/test/metrics-export-role-luatest/CMakeLists.txt
@@ -1,0 +1,26 @@
+set(TEST_SUITE_NAME "metrics-export-role-luatest")
+
+message(STATUS "Add test suite ${TEST_SUITE_NAME}")
+
+# XXX: The call produces both test and target
+# <metrics-export-role-luatest-deps> as a side effect.
+_add_test_suite_target(${TEST_SUITE_NAME}
+  LABELS "${TEST_SUITE_NAME};regression;"
+)
+
+list(APPEND TEST_ENV
+  "LUA_PATH=${LUATEST_LUA_PATH}"
+  "VARDIR=${VARDIR}"
+)
+
+file(GLOB tests ${CMAKE_CURRENT_SOURCE_DIR} *_test.lua)
+foreach(test_path ${tests})
+  get_filename_component(test_name ${test_path} NAME)
+  # FIXME: By default, GLOB lists directories.
+  # Directories are omitted in the result if LIST_DIRECTORIES
+  # is set to false. New in version CMake 3.3.
+  if(${test_name} STREQUAL ${TEST_SUITE_NAME})
+    continue()
+  endif()
+  add_luatest_test(${TEST_SUITE_NAME} ${test_name} "${TEST_ENV}" TRUE)
+endforeach()

--- a/test/metrics-export-role-luatest/helper.lua
+++ b/test/metrics-export-role-luatest/helper.lua
@@ -1,0 +1,133 @@
+local fio = require('fio')
+local fun = require('fun')
+
+-- Ensure local HTTP requests in tests are not routed via proxy from
+-- environment variables set in CI / development containers.
+os.setenv('http_proxy', '')
+os.setenv('https_proxy', '')
+os.setenv('HTTP_PROXY', '')
+os.setenv('HTTPS_PROXY', '')
+os.setenv('no_proxy', '*')
+os.setenv('NO_PROXY', '*')
+
+-- There are many tests in metrics-export-role. Here we check
+-- that no one has been forgotten to include.
+
+-- Borrowed from
+-- https://github.com/tarantool/luatest/blob/master/luatest/loader.lua
+-- Can't just require luatest internals since the function is not exposed.
+
+-- Returns a list of all nested files within a given path.
+-- As the `fio.glob` function does not support `**/*`, this method adds `/*` to
+-- the path and globs it until result is empty.
+local function glob_recursive(path)
+    local pattern = path
+    local result = {}
+    repeat
+        pattern = pattern .. '/*'
+        local last_result = fio.glob(pattern)
+        for _, item in ipairs(last_result) do
+            result[#result + 1] = item
+        end
+    until #last_result == 0
+    return result
+end
+
+-- If a directory is given, then it's scanned recursively for the files
+-- ending with `_test.lua`.
+-- If a `.lua` file is given then it's used as is.
+-- The resulting list of files is mapped to Lua's module names.
+local function get_test_modules_list(path)
+    local files
+    if path:endswith('.lua') then
+        files = fun.iter({path})
+    else
+        local list = glob_recursive(path)
+        table.sort(list)
+        files = fun.iter(list):filter(
+            function(x) return x:endswith('_test.lua') end
+        )
+    end
+    return files:
+        map(function(x) return x:gsub('%.lua$', '') end):
+        map(function(x) return x:gsub('/+', '.') end):
+        totable()
+end
+
+local function array_to_map(arr)
+    local map = {}
+    for _, v in ipairs(arr) do
+        map[v] = true
+    end
+    return map
+end
+
+local third_party_tests =
+    get_test_modules_list('third_party/metrics-export-role/test')
+local core_tests = get_test_modules_list('test/metrics-export-role-luatest')
+
+core_tests = array_to_map(core_tests)
+third_party_tests = array_to_map(third_party_tests)
+
+for third_party_test, _ in pairs(third_party_tests) do
+    -- Replace . to _ since tests here is not hierarchic:
+    -- test-run does not expect hierarchic structure.
+    local name =
+        third_party_test:gsub('^third_party.metrics%-export%-role.test.', '')
+                        :gsub('%.', '_')
+    local core_test = 'test.metrics-export-role-luatest.' .. name
+
+    assert(core_tests[core_test],
+           'Expected ' .. core_test .. ' test, but it was not provided')
+end
+
+local repo_root = fio.cwd()
+
+local function preload_from_file(module_name, path)
+    local abs_path = fio.pathjoin(repo_root, path)
+    package.preload[module_name] = function()
+        return dofile(abs_path)
+    end
+end
+
+-- Workaround paths to reuse existing submodule tests.
+preload_from_file('test.helpers',
+                  'third_party/metrics-export-role/test/helpers/init.lua')
+preload_from_file('test.helpers.server',
+                  'third_party/metrics-export-role/test/helpers/server.lua')
+preload_from_file('test.helpers.mocks',
+                  'third_party/metrics-export-role/test/helpers/mocks.lua')
+preload_from_file('test.helpers.graphite',
+                  'third_party/metrics-export-role/test/helpers/graphite.lua')
+
+local function preload_upstream_test_module(path)
+    local module_name = path:gsub('%.lua$', ''):gsub('/+', '.')
+    local abs_path = fio.pathjoin(repo_root, path)
+    package.preload[module_name] = function()
+        return dofile(abs_path)
+    end
+end
+
+for _, p in ipairs(glob_recursive('third_party/metrics-export-role/test')) do
+    if p:endswith('_test.lua') then
+        preload_upstream_test_module(p)
+    end
+end
+
+local test_root = 'third_party/metrics-export-role/test'
+local orig_pathjoin = fio.pathjoin
+fio.pathjoin = function(...)
+    local args = {...}
+    if args[1] == 'test' then
+        args[1] = test_root
+    end
+    return orig_pathjoin(unpack(args))
+end
+
+local orig_abspath = fio.abspath
+fio.abspath = function(path)
+    if type(path) == 'string' and path:startswith('test/') then
+        path = path:gsub('^test/', test_root .. '/')
+    end
+    return orig_abspath(path)
+end

--- a/test/metrics-export-role-luatest/integration_error_test.lua
+++ b/test/metrics-export-role-luatest/integration_error_test.lua
@@ -1,0 +1,62 @@
+local fio = require('fio')
+local socket = require('socket')
+local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('luatest.cluster')
+
+local g = t.group()
+
+g.after_each(function(cg)
+    if cg.cluster ~= nil then
+        cg.cluster:stop()
+    end
+end)
+
+local function get_free_port()
+    local server = socket.tcp_server('127.0.0.1', 0, function() end)
+    t.assert(server ~= nil)
+    local addr = server:name()
+    server:close()
+    if type(addr) == 'table' then
+        return addr.port
+    end
+    return tonumber(tostring(addr):match(':(%d+)$'))
+end
+
+g.test_incorrect_httpd_sequence = function(cg)
+    local log_path = fio.pathjoin(fio.tempdir(), 'log.txt')
+    local config = cbuilder:new()
+        :set_global_option('log', {
+            to = 'file',
+            file = log_path,
+        })
+        :set_global_option('roles', {
+            'roles.metrics-export',
+            'roles.httpd',
+        })
+        :set_global_option('roles_cfg', {
+            ['roles.metrics-export'] = {
+                http = {{
+                    server = 'default',
+                    endpoints = {{
+                        path = '/metrics',
+                        format = 'prometheus',
+                    }},
+                }},
+            },
+            ['roles.httpd'] = {
+                default = {listen = get_free_port()},
+            },
+        })
+        :add_instance('i-001', {})
+        :config()
+
+    cg.cluster = cluster:new(config)
+    t.assert_error(cg.cluster.start, cg.cluster)
+
+    local file = fio.open(log_path, {'O_RDONLY'})
+    t.assert(file ~= nil)
+    local log = file:read()
+    file:close()
+    t.assert_str_contains(log, 'failed to get server by name "default"')
+end

--- a/test/metrics-export-role-luatest/integration_reload_config_test.lua
+++ b/test/metrics-export-role-luatest/integration_reload_config_test.lua
@@ -1,0 +1,12 @@
+require('test.metrics-export-role-luatest.helper')
+
+if jit.os == 'OSX' then
+    local t = require('luatest')
+    local g = t.group()
+    g.test_skip_on_macos = function()
+        t.skip('the upstream test requires Linux loopback semantics')
+    end
+    return
+end
+
+require('third_party.metrics-export-role.test.integration.reload_config_test')

--- a/test/metrics-export-role-luatest/integration_role_test.lua
+++ b/test/metrics-export-role-luatest/integration_role_test.lua
@@ -1,0 +1,3 @@
+require('test.metrics-export-role-luatest.helper')
+
+require('third_party.metrics-export-role.test.integration.role_test')

--- a/test/metrics-export-role-luatest/suite.ini
+++ b/test/metrics-export-role-luatest/suite.ini
@@ -1,0 +1,4 @@
+[default]
+core = luatest
+description = metrics-export-role module tests on luatest
+is_parallel = False

--- a/test/metrics-export-role-luatest/unit_graphite_test.lua
+++ b/test/metrics-export-role-luatest/unit_graphite_test.lua
@@ -1,0 +1,3 @@
+require('test.metrics-export-role-luatest.helper')
+
+require('third_party.metrics-export-role.test.unit.graphite_test')

--- a/test/metrics-export-role-luatest/unit_http_test.lua
+++ b/test/metrics-export-role-luatest/unit_http_test.lua
@@ -1,0 +1,12 @@
+require('test.metrics-export-role-luatest.helper')
+
+if jit.os == 'OSX' then
+    local t = require('luatest')
+    local g = t.group()
+    g.test_skip_on_macos = function()
+        t.skip('the upstream test requires Linux loopback semantics')
+    end
+    return
+end
+
+require('third_party.metrics-export-role.test.unit.http_test')

--- a/test/metrics-export-role-luatest/unit_middleware_test.lua
+++ b/test/metrics-export-role-luatest/unit_middleware_test.lua
@@ -1,0 +1,3 @@
+require('test.metrics-export-role-luatest.helper')
+
+require('third_party.metrics-export-role.test.unit.middleware_test')

--- a/test/metrics-export-role-luatest/unit_validate_test.lua
+++ b/test/metrics-export-role-luatest/unit_validate_test.lua
@@ -1,0 +1,3 @@
+require('test.metrics-export-role-luatest.helper')
+
+require('third_party.metrics-export-role.test.unit.validate_test')


### PR DESCRIPTION
This patch set integrates tarantool/http and metrics-export-role as bundled third-party modules.

The first patch adds the built-in `http.server`, `http.sslsocket`, and `roles.httpd` modules. It also ports the upstream tarantool/http tests to the in-tree luatest suite, including TLS coverage.

The second patch adds the built-in `roles.metrics-export` module and introduces the declarative `metrics.export` configuration section. Metrics export lifecycle, endpoint handling, output formats, and TLS configuration are delegated to metrics-export-role instead of being duplicated in Tarantool core.
