### PR TITLE
xrow: reject a non-map raft request body

### DIFF
--- a/changelogs/unreleased/gh-noticket-raft-decode-non-map.md
+++ b/changelogs/unreleased/gh-noticket-raft-decode-non-map.md
@@ -1,0 +1,5 @@
+## bugfix/replication
+
+* Fixed an out-of-bounds read on an `IPROTO_RAFT` request whose body is
+  valid MsgPack but not a map. Such a body is now rejected while the
+  request is decoded.

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -1584,6 +1584,8 @@ xrow_decode_raft(const struct xrow_header *row, struct raft_request *r)
 
 	r->group_id = row->group_id;
 	const char *pos = row->body[0].iov_base;
+	if (mp_typeof(*pos) != MP_MAP)
+		goto bad_msgpack;
 	uint32_t map_size = mp_decode_map(&pos);
 	for (uint32_t i = 0; i < map_size; ++i)
 	{

--- a/test/unit/xrow.cc
+++ b/test/unit/xrow.cc
@@ -1390,13 +1390,49 @@ test_xrow_decode_error_gh_9136(void)
 	footer();
 }
 
+/*
+ * xrow_decode() only guarantees that a request body is well-formed
+ * MsgPack, not that it is a map. A raft request whose body is any other
+ * type must be rejected rather than handed to mp_decode_map(), which
+ * treats a non-map marker as unreachable.
+ */
+static void
+test_xrow_decode_raft_no_map(void)
+{
+	header();
+	plan(2);
+
+	char buf[16];
+	struct xrow_header row;
+	memset(&row, 0, sizeof(row));
+	row.type = IPROTO_RAFT;
+	row.group_id = GROUP_LOCAL;
+	row.bodycnt = 1;
+	row.body[0].iov_base = buf;
+
+	struct raft_request raft;
+
+	/* An empty array is valid MsgPack but not a map. */
+	row.body[0].iov_len = mp_format(buf, sizeof(buf), "[]");
+	is(xrow_decode_raft(&row, &raft), -1, "array body is rejected");
+	box_error_clear();
+
+	/* A scalar is valid MsgPack but not a map. */
+	row.body[0].iov_len = mp_format(buf, sizeof(buf), "%u", 42);
+	is(xrow_decode_raft(&row, &raft), -1, "scalar body is rejected");
+	box_error_clear();
+
+	check_plan();
+	footer();
+}
+
 int
 main(void)
 {
 	memory_init();
 	fiber_init(fiber_c_invoke);
 	header();
-	plan(15);
+	plan(16);
 
 	random_init();
 
@@ -1416,6 +1452,7 @@ main(void)
 	test_xrow_decode_error_gh_9098();
 	test_xrow_decode_error_gh_9136();
 	test_xrow_decode_synchro_types();
+	test_xrow_decode_raft_no_map();
 
 	random_free();
 	fiber_free();


### PR DESCRIPTION
xrow_decode_raft() runs mp_decode_map() straight on the request body, but xrow_decode() only guarantees the body is well-formed MsgPack, not that it is a map. Every sibling body decoder in this file checks for MP_MAP first; this one skips it, so a raft peer that sends an IPROTO_RAFT row with a valid non-map body (an array, a scalar) reaches mp_decode_map() with a non-map marker. That hits mp_unreachable(): an out-of-bounds read past the body on a release build, an abort where asserts stay on.

Check for MP_MAP before decoding, the same guard the other body decoders already use. Holding it at the decode entry lets the count-driven loop keep trusting map_size, which xrow_decode() already bounds-checks with mp_check.
