### PR TITLE
sql: fix representation of bind variables

### DIFF
--- a/changelogs/unreleased/gh-13012-fix-representation-of-named-numbered-anonymous-bind-variables.md
+++ b/changelogs/unreleased/gh-13012-fix-representation-of-named-numbered-anonymous-bind-variables.md
@@ -1,0 +1,6 @@
+## bugfix/sql
+
+* A named bind variable must now always begin with `#`, `:`, or `@` followed by
+  a letter. A numeric bind argument must begin with `$` followed by a number.
+  An anonymous bind variable is denoted `?` followed by a non-numeric,
+  non-alphabetic character (gh-13012).

--- a/changelogs/unreleased/gh-13012-fix-representation-of-named-numbered-anonymous-bind-variables.md
+++ b/changelogs/unreleased/gh-13012-fix-representation-of-named-numbered-anonymous-bind-variables.md
@@ -1,0 +1,8 @@
+## bugfix/sql
+
+* A named bind variable must now always begin with `#`, `:`, or `@` followed by
+  a letter or a non-digit identifier character (variants such as `@number` are
+  no longer supported). A numeric bind variable must begin with `$` followed by
+  a number (variants such as `$name` are no longer supported). An anonymous
+  bind variable is denoted by `?` followed by a non-numeric, non-alphabetic
+  character (gh-13012).

--- a/src/box/sql/ast.c
+++ b/src/box/sql/ast.c
@@ -335,7 +335,7 @@ expr_leaf(struct ast_expr *expr, enum field_type type)
 	return res;
 }
 
-/** Build a `struct Expr` for a bound variable (`?`, `:name`, etc). */
+/** Build a `struct Expr` for a bound variable. */
 static struct Expr *
 expr_var(struct Parse *parser, struct ast_expr *expr)
 {
@@ -350,22 +350,17 @@ expr_var(struct Parse *parser, struct ast_expr *expr)
 		parser->is_aborted = true;
 		return NULL;
 	}
-	if (expr->len > 1) {
-		assert(expr->str[0] != '?');
-		if (!IdChar(expr->str[1])) {
-			diag_set(ClientError, ER_SQL_UNKNOWN_TOKEN,
-				 parser->line_count,
-				 expr->str - parser->zTail + 1,
-				 tt_cstr(expr->str, 1));
-			parser->is_aborted = true;
-			return NULL;
-		}
-		if (expr->str[0] == '#' && sqlIsdigit(expr->str[1])) {
-			diag_set(ClientError, ER_SQL_SYNTAX_NEAR_TOKEN,
-				 parser->line_count, tt_cstr(expr->str, 1));
-			parser->is_aborted = true;
-			return NULL;
-		}
+	/*
+	 * The check exists only for the `:` case,
+	 * because the other variants (`@`, `#`, `?`, `$`)
+	 * are checked during tokenization.
+	 */
+	if (expr->str[0] == ':' && (IdChar(expr->str[1]) == 0)) {
+		diag_set(ClientError, ER_SQL_PARSER_GENERIC,
+			 tt_sprintf("Wrong bind variable name '%.*s'",
+				    expr->len, expr->str));
+		parser->is_aborted = true;
+		return NULL;
 	}
 	struct Expr *res = sql_expr_new_dequoted(expr->op, &t);
 	res->type = FIELD_TYPE_BOOLEAN;
@@ -556,7 +551,9 @@ expr_from_ast(struct Parse *parser, struct ast_expr *expr)
 	case TK_UNKNOWN:
 		res = expr_leaf(expr, FIELD_TYPE_BOOLEAN);
 		break;
-	case TK_VARIABLE:
+	case TK_VAR_ANON:
+	case TK_VAR_NUM:
+	case TK_VAR_NAME:
 		res = expr_var(parser, expr);
 		break;
 	case TK_AND:

--- a/src/box/sql/ast.c
+++ b/src/box/sql/ast.c
@@ -351,7 +351,7 @@ expr_leaf(struct ast_expr *expr, enum field_type type)
 	return res;
 }
 
-/** Build a `struct Expr` for a bound variable (`?`, `:name`, etc). */
+/** Build a `struct Expr` for a bound variable. */
 static struct Expr *
 expr_var(struct Parse *parser, struct ast_expr *expr)
 {
@@ -366,22 +366,17 @@ expr_var(struct Parse *parser, struct ast_expr *expr)
 		parser->is_aborted = true;
 		return NULL;
 	}
-	if (expr->len > 1) {
-		assert(expr->str[0] != '?');
-		if (!IdChar(expr->str[1])) {
-			diag_set(ClientError, ER_SQL_UNKNOWN_TOKEN,
-				 parser->line_count,
-				 expr->str - parser->zTail + 1,
-				 tt_cstr(expr->str, 1));
-			parser->is_aborted = true;
-			return NULL;
-		}
-		if (expr->str[0] == '#' && sqlIsdigit(expr->str[1])) {
-			diag_set(ClientError, ER_SQL_SYNTAX_NEAR_TOKEN,
-				 parser->line_count, tt_cstr(expr->str, 1));
-			parser->is_aborted = true;
-			return NULL;
-		}
+	/*
+	 * The check exists only for the `:` case,
+	 * because the other variants (`@`, `#`, `?`, `$`)
+	 * are checked during tokenization.
+	 */
+	if (expr->str[0] == ':' && (IdChar(expr->str[1]) == 0)) {
+		diag_set(ClientError, ER_SQL_PARSER_GENERIC,
+			 tt_sprintf("Wrong bind variable name '%.*s'",
+				    expr->len, expr->str));
+		parser->is_aborted = true;
+		return NULL;
 	}
 	struct Expr *res = sql_expr_new_dequoted(expr->op, &t);
 	res->type = FIELD_TYPE_BOOLEAN;
@@ -572,7 +567,9 @@ expr_from_ast(struct Parse *parser, struct ast_expr *expr)
 	case TK_UNKNOWN:
 		res = expr_leaf(expr, FIELD_TYPE_BOOLEAN);
 		break;
-	case TK_VARIABLE:
+	case TK_VAR_ANON:
+	case TK_VAR_NUM:
+	case TK_VAR_NAME:
 		res = expr_var(parser, expr);
 		break;
 	case TK_AND:

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -52,7 +52,7 @@ static int exprCodeVector(Parse * pParse, Expr * p, int *piToFree);
 static enum field_type
 sql_highest_type(enum field_type a, struct Expr *expr)
 {
-	if (a == FIELD_TYPE_ANY || expr->op == TK_VARIABLE)
+	if (a == FIELD_TYPE_ANY || sql_expr_is_variable(expr->op))
 		return FIELD_TYPE_ANY;
 	if (expr->op == TK_NULL)
 		return a;
@@ -134,7 +134,7 @@ sql_expr_type(struct Expr *pExpr)
 		if (i >= count)
 			return FIELD_TYPE_ANY;
 		enum field_type res_type = sql_expr_type(cs->a[i].pExpr);
-		if (cs->a[i].pExpr->op == TK_VARIABLE)
+		if (sql_expr_is_variable(cs->a[i].pExpr->op))
 			res_type = FIELD_TYPE_ANY;
 		for (i += 2; i < count; i += 2)
 			res_type = sql_highest_type(res_type, cs->a[i].pExpr);
@@ -1938,7 +1938,9 @@ exprNodeIsConstant(Walker * pWalker, Expr * pExpr)
 			pWalker->eCode = 0;
 			return WRC_Abort;
 		}
-	case TK_VARIABLE:
+	case TK_VAR_NUM:
+	case TK_VAR_ANON:
+	case TK_VAR_NAME:
 		if (pWalker->eCode == 4) {
 			/* A bound parameter in a CREATE statement that originates from
 			 * sql_prepare() causes an error
@@ -3199,8 +3201,10 @@ expr_code_map(struct Parse *parser, struct Expr *expr, int reg)
 	for (int i = 0; i < count; ++i) {
 		struct Expr *expr = list->a[2 * i].pExpr;
 		enum field_type type = sql_expr_type(expr);
-		if (expr->op != TK_VARIABLE && type != FIELD_TYPE_INTEGER &&
-		    type != FIELD_TYPE_UNSIGNED && type != FIELD_TYPE_STRING &&
+		if (!sql_expr_is_variable(expr->op) &&
+		    type != FIELD_TYPE_INTEGER &&
+		    type != FIELD_TYPE_UNSIGNED &&
+		    type != FIELD_TYPE_STRING &&
 		    type != FIELD_TYPE_UUID) {
 			diag_set(ClientError, ER_SQL_PARSER_GENERIC, "Only "
 				 "integer, string and uuid can be keys in map");
@@ -3242,7 +3246,7 @@ expr_code_getitem(struct Parse *parser, struct Expr *expr, int reg)
 
 	enum field_type type = value->op != TK_NULL ? sql_expr_type(value) :
 			       field_type_MAX;
-	if (value->op != TK_VARIABLE &&
+	if (!sql_expr_is_variable(value->op) &&
 	    type != FIELD_TYPE_MAP && type != FIELD_TYPE_ARRAY) {
 		diag_set(ClientError, ER_SQL_PARSER_GENERIC, "Selecting is "
 			 "only possible from map and array values");
@@ -3683,21 +3687,27 @@ sqlExprCodeTarget(Parse * pParse, Expr * pExpr, int target)
 					  P4_DYNAMIC);
 			return target;
 		}
-	case TK_VARIABLE:{
+	case TK_VAR_NUM:
+	case TK_VAR_NAME: {
 			assert(!ExprHasProperty(pExpr, EP_IntValue));
 			assert(pExpr->u.zToken != 0);
 			assert(pExpr->u.zToken[0] != 0);
 			sqlVdbeAddOp2(v, OP_Variable, pExpr->iColumn,
 					  target);
-			if (pExpr->u.zToken[1] != 0) {
-				const char *z =
-				    sqlVListNumToName(pParse->pVList,
+			assert(pExpr->u.zToken[1] != 0);
+			const char *z = sqlVListNumToName(pParse->pVList,
 							  pExpr->iColumn);
-				assert(pExpr->u.zToken[0] == '$'
-				       || strcmp(pExpr->u.zToken, z) == 0);
-				pParse->pVList[0] = 0;	/* Indicate VList may no longer be enlarged */
-				sqlVdbeAppendP4(v, (char *)z, P4_STATIC);
-			}
+			assert(pExpr->u.zToken[0] == '$' ||
+			       strcmp(pExpr->u.zToken, z) == 0);
+			/* Indicate VList may no longer be enlarged */
+			pParse->pVList[0] = 0;
+			sqlVdbeAppendP4(v, (char *)z, P4_STATIC);
+			return target;
+		}
+	case TK_VAR_ANON: {
+			assert(pExpr->u.zToken[0] == '?');
+			sqlVdbeAddOp2(v, OP_Variable, pExpr->iColumn,
+				      target);
 			return target;
 		}
 	case TK_REGISTER:{

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -52,7 +52,7 @@ static int exprCodeVector(Parse * pParse, Expr * p, int *piToFree);
 static enum field_type
 sql_highest_type(enum field_type a, struct Expr *expr)
 {
-	if (a == FIELD_TYPE_ANY || expr->op == TK_VARIABLE)
+	if (a == FIELD_TYPE_ANY || sql_token_is_variable(expr->op))
 		return FIELD_TYPE_ANY;
 	if (expr->op == TK_NULL)
 		return a;
@@ -134,7 +134,7 @@ sql_expr_type(struct Expr *pExpr)
 		if (i >= count)
 			return FIELD_TYPE_ANY;
 		enum field_type res_type = sql_expr_type(cs->a[i].pExpr);
-		if (cs->a[i].pExpr->op == TK_VARIABLE)
+		if (sql_token_is_variable(cs->a[i].pExpr->op))
 			res_type = FIELD_TYPE_ANY;
 		for (i += 2; i < count; i += 2)
 			res_type = sql_highest_type(res_type, cs->a[i].pExpr);
@@ -1938,7 +1938,9 @@ exprNodeIsConstant(Walker * pWalker, Expr * pExpr)
 			pWalker->eCode = 0;
 			return WRC_Abort;
 		}
-	case TK_VARIABLE:
+	case TK_VAR_NUM:
+	case TK_VAR_ANON:
+	case TK_VAR_NAME:
 		if (pWalker->eCode == 4) {
 			/* A bound parameter in a CREATE statement that originates from
 			 * sql_prepare() causes an error
@@ -3189,8 +3191,10 @@ expr_code_map(struct Parse *parser, struct Expr *expr, int reg)
 	for (int i = 0; i < count; ++i) {
 		struct Expr *expr = list->a[2 * i].pExpr;
 		enum field_type type = sql_expr_type(expr);
-		if (expr->op != TK_VARIABLE && type != FIELD_TYPE_INTEGER &&
-		    type != FIELD_TYPE_UNSIGNED && type != FIELD_TYPE_STRING &&
+		if (!sql_token_is_variable(expr->op) &&
+		    type != FIELD_TYPE_INTEGER &&
+		    type != FIELD_TYPE_UNSIGNED &&
+		    type != FIELD_TYPE_STRING &&
 		    type != FIELD_TYPE_UUID) {
 			diag_set(ClientError, ER_SQL_PARSER_GENERIC, "Only "
 				 "integer, string and uuid can be keys in map");
@@ -3232,7 +3236,7 @@ expr_code_getitem(struct Parse *parser, struct Expr *expr, int reg)
 
 	enum field_type type = value->op != TK_NULL ? sql_expr_type(value) :
 			       field_type_MAX;
-	if (value->op != TK_VARIABLE &&
+	if (!sql_token_is_variable(value->op) &&
 	    type != FIELD_TYPE_MAP && type != FIELD_TYPE_ARRAY) {
 		diag_set(ClientError, ER_SQL_PARSER_GENERIC, "Selecting is "
 			 "only possible from map and array values");
@@ -3673,21 +3677,27 @@ sqlExprCodeTarget(Parse * pParse, Expr * pExpr, int target)
 					  P4_DYNAMIC);
 			return target;
 		}
-	case TK_VARIABLE:{
+	case TK_VAR_NUM:
+	case TK_VAR_NAME: {
 			assert(!ExprHasProperty(pExpr, EP_IntValue));
 			assert(pExpr->u.zToken != 0);
 			assert(pExpr->u.zToken[0] != 0);
 			sqlVdbeAddOp2(v, OP_Variable, pExpr->iColumn,
 					  target);
-			if (pExpr->u.zToken[1] != 0) {
-				const char *z =
-				    sqlVListNumToName(pParse->pVList,
+			assert(pExpr->u.zToken[1] != 0);
+			const char *z = sqlVListNumToName(pParse->pVList,
 							  pExpr->iColumn);
-				assert(pExpr->u.zToken[0] == '$'
-				       || strcmp(pExpr->u.zToken, z) == 0);
-				pParse->pVList[0] = 0;	/* Indicate VList may no longer be enlarged */
-				sqlVdbeAppendP4(v, (char *)z, P4_STATIC);
-			}
+			assert(pExpr->u.zToken[0] == '$' ||
+			       strcmp(pExpr->u.zToken, z) == 0);
+			/* Indicate VList may no longer be enlarged */
+			pParse->pVList[0] = 0;
+			sqlVdbeAppendP4(v, (char *)z, P4_STATIC);
+			return target;
+		}
+	case TK_VAR_ANON: {
+			assert(pExpr->u.zToken[0] == '?');
+			sqlVdbeAddOp2(v, OP_Variable, pExpr->iColumn,
+				      target);
 			return target;
 		}
 	case TK_REGISTER:{

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -2202,7 +2202,7 @@ is_upcast(int op, enum field_type a, enum field_type b)
 static inline bool
 is_castable(int op, enum field_type a, enum field_type b)
 {
-	return is_upcast(op, a, b) || op == TK_VARIABLE || op == TK_ID ||
+	return is_upcast(op, a, b) || sql_expr_is_variable(op) || op == TK_ID ||
 	       (sql_type_is_numeric(a) && sql_type_is_numeric(b)) ||
 	       b == FIELD_TYPE_ANY;
 }

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -2202,7 +2202,8 @@ is_upcast(int op, enum field_type a, enum field_type b)
 static inline bool
 is_castable(int op, enum field_type a, enum field_type b)
 {
-	return is_upcast(op, a, b) || op == TK_VARIABLE || op == TK_ID ||
+	return is_upcast(op, a, b) || sql_token_is_variable(op) ||
+	       op == TK_ID ||
 	       (sql_type_is_numeric(a) && sql_type_is_numeric(b)) ||
 	       b == FIELD_TYPE_ANY;
 }

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -907,16 +907,11 @@ expr(A) ::= nm(X) DOT nm(Y). {
   A->left = ast_expr_new(pParse, X.z, X.n, TK_ID);
   A->right = ast_expr_new(pParse, Y.z, Y.n, TK_ID);
 }
-expr(A) ::= VARNUM(X). {
-  A = ast_expr_new(pParse, X.z, X.n, TK_VARIABLE);
+expr(A) ::= VAR_ANON|VAR_NUM|VAR_NAME(X). {
+  A = ast_expr_new(pParse, X.z, X.n, @X);
 }
-expr(A) ::= COLON|VARIABLE(X) id(Y).     {
-  A = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_VARIABLE);
-  A->left = ast_expr_new(pParse, Y.z, Y.n, TK_STRING);
-}
-expr(A) ::= COLON|VARIABLE(X) INTEGER(Y).     {
-  A = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_VARIABLE);
-  A->left = ast_expr_new(pParse, Y.z, Y.n, TK_INTEGER);
+expr(A) ::= COLON(X) id(Y). {
+  A = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_VAR_NAME);
 }
 expr(A) ::= expr(X) COLLATE id(C). {
   A = ast_expr_new(pParse, X->str, (C.z - X->str) + C.n, TK_COLLATE);

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -889,16 +889,11 @@ expr(A) ::= nm(X) DOT nm(Y). {
   A->left = ast_expr_new(pParse, X.z, X.n, TK_ID);
   A->right = ast_expr_new(pParse, Y.z, Y.n, TK_ID);
 }
-expr(A) ::= VARNUM(X). {
-  A = ast_expr_new(pParse, X.z, X.n, TK_VARIABLE);
+expr(A) ::= VAR_ANON|VAR_NUM|VAR_NAME(X). {
+  A = ast_expr_new(pParse, X.z, X.n, @X);
 }
-expr(A) ::= COLON|VARIABLE(X) id(Y).     {
-  A = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_VARIABLE);
-  A->left = ast_expr_new(pParse, Y.z, Y.n, TK_STRING);
-}
-expr(A) ::= COLON|VARIABLE(X) INTEGER(Y).     {
-  A = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_VARIABLE);
-  A->left = ast_expr_new(pParse, Y.z, Y.n, TK_INTEGER);
+expr(A) ::= COLON(X) id(Y). {
+  A = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_VAR_NAME);
 }
 expr(A) ::= expr(X) COLLATE id(C). {
   A = ast_expr_new(pParse, X->str, (C.z - X->str) + C.n, TK_COLLATE);

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -1850,7 +1850,7 @@ generate_column_metadata(struct Parse *pParse, struct SrcList *pTabList,
 		p = pEList->a[i].pExpr;
 		if (NEVER(p == 0))
 			continue;
-		if (p->op == TK_VARIABLE)
+		if (sql_token_is_variable(p->op))
 			var_count++;
 		enum field_type type = sql_expr_type(p);
 		vdbe_metadata_set_col_type(v, i, field_type_strs[type]);
@@ -1930,7 +1930,7 @@ generate_column_metadata(struct Parse *pParse, struct SrcList *pTabList,
 	for (int i = 0, j = 0; i < pEList->nExpr; i++) {
 		struct Expr *e = pEList->a[i].pExpr;
 		assert(e != NULL);
-		if (e->op == TK_VARIABLE)
+		if (sql_token_is_variable(e->op))
 			var_pos[j++] = i;
 	}
 	v->var_pos = var_pos;

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -1940,7 +1940,7 @@ generate_column_metadata(struct Parse *pParse, struct SrcList *pTabList,
 		p = pEList->a[i].pExpr;
 		if (NEVER(p == 0))
 			continue;
-		if (p->op == TK_VARIABLE)
+		if (sql_expr_is_variable(p->op))
 			var_count++;
 		enum field_type type = sql_expr_type(p);
 		vdbe_metadata_set_col_type(v, i, field_type_strs[type]);
@@ -2020,7 +2020,7 @@ generate_column_metadata(struct Parse *pParse, struct SrcList *pTabList,
 	for (int i = 0, j = 0; i < pEList->nExpr; i++) {
 		struct Expr *e = pEList->a[i].pExpr;
 		assert(e != NULL);
-		if (e->op == TK_VARIABLE)
+		if (sql_expr_is_variable(e->op))
 			var_pos[j++] = i;
 	}
 	v->var_pos = var_pos;

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1234,9 +1234,10 @@ typedef int ynVar;
  *
  * If the expression is an SQL literal (TK_INTEGER, TK_FLOAT, TK_BLOB,
  * or TK_STRING), then Expr.token contains the text of the SQL literal. If
- * the expression is a variable (TK_VARIABLE), then Expr.token contains the
- * variable name. Finally, if the expression is an SQL function (TK_FUNCTION),
- * then Expr.token contains the name of the function.
+ * the expression is a variable (TK_VAR_NAME or TK_VAR_NUM or TK_VAR_ANON),
+ * then Expr.token contains the variable name. Finally, if the expression
+ * is an SQL function (TK_FUNCTION), then Expr.token contains the name of
+ * the function.
  *
  * Expr.pRight and Expr.pLeft are the left and right subexpressions of a
  * binary operator. Either or both may be NULL.
@@ -1326,7 +1327,8 @@ struct Expr {
 				 * TK_SELECT: 1st register of result vector
 				 */
 	ynVar iColumn;		/* TK_COLUMN_REF: column index.
-				 * TK_VARIABLE: variable number (always >= 1).
+				 * TK_VAR_NAME or TK_VAR_NUM or TK_VAR_ANON:
+				 * variable number (always >= 1).
 				 * TK_SELECT_COLUMN: column of the result vector
 				 */
 	i16 iAgg;		/* Which entry in pAggInfo->aCol[] or ->aFunc[] */
@@ -2530,7 +2532,14 @@ sql_and_expr_new(struct Expr *left_expr, struct Expr *right_expr);
 Expr *sqlExprFunction(Parse *, ExprList *, Token *);
 void sqlExprAssignVarNumber(Parse *, Expr *, u32);
 
-/*
+/** Check if the token type denotes a bind variable. */
+static inline bool
+sql_token_is_variable(int op)
+{
+	return op == TK_VAR_NAME || op == TK_VAR_NUM || op == TK_VAR_ANON;
+}
+
+/**
  * pColumns and pExpr form a vector assignment which is part of the SET
  * clause of an UPDATE statement.  Like this:
  *

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1271,9 +1271,10 @@ typedef int ynVar;
  *
  * If the expression is an SQL literal (TK_INTEGER, TK_FLOAT, TK_BLOB,
  * or TK_STRING), then Expr.token contains the text of the SQL literal. If
- * the expression is a variable (TK_VARIABLE), then Expr.token contains the
- * variable name. Finally, if the expression is an SQL function (TK_FUNCTION),
- * then Expr.token contains the name of the function.
+ * the expression is a variable (TK_VAR_NAME or TK_VAR_NUM or TK_VAR_ANON),
+ * then Expr.token contains the variable name. Finally, if the expression
+ * is an SQL function (TK_FUNCTION), then Expr.token contains the name of
+ * the function.
  *
  * Expr.pRight and Expr.pLeft are the left and right subexpressions of a
  * binary operator. Either or both may be NULL.
@@ -1363,7 +1364,8 @@ struct Expr {
 				 * TK_SELECT: 1st register of result vector
 				 */
 	ynVar iColumn;		/* TK_COLUMN_REF: column index.
-				 * TK_VARIABLE: variable number (always >= 1).
+				 * TK_VAR_NAME or TK_VAR_NUM or TK_VAR_ANON:
+				 * variable number (always >= 1).
 				 * TK_SELECT_COLUMN: column of the result vector
 				 */
 	i16 iAgg;		/* Which entry in pAggInfo->aCol[] or ->aFunc[] */
@@ -2572,7 +2574,14 @@ sql_and_expr_new(struct Expr *left_expr, struct Expr *right_expr);
 Expr *sqlExprFunction(Parse *, ExprList *, Token *);
 void sqlExprAssignVarNumber(Parse *, Expr *, u32);
 
-/*
+/** Check if the expression is an expression for a bind variable. */
+static inline bool
+sql_expr_is_variable(int op)
+{
+	return op == TK_VAR_NAME || op == TK_VAR_NUM || op == TK_VAR_ANON;
+}
+
+/**
  * pColumns and pExpr form a vector assignment which is part of the SET
  * clause of an UPDATE statement.  Like this:
  *

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -60,9 +60,10 @@
 #define CC_DIGIT      3		/* Digits */
 /** Character ':'. */
 #define CC_COLON      4
-/** SQL variable special characters: '@', '#', and '$'. */
-#define CC_VARALPHA   5
-#define CC_VARNUM     6		/* '?'.  Numeric SQL variables */
+/** SQL variable special characters: '@', '#'. */
+#define CC_VAR_NAME   5
+/** '?'.  Numeric SQL variables. */
+#define CC_VAR_ANON   6
 #define CC_SPACE      7		/* Space characters */
 #define CC_QUOTE      8		/* '\''. String literals */
 #define CC_DQUOTE     9		/* '"'. Identifiers*/
@@ -91,12 +92,14 @@
 #define CC_LCB       31
 /** Character '}'. */
 #define CC_RCB       32
+/** SQL variable special characters: '$'. */
+#define CC_VAR_NUM   33
 
 static const char sql_ascii_class[] = {
 /*       x0  x1  x2  x3  x4  x5  x6  x7  x8 x9  xa xb  xc xd xe  xf */
 /* 0x */ 27, 27, 27, 27, 27, 27, 27, 27, 27, 7, 28, 7, 7, 7, 27, 27,
 /* 1x */ 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27,
-/* 2x */ 7, 15, 9, 5, 5, 22, 24, 8, 17, 18, 21, 20, 23, 11, 26, 16,
+/* 2x */ 7, 15, 9, 5, 33, 22, 24, 8, 17, 18, 21, 20, 23, 11, 26, 16,
 /* 3x */ 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 19, 12, 14, 13, 6,
 /* 4x */ 5, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 /* 5x */ 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 29, 27, 30, 27, 1,
@@ -380,15 +383,43 @@ sql_token(const char *z, int *type, bool *is_reserved)
 			}
 		}
 		return i;
-	case CC_VARNUM:
-		*type = TK_VARNUM;
-		return 1;
+	case CC_VAR_ANON:
+		*type = TK_VAR_ANON;
+		i = 1;
+		if (IdChar(z[i]) != 0) {
+			*type = TK_ILLEGAL;
+			while (IdChar(z[++i]) != 0) {
+			}
+		}
+		return i;
 	case CC_COLON:
 		*type = TK_COLON;
 		return 1;
-	case CC_VARALPHA:
-		*type = TK_VARIABLE;
-		return 1;
+	case CC_VAR_NAME:
+		*type = TK_VAR_NAME;
+		if (IdChar(z[1]) == 0) {
+			*type = TK_ILLEGAL;
+			return 1;
+		}
+		i = 1;
+		while (IdChar(z[++i]) != 0) {
+		}
+		if (sqlIsdigit(z[1]) != 0) {
+			*type = TK_ILLEGAL;
+		}
+		return i;
+	case CC_VAR_NUM:
+		*type = TK_VAR_NUM;
+		if (sqlIsdigit(z[1]) == 0)
+			*type = TK_ILLEGAL;
+		for (i = 1; sqlIsdigit(z[i]) != 0; i++) {
+		}
+		if (IdChar(z[i]) != 0) {
+			*type = TK_ILLEGAL;
+			while (IdChar(z[++i]) != 0) {
+			}
+		}
+		return i;
 	case CC_KYWD:
 		for (i = 1; sql_ascii_class[*(unsigned char*)(z+i)] <= CC_KYWD;
 		     i++) {

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -57,9 +57,10 @@
 #define CC_DIGIT      3		/* Digits */
 /** Character ':'. */
 #define CC_COLON      4
-/** SQL variable special characters: '@', '#', and '$'. */
-#define CC_VARALPHA   5
-#define CC_VARNUM     6		/* '?'.  Numeric SQL variables */
+/** SQL variable special characters: '@', '#'. */
+#define CC_VAR_NAME   5
+/** '?'.  Numeric SQL variables. */
+#define CC_VAR_ANON   6
 #define CC_SPACE      7		/* Space characters */
 #define CC_QUOTE      8		/* '\''. String literals */
 #define CC_DQUOTE     9		/* '"'. Identifiers*/
@@ -88,12 +89,14 @@
 #define CC_LCB       31
 /** Character '}'. */
 #define CC_RCB       32
+/** SQL variable special characters: '$'. */
+#define CC_VAR_NUM   33
 
 static const char sql_ascii_class[] = {
 /*       x0  x1  x2  x3  x4  x5  x6  x7  x8 x9  xa xb  xc xd xe  xf */
 /* 0x */ 27, 27, 27, 27, 27, 27, 27, 27, 27, 7, 28, 7, 7, 7, 27, 27,
 /* 1x */ 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27, 27,
-/* 2x */ 7, 15, 9, 5, 5, 22, 24, 8, 17, 18, 21, 20, 23, 11, 26, 16,
+/* 2x */ 7, 15, 9, 5, 33, 22, 24, 8, 17, 18, 21, 20, 23, 11, 26, 16,
 /* 3x */ 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 19, 12, 14, 13, 6,
 /* 4x */ 5, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 /* 5x */ 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 29, 27, 30, 27, 1,
@@ -377,15 +380,43 @@ sql_token(const char *z, int *type, bool *is_reserved)
 			}
 		}
 		return i;
-	case CC_VARNUM:
-		*type = TK_VARNUM;
-		return 1;
+	case CC_VAR_ANON:
+		*type = TK_VAR_ANON;
+		i = 1;
+		if (IdChar(z[i]) != 0) {
+			*type = TK_ILLEGAL;
+			while (IdChar(z[++i]) != 0) {
+			}
+		}
+		return i;
 	case CC_COLON:
 		*type = TK_COLON;
 		return 1;
-	case CC_VARALPHA:
-		*type = TK_VARIABLE;
-		return 1;
+	case CC_VAR_NAME:
+		*type = TK_VAR_NAME;
+		if (IdChar(z[1]) == 0) {
+			*type = TK_ILLEGAL;
+			return 1;
+		}
+		i = 1;
+		while (IdChar(z[++i]) != 0) {
+		}
+		if (sqlIsdigit(z[1]) != 0) {
+			*type = TK_ILLEGAL;
+		}
+		return i;
+	case CC_VAR_NUM:
+		*type = TK_VAR_NUM;
+		if (sqlIsdigit(z[1]) == 0)
+			*type = TK_ILLEGAL;
+		for (i = 1; sqlIsdigit(z[i]) != 0; i++) {
+		}
+		if (IdChar(z[i]) != 0) {
+			*type = TK_ILLEGAL;
+			while (IdChar(z[++i]) != 0) {
+			}
+		}
+		return i;
 	case CC_KYWD:
 		for (i = 1; sql_ascii_class[*(unsigned char*)(z+i)] <= CC_KYWD;
 		     i++) {

--- a/src/box/sql/treeview.c
+++ b/src/box/sql/treeview.c
@@ -362,7 +362,9 @@ sqlTreeViewExpr(TreeView * pView, const Expr * pExpr, u8 moreToFollow)
 			sqlTreeViewLine(pView, "%s", pExpr->u.zToken);
 			break;
 		}
-	case TK_VARIABLE:{
+	case TK_VAR_NUM:
+	case TK_VAR_ANON:
+	case TK_VAR_NAME: {
 			sqlTreeViewLine(pView, "VARIABLE(%s,%d)",
 					    pExpr->u.zToken, pExpr->iColumn);
 			break;

--- a/src/box/sql/vdbetrace.c
+++ b/src/box/sql/vdbetrace.c
@@ -58,7 +58,7 @@ findNextHostParameter(const char *zSql, int *pnToken)
 	while (zSql[0]) {
 		n = sql_token(zSql, &tokenType, &unused);
 		assert(n > 0 && tokenType != TK_ILLEGAL);
-		if (tokenType == TK_VARIABLE) {
+		if (sql_expr_is_variable(tokenType)) {
 			*pnToken = n;
 			break;
 		}

--- a/src/box/sql/vdbetrace.c
+++ b/src/box/sql/vdbetrace.c
@@ -58,7 +58,7 @@ findNextHostParameter(const char *zSql, int *pnToken)
 	while (zSql[0]) {
 		n = sql_token(zSql, &tokenType, &unused);
 		assert(n > 0 && tokenType != TK_ILLEGAL);
-		if (tokenType == TK_VARIABLE) {
+		if (sql_token_is_variable(tokenType)) {
 			*pnToken = n;
 			break;
 		}

--- a/src/box/sql/whereexpr.c
+++ b/src/box/sql/whereexpr.c
@@ -293,7 +293,7 @@ like_optimization_is_valid(Parse *pParse, Expr *pExpr, Expr **ppPrefix,
 	op = pRight->op;
 	struct region *region = &pParse->region;
 	size_t svp = region_used(region);
-	if (op == TK_VARIABLE) {
+	if (sql_expr_is_variable(op)) {
 		Vdbe *pReprepare = pParse->pReprepare;
 		int iCol = pRight->iColumn;
 		const struct Mem *var = vdbe_get_bound_value(pReprepare, iCol);
@@ -304,7 +304,6 @@ like_optimization_is_valid(Parse *pParse, Expr *pExpr, Expr **ppPrefix,
 			str[var->n] = '\0';
 			z = str;
 		}
-		assert(pRight->op == TK_VARIABLE || pRight->op == TK_REGISTER);
 	} else if (op == TK_STRING) {
 		z = pRight->u.zToken;
 	}
@@ -320,7 +319,7 @@ like_optimization_is_valid(Parse *pParse, Expr *pExpr, Expr **ppPrefix,
 			pPrefix = sql_expr_new_named(TK_STRING, z);
 			pPrefix->u.zToken[cnt] = 0;
 			*ppPrefix = pPrefix;
-			if (op == TK_VARIABLE) {
+			if (sql_expr_is_variable(op)) {
 				Vdbe *v = pParse->pVdbe;
 				if (*pisComplete && pRight->u.zToken[1]) {
 					/* If the rhs of the LIKE expression is a variable, and the current

--- a/src/box/sql/whereexpr.c
+++ b/src/box/sql/whereexpr.c
@@ -293,7 +293,7 @@ like_optimization_is_valid(Parse *pParse, Expr *pExpr, Expr **ppPrefix,
 	op = pRight->op;
 	struct region *region = &pParse->region;
 	size_t svp = region_used(region);
-	if (op == TK_VARIABLE) {
+	if (sql_token_is_variable(op)) {
 		Vdbe *pReprepare = pParse->pReprepare;
 		int iCol = pRight->iColumn;
 		const struct Mem *var = vdbe_get_bound_value(pReprepare, iCol);
@@ -304,7 +304,6 @@ like_optimization_is_valid(Parse *pParse, Expr *pExpr, Expr **ppPrefix,
 			str[var->n] = '\0';
 			z = str;
 		}
-		assert(pRight->op == TK_VARIABLE || pRight->op == TK_REGISTER);
 	} else if (op == TK_STRING) {
 		z = pRight->u.zToken;
 	}
@@ -320,7 +319,7 @@ like_optimization_is_valid(Parse *pParse, Expr *pExpr, Expr **ppPrefix,
 			pPrefix = sql_expr_new_named(TK_STRING, z);
 			pPrefix->u.zToken[cnt] = 0;
 			*ppPrefix = pPrefix;
-			if (op == TK_VARIABLE) {
+			if (sql_token_is_variable(op)) {
 				Vdbe *v = pParse->pVdbe;
 				if (*pisComplete && pRight->u.zToken[1]) {
 					/* If the rhs of the LIKE expression is a variable, and the current

--- a/test/sql-luatest/bind_test.lua
+++ b/test/sql-luatest/bind_test.lua
@@ -15,7 +15,8 @@ end)
 g.test_bind_1 = function()
     g.server:exec(function()
         local sql = [[SELECT @1asd;]]
-        local res = "At line 1 at or near position 9: unrecognized token '1asd'"
+        local res = "At line 1 at or near position 8: " ..
+                    "unrecognized token '@1asd'"
         local _, err = box.execute(sql, {{['@1asd'] = 123}})
         t.assert_equals(err.message, res)
     end)
@@ -24,9 +25,103 @@ end
 g.test_bind_2 = function()
     local conn = g.server.net_box
     local sql = [[SELECT @1asd;]]
-    local res = [[At line 1 at or near position 9: unrecognized token '1asd']]
+    local res = [[At line 1 at or near position 8: unrecognized token '@1asd']]
     local _, err = pcall(conn.execute, conn, sql, {{['@1asd'] = 123}})
     t.assert_equals(err.message, res)
+end
+
+g.test_bind_3 = function()
+    g.server:exec(function()
+        local sql = [[SELECT @1;]]
+        local exp_err = "At line 1 at or near position 8: " ..
+                        "unrecognized token '@1'"
+        local _, err = box.execute(sql)
+        t.assert_equals(err.message, exp_err)
+
+        sql = [[SELECT #1;]]
+        exp_err = "At line 1 at or near position 8: unrecognized token '#1'"
+        _, err = box.execute(sql)
+        t.assert_equals(err.message, exp_err)
+
+        sql = [[SELECT $a;]]
+        exp_err = "At line 1 at or near position 8: unrecognized token '$a'"
+        _, err = box.execute(sql)
+        t.assert_equals(err.message, exp_err)
+
+        sql = [[SELECT $F1;]]
+        exp_err = "At line 1 at or near position 8: unrecognized token '$F1'"
+        _, err = box.execute(sql)
+        t.assert_equals(err.message, exp_err)
+
+        sql = [[SELECT ?asd;]]
+        exp_err = "At line 1 at or near position 8: unrecognized token '?asd'"
+        _, err = box.execute(sql)
+        t.assert_equals(err.message, exp_err)
+
+        sql = [[SELECT :1;]]
+        exp_err = "Syntax error at line 1 near '1'"
+        _, err = box.execute(sql)
+        t.assert_equals(err.message, exp_err)
+
+        sql = [[SELECT :1asd;]]
+        exp_err = "At line 1 at or near position 9: unrecognized token '1asd'"
+        _, err = box.execute(sql)
+        t.assert_equals(err.message, exp_err)
+
+        sql = [[SELECT :"asd";]]
+        exp_err = [[Wrong bind variable name ':"asd"']]
+        _, err = box.execute(sql)
+        t.assert_equals(err.message, exp_err)
+
+        sql = [[SELECT $;]]
+        exp_err = "At line 1 at or near position 8: unrecognized token '$'"
+        _, err = box.execute(sql)
+        t.assert_equals(err.message, exp_err)
+
+        sql = [[SELECT #;]]
+        exp_err = "At line 1 at or near position 8: unrecognized token '#'"
+        _, err = box.execute(sql)
+        t.assert_equals(err.message, exp_err)
+
+        sql = [[SELECT @;]]
+        exp_err = "At line 1 at or near position 8: unrecognized token '@'"
+        _, err = box.execute(sql)
+        t.assert_equals(err.message, exp_err)
+
+        sql = [[select : asd;]]
+        exp_err = "Wrong bind variable name ': asd'"
+        _, err = box.execute(sql, {{[': asd'] = '123'}})
+        t.assert_equals(err.message, exp_err)
+
+        sql = [[SELECT :a;]]
+        local res = box.execute(sql, {{[':a'] = 'a'}})
+        t.assert_equals(res.rows, {{'a'}})
+
+        sql = [[SELECT @a;]]
+        local res = box.execute(sql, {{['@a'] = 'a'}})
+        t.assert_equals(res.rows, {{'a'}})
+
+        sql = [[SELECT #a;]]
+        res = box.execute(sql, {{['#a'] = 'a'}})
+        t.assert_equals(res.rows, {{'a'}})
+
+        sql = [[SELECT $1;]]
+        res = box.execute(sql, {'a'})
+        t.assert_equals(res.rows, {{'a'}})
+
+        sql = [[SELECT ? asd;]]
+        local exp = {
+            metadata = {
+                 {
+                    name =  "asd",
+                    type = "text",
+                 },
+            },
+            rows = {{'a'}},
+        }
+        res = box.execute(sql, {'a'})
+        t.assert_equals(res, exp)
+    end)
 end
 
 g = t.group("bind2", {{remote = true}, {remote = false}})

--- a/test/sql-luatest/iproto_test.lua
+++ b/test/sql-luatest/iproto_test.lua
@@ -285,13 +285,14 @@ g.test_2948_remove_unnecessary_temlates = function(cg)
         space:replace{1, 2, '3'}
         space:replace{7, 8.5, '9'}
         cn:execute('INSERT INTO test VALUES (10, 11, NULL);')
-        local exp_err = "Syntax error at line 1 near '1'"
+        local exp_err = "At line 1 at or near position 8: " ..
+                        "unrecognized token '?1'"
         local sql = 'SELECT ?1, ?2, ?3;'
         t.assert_error_msg_content_equals(exp_err,
                                           cn.execute,
                                           cn, sql, {1, 2, 3})
 
-        exp_err = 'Index of binding slots must start from 1'
+        exp_err = "At line 1 at or near position 8: unrecognized token '$name'"
         sql = 'SELECT $name, $name2;'
         t.assert_error_msg_content_equals(exp_err, cn.execute, cn, sql, {1, 2})
 
@@ -303,7 +304,7 @@ g.test_2948_remove_unnecessary_temlates = function(cg)
         local res = cn:execute('SELECT $2, $1, $3;', parameters)
         t.assert_equals(res.rows, {{22, 11, 33}})
 
-        res = cn:execute('SELECT * FROM test WHERE id = :1;', {1})
+        res = cn:execute('SELECT * FROM test WHERE id = $1;', {1})
         t.assert_equals(res.rows, {{1, 2, '3'}})
         box.execute([[DROP TABLE test;]])
         cn:close()

--- a/test/sql-tap/built-in-functions.test.lua
+++ b/test/sql-tap/built-in-functions.test.lua
@@ -623,7 +623,7 @@ test:do_test(
 test:do_test(
     "builtins-4.10",
     function()
-        return box.execute([[SELECT REPLACE(@1, @1, @1);]], {'a'}).metadata[1]
+        return box.execute([[SELECT REPLACE($1, $1, $1);]], {{['$1'] = 'a'}}).metadata[1]
     end, {
         name = "COLUMN_1", type = 'string'
     })

--- a/test/sql-tap/misc1.test.lua
+++ b/test/sql-tap/misc1.test.lua
@@ -1052,7 +1052,7 @@ test:do_catchsql_test(
         select''like''like''like#0;
     ]], {
         -- <misc1-21.1>
-        1, [[Syntax error at line 1 near '#']]
+        1, [[At line 1 at or near position 33: unrecognized token '#0']]
         -- </misc1-21.1>
     })
 
@@ -1062,7 +1062,7 @@ test:do_catchsql_test(
         VALUES(0,0x0MATCH#0;
     ]], {
         -- <misc1-21.2>
-        1, [[Syntax error at line 1 near ';']]
+        1, [[At line 1 at or near position 26: unrecognized token '#0']]
         -- </misc1-21.2>
     })
 


### PR DESCRIPTION
After this patch:
named bind variable always begins with `#`, `:`, or `@` followed by
a letter or another non-digit identifier character (variants
(`@number`, etc.) are no longer supported);
numeric bind arguments always begin with `$` followed by a number
(variants (`$name`, etc.) are no longer supported);
anonymous bind variable is denoted by `?` followed by a non-numeric,
non-alphabetic character.

Closes #13012
Part of #12733

@TarantoolBot document
Title: change in bind variable notation

Now named bind variable always begins with `#`, `:`, or `@` followed by
a letter or another non-digit identifier character (variants
(`@number`, etc.) are no longer supported);
numeric bind arguments always begin with `$` followed by a number
(variants (`$name`, etc.) are no longer supported);
anonymous bind variable is denoted by `?` followed by a non-numeric,
non-alphabetic character.