### PR TITLE
ci: enable tarantool-python integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -123,12 +123,11 @@ jobs:
     with:
       artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
-  # FIXME: Disabled due to tarantool/tarantool-python#334.
-  # tarantool-python:
-  #   needs: tarantool
-  #   uses: tarantool/tarantool-python/.github/workflows/reusable_testing.yml@master
-  #   with:
-  #     artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
+  tarantool-python:
+    needs: tarantool
+    uses: tarantool/tarantool-python/.github/workflows/reusable_testing.yml@master
+    with:
+      artifact_name: tarantool-ubuntu-noble-${{ needs.tarantool.outputs.sha }}
 
   # FIXME: Disabled due to tarantool-php/client#100
   # php-client:


### PR DESCRIPTION
I fixed issue in _tarantool/tarantool-python_ https://github.com/tarantool/tarantool-python/issues/334. Now the integration test for _tarantoo-python_ should pass successfully and I have enabled this test in the CI.