### PR TITLE
lua: enable JIT for macOS by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -719,12 +719,6 @@ if (TARGET_OS_DARWIN)
     # LuaJIT is unusable on OS X without enabled GC64
     # See https://github.com/tarantool/tarantool/issues/2643
     set(LUAJIT_ENABLE_GC64_DEFAULT ON)
-    # To improve customer experience JIT engine is turned off on
-    # Tarantool startup for macOS builds. Either way, JIT will be
-    # aboard as a result of the changes and more adventurous users
-    # will be able to enable it via jit.on() in their code.
-    # See https://github.com/tarantool/tarantool/issues/8252.
-    set(LUAJIT_JIT_STATUS_DEFAULT OFF)
 endif()
 option(LUAJIT_ENABLE_GC64 "Use 64-bit GC objects by default."
        ${LUAJIT_ENABLE_GC64_DEFAULT})

--- a/changelogs/unreleased/gh-noticket-jit-enable-macos.md
+++ b/changelogs/unreleased/gh-noticket-jit-enable-macos.md
@@ -1,0 +1,3 @@
+## bugfix/luajit
+
+The JIT engine is now enabled on Tarantool startup for macOS builds.

--- a/test/app-luatest/gh_8252_jit_off_on_macOS_by_default_test.lua
+++ b/test/app-luatest/gh_8252_jit_off_on_macOS_by_default_test.lua
@@ -1,8 +1,0 @@
-local t = require('luatest')
-
-local g = t.group()
-
-g.test_jit_off_on_macOS_by_default = function()
-    t.assert_equals(jit.os == 'OSX', not jit.status(),
-                    'JIT is disabled by default on macOS')
-end


### PR DESCRIPTION
Since the commit 51e4c97d4cbef244ed7b6611f1d6c444b8b6d4d7 ("luajit: bump new version") the JIT behaves correctly on macOS for the digest calculations, so JIT is enabled again. The corresponding test is removed as obsolete.

Relates to #6097

NO_DOC=no behaviour changes