### PR TITLE
test: fix `replicaset_ro_mostly.test.lua` flake

### DIFF
--- a/test/replication/replicaset_ro_mostly.result
+++ b/test/replication/replicaset_ro_mostly.result
@@ -63,7 +63,7 @@ test_run:cmd(create_cluster_cmd1:format(name, name))
 ---
 - true
 ...
-test_run:cmd(create_cluster_cmd2:format(name, uuid.new(), "0.1"))
+test_run:cmd(('start server %s with args="%s"'):format(name, uuid.new()))
 ---
 - true
 ...
@@ -74,6 +74,9 @@ test_run:cmd('switch replica_uuid_ro3')
 test_run:cmd('switch default')
 ---
 - true
+...
+SERVERS[#SERVERS + 1] = name
+---
 ...
 -- Cleanup.
 test_run:drop_cluster(SERVERS)

--- a/test/replication/replicaset_ro_mostly.test.lua
+++ b/test/replication/replicaset_ro_mostly.test.lua
@@ -32,9 +32,10 @@ test_run:wait_fullmesh(SERVERS)
 -- Add third replica
 name = 'replica_uuid_ro3'
 test_run:cmd(create_cluster_cmd1:format(name, name))
-test_run:cmd(create_cluster_cmd2:format(name, uuid.new(), "0.1"))
+test_run:cmd(('start server %s with args="%s"'):format(name, uuid.new()))
 test_run:cmd('switch replica_uuid_ro3')
 test_run:cmd('switch default')
+SERVERS[#SERVERS + 1] = name
 
 -- Cleanup.
 test_run:drop_cluster(SERVERS)


### PR DESCRIPTION
This patch fixes a bug in `test/replication/replicaset_ro_mostly.test.lua` that allowed the test to stop the bootstrap leader before the third replica finished loading. Wait for the third replica to finish loading and include it in cleanup.

Closes #12926

NO_DOC=test
NO_CHANGELOG=test