### PR TITLE
box: improve read-only diagnostics

### DIFF
--- a/changelogs/unreleased/box-cfg-ro-reason.md
+++ b/changelogs/unreleased/box-cfg-ro-reason.md
@@ -1,0 +1,5 @@
+## feature/box
+
+* Allow setting a custom read-only reason via
+  `box.cfg{read_only = true, ro_reason = 'reason'}`. The custom reason is
+  reported via `box.info.ro_reason` and in `ER_READONLY` errors (gh-10404).

--- a/changelogs/unreleased/gh-10405-ro-auto-reason.md
+++ b/changelogs/unreleased/gh-10405-ro-auto-reason.md
@@ -1,0 +1,4 @@
+## feature/config
+
+* `box.info.ro_reason` now reports which declarative configuration mode made
+  an instance read-only instead of the generic `config` reason (gh-10405).

--- a/changelogs/unreleased/gh-10405-ro-auto-reason.md
+++ b/changelogs/unreleased/gh-10405-ro-auto-reason.md
@@ -1,0 +1,7 @@
+## feature/config
+
+* **[Breaking change]** `box.info.ro_reason` and `ER_READONLY` errors now
+  report which declarative configuration mode made an instance read-only
+  instead of the generic `config` reason. Applications that check
+  `box.info.ro_reason == 'config'` must account for the new reasons
+  (gh-10405).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -180,6 +180,11 @@ static bool is_storage_initialized = false;
 /** Set if storage shutdown is started. */
 static bool is_storage_shutdown = false;
 static bool is_ro = true;
+/**
+ * Custom read-only reason set via box.cfg.ro_reason. NULL when no custom reason
+ * is configured. Owns its memory, since cfg_gets() returns a transient buffer.
+ */
+static char *box_ro_reason_cfg;
 static fiber_cond ro_cond;
 
 /**
@@ -410,10 +415,21 @@ box_ro_state_msg_snprint(char *buf, int size)
 				" and is frozen until promotion");
 		}
 	} else {
-		if (is_ro)
+		if (is_ro) {
 			SNPRINT(total, snprintf, buf, size,
 				"box.cfg.read_only is true");
-		else if (is_waiting_for_own_rows)
+			if (box_ro_reason_cfg != NULL) {
+				/*
+				 * The reason is arbitrary user text. Escape it
+				 * so that newlines and other control characters
+				 * don't break the single-line log/error record.
+				 * box.cfg.ro_reason keeps the original value.
+				 */
+				SNPRINT(total, snprintf, buf, size, " - ");
+				SNPRINT(total, json_escape, buf, size,
+					box_ro_reason_cfg);
+			}
+		} else if (is_waiting_for_own_rows)
 			SNPRINT(total, snprintf, buf, size,
 				"it has lost some of its own transactions "
 				"and is waiting to receive them back from "
@@ -471,7 +487,7 @@ box_ro_reason(void)
 	if (is_box_configured && box_raft_is_ro())
 		return "synchro";
 	if (is_ro)
-		return "config";
+		return box_ro_reason_cfg != NULL ? box_ro_reason_cfg : "config";
 	if (is_waiting_for_own_rows)
 		return "waiting to receive its own transactions "
 			"back from the replicaset";
@@ -604,10 +620,15 @@ error:
 static bool
 box_check_ro(void);
 
+/** Update box_ro_reason_cfg from box.cfg.ro_reason. */
+static void
+box_update_ro_reason_cfg(void);
+
 void
 box_set_ro(void)
 {
 	is_ro = box_check_ro();
+	box_update_ro_reason_cfg();
 	box_update_ro_summary();
 }
 
@@ -1703,6 +1724,20 @@ box_check_ro(void)
 			  "replication_anon is false");
 	}
 	return ro;
+}
+
+static void
+box_update_ro_reason_cfg(void)
+{
+	free(box_ro_reason_cfg);
+	box_ro_reason_cfg = NULL;
+	if (!is_ro)
+		return;
+	if (!is_box_configured)
+		return;
+	const char *reason = cfg_gets("ro_reason");
+	if (reason != NULL)
+		box_ro_reason_cfg = (char *)xstrdup(reason);
 }
 
 static bool
@@ -6750,6 +6785,8 @@ box_free(void)
 	coll_id_cache_destroy();
 	port_free();
 	box_lua_call_runtime_priv_reset();
+	free(box_ro_reason_cfg);
+	box_ro_reason_cfg = NULL;
 	/* schema_module_free(); */
 	/* session_free(); */
 }

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -182,6 +182,11 @@ static bool is_storage_shutdown = false;
 static bool is_ro = true;
 /** Whether the read_only option has been applied at least once. */
 static bool is_ro_cfg_applied;
+/**
+ * Custom read-only reason set via box.cfg.ro_reason. NULL when no custom reason
+ * is configured. Owns its memory, since cfg_gets() returns a transient buffer.
+ */
+static char *box_ro_reason_cfg;
 static fiber_cond ro_cond;
 
 /**
@@ -419,10 +424,21 @@ box_ro_state_msg_snprint(char *buf, int size)
 				" and is frozen until promotion");
 		}
 	} else {
-		if (is_ro)
+		if (is_ro) {
 			SNPRINT(total, snprintf, buf, size,
 				"box.cfg.read_only is true");
-		else if (is_waiting_for_own_rows)
+			if (box_ro_reason_cfg != NULL) {
+				/*
+				 * The reason is arbitrary user text. Escape it
+				 * so that newlines and other control characters
+				 * don't break the single-line log/error record.
+				 * box.cfg.ro_reason keeps the original value.
+				 */
+				SNPRINT(total, snprintf, buf, size, " - ");
+				SNPRINT(total, json_escape, buf, size,
+					box_ro_reason_cfg);
+			}
+		} else if (is_waiting_for_own_rows)
 			SNPRINT(total, snprintf, buf, size,
 				"it has lost some of its own transactions "
 				"and is waiting to receive them back from "
@@ -480,7 +496,7 @@ box_ro_reason(void)
 	if (is_box_configured && box_raft_is_ro())
 		return "synchro";
 	if (is_ro)
-		return "config";
+		return box_ro_reason_cfg != NULL ? box_ro_reason_cfg : "config";
 	if (is_waiting_for_own_rows)
 		return "waiting to receive its own transactions "
 			"back from the replicaset";
@@ -613,11 +629,16 @@ error:
 static bool
 box_check_ro(void);
 
+/** Update box_ro_reason_cfg from box.cfg.ro_reason. */
+static void
+box_update_ro_reason_cfg(void);
+
 void
 box_set_ro(void)
 {
 	is_ro = box_check_ro();
 	is_ro_cfg_applied = true;
+	box_update_ro_reason_cfg();
 	box_update_ro_summary();
 }
 
@@ -1788,6 +1809,20 @@ box_check_ro(void)
 	if (mode == RO_CFG_UNLESS_BOOTSTRAP)
 		return !box_is_bootstrap_leader();
 	return mode == RO_CFG_TRUE;
+}
+
+static void
+box_update_ro_reason_cfg(void)
+{
+	free(box_ro_reason_cfg);
+	box_ro_reason_cfg = NULL;
+	if (!is_ro)
+		return;
+	if (!is_box_configured)
+		return;
+	const char *reason = cfg_gets("ro_reason");
+	if (reason != NULL)
+		box_ro_reason_cfg = (char *)xstrdup(reason);
 }
 
 static bool
@@ -6884,6 +6919,8 @@ box_free(void)
 	coll_id_cache_destroy();
 	port_free();
 	box_lua_call_runtime_priv_reset();
+	free(box_ro_reason_cfg);
+	box_ro_reason_cfg = NULL;
 	/* schema_module_free(); */
 	/* session_free(); */
 }

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -227,7 +227,10 @@ local function wait_if_not_bootstrap_leader()
 
     if box.info.id ~= 1 then
         -- Not really a bootstrap leader, just a replica. Go to RO.
-        box.cfg({read_only = true})
+        box.cfg({
+            read_only = true,
+            ro_reason = 'joined an existing replicaset as a replica',
+        })
     end
 end
 
@@ -260,6 +263,7 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
         local mode = configdata:get('database.mode', {use_default = true})
         if mode == 'ro' then
             box_cfg.read_only = true
+            box_cfg.ro_reason = 'database.mode is set to "ro"'
         elseif mode == 'rw' then
             box_cfg.read_only = false
         elseif #configdata:peers() == 1 then
@@ -268,6 +272,8 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
         elseif #configdata:peers() > 1 then
             assert(mode == nil)
             box_cfg.read_only = true
+            box_cfg.ro_reason = 'database.mode defaults to "ro" for a ' ..
+                'multi-instance replicaset'
         else
             assert(false)
         end
@@ -280,6 +286,9 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
         -- NB: configdata.lua verifies that an anonymous replica
         -- is not set as a leader.
         box_cfg.read_only = not configdata:is_leader()
+        if box_cfg.read_only then
+            box_cfg.ro_reason = 'not the leader in manual failover mode'
+        end
     elseif failover == 'election' then
         -- Enable leader election on non-anonymous instances.
         if box_cfg.election_mode == nil then
@@ -322,6 +331,7 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
         -- underneath logic).
         if box_cfg.election_mode == 'off' then
             box_cfg.read_only = true  -- forced RO
+            box_cfg.ro_reason = 'replication.election_mode is set to "off"'
         elseif box_cfg.election_mode == 'voter' then
             box_cfg.read_only = false -- means no restrictions
         elseif box_cfg.election_mode == 'manual' then
@@ -348,6 +358,8 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
         if externally_managed_mode_strategies[bootstrap_strategy] then
             if is_startup then
                 box_cfg.read_only = true
+                box_cfg.ro_reason = 'waiting for an external failover ' ..
+                    'coordinator'
             else
                 -- Don't change the read_only flag on the
                 -- reconfiguration. It is managed by an external
@@ -400,6 +412,10 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
                 snapshot.get_path(configdata._iconfig_def) == nil and
                 instance_name == configdata:bootstrap_leader_name()
             box_cfg.read_only = not am_i_bootstrap_leader
+            if box_cfg.read_only then
+                box_cfg.ro_reason = 'not the bootstrap leader in supervised ' ..
+                    'failover mode'
+            end
         end
 
         -- It is possible that an instance with the minimal
@@ -900,8 +916,8 @@ local function switch_isolated_mode_before_box_cfg(config, box_cfg)
     -- [^1]: Unless the data operations are carefully designed to
     --       be idempotent to use in the master-master mode.
     --
-    -- TODO(gh-10404): Set ro_reason=isolated.
     box_cfg.read_only = true
+    box_cfg.ro_reason = 'isolated mode is enabled'
 
     -- Don't accept new iproto connections.
     --
@@ -1165,6 +1181,7 @@ local function force_ro_on_startup(configdata, box_cfg)
 
     if force_read_only then
         box_cfg.read_only = true
+        box_cfg.ro_reason = 'safe startup mode is enabled'
     end
 
     -- NB: needs_retry should be true when force_read_only is

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -229,7 +229,12 @@ end
 -- demote, and a truthy value correctly reports that the
 -- configuration does not ask for RW unconditionally.
 local function normalize_read_only()
-    box.cfg({read_only = not box.internal.is_bootstrap_leader()})
+    local read_only_ = not box.internal.is_bootstrap_leader()
+    local cfg = {read_only = read_only_}
+    if read_only_ then
+        cfg.ro_reason = 'joined an existing replicaset as a replica'
+    end
+    box.cfg(cfg)
 end
 
 local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
@@ -261,6 +266,7 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
         local mode = configdata:get('database.mode', {use_default = true})
         if mode == 'ro' then
             box_cfg.read_only = true
+            box_cfg.ro_reason = 'database.mode is set to "ro"'
         elseif mode == 'rw' then
             box_cfg.read_only = false
         elseif #configdata:peers() == 1 then
@@ -269,6 +275,8 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
         elseif #configdata:peers() > 1 then
             assert(mode == nil)
             box_cfg.read_only = true
+            box_cfg.ro_reason = 'database.mode defaults to "ro" for a ' ..
+                'multi-instance replicaset'
         else
             assert(false)
         end
@@ -281,6 +289,9 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
         -- NB: configdata.lua verifies that an anonymous replica
         -- is not set as a leader.
         box_cfg.read_only = not configdata:is_leader()
+        if box_cfg.read_only then
+            box_cfg.ro_reason = 'not the leader in manual failover mode'
+        end
     elseif failover == 'election' then
         -- Enable leader election on non-anonymous instances.
         if box_cfg.election_mode == nil then
@@ -323,6 +334,7 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
         -- underneath logic).
         if box_cfg.election_mode == 'off' then
             box_cfg.read_only = true  -- forced RO
+            box_cfg.ro_reason = 'replication.election_mode is set to "off"'
         elseif box_cfg.election_mode == 'voter' then
             box_cfg.read_only = false -- means no restrictions
         elseif box_cfg.election_mode == 'manual' then
@@ -349,6 +361,8 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
         if externally_managed_mode_strategies[bootstrap_strategy] then
             if is_startup then
                 box_cfg.read_only = true
+                box_cfg.ro_reason = 'waiting for an external failover ' ..
+                    'coordinator'
             else
                 -- Don't change the read_only flag on the
                 -- reconfiguration. It is managed by an external
@@ -408,6 +422,11 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
                 instance_name == configdata:bootstrap_leader_name()
             box_cfg.read_only =
                 am_i_bootstrap_leader and 'unless_bootstrap' or true
+
+            if not am_i_bootstrap_leader then
+                box_cfg.ro_reason = 'not the bootstrap leader in supervised ' ..
+                    'failover mode'
+            end
         end
 
         -- Replace 'unless_bootstrap' with the resolved boolean once box.cfg()
@@ -890,8 +909,8 @@ local function switch_isolated_mode_before_box_cfg(config, box_cfg)
     -- [^1]: Unless the data operations are carefully designed to
     --       be idempotent to use in the master-master mode.
     --
-    -- TODO(gh-10404): Set ro_reason=isolated.
     box_cfg.read_only = true
+    box_cfg.ro_reason = 'isolated mode is enabled'
 
     -- Don't accept new iproto connections.
     --
@@ -1155,6 +1174,7 @@ local function force_ro_on_startup(configdata, box_cfg)
 
     if force_read_only then
         box_cfg.read_only = true
+        box_cfg.ro_reason = 'safe startup mode is enabled'
     end
 
     -- NB: needs_retry should be true when force_read_only is

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -184,6 +184,7 @@ local default_cfg = {
     username            = nil,
     coredump            = false,
     read_only           = false,
+    ro_reason           = nil,
     hot_standby         = false,
     memtx_use_mvcc_engine = false,
     checkpoint_interval = 3600,
@@ -398,6 +399,7 @@ local template_cfg = {
     wal_queue_max_size  = 'number',
     checkpoint_count    = 'number',
     read_only           = 'boolean',
+    ro_reason           = 'string',
     hot_standby         = 'boolean',
     memtx_use_mvcc_engine = 'boolean',
     txn_isolation = 'string, number',
@@ -623,7 +625,6 @@ local dynamic_cfg = {
     readahead               = private.cfg_set_readahead,
     too_long_threshold      = private.cfg_set_too_long_threshold,
     snap_io_rate_limit      = private.cfg_set_snap_io_rate_limit,
-    read_only               = private.cfg_set_read_only,
     memtx_memory            = private.cfg_set_memtx_memory,
     memtx_use_sort_data     = private.cfg_set_memtx_use_sort_data,
     memtx_max_tuple_size    = private.cfg_set_memtx_max_tuple_size,
@@ -714,6 +715,13 @@ local dynamic_cfg = {
 -- to "safe" value given in `revert_fallback`. "safe" in sense that
 -- reverting to it should always be successful.
 local dynamic_cfg_modules = {
+    read_only = {
+        cfg = private.cfg_set_read_only,
+        options = {
+            read_only = true,
+            ro_reason = true,
+        },
+    },
     listen = {
         cfg = private.cfg_set_listen,
         options = {
@@ -1138,8 +1146,46 @@ local function reconfig_modules(module_keys, oldcfg, newcfg, log_basecfg)
     end
 end
 
+-- The reason is passed to the C side via cfg_gets(), which copies it into a
+-- fixed-size buffer. Reject values that would not survive the round-trip so
+-- that box.cfg.ro_reason, box.info.ro_reason and ER_READONLY always agree.
+local ro_reason_max_len = 511
+
+local function normalize_ro_reason(cfg)
+    if cfg.ro_reason == nil then
+        if cfg.read_only ~= nil then
+            -- Keep the key in cfg so that the read_only module clears an
+            -- earlier custom reason.
+            cfg.ro_reason = box.NULL
+        end
+        return
+    end
+
+    if cfg.read_only ~= true then
+        box.error(box.error.CFG, 'ro_reason',
+                  'may be set only when read_only is true')
+    end
+
+    -- Let prepare_cfg() report the usual type error for non-string values.
+    if type(cfg.ro_reason) ~= 'string' then
+        return
+    end
+
+    if #cfg.ro_reason > ro_reason_max_len then
+        box.error(box.error.CFG, 'ro_reason',
+                  'the value must not exceed ' .. ro_reason_max_len ..
+                  ' bytes')
+    end
+
+    if cfg.ro_reason:find('\0', 1, true) ~= nil then
+        box.error(box.error.CFG, 'ro_reason',
+                  'the value must not contain a zero byte')
+    end
+end
+
 local function reload_cfg(oldcfg, cfg)
     cfg = upgrade_cfg(cfg, translate_cfg)
+    normalize_ro_reason(cfg)
     local newcfg = prepare_cfg(cfg, {}, default_cfg, template_cfg,
                                modify_cfg)
     local module_keys = {}
@@ -1247,6 +1293,8 @@ local function load_cfg(cfg)
 
     -- Set options passed through environment variables.
     apply_env_cfg(cfg, box.internal.cfg.env, pre_load_cfg_is_set)
+
+    normalize_ro_reason(cfg)
 
     cfg = prepare_cfg(cfg, pre_load_cfg, default_cfg, template_cfg, modify_cfg)
 

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -184,6 +184,7 @@ local default_cfg = {
     username            = nil,
     coredump            = false,
     read_only           = false,
+    ro_reason           = nil,
     hot_standby         = false,
     memtx_use_mvcc_engine = false,
     checkpoint_interval = 3600,
@@ -398,6 +399,7 @@ local template_cfg = {
     wal_queue_max_size  = 'number',
     checkpoint_count    = 'number',
     read_only           = 'boolean, string',
+    ro_reason           = 'string',
     hot_standby         = 'boolean',
     memtx_use_mvcc_engine = 'boolean',
     txn_isolation = 'string, number',
@@ -623,7 +625,6 @@ local dynamic_cfg = {
     readahead               = private.cfg_set_readahead,
     too_long_threshold      = private.cfg_set_too_long_threshold,
     snap_io_rate_limit      = private.cfg_set_snap_io_rate_limit,
-    read_only               = private.cfg_set_read_only,
     memtx_memory            = private.cfg_set_memtx_memory,
     memtx_use_sort_data     = private.cfg_set_memtx_use_sort_data,
     memtx_max_tuple_size    = private.cfg_set_memtx_max_tuple_size,
@@ -714,6 +715,13 @@ local dynamic_cfg = {
 -- to "safe" value given in `revert_fallback`. "safe" in sense that
 -- reverting to it should always be successful.
 local dynamic_cfg_modules = {
+    read_only = {
+        cfg = private.cfg_set_read_only,
+        options = {
+            read_only = true,
+            ro_reason = true,
+        },
+    },
     listen = {
         cfg = private.cfg_set_listen,
         options = {
@@ -1138,8 +1146,46 @@ local function reconfig_modules(module_keys, oldcfg, newcfg, log_basecfg)
     end
 end
 
+-- The reason is passed to the C side via cfg_gets(), which copies it into a
+-- fixed-size buffer. Reject values that would not survive the round-trip so
+-- that box.cfg.ro_reason, box.info.ro_reason and ER_READONLY always agree.
+local ro_reason_max_len = 511
+
+local function normalize_ro_reason(cfg)
+    if cfg.ro_reason == nil then
+        if cfg.read_only ~= nil then
+            -- Keep the key in cfg so that the read_only module clears an
+            -- earlier custom reason.
+            cfg.ro_reason = box.NULL
+        end
+        return
+    end
+
+    if cfg.read_only ~= true then
+        box.error(box.error.CFG, 'ro_reason',
+                  'may be set only when read_only is true')
+    end
+
+    -- Let prepare_cfg() report the usual type error for non-string values.
+    if type(cfg.ro_reason) ~= 'string' then
+        return
+    end
+
+    if #cfg.ro_reason > ro_reason_max_len then
+        box.error(box.error.CFG, 'ro_reason',
+                  'the value must not exceed ' .. ro_reason_max_len ..
+                  ' bytes')
+    end
+
+    if cfg.ro_reason:find('\0', 1, true) ~= nil then
+        box.error(box.error.CFG, 'ro_reason',
+                  'the value must not contain a zero byte')
+    end
+end
+
 local function reload_cfg(oldcfg, cfg)
     cfg = upgrade_cfg(cfg, translate_cfg)
+    normalize_ro_reason(cfg)
     local newcfg = prepare_cfg(cfg, {}, default_cfg, template_cfg,
                                modify_cfg)
     local module_keys = {}
@@ -1247,6 +1293,8 @@ local function load_cfg(cfg)
 
     -- Set options passed through environment variables.
     apply_env_cfg(cfg, box.internal.cfg.env, pre_load_cfg_is_set)
+
+    normalize_ro_reason(cfg)
 
     cfg = prepare_cfg(cfg, pre_load_cfg, default_cfg, template_cfg, modify_cfg)
 

--- a/test/config-luatest/gh_10405_ro_auto_reason_test.lua
+++ b/test/config-luatest/gh_10405_ro_auto_reason_test.lua
@@ -1,0 +1,179 @@
+local t = require('luatest')
+local cbuilder = require('luatest.cbuilder')
+local cluster = require('luatest.cluster')
+local it = require('test.interactive_tarantool')
+
+local function assert_ro_reason(server, reason)
+    server:exec(function(reason)
+        t.assert_equals(box.info.ro, reason ~= nil)
+        t.assert_equals(box.info.ro_reason, reason)
+    end, {reason})
+end
+
+local function cleanup(g)
+    if g.it ~= nil then
+        g.it:close()
+        g.it = nil
+    end
+    if g.cluster ~= nil then
+        g.cluster:drop()
+        g.cluster = nil
+    end
+end
+
+local g = t.group()
+
+g.after_each(cleanup)
+
+-- Check explicit and default database modes with failover disabled.
+g.test_failover_off = function(g)
+    local config = cbuilder:new()
+        :add_instance('i-001', {})
+        :add_instance('i-002', {})
+        :add_instance('i-003', {})
+        :set_instance_option('i-001', 'database.mode', 'rw')
+        :set_instance_option('i-002', 'database.mode', 'ro')
+        :config()
+
+    g.cluster = cluster:new(config)
+    g.cluster:start()
+
+    assert_ro_reason(g.cluster['i-001'], nil)
+    assert_ro_reason(g.cluster['i-002'], 'database.mode is set to "ro"')
+    assert_ro_reason(g.cluster['i-003'],
+        'database.mode defaults to "ro" for a multi-instance replicaset')
+end
+
+-- Check manual failover, isolated mode precedence, and safe startup.
+g.test_manual_isolated_and_safe_startup = function(g)
+    local config = cbuilder:new()
+        :set_replicaset_option('replication.failover', 'manual')
+        :set_replicaset_option('leader', 'i-001')
+        :add_instance('i-001', {})
+        :add_instance('i-002', {})
+        :config()
+
+    g.cluster = cluster:new(config)
+    g.cluster:start()
+
+    -- Only a non-leader gets the manual failover reason.
+    assert_ro_reason(g.cluster['i-001'], nil)
+    assert_ro_reason(g.cluster['i-002'],
+        'not the leader in manual failover mode')
+
+    -- Isolated mode overrides the reason that made the instance RO before it.
+    g.it = it.connect(g.cluster['i-002'])
+    local config_isolated = cbuilder:new(config)
+        :set_instance_option('i-002', 'isolated', true)
+        :config()
+    g.cluster:sync(config_isolated)
+    g.it:roundtrip("require('config'):reload()")
+    g.it:roundtrip('box.info.ro_reason', 'isolated mode is enabled')
+
+    -- Leaving isolated mode restores the manual failover reason.
+    local config_not_isolated = cbuilder:new(config_isolated)
+        :set_instance_option('i-002', 'isolated', nil)
+        :config()
+    g.cluster:sync(config_not_isolated)
+    g.it:roundtrip("require('config'):reload()")
+    g.it:roundtrip('box.info.ro_reason',
+        'not the leader in manual failover mode')
+    g.it:close()
+    g.it = nil
+
+    -- A restarted new leader is temporarily RO during safe startup. The final
+    -- state is RW, so verify the transient reason in the log.
+    g.cluster['i-002']:stop()
+    local config_new_leader = cbuilder:new(config_not_isolated)
+        :set_replicaset_option('leader', 'i-002')
+        :config()
+    g.cluster:sync(config_new_leader)
+    g.cluster['i-002']:start()
+
+    assert_ro_reason(g.cluster['i-002'], nil)
+    t.assert(g.cluster['i-002']:grep_log('safe startup mode is enabled'))
+end
+
+-- Check forced RO when an instance does not participate in elections.
+g.test_election_mode_off = function(g)
+    local config = cbuilder:new()
+        :set_replicaset_option('replication.failover', 'election')
+        :add_instance('i-001', {})
+        :add_instance('i-002', {
+            replication = {election_mode = 'off'},
+        })
+        :config()
+
+    g.cluster = cluster:new(config)
+    g.cluster:start()
+
+    g.cluster['i-002']:exec(function()
+        t.assert_equals(box.info.ro, true)
+        t.assert_equals(box.cfg.ro_reason,
+            'replication.election_mode is set to "off"')
+        t.assert_equals(box.info.ro_reason, 'synchro')
+    end)
+end
+
+-- Check supervised bootstrap reasons for existing and newly added replicas.
+g.test_supervised_auto = function(g)
+    local config = cbuilder:new()
+        :set_replicaset_option('replication.failover', 'supervised')
+        :set_replicaset_option('replication.bootstrap_strategy', 'auto')
+        :add_instance('i-001', {})
+        :add_instance('i-002', {})
+        :config()
+
+    g.cluster = cluster:new(config)
+    g.cluster:start()
+
+    assert_ro_reason(g.cluster['i-002'],
+        'not the bootstrap leader in supervised failover mode')
+
+    local config_upscaled = cbuilder:new(config)
+        :add_instance('i-000', {})
+        :config()
+    g.cluster:sync(config_upscaled)
+    g.cluster:start_instance('i-000')
+
+    assert_ro_reason(g.cluster['i-000'],
+        'joined an existing replicaset as a replica')
+end
+
+local g_external = t.group('external', {
+    {strategy = 'supervised'},
+    {strategy = 'native'},
+})
+
+g_external.after_each(cleanup)
+
+-- Check RO while an external coordinator controls instance writability.
+g_external.test_wait_for_coordinator = function(g)
+    local config = cbuilder:new()
+        :set_replicaset_option('replication.failover', 'supervised')
+        :set_replicaset_option('replication.bootstrap_strategy',
+            g.params.strategy)
+        :add_instance('i-001', {})
+        :config()
+
+    g.cluster = cluster:new(config)
+    g.cluster:start({wait_until_ready = false})
+
+    -- The instance stays RO waiting for the coordinator, so its control socket
+    -- may appear with a delay. Retry until the console connection succeeds.
+    t.helpers.retrying({timeout = 60}, function()
+        g.it = it.connect(g.cluster['i-001'])
+    end)
+    g.it:roundtrip([[
+        require('fiber').new(function()
+            box.ctl.make_bootstrap_leader({graceful = true})
+        end)
+    ]])
+    t.helpers.retrying({timeout = 60}, function()
+        local status = g.it:roundtrip("require('config'):info().status")
+        t.assert_equals(status, 'ready')
+    end)
+    g.it:roundtrip('box.info.ro', true)
+    g.it:roundtrip('box.info.ro_reason',
+        'waiting for an external failover coordinator')
+end

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1529,6 +1529,9 @@ g.test_box_cfg_coverage = function()
         -- handled by the box_cfg applier.
         read_only = true,
 
+        -- Read only is ignored, so the reason too
+        ro_reason = true,
+
         -- Deliberately moved out of the config, because the
         -- box.cfg() options is deprecated.
         replication_connect_quorum = true,

--- a/test/replication-luatest/gh_10404_read_only_custom_reason_test.lua
+++ b/test/replication-luatest/gh_10404_read_only_custom_reason_test.lua
@@ -1,0 +1,200 @@
+local t = require('luatest')
+local cluster = require('luatest.replica_set')
+local server = require('luatest.server')
+
+local function ro_reason(s)
+    return s:exec(function() return box.info.ro_reason end)
+end
+
+local function assert_cfg_error(s, cfg, message)
+    local ok, err = s:exec(function(cfg)
+        local ok, err = pcall(box.cfg, cfg)
+        return ok, err:unpack()
+    end, {cfg})
+    t.assert(not ok)
+    t.assert_str_contains(err.message, message)
+end
+
+-- Single-instance cases: custom reason, default 'config', and error reporting.
+local g = t.group('single')
+
+g.before_all(function()
+    g.server = server:new()
+    g.server:start()
+end)
+
+g.after_all(function()
+    if g.server ~= nil then
+        g.server:drop()
+        g.server = nil
+    end
+end)
+
+g.after_each(function()
+    g.server:exec(function()
+        box.cfg{read_only = false, ro_reason = nil}
+    end)
+end)
+
+-- Custom reason is passed and returned as is.
+g.test_custom_reason = function()
+    g.server:exec(function()
+        box.cfg{read_only = true, ro_reason = 'custom reason'}
+        t.assert_equals(box.cfg.ro_reason, 'custom reason')
+    end)
+    t.assert_equals(ro_reason(g.server), 'custom reason')
+end
+
+-- No reason is passed, so the default 'config' value is returned.
+g.test_default_reason = function()
+    g.server:exec(function()
+        box.cfg{read_only = true}
+        t.assert_equals(box.cfg.ro_reason, nil)
+    end)
+    t.assert_equals(ro_reason(g.server), 'config')
+end
+
+-- A stale custom reason must not leak: reconfiguring read_only without a fresh
+-- ro_reason resets it to the default 'config'.
+g.test_stale_reason_is_cleared = function()
+    g.server:exec(function()
+        box.cfg{read_only = true, ro_reason = 'custom reason'}
+        box.cfg{read_only = false}
+        box.cfg{read_only = true}
+    end)
+    t.assert_equals(ro_reason(g.server), 'config')
+end
+
+-- ro_reason cannot be set without read_only = true.
+g.test_ro_reason_requires_read_only = function()
+    assert_cfg_error(g.server, {ro_reason = 'custom reason'},
+                     'may be set only when read_only is true')
+end
+
+-- ro_reason cannot be set when read_only = false.
+g.test_ro_reason_rejects_read_only_false = function()
+    assert_cfg_error(g.server, {
+        read_only = false,
+        ro_reason = 'custom reason',
+    }, 'read_only is true')
+end
+
+-- Custom reason is carried in the ER_READONLY error.
+g.test_custom_reason_in_error = function()
+    local err = g.server:exec(function()
+        box.cfg{read_only = true, ro_reason = 'custom reason'}
+        local _, err = pcall(box.schema.create_space, 'test')
+        return err:unpack()
+    end)
+    t.assert_covers(err, {
+        reason = 'custom reason',
+        code = box.error.READONLY,
+        type = 'ClientError',
+    })
+    t.assert_str_contains(err.message,
+                          'box.cfg.read_only is true - custom reason')
+end
+
+-- An over-long reason is rejected instead of being silently truncated.
+g.test_ro_reason_too_long_is_rejected = function()
+    assert_cfg_error(g.server, {
+        read_only = true,
+        ro_reason = string.rep('x', 512),
+    }, 'must not exceed')
+end
+
+-- The largest accepted reason survives the round-trip without truncation.
+g.test_ro_reason_max_len_round_trip = function()
+    local len = g.server:exec(function()
+        local reason = string.rep('x', 511)
+        box.cfg{read_only = true, ro_reason = reason}
+        return #box.info.ro_reason
+    end)
+    t.assert_equals(len, 511)
+end
+
+-- Special characters are kept verbatim in box.cfg/box.info but escaped in the
+-- ER_READONLY message, so it stays a single line.
+g.test_special_chars_are_escaped_in_error = function()
+    local raw = 'tab\there\nnew"quote"\\slash\r\b'
+    local cfg_reason, err = g.server:exec(function(raw)
+        box.cfg{read_only = true, ro_reason = raw}
+        local _, err = pcall(box.schema.create_space, 'test')
+        return box.cfg.ro_reason, err:unpack()
+    end, {raw})
+    -- The original value is preserved as is.
+    t.assert_equals(cfg_reason, raw)
+    t.assert_equals(ro_reason(g.server), raw)
+    -- The message carries the escaped form and no raw control characters.
+    t.assert_str_contains(err.message, 'box.cfg.read_only is true - ' ..
+        'tab\\there\\nnew\\"quote\\"\\\\slash\\r\\b')
+    for _, c in ipairs({'\n', '\t', '\r', '\b'}) do
+        t.assert_not_str_contains(err.message, c)
+    end
+end
+
+-- Priority cases: need a replicaset to drive 'synchro' via elections.
+local g2 = t.group('priority')
+
+g2.before_each(function()
+    g2.cluster = cluster:new({})
+    local master_uri = server.build_listen_uri('master', g2.cluster.id)
+    local replica_uri = server.build_listen_uri('replica', g2.cluster.id)
+    local box_cfg = {
+        replication = {master_uri, replica_uri},
+        replication_timeout = 0.1,
+        bootstrap_strategy = 'legacy',
+    }
+    box_cfg.listen = master_uri
+    g2.master = g2.cluster:build_and_add_server({alias = 'master',
+                                                 box_cfg = box_cfg})
+    box_cfg.listen = replica_uri
+    g2.replica = g2.cluster:build_and_add_server({alias = 'replica',
+                                                  box_cfg = box_cfg})
+    g2.cluster:start()
+    g2.cluster:wait_for_fullmesh()
+end)
+
+g2.after_each(function()
+    g2.cluster:drop()
+end)
+
+-- The higher-priority 'synchro' reason is returned while a custom reason is
+-- configured and read_only remains true.
+g2.test_synchro_overrides_custom_reason = function()
+    g2.master:exec(function()
+        box.cfg{election_mode = 'candidate', replication_synchro_quorum = 2}
+    end)
+    g2.replica:exec(function()
+        box.cfg{read_only = true, ro_reason = 'custom reason'}
+        box.cfg{election_mode = 'voter'}
+    end)
+    g2.master:wait_for_election_leader()
+    g2.replica:wait_until_election_leader_found()
+
+    t.assert_equals(g2.replica:exec(function()
+        return box.cfg.read_only
+    end), true)
+    t.assert_equals(ro_reason(g2.replica), 'synchro')
+end
+
+-- read_only is false, but the instance is RO because it is an orphan, so the
+-- 'orphan' reason is returned.
+g2.test_orphan_reason_when_not_ro = function()
+    local fake_uri = server.build_listen_uri('fake', g2.cluster.id)
+    g2.master:exec(function(fake_uri)
+        local repl = table.copy(box.cfg.replication)
+        table.insert(repl, fake_uri)
+        box.cfg{replication = repl, replication_connect_timeout = 0.001}
+    end, {fake_uri})
+
+    t.helpers.retrying({timeout = 100}, function()
+        t.assert_equals(g2.master:exec(function()
+            return box.info.status
+        end), 'orphan')
+    end)
+    t.assert_equals(g2.master:exec(function()
+        return box.cfg.read_only
+    end), false)
+    t.assert_equals(ro_reason(g2.master), 'orphan')
+end


### PR DESCRIPTION
Before this change, read-only states imposed by configuration were generally
reported with the generic `config` reason, making it difficult to understand
why an instance was not writable.

Introduce `box.cfg.ro_reason` for specifying a custom reason alongside
`read_only = true`. The reason is available in `box.info.ro_reason` and
`ER_READONLY` errors.

Declarative configuration now supplies a reason for each mode that can make
an instance read-only, including failover, bootstrap, election, isolation,
and safe startup.

Closes #10404
Closes #10405

@TarantoolBot document
    Title: Custom read-only reason
    
    The `box.cfg.ro_reason` option sets a custom reason for an instance
    configured as read-only.
    
    Set it together with `read_only = true`:
    
    ```lua
    box.cfg{
        read_only = true,
        ro_reason = 'maintenance',
    }
    ```
    
    The value is returned from box.info.ro_reason and is included in the
    reason field of ER_READONLY errors:
    box.info.ro_reason
    -- 'maintenance'
    ro_reason can be set only in the same box.cfg() call as
    read_only = true. Setting read_only without ro_reason clears a
    previous custom reason. In this case, box.info.ro_reason returns the
    default value 'config'.
    The custom reason is used only for read-only mode configured with
    box.cfg.read_only. Other read-only causes keep their existing reasons.
    Synchronous replication has higher priority and reports 'synchro'
    instead of the custom reason.
    
    The custom reason must not exceed 511 bytes and must not contain a zero
    byte.