### PR TITLE
coio: do not use pthread_atfork to restart threads

### DIFF
--- a/changelogs/unreleased/gh-12936-app-threads-coio-hang-fix.md
+++ b/changelogs/unreleased/gh-12936-app-threads-coio-hang-fix.md
@@ -1,0 +1,4 @@
+## bugfix/core
+
+* Fixed a bug where Tarantool could hang at startup when application threads
+  were configured (gh-12936).

--- a/src/lib/core/coio_task.c
+++ b/src/lib/core/coio_task.c
@@ -129,6 +129,7 @@ coio_on_stop(void *data)
 void
 coio_init(void)
 {
+	eio_init();
 	eio_set_thread_on_start(coio_on_start, NULL);
 	eio_set_thread_on_stop(coio_on_stop, NULL);
 }
@@ -141,7 +142,7 @@ coio_init(void)
 void
 coio_enable(void)
 {
-	eio_init(&coio_manager, coio_want_poll_cb, coio_done_poll_cb);
+	eio_enable(&coio_manager, coio_want_poll_cb, coio_done_poll_cb);
 	coio_manager.loop = loop();
 
 	ev_idle_init(&coio_manager.coio_idle, coio_idle_cb);

--- a/src/lib/core/coio_task.c
+++ b/src/lib/core/coio_task.c
@@ -156,6 +156,29 @@ coio_shutdown(void)
 	eio_set_max_parallel(0);
 }
 
+/**
+ * We store the number of configured coio threads in this variable in
+ * coio_prefork() so as to restore it in coio_postfork().
+ */
+static int coio_prefork_threads;
+
+void
+coio_prefork(void)
+{
+	assert(cord_is_main());
+	assert(coio_prefork_threads == 0);
+	coio_prefork_threads = eio_set_max_parallel(0);
+}
+
+void
+coio_postfork(void)
+{
+	assert(cord_is_main());
+	assert(coio_prefork_threads > 0);
+	eio_set_min_parallel(coio_prefork_threads);
+	coio_prefork_threads = 0;
+}
+
 static void
 coio_on_feed(eio_req *req)
 {

--- a/src/lib/core/coio_task.h
+++ b/src/lib/core/coio_task.h
@@ -53,6 +53,21 @@ void coio_init(void);
 void coio_enable(void);
 void coio_shutdown(void);
 
+/**
+ * This function is supposed to be called before fork() if the child process
+ * will use coio. It stops coio threads to make sure that all internal coio
+ * locks have been released by the time fork() is called. After fork() is done,
+ * coio_postfork() must be called to restart coio threads.
+ *
+ * This function isn't thread-safe: it may only be called by the main thread.
+ */
+void
+coio_prefork(void);
+
+/** See coio_prefork(). */
+void
+coio_postfork(void);
+
 struct coio_task;
 
 typedef ssize_t (*coio_call_cb)(va_list ap);

--- a/src/main.cc
+++ b/src/main.cc
@@ -312,6 +312,9 @@ daemonize(void)
 	fflush(stdin);
 	fflush(stdout);
 	fflush(stderr);
+
+	coio_prefork();
+
 	pid = fork();
 	switch (pid) {
 	case -1:
@@ -334,6 +337,8 @@ daemonize(void)
 	 * kqueue on FreeBSD.
 	 */
 	ev_loop_fork(cord()->loop);
+
+	coio_postfork();
 
 	/* redirect stdin; stdout and stderr handled in say_logger_init */
 	fd = open("/dev/null", O_RDONLY);

--- a/third_party/libeio/eio.c
+++ b/third_party/libeio/eio.c
@@ -368,20 +368,10 @@ static void eio_execute (struct etp_worker *self, eio_req *req);
 
 #include "etp.c"
 
-static void
-eio_warn_uninitialized()
-{
-  fputs("Please initialize libeio in this thread.\n", stderr);
-  assert(0);
-}
-
 static struct etp_pool eio_pool;
 static __thread struct etp_pool_user eio_pool_user;
-static struct etp_pool_user *eio_main_user;
 #define EIO_POOL (&eio_pool)
-#define EIO_POOL_USER (ecb_expect_true(eio_pool_user.pool) ? \
-  &eio_pool_user : \
-  (eio_warn_uninitialized(), eio_main_user))
+#define EIO_POOL_USER (&eio_pool_user)
 
 /*****************************************************************************/
 
@@ -1718,23 +1708,17 @@ eio__statvfsat (int dirfd, const char *path, struct statvfs *buf)
 
 /*****************************************************************************/
 
-static void ecb_cold
-eio_init_once()
+void ecb_cold
+eio_init()
 {
   etp_init (EIO_POOL);
-  eio_main_user = &eio_pool_user;
 }
 
-int ecb_cold
-eio_init (void *user, void (*want_poll)(void *), void (*done_poll)(void *))
+void ecb_cold
+eio_enable (void *user, void (*want_poll)(void *), void (*done_poll)(void *))
 {
-  static pthread_once_t once = PTHREAD_ONCE_INIT;
-  pthread_once(&once, eio_init_once);
-
   etp_user_init (&eio_pool_user, user, want_poll, done_poll);
-
   eio_pool_user.pool = EIO_POOL;
-  return 0;
 }
 
 ecb_inline void

--- a/third_party/libeio/eio.c
+++ b/third_party/libeio/eio.c
@@ -533,10 +533,10 @@ eio_set_min_parallel (unsigned int nthreads)
   etp_set_min_parallel (EIO_POOL, nthreads);
 }
 
-void ecb_cold
+int ecb_cold
 eio_set_max_parallel (unsigned int nthreads)
 {
-  etp_set_max_parallel (EIO_POOL, nthreads);
+  return etp_set_max_parallel (EIO_POOL, nthreads);
 }
 
 int eio_poll (void)
@@ -1718,26 +1718,11 @@ eio__statvfsat (int dirfd, const char *path, struct statvfs *buf)
 
 /*****************************************************************************/
 
-static int eio_threads;
-
-static void ecb_cold
-eio_prefork()
-{
-    eio_threads = etp_set_max_parallel(EIO_POOL, 0);
-}
-
-static void ecb_cold
-eio_postfork()
-{
-    etp_set_min_parallel(EIO_POOL, eio_threads);
-}
-
 static void ecb_cold
 eio_init_once()
 {
   etp_init (EIO_POOL);
   eio_main_user = &eio_pool_user;
-  X_THREAD_ATFORK(eio_prefork, eio_postfork, eio_postfork);
 }
 
 int ecb_cold

--- a/third_party/libeio/eio.h
+++ b/third_party/libeio/eio.h
@@ -319,7 +319,7 @@ void eio_set_thread_on_stop(int (*on_stop_cb)(void *), void *data);
  * maximum wanted number
  * or maximum idle number of threads */
 void eio_set_min_parallel (unsigned int nthreads);
-void eio_set_max_parallel (unsigned int nthreads);
+int  eio_set_max_parallel (unsigned int nthreads);
 void eio_set_max_idle     (unsigned int nthreads);
 void eio_set_idle_timeout (unsigned int seconds);
 

--- a/third_party/libeio/eio.h
+++ b/third_party/libeio/eio.h
@@ -293,12 +293,15 @@ enum {
 /* undocumented/unsupported/private helper */
 /*void eio_page_align (void **addr, size_t *length);*/
 
-/* returns < 0 on error, errno set
+/* initialize eio subsystem */
+void eio_init (void);
+
+/* enable eio in the calling thread
  * need_poll, if non-zero, will be called when results are available
  * and eio_poll_cb needs to be invoked (it MUST NOT call eio_poll_cb itself).
  * done_poll is called when the need to poll is gone.
  */
-int eio_init (void *, void (*want_poll)(void *), void (*done_poll)(void *));
+void eio_enable (void *, void (*want_poll)(void *), void (*done_poll)(void *));
 
 /* must be called regularly to handle pending requests */
 /* returns 0 if all requests were handled, -1 if not, or the value of EIO_FINISH if != 0 */


### PR DESCRIPTION
The coio subsystem is based on the eio thread pool. To continue using eio threads in a child process after fork, we must gracefully stop all eio threads before fork because only this guarantees that internal eio mutexes are released. After fork is done, we must re-enable eio threads.  We do this in the eio_prefork and eio_postfork callbacks installed with pthread_atfork. The first callback sets the max number of eio threads to 0 with etp_set_max_parallel and saves the old value to a global variable. The second callback sets the min number of eio threads to the saved value with etp_set_min_parallel.

This works fine if fork is called only by the main thread but if it's called concurrently by different threads, it may occur that we override the global variable with 0 and instead of restoring the number of eio threads, we reset it to 0, forever disabling coio. This is what happens on CentOS 7 based systems when application threads start up because the built-in metrics.tarantool.memory Lua module calls io.popen on load.  Newer systems aren't affected because they implement io.popen with posix_spawn, which doesn't call pthread_atfork callbacks.

Actually, we need to enable coio in a child only when we daemonize the main process. So let's fix this issue by doing the pre/post fork hack directly where we call fork in daemonize.

Closes #12936