### PR TITLE
sql: properly process -0 and -0x0 defaults

### DIFF
--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -583,6 +583,12 @@ sql_add_term_default(struct Parse *parser, struct ExprSpan *expr_span)
 		if (expr->op == TK_UMINUS) {
 			int64_t val;
 			if (sql_expr_nint(expr->pLeft, &val) == 0) {
+				if (val == 0) {
+					size = mp_sizeof_uint(val);
+					buf = xregion_alloc(region, size);
+					mp_encode_uint(buf, val);
+					break;
+				}
 				size = mp_sizeof_int(val);
 				buf = xregion_alloc(region, size);
 				mp_encode_int(buf, val);

--- a/test/sql-luatest/defaults_test.lua
+++ b/test/sql-luatest/defaults_test.lua
@@ -285,3 +285,17 @@ g.test_func_defaults_with_null_and_collate = function()
         box.schema.func.drop(func_id)
     end)
 end
+
+--
+-- Make sure that -0 and -0x0 does not cause an error.
+--
+g.test_negative_zero_int = function()
+    g.server:exec(function()
+        local sql = [[CREATE TABLE T(I INT PRIMARY KEY,
+                      A INT DEFAULT -0, B INT DEFAULT -0x0);]]
+        box.execute(sql)
+        t.assert_equals(box.space.T:format()[2].default, 0)
+        t.assert_equals(box.space.T:format()[3].default, 0)
+        box.space.T:drop()
+    end)
+end


### PR DESCRIPTION
After commit 78e0faa1bdc2e014a73550cac32ae0a4c46f1a37 ("sql: rework parsing of DEFAULT") an error appeared with these defaults. This patch fixes the regression

NO_DOC=fixes bug added in previous patch
NO_CHANGELOG=fixes bug added in previous patch