### PR TITLE
datetime: fix out-of-bounds read on bad tzindex

### DIFF
--- a/changelogs/unreleased/gh-noticket-datetime-tzindex-oob.md
+++ b/changelogs/unreleased/gh-noticket-datetime-tzindex-oob.md
@@ -1,0 +1,5 @@
+## bugfix/datetime
+
+* Fixed an out-of-bounds read on a datetime value whose timezone index equals
+  the timezone table size. Such an index is now rejected while the value is
+  decoded.

--- a/src/lib/core/datetime.h
+++ b/src/lib/core/datetime.h
@@ -425,7 +425,7 @@ datetime_validate(const struct datetime *date)
 	    unlikely(date->tzoffset > TZOFFSET_MAX))
 		return false;
 	if (unlikely(date->tzindex < 0) ||
-	    unlikely(date->tzindex > MAX_TZINDEX))
+	    unlikely(date->tzindex >= MAX_TZINDEX))
 		return false;
 	return true;
 }

--- a/test/unit/datetime.c
+++ b/test/unit/datetime.c
@@ -618,7 +618,7 @@ mp_datetime_unpack_ok_test(void)
 		{.nsec = 0},
 		{.tzoffset = TZOFFSET_MIN},
 		{.tzoffset = TZOFFSET_MAX},
-		{.tzindex = MAX_TZINDEX},
+		{.tzindex = MAX_TZINDEX - 1},
 		{.tzindex = 0},
 	};
 	size_t index;
@@ -650,7 +650,7 @@ mp_datetime_unpack_fail_test(void)
 		{.nsec = -1},
 		{.tzoffset = TZOFFSET_MIN - 1},
 		{.tzoffset = TZOFFSET_MAX + 1},
-		{.tzindex = MAX_TZINDEX + 1},
+		{.tzindex = MAX_TZINDEX},
 		{.tzindex = -1},
 	};
 


### PR DESCRIPTION
`datetime_validate` accepts a `tzindex` equal to `MAX_TZINDEX`, but the `zones_unsorted` table it indexes holds `MAX_TZINDEX` entries, so the last valid id is `MAX_TZINDEX - 1`. A datetime decoded from an MP_DATETIME ext with `tzindex == MAX_TZINDEX` passes validation, and converting it to a string calls `timezone_name(tzindex)`, which reads `zones_unsorted[MAX_TZINDEX]` one past the array and dereferences the returned name pointer. The bounds assert in `timezone_name` is compiled out under NDEBUG, so release builds take the out-of-bounds read.

Reject `tzindex >= MAX_TZINDEX` on decode. Validating here holds the bound at the single point every datetime passes through, so the timezone lookups downstream don't each need their own check. No real zone id equals `MAX_TZINDEX`, so valid values are unaffected; the unit test that treated it as the accepted boundary is corrected.
