### PR TITLE
sql: check privileges on DROP TRIGGER

### DIFF
--- a/changelogs/unreleased/ghs-163-check-privileges-on-drop-trigger.md
+++ b/changelogs/unreleased/ghs-163-check-privileges-on-drop-trigger.md
@@ -1,0 +1,5 @@
+## feature/sql
+
+* Added permission checks when dropping a trigger in SQL.
+  Now only users with 'alter' privileges on a table can drop
+  triggers for that table (ghs-163).

--- a/src/box/alter.cc
+++ b/src/box/alter.cc
@@ -5590,6 +5590,11 @@ on_replace_dd_trigger(struct trigger * /* trigger */, void *event)
 		if (tuple_field_u32(old_tuple, BOX_TRIGGER_FIELD_SPACE_ID,
 				    &space_id) != 0)
 			return -1;
+		struct space *space = space_cache_find(space_id);
+		assert(space != NULL);
+		if (access_check_ddl(space->def->name, space->def->uid,
+				     space->access, SC_SPACE, PRIV_A) != 0)
+			return -1;
 		RegionGuard region_guard(&fiber()->gc);
 		char *trigger_name = (char *)region_alloc(&fiber()->gc,
 							  trigger_name_len + 1);

--- a/test/sql-luatest/triggers_test.lua
+++ b/test/sql-luatest/triggers_test.lua
@@ -720,3 +720,42 @@ end
         box.execute([[DROP TABLE t2;]])
     end)
 end
+
+--
+-- ghs-163: Check access privileges when dropping triggers.
+--
+ g.test_163_check_privileges_on_drop_trigger = function(cg)
+    cg.server:exec(function()
+        local admin = box.session.user()
+        box.execute([[CREATE TABLE t1 (i INT PRIMARY KEY);]])
+        box.execute([[CREATE TABLE t2 (i INT PRIMARY KEY);]])
+        box.execute([[CREATE TRIGGER t1t AFTER INSERT ON t1
+                      FOR EACH ROW BEGIN INSERT INTO t2 VALUES(1); END;]])
+
+        box.schema.user.create('user')
+        box.schema.user.grant('user', 'read,write,create', 'space', '_trigger')
+        box.schema.user.grant('user', 'read', 'space', '_space')
+        box.session.su('user')
+        local exp_err = "Alter access to space 't1' is denied for user 'user'"
+        local _, err = box.execute([[DROP TRIGGER t1t;]])
+        t.assert_equals(err.message, exp_err)
+
+        box.session.su(admin)
+        box.schema.user.grant('user', 'read,write,create', 'space', 't1')
+        box.session.su('user')
+        _, err = box.execute([[DROP TRIGGER t1t;]])
+        t.assert_equals(err.message, exp_err)
+
+        box.session.su(admin)
+        box.schema.user.grant('user', 'alter', 'space', 't1')
+        box.session.su('user')
+        local res, err = box.execute([[DROP TRIGGER t1t;]])
+        t.assert_equals(res, {row_count = 1})
+        t.assert_equals(err, nil)
+
+        box.session.su(admin)
+        box.schema.user.drop('user')
+        box.execute([[DROP TABLE t1;]])
+        box.execute([[DROP TABLE t2;]])
+    end)
+end


### PR DESCRIPTION
After this patch, only users with `alter` permissions on the space will be able to drop triggers of the space.

Follow-up https://github.com/tarantool/security/issues/163

NO_DOC=bugfix