### PR TITLE
sql: introduce basic AST structures

### DIFF
--- a/extra/addopcodes.sh
+++ b/extra/addopcodes.sh
@@ -50,6 +50,7 @@ extras="            \
     ASTERISK        \
     SPAN            \
     ANALYZE         \
+    PARENTHESES     \
     LINEFEED        \
     SPACE           \
     ILLEGAL         \

--- a/src/box/CMakeLists.txt
+++ b/src/box/CMakeLists.txt
@@ -87,6 +87,7 @@ bin_source(bin_sources bootstrap.snap bootstrap.h bootstrap_bin)
 set(sql_sources
     sql/opcodes.c
     sql/parse.c
+    sql/ast.c
     sql/alter.c
     sql/cursor.c
     sql/build.c

--- a/src/box/sql/ast.c
+++ b/src/box/sql/ast.c
@@ -47,7 +47,7 @@ void
 ast_source_destroy(struct ast_source *src)
 {
 	sql_expr_list_delete(src->func_args);
-	sql_select_delete(src->select);
+	ast_select_list_destroy(src->select);
 	sql_expr_delete(src->join_on);
 }
 
@@ -77,23 +77,108 @@ ast_source_list_destroy(struct ast_source_list *list)
 }
 
 struct SrcList *
-src_list_from_ast(struct ast_source_list *list)
+src_list_from_ast(struct Parse *parser, struct ast_source_list *list)
 {
 	if (list == NULL)
 		return NULL;
 	struct SrcList *res = NULL;
 	struct ast_source *src;
 	stailq_foreach_entry(src, &list->head, link) {
+		struct Select *select = select_from_ast(parser, src->select);
 		struct Token *name = src->name.n > 0 ? &src->name: NULL;
-		res = sqlSrcListAppendFromTerm(res, name, &src->alias,
-					       src->select, src->join_on,
-					       src->join_using,
+		res = sqlSrcListAppendFromTerm(res, name, &src->alias, select,
+					       src->join_on, src->join_using,
 					       src->disallow_scan);
 		if (src->indexed_by.n != 0)
 			sqlSrcListIndexedBy(res, &src->indexed_by);
 		if (src->is_tab_func)
 			sqlSrcListFuncArgs(res, src->func_args);
 		res->a[res->nSrc - 1].fg.jointype = src->join_type;
+	}
+	if (parser->is_aborted) {
+		sqlSrcListDelete(res);
+		return NULL;
+	}
+	return res;
+}
+
+struct ast_select *
+ast_select_new(struct Parse *parser)
+{
+	struct ast_select *res = xregion_alloc(&parser->region, sizeof(*res));
+	memset(res, 0, sizeof(*res));
+	rlist_create(&res->link);
+	res->op = TK_SELECT;
+	return res;
+}
+
+/** Clear single `struct Select` object. */
+static void
+ast_select_destroy(struct ast_select *select)
+{
+	ast_source_list_destroy(select->sources);
+	sql_expr_list_delete(select->columns);
+	sql_expr_list_delete(select->group_by);
+	sql_expr_list_delete(select->order_by);
+	sql_expr_delete(select->where);
+	sql_expr_delete(select->having);
+	sql_expr_delete(select->limit);
+	sql_expr_delete(select->offset);
+	sqlWithDelete(select->with);
+}
+
+void
+ast_select_list_destroy(struct ast_select *select)
+{
+	if (select == NULL)
+		return;
+	ast_select_destroy(select);
+	struct ast_select *next;
+	struct ast_select *tmp;
+	rlist_foreach_entry_safe(next, &select->link, link, tmp) {
+		ast_select_destroy(select);
+	}
+}
+
+/** Build single `struct Select` object from `struct ast_select` object. */
+static struct Select *
+select_from_ast_single(struct Parse *parser, struct ast_select *select)
+{
+	struct SrcList *list = src_list_from_ast(parser, select->sources);
+	struct Select *res = sqlSelectNew(parser, select->columns, list,
+					  select->where, select->group_by,
+					  select->having, select->order_by,
+					  select->flags, select->limit,
+					  select->offset);
+	res->op = select->op;
+	res->pWith = select->with;
+	return res;
+}
+
+struct Select *
+select_from_ast(struct Parse *parser, struct ast_select *select)
+{
+	if (select == NULL)
+		return NULL;
+	struct Select *res = select_from_ast_single(parser, select);
+	struct Select *next = res;
+	struct ast_select *prev;
+	int count = 1;
+	rlist_foreach_entry_reverse(prev, &select->link, link) {
+		struct Select *prior = select_from_ast_single(parser, prev);
+		next->pPrior = prior;
+		prior->pNext = next;
+		next = prior;
+		count++;
+	}
+	if ((res->selFlags & SF_MultiValue) == 0 &&
+	    count > SQL_MAX_COMPOUND_SELECT) {
+		diag_set(ClientError, ER_SQL_PARSER_LIMIT, "The number of "
+			 "UNION or EXCEPT or INTERSECT operations", count,
+			 SQL_MAX_COMPOUND_SELECT);
+		parser->is_aborted = true;
+		sql_select_delete(res);
+		return NULL;
 	}
 	return res;
 }

--- a/src/box/sql/ast.c
+++ b/src/box/sql/ast.c
@@ -34,3 +34,66 @@ id_list_from_ast(struct ast_id_list *list)
 	}
 	return res;
 }
+
+struct ast_source *
+ast_source_new(struct Parse *parser)
+{
+	struct ast_source *src = xregion_alloc(&parser->region, sizeof(*src));
+	memset(src, 0, sizeof(*src));
+	return src;
+}
+
+void
+ast_source_destroy(struct ast_source *src)
+{
+	sql_expr_list_delete(src->func_args);
+	sql_select_delete(src->select);
+	sql_expr_delete(src->join_on);
+}
+
+struct ast_source_list *
+ast_source_list_append(struct Parse *parser, struct ast_source_list *list,
+		       struct ast_source *src)
+{
+	if (list == NULL) {
+		list = xregion_alloc(&parser->region, sizeof(*list));
+		stailq_create(&list->head);
+		list->len = 0;
+	}
+	stailq_add_tail(&list->head, &src->link);
+	list->len++;
+	return list;
+}
+
+void
+ast_source_list_destroy(struct ast_source_list *list)
+{
+	if (list == NULL)
+		return;
+	struct ast_source *src;
+	stailq_foreach_entry(src, &list->head, link) {
+		ast_source_destroy(src);
+	}
+}
+
+struct SrcList *
+src_list_from_ast(struct ast_source_list *list)
+{
+	if (list == NULL)
+		return NULL;
+	struct SrcList *res = NULL;
+	struct ast_source *src;
+	stailq_foreach_entry(src, &list->head, link) {
+		struct Token *name = src->name.n > 0 ? &src->name: NULL;
+		res = sqlSrcListAppendFromTerm(res, name, &src->alias,
+					       src->select, src->join_on,
+					       src->join_using,
+					       src->disallow_scan);
+		if (src->indexed_by.n != 0)
+			sqlSrcListIndexedBy(res, &src->indexed_by);
+		if (src->is_tab_func)
+			sqlSrcListFuncArgs(res, src->func_args);
+		res->a[res->nSrc - 1].fg.jointype = src->join_type;
+	}
+	return res;
+}

--- a/src/box/sql/ast.c
+++ b/src/box/sql/ast.c
@@ -124,7 +124,7 @@ ast_select_destroy(struct ast_select *select)
 	sql_expr_delete(select->having);
 	sql_expr_delete(select->limit);
 	sql_expr_delete(select->offset);
-	sqlWithDelete(select->with);
+	ast_with_destroy(select->with);
 }
 
 void
@@ -151,7 +151,7 @@ select_from_ast_single(struct Parse *parser, struct ast_select *select)
 					  select->flags, select->limit,
 					  select->offset);
 	res->op = select->op;
-	res->pWith = select->with;
+	res->pWith = with_from_ast(parser, select->with);
 	return res;
 }
 
@@ -181,4 +181,70 @@ select_from_ast(struct Parse *parser, struct ast_select *select)
 		return NULL;
 	}
 	return res;
+}
+
+struct ast_with_list *
+ast_with_list_append(struct Parse *parser, struct ast_with_list *list,
+		     const struct Token *name, struct ast_id_list *columns,
+		     struct ast_select *select)
+{
+	if (list == NULL) {
+		list = xregion_alloc(&parser->region, sizeof(*list));
+		stailq_create(&list->head);
+		list->len = 0;
+	}
+	struct ast_with_entry *entry = xregion_alloc(&parser->region,
+						     sizeof(*entry));
+	entry->name = *name;
+	entry->columns = columns;
+	entry->select = select;
+	stailq_add_tail(&list->head, &entry->link);
+	list->len++;
+	return list;
+}
+
+/** Convert `struct ast_id_list` to `struct ExprList` of column names. */
+static struct ExprList *
+expr_list_from_ids(struct Parse *parser, struct ast_id_list *list)
+{
+	if (list == NULL)
+		return NULL;
+	struct ExprList *res = NULL;
+	struct ast_id_entry *entry;
+	stailq_foreach_entry(entry, &list->head, link) {
+		res = sql_expr_list_append(res, NULL);
+		sqlExprListSetName(parser, res, &entry->id, 1);
+	}
+	return res;
+}
+
+struct With *
+with_from_ast(struct Parse *parser, struct ast_with_list *list)
+{
+	if (list == NULL)
+		return NULL;
+	struct With *res = NULL;
+	struct ast_with_entry *entry;
+	stailq_foreach_entry(entry, &list->head, link) {
+		struct ExprList *cols =
+			expr_list_from_ids(parser, entry->columns);
+		struct Select *select = select_from_ast(parser, entry->select);
+		res = sqlWithAdd(parser, res, &entry->name, cols, select);
+	}
+	if (parser->is_aborted) {
+		sqlWithDelete(res);
+		return NULL;
+	}
+	return res;
+}
+
+void
+ast_with_destroy(struct ast_with_list *list)
+{
+	if (list == NULL)
+		return;
+	struct ast_with_entry *entry;
+	stailq_foreach_entry(entry, &list->head, link) {
+		ast_select_list_destroy(entry->select);
+	}
 }

--- a/src/box/sql/ast.c
+++ b/src/box/sql/ast.c
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2026, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#include "sqlInt.h"
+
+struct ast_id_list *
+ast_id_list_append(struct Parse *parser, struct ast_id_list *list,
+		   const struct Token *id)
+{
+	if (list == NULL) {
+		list = xregion_alloc(&parser->region, sizeof(*list));
+		stailq_create(&list->head);
+		list->len = 0;
+	}
+	struct ast_id_entry *entry = xregion_alloc(&parser->region,
+						   sizeof(*entry));
+	entry->id = *id;
+	stailq_add_tail(&list->head, &entry->link);
+	list->len++;
+	return list;
+}
+
+struct IdList *
+id_list_from_ast(struct ast_id_list *list)
+{
+	if (list == NULL)
+		return NULL;
+	struct IdList *res = NULL;
+	struct ast_id_entry *entry;
+	stailq_foreach_entry(entry, &list->head, link) {
+		res = sql_id_list_append(res, &entry->id);
+	}
+	return res;
+}

--- a/src/box/sql/ast.c
+++ b/src/box/sql/ast.c
@@ -43,14 +43,6 @@ ast_source_new(struct Parse *parser)
 	return src;
 }
 
-void
-ast_source_destroy(struct ast_source *src)
-{
-	sql_expr_list_delete(src->func_args);
-	ast_select_list_destroy(src->select);
-	sql_expr_delete(src->join_on);
-}
-
 struct ast_source_list *
 ast_source_list_append(struct Parse *parser, struct ast_source_list *list,
 		       struct ast_source *src)
@@ -65,17 +57,6 @@ ast_source_list_append(struct Parse *parser, struct ast_source_list *list,
 	return list;
 }
 
-void
-ast_source_list_destroy(struct ast_source_list *list)
-{
-	if (list == NULL)
-		return;
-	struct ast_source *src;
-	stailq_foreach_entry(src, &list->head, link) {
-		ast_source_destroy(src);
-	}
-}
-
 struct SrcList *
 src_list_from_ast(struct Parse *parser, struct ast_source_list *list)
 {
@@ -85,14 +66,18 @@ src_list_from_ast(struct Parse *parser, struct ast_source_list *list)
 	struct ast_source *src;
 	stailq_foreach_entry(src, &list->head, link) {
 		struct Select *select = select_from_ast(parser, src->select);
+		struct Expr *join_on = expr_from_ast(parser, src->join_on);
 		struct Token *name = src->name.n > 0 ? &src->name: NULL;
 		res = sqlSrcListAppendFromTerm(res, name, &src->alias, select,
-					       src->join_on, src->join_using,
+					       join_on, src->join_using,
 					       src->disallow_scan);
 		if (src->indexed_by.n != 0)
 			sqlSrcListIndexedBy(res, &src->indexed_by);
-		if (src->is_tab_func)
-			sqlSrcListFuncArgs(res, src->func_args);
+		if (src->is_tab_func) {
+			struct ExprList *func_args =
+				expr_list_from_ast(parser, src->func_args);
+			sqlSrcListFuncArgs(res, func_args);
+		}
 		res->a[res->nSrc - 1].fg.jointype = src->join_type;
 	}
 	if (parser->is_aborted) {
@@ -112,44 +97,23 @@ ast_select_new(struct Parse *parser)
 	return res;
 }
 
-/** Clear single `struct Select` object. */
-static void
-ast_select_destroy(struct ast_select *select)
-{
-	ast_source_list_destroy(select->sources);
-	sql_expr_list_delete(select->columns);
-	sql_expr_list_delete(select->group_by);
-	sql_expr_list_delete(select->order_by);
-	sql_expr_delete(select->where);
-	sql_expr_delete(select->having);
-	sql_expr_delete(select->limit);
-	sql_expr_delete(select->offset);
-	ast_with_destroy(select->with);
-}
-
-void
-ast_select_list_destroy(struct ast_select *select)
-{
-	if (select == NULL)
-		return;
-	ast_select_destroy(select);
-	struct ast_select *next;
-	struct ast_select *tmp;
-	rlist_foreach_entry_safe(next, &select->link, link, tmp) {
-		ast_select_destroy(select);
-	}
-}
-
 /** Build single `struct Select` object from `struct ast_select` object. */
 static struct Select *
 select_from_ast_single(struct Parse *parser, struct ast_select *select)
 {
 	struct SrcList *list = src_list_from_ast(parser, select->sources);
-	struct Select *res = sqlSelectNew(parser, select->columns, list,
-					  select->where, select->group_by,
-					  select->having, select->order_by,
-					  select->flags, select->limit,
-					  select->offset);
+	struct Expr *where = expr_from_ast(parser, select->where);
+	struct Expr *having = expr_from_ast(parser, select->having);
+	struct Expr *limit = expr_from_ast(parser, select->limit);
+	struct Expr *offset = expr_from_ast(parser, select->offset);
+	struct ExprList *columns = expr_list_from_ast(parser, select->columns);
+	struct ExprList *group_by = expr_list_from_ast(parser,
+						       select->group_by);
+	struct ExprList *order_by = expr_list_from_ast(parser,
+						       select->order_by);
+	struct Select *res = sqlSelectNew(parser, columns, list, where,
+					  group_by, having, order_by,
+					  select->flags, limit, offset);
 	res->op = select->op;
 	res->pWith = with_from_ast(parser, select->with);
 	return res;
@@ -238,13 +202,432 @@ with_from_ast(struct Parse *parser, struct ast_with_list *list)
 	return res;
 }
 
+struct ast_expr *
+ast_expr_new(struct Parse *parser, const char *str, uint32_t len, uint8_t op)
+{
+	struct ast_expr *expr = xregion_alloc(&parser->region, sizeof(*expr));
+	expr->left = NULL;
+	expr->right = NULL;
+	expr->str = str;
+	expr->len = len;
+	expr->op = op;
+	return expr;
+}
+
+struct ast_expr_list *
+ast_expr_list_append(struct Parse *parser, struct ast_expr_list *list,
+		     struct ast_expr *expr)
+{
+	size_t n = sizeof(struct ast_expr_list_entry);
+	struct ast_expr_list_entry *entry = xregion_alloc(&parser->region, n);
+	entry->name = Token_nil;
+	entry->expr = expr;
+	entry->order = SORT_ORDER_ASC;
+	if (list == NULL) {
+		list = xregion_alloc(&parser->region, sizeof(*list));
+		stailq_create(&list->head);
+		list->len = 0;
+		list->is_select_list = false;
+	}
+	stailq_add_tail(&list->head, &entry->link);
+	list->len++;
+	return list;
+}
+
 void
-ast_with_destroy(struct ast_with_list *list)
+ast_expr_list_set_name(struct ast_expr_list *list, struct Token *name)
+{
+	struct ast_expr_list_entry *entry =
+		stailq_last_entry(&list->head, typeof(*entry), link);
+	entry->name = *name;
+}
+
+void
+ast_expr_list_set_order(struct ast_expr_list *list, enum sort_order order)
+{
+	struct ast_expr_list_entry *entry =
+		stailq_last_entry(&list->head, typeof(*entry), link);
+	entry->order = order;
+}
+
+struct ExprList *
+expr_list_from_ast(struct Parse *parser, struct ast_expr_list *list)
 {
 	if (list == NULL)
-		return;
-	struct ast_with_entry *entry;
+		return NULL;
+	struct ExprList *res = NULL;
+	struct ast_expr_list_entry *entry;
 	stailq_foreach_entry(entry, &list->head, link) {
-		ast_select_list_destroy(entry->select);
+		struct ast_expr *ast_expr = entry->expr;
+		struct Expr *expr = expr_from_ast(parser, ast_expr);
+		if (expr == NULL)
+			break;
+		res = sql_expr_list_append(res, expr);
+		if (entry->name.n > 0)
+			sqlExprListSetName(parser, res, &entry->name, 1);
+		if (list->is_select_list)
+			sqlExprListSetSpan(res, ast_expr->str, ast_expr->len);
+		if (entry->order != SORT_ORDER_ASC)
+			sqlExprListSetSortOrder(res, entry->order);
 	}
+	if (parser->is_aborted) {
+		sql_expr_list_delete(res);
+		return NULL;
+	}
+	return res;
+}
+
+/** Build an identifier `struct Expr`, e.g. a function or collation name. */
+static struct Expr *
+expr_id(struct ast_expr *expr)
+{
+	struct Token t;
+	t.z = expr->str;
+	t.n = expr->len;
+	t.isReserved = false;
+	struct Expr *res = sql_expr_new_dequoted(expr->op, &t);
+	res->type = FIELD_TYPE_SCALAR;
+	if (expr->str[0] != '"')
+		res->flags |= EP_Lookup2;
+	return res;
+}
+
+/** Build a leaf `struct Expr` (a literal) of the given field type. */
+static struct Expr *
+expr_leaf(struct ast_expr *expr, enum field_type type)
+{
+	struct Token t;
+	t.z = expr->str;
+	t.n = expr->len;
+	t.isReserved = false;
+	struct Expr *res = sql_expr_new_dequoted(expr->op, &t);
+	res->type = type;
+	res->flags |= EP_Leaf;
+	return res;
+}
+
+/** Build a `struct Expr` for a bound variable (`?`, `:name`, etc). */
+static struct Expr *
+expr_var(struct Parse *parser, struct ast_expr *expr)
+{
+	struct Token t;
+	t.z = expr->str;
+	t.n = expr->len;
+	t.isReserved = false;
+	if (parser->parse_only) {
+		diag_set(ClientError, ER_SQL_PARSER_GENERIC_WITH_POS,
+			 parser->line_count, parser->line_pos,
+			 "bindings are not allowed in DDL");
+		parser->is_aborted = true;
+		return NULL;
+	}
+	if (expr->len > 1) {
+		assert(expr->str[0] != '?');
+		if (!IdChar(expr->str[1])) {
+			diag_set(ClientError, ER_SQL_UNKNOWN_TOKEN,
+				 parser->line_count,
+				 expr->str - parser->zTail + 1,
+				 tt_cstr(expr->str, 1));
+			parser->is_aborted = true;
+			return NULL;
+		}
+		if (expr->str[0] == '#' && sqlIsdigit(expr->str[1])) {
+			diag_set(ClientError, ER_SQL_SYNTAX_NEAR_TOKEN,
+				 parser->line_count, tt_cstr(expr->str, 1));
+			parser->is_aborted = true;
+			return NULL;
+		}
+	}
+	struct Expr *res = sql_expr_new_dequoted(expr->op, &t);
+	res->type = FIELD_TYPE_BOOLEAN;
+	res->flags |= EP_Leaf;
+	sqlExprAssignVarNumber(parser, res, expr->len);
+	return res;
+}
+
+/** Build a `struct Expr` for a unary operator applied to `expr->left`. */
+static struct Expr *
+expr_unary(struct Parse *parser, struct ast_expr *expr)
+{
+	struct Expr *left = expr_from_ast(parser, expr->left);
+	if (parser->is_aborted)
+		return NULL;
+	return sqlPExpr(parser, expr->op, left, NULL);
+}
+
+/** Build a `struct Expr` for a binary operator applied to left and right. */
+static struct Expr *
+expr_binary(struct Parse *parser, struct ast_expr *expr)
+{
+	struct Expr *left = expr_from_ast(parser, expr->left);
+	if (parser->is_aborted)
+		return NULL;
+	struct Expr *right = expr_from_ast(parser, expr->right);
+	if (parser->is_aborted) {
+		sql_expr_delete(left);
+		return NULL;
+	}
+	return sqlPExpr(parser, expr->op, left, right);
+}
+
+/** Build a `struct Expr` of the given type whose operand is expr->list. */
+static struct Expr *
+expr_list(struct Parse *parser, struct ast_expr *expr, enum field_type type)
+{
+	struct Expr *res = sql_expr_new_anon(expr->op);
+	res->x.pList = expr_list_from_ast(parser, expr->list);
+	if (parser->is_aborted) {
+		sql_expr_delete(res);
+		return NULL;
+	}
+	res->type = type;
+	sqlExprSetHeightAndFlags(parser, res);
+	return res;
+}
+
+/** Build a `struct Expr` with a left operand and an expression list operand. */
+static struct Expr *
+expr_left_and_list(struct Parse *parser, struct ast_expr *expr)
+{
+	struct Expr *left = expr_from_ast(parser, expr->left);
+	if (parser->is_aborted)
+		return NULL;
+	struct Expr *res = sqlPExpr(parser, expr->op, left, NULL);
+	res->x.pList = expr_list_from_ast(parser, expr->list);
+	if (parser->is_aborted) {
+		sql_expr_delete(res);
+		return NULL;
+	}
+	sqlExprSetHeightAndFlags(parser, res);
+	return res;
+}
+
+/** Build a `struct Expr` for a function call expression. */
+static struct Expr *
+expr_function(struct Parse *parser, struct ast_expr *expr)
+{
+	struct Expr *res = expr_id(expr->left);
+	res->op = TK_FUNCTION;
+	if (expr->right == NULL)
+		return res;
+	if (expr->right->op == TK_DISTINCT)
+		res->flags |= EP_Distinct;
+	if (expr->right->list == NULL)
+		return res;
+	if (expr->right->list->len > SQL_MAX_FUNCTION_ARG) {
+		const char *err = tt_sprintf("Number of arguments to "
+					     "function %s", res->u.zToken);
+		diag_set(ClientError, ER_SQL_PARSER_LIMIT, err,
+			 expr->right->list->len, SQL_MAX_FUNCTION_ARG);
+		parser->is_aborted = true;
+		sql_expr_delete(res);
+		return NULL;
+	}
+	res->x.pList = expr_list_from_ast(parser, expr->right->list);
+	if (parser->is_aborted) {
+		sql_expr_delete(res);
+		return NULL;
+	}
+	sqlExprSetHeightAndFlags(parser, res);
+	return res;
+}
+
+/** Build a `struct Expr` for an IN expression (subquery or value list). */
+static struct Expr *
+expr_in(struct Parse *parser, struct ast_expr *expr)
+{
+	if (expr->right->op == TK_SELECT) {
+		struct Expr *left = expr_from_ast(parser, expr->left);
+		if (parser->is_aborted)
+			return NULL;
+		struct Select *select = select_from_ast(parser,
+							expr->right->select);
+		if (parser->is_aborted) {
+			sql_expr_delete(left);
+			return NULL;
+		}
+		struct Expr *res = sqlPExpr(parser, expr->op, left, NULL);
+		sqlPExprAddSelect(parser, res, select);
+		return res;
+	}
+	assert(expr->right->op == TK_VECTOR);
+	if (expr->right->list == NULL || expr->right->list->len == 0) {
+		struct Expr *res = sql_expr_new_anon(TK_FALSE);
+		res->type = FIELD_TYPE_BOOLEAN;
+		return res;
+	}
+	if (expr->right->list->len == 1) {
+		struct Expr *left = expr_from_ast(parser, expr->left);
+		if (parser->is_aborted)
+			return NULL;
+		struct ast_expr_list_entry *entry =
+			stailq_first_entry(&expr->right->list->head,
+					   typeof(*entry), link);
+		struct Expr *right = expr_from_ast(parser, entry->expr);
+		if (parser->is_aborted) {
+			sql_expr_delete(left);
+			return NULL;
+		}
+		return sqlPExpr(parser, TK_EQ, left, right);
+	}
+	struct Expr *left = expr_from_ast(parser, expr->left);
+	if (parser->is_aborted)
+		return NULL;
+	struct Expr *res = sqlPExpr(parser, expr->op, left, NULL);
+	res->x.pList = expr_list_from_ast(parser, expr->right->list);
+	if (parser->is_aborted) {
+		sql_expr_delete(res);
+		return NULL;
+	}
+	sqlExprSetHeightAndFlags(parser, res);
+	return res;
+}
+
+/** Build a `struct Expr` for a subscripting operator expression. */
+static struct Expr *
+expr_getitem(struct Parse *parser, struct ast_expr *expr)
+{
+	struct ExprList *list = expr_list_from_ast(parser, expr->list);
+	if (parser->is_aborted)
+		return NULL;
+	struct Expr *left = expr_from_ast(parser, expr->left);
+	if (parser->is_aborted)
+		return NULL;
+	struct Expr *res = sql_expr_new_anon(expr->op);
+	res->x.pList = sql_expr_list_append(list, left);
+	res->type = FIELD_TYPE_ANY;
+	sqlExprSetHeightAndFlags(parser, res);
+	return res;
+}
+
+struct Expr *
+expr_from_ast(struct Parse *parser, struct ast_expr *expr)
+{
+	if (expr == NULL)
+		return NULL;
+	struct Expr *res = NULL;
+	switch (expr->op) {
+	case TK_STRING:
+		res = expr_leaf(expr, FIELD_TYPE_STRING);
+		break;
+	case TK_BLOB:
+		res = expr_leaf(expr, FIELD_TYPE_VARBINARY);
+		break;
+	case TK_INTEGER:
+		res = expr_leaf(expr, FIELD_TYPE_INTEGER);
+		break;
+	case TK_FLOAT:
+		res = expr_leaf(expr, FIELD_TYPE_DOUBLE);
+		break;
+	case TK_DECIMAL:
+		res = expr_leaf(expr, FIELD_TYPE_DECIMAL);
+		break;
+	case TK_TRUE:
+	case TK_FALSE:
+	case TK_UNKNOWN:
+		res = expr_leaf(expr, FIELD_TYPE_BOOLEAN);
+		break;
+	case TK_VARIABLE:
+		res = expr_var(parser, expr);
+		break;
+	case TK_AND:
+	case TK_OR:
+	case TK_LT:
+	case TK_LE:
+	case TK_GT:
+	case TK_GE:
+	case TK_EQ:
+	case TK_NE:
+	case TK_BITAND:
+	case TK_BITOR:
+	case TK_LSHIFT:
+	case TK_RSHIFT:
+	case TK_PLUS:
+	case TK_MINUS:
+	case TK_STAR:
+	case TK_SLASH:
+	case TK_REM:
+	case TK_CONCAT:
+	case TK_DOT:
+		res = expr_binary(parser, expr);
+		break;
+	case TK_PARENTHESES:
+		while (expr->op == TK_PARENTHESES)
+			expr = expr->left;
+		res = expr_from_ast(parser, expr);
+		break;
+	case TK_COLLATE:
+		res = expr_id(expr->right);
+		assert(res != NULL);
+		res->op = TK_COLLATE;
+		res->flags |= EP_Collate | EP_Skip;
+		res->pLeft = expr_from_ast(parser, expr->left);
+		break;
+	case TK_CAST:
+		res = expr_unary(parser, expr);
+		if (res == NULL)
+			break;
+		res->type = expr->type;
+		break;
+	case TK_NOT:
+	case TK_BITNOT:
+	case TK_UMINUS:
+	case TK_UPLUS:
+	case TK_NOTNULL:
+	case TK_ISNULL:
+		res = expr_unary(parser, expr);
+		break;
+	case TK_ARRAY:
+		res = expr_list(parser, expr, FIELD_TYPE_ARRAY);
+		break;
+	case TK_MAP:
+		res = expr_list(parser, expr, FIELD_TYPE_MAP);
+		break;
+	case TK_GETITEM:
+		res = expr_getitem(parser, expr);
+		break;
+	case TK_FUNCTION:
+		res = expr_function(parser, expr);
+		break;
+	case TK_BETWEEN:
+		res = expr_left_and_list(parser, expr);
+		break;
+	case TK_VECTOR:
+		res = expr_list(parser, expr, FIELD_TYPE_ANY);
+		break;
+	case TK_IN:
+		res = expr_in(parser, expr);
+		break;
+	case TK_EXISTS:
+	case TK_SELECT: {
+		struct Select *select = select_from_ast(parser, expr->select);
+		if (parser->is_aborted)
+			return NULL;
+		res = sql_expr_new_anon(expr->op);
+		sqlPExprAddSelect(parser, res, select);
+		break;
+	}
+	case TK_RAISE:
+		if (expr->on_conflict_action != ON_CONFLICT_ACTION_IGNORE)
+			res = expr_leaf(expr->left, FIELD_TYPE_STRING);
+		else
+			res = sql_expr_new_anon(expr->op);
+		res->op = TK_RAISE;
+		res->on_conflict_action = expr->on_conflict_action;
+		break;
+	case TK_CASE:
+		if (expr->left != NULL)
+			res = expr_left_and_list(parser, expr);
+		else
+			res = expr_list(parser, expr, FIELD_TYPE_ANY);
+		break;
+	default:
+		res = expr_leaf(expr, FIELD_TYPE_SCALAR);
+		break;
+	}
+	if (parser->is_aborted) {
+		sql_expr_delete(res);
+		return NULL;
+	}
+	return res;
 }

--- a/src/box/sql/ast.h
+++ b/src/box/sql/ast.h
@@ -82,11 +82,31 @@ struct ast_select {
 	/** OFFSET clause of the SELECT. */
 	struct Expr *offset;
 	/** WITH clause of the SELECT. */
-	struct With *with;
+	struct ast_with_list *with;
 	/** Flags of the SELECT. */
 	uint32_t flags;
 	/** Link type between linked SELECTs. */
 	uint8_t op;
+};
+
+/** List of WITH clauses received from parser. */
+struct ast_with_list {
+	/** Head of the list. */
+	struct stailq head;
+	/** Length of the list. */
+	uint32_t len;
+};
+
+/** Element of the WITH clause list, describing one entry of a WITH clause. */
+struct ast_with_entry {
+	/** Link to the next element of the list. */
+	struct stailq_entry link;
+	/** Name of the table in the WITH clause. */
+	struct Token name;
+	/** Column names of the table, if specified explicitly. */
+	struct ast_id_list *columns;
+	/** SELECT statement of the WITH clause. */
+	struct ast_select *select;
 };
 
 /** Append an ID to ID list. */
@@ -130,3 +150,19 @@ ast_select_list_destroy(struct ast_select *select);
 /** Build `struct Select` object from `struct ast_select` object. */
 struct Select *
 select_from_ast(struct Parse *parser, struct ast_select *select);
+
+/**
+ * Append a WITH clause to the WITH clause list, creating the list if needed.
+ */
+struct ast_with_list *
+ast_with_list_append(struct Parse *parser, struct ast_with_list *list,
+		     const struct Token *name, struct ast_id_list *columns,
+		     struct ast_select *select);
+
+/** Convert `struct ast_with_list` to `struct With`. */
+struct With *
+with_from_ast(struct Parse *parser, struct ast_with_list *list);
+
+/** Destroy the resources owned by the WITH clauses in the list. */
+void
+ast_with_destroy(struct ast_with_list *list);

--- a/src/box/sql/ast.h
+++ b/src/box/sql/ast.h
@@ -9,6 +9,7 @@
 
 #include "parse_def.h"
 #include "salad/stailq.h"
+#include "small/rlist.h"
 
 /** List of IDs received from parser. */
 struct ast_id_list {
@@ -45,7 +46,7 @@ struct ast_source {
 	/** Name of the index specified via INDEXED BY, if any. */
 	struct Token indexed_by;
 	/** SELECT statement of a subquery. */
-	struct Select *select;
+	struct ast_select *select;
 	/** Expression of a join's ON clause. */
 	struct Expr *join_on;
 	/** Column names of a join's USING clause. */
@@ -58,6 +59,34 @@ struct ast_source {
 	bool is_tab_func;
 	/** True if scanning is not allowed for this source. */
 	bool disallow_scan;
+};
+
+/** Structure that describes SELECT. */
+struct ast_select {
+	/** Link to other SELECTs. */
+	struct rlist link;
+	/** The FROM clause of the SELECT. */
+	struct ast_source_list *sources;
+	/** Resulting expressions of the SELECT. */
+	struct ExprList *columns;
+	/** GROUP BY clause of the SELECT. */
+	struct ExprList *group_by;
+	/** ORDER BY clause of the SELECT. */
+	struct ExprList *order_by;
+	/** WHERE clause of the SELECT. */
+	struct Expr *where;
+	/** HAVING clause of the SELECT. */
+	struct Expr *having;
+	/** LIMIT clause of the SELECT. */
+	struct Expr *limit;
+	/** OFFSET clause of the SELECT. */
+	struct Expr *offset;
+	/** WITH clause of the SELECT. */
+	struct With *with;
+	/** Flags of the SELECT. */
+	uint32_t flags;
+	/** Link type between linked SELECTs. */
+	uint8_t op;
 };
 
 /** Append an ID to ID list. */
@@ -88,4 +117,16 @@ ast_source_list_destroy(struct ast_source_list *list);
 
 /** Convert `struct ast_source_list` to `struct SrcList`. */
 struct SrcList *
-src_list_from_ast(struct ast_source_list *list);
+src_list_from_ast(struct Parse *parser, struct ast_source_list *list);
+
+/** Create new empty SELECT structure. */
+struct ast_select *
+ast_select_new(struct Parse *parser);
+
+/** Clear the SELECT and all linked SELECTs. */
+void
+ast_select_list_destroy(struct ast_select *select);
+
+/** Build `struct Select` object from `struct ast_select` object. */
+struct Select *
+select_from_ast(struct Parse *parser, struct ast_select *select);

--- a/src/box/sql/ast.h
+++ b/src/box/sql/ast.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright 2010-2026, Tarantool AUTHORS, please see AUTHORS file.
+ */
+#pragma once
+
+#include <stdint.h>
+
+#include "parse_def.h"
+#include "salad/stailq.h"
+
+/** List of IDs received from parser. */
+struct ast_id_list {
+	/** Head of the list. */
+	struct stailq head;
+	/** Length of the list. */
+	uint32_t len;
+};
+
+/** Element of the IDs list. */
+struct ast_id_entry {
+	/** Link to the next element of the list. */
+	struct stailq_entry link;
+	/** ID from parser. */
+	struct Token id;
+};
+
+/** Append an ID to ID list. */
+struct ast_id_list *
+ast_id_list_append(struct Parse *parser, struct ast_id_list *list,
+		   const struct Token *id);
+
+/** Convert `struct ast_id_list` to `struct IdList`. */
+struct IdList *
+id_list_from_ast(struct ast_id_list *list);

--- a/src/box/sql/ast.h
+++ b/src/box/sql/ast.h
@@ -48,11 +48,11 @@ struct ast_source {
 	/** SELECT statement of a subquery. */
 	struct ast_select *select;
 	/** Expression of a join's ON clause. */
-	struct Expr *join_on;
+	struct ast_expr *join_on;
 	/** Column names of a join's USING clause. */
 	struct ast_id_list *join_using;
 	/** Arguments of a table-valued function. */
-	struct ExprList *func_args;
+	struct ast_expr_list *func_args;
 	/** Type of join between this source and the previous one. */
 	int join_type;
 	/** True if the source is a table-valued function. */
@@ -68,19 +68,19 @@ struct ast_select {
 	/** The FROM clause of the SELECT. */
 	struct ast_source_list *sources;
 	/** Resulting expressions of the SELECT. */
-	struct ExprList *columns;
+	struct ast_expr_list *columns;
 	/** GROUP BY clause of the SELECT. */
-	struct ExprList *group_by;
+	struct ast_expr_list *group_by;
 	/** ORDER BY clause of the SELECT. */
-	struct ExprList *order_by;
+	struct ast_expr_list *order_by;
 	/** WHERE clause of the SELECT. */
-	struct Expr *where;
+	struct ast_expr *where;
 	/** HAVING clause of the SELECT. */
-	struct Expr *having;
+	struct ast_expr *having;
 	/** LIMIT clause of the SELECT. */
-	struct Expr *limit;
+	struct ast_expr *limit;
 	/** OFFSET clause of the SELECT. */
-	struct Expr *offset;
+	struct ast_expr *offset;
 	/** WITH clause of the SELECT. */
 	struct ast_with_list *with;
 	/** Flags of the SELECT. */
@@ -109,6 +109,56 @@ struct ast_with_entry {
 	struct ast_select *select;
 };
 
+/** Description of list of expressions. */
+struct ast_expr_list {
+	/** Head of the list. */
+	struct stailq head;
+	/** Length of the list. */
+	uint32_t len;
+	/** True if this is the column list of a SELECT statement. */
+	bool is_select_list;
+};
+
+/** Description of a parsed expression. */
+struct ast_expr {
+	/** Left (or the only) operand of the expression. */
+	struct ast_expr *left;
+	union {
+		/** Right operand of a binary expression. */
+		struct ast_expr *right;
+		/** Sub-expressions, e.g. function args or an IN list. */
+		struct ast_expr_list *list;
+		/** Subquery of an EXISTS, SELECT, or IN expression. */
+		struct ast_select *select;
+		/** Target type of a CAST expression. */
+		enum field_type type;
+		/** Conflict resolution action of a RAISE expression. */
+		enum on_conflict_action on_conflict_action;
+	};
+	/** Pointer to the token text this expression is built from. */
+	const char *str;
+	/** Length of the token text pointed to by str. */
+	uint32_t len;
+	/** Parser token code identifying the kind of expression. */
+	uint8_t op;
+};
+
+/** Element of the expressions list. */
+struct ast_expr_list_entry {
+	/** Link to the next element of the list. */
+	struct stailq_entry link;
+	/**
+	 * Name linked to the expression, if any.
+	 * This name can be an alias, a column name in the SET clause of
+	 * an UPDATE statement, etc.
+	 */
+	struct Token name;
+	/** The expression itself. */
+	struct ast_expr *expr;
+	/** Sort order of the entry, used for ORDER BY lists. */
+	enum sort_order order;
+};
+
 /** Append an ID to ID list. */
 struct ast_id_list *
 ast_id_list_append(struct Parse *parser, struct ast_id_list *list,
@@ -122,18 +172,10 @@ id_list_from_ast(struct ast_id_list *list);
 struct ast_source *
 ast_source_new(struct Parse *parser);
 
-/** Destroy the resources owned by the source. */
-void
-ast_source_destroy(struct ast_source *src);
-
 /** Append a source to the sources list, creating the list if needed. */
 struct ast_source_list *
 ast_source_list_append(struct Parse *parser, struct ast_source_list *list,
 		       struct ast_source *src);
-
-/** Destroy the resources owned by the sources in the list. */
-void
-ast_source_list_destroy(struct ast_source_list *list);
 
 /** Convert `struct ast_source_list` to `struct SrcList`. */
 struct SrcList *
@@ -142,10 +184,6 @@ src_list_from_ast(struct Parse *parser, struct ast_source_list *list);
 /** Create new empty SELECT structure. */
 struct ast_select *
 ast_select_new(struct Parse *parser);
-
-/** Clear the SELECT and all linked SELECTs. */
-void
-ast_select_list_destroy(struct ast_select *select);
 
 /** Build `struct Select` object from `struct ast_select` object. */
 struct Select *
@@ -163,6 +201,27 @@ ast_with_list_append(struct Parse *parser, struct ast_with_list *list,
 struct With *
 with_from_ast(struct Parse *parser, struct ast_with_list *list);
 
-/** Destroy the resources owned by the WITH clauses in the list. */
+/** Allocate a new expression node from a token's text. */
+struct ast_expr *
+ast_expr_new(struct Parse *parser, const char *start, uint32_t len, uint8_t op);
+
+/** Append an expression to the expressions list, creating it if needed. */
+struct ast_expr_list *
+ast_expr_list_append(struct Parse *parser, struct ast_expr_list *list,
+		     struct ast_expr *expr);
+
+/** Set the name of the last expression appended to the list. */
 void
-ast_with_destroy(struct ast_with_list *list);
+ast_expr_list_set_name(struct ast_expr_list *list, struct Token *name);
+
+/** Set the sort order of the last expression appended to the list. */
+void
+ast_expr_list_set_order(struct ast_expr_list *list, enum sort_order order);
+
+/** Convert `struct ast_expr` to `struct Expr`. */
+struct Expr *
+expr_from_ast(struct Parse *parser, struct ast_expr *expr);
+
+/** Convert `struct ast_expr_list` to `struct ExprList`. */
+struct ExprList *
+expr_list_from_ast(struct Parse *parser, struct ast_expr_list *list);

--- a/src/box/sql/ast.h
+++ b/src/box/sql/ast.h
@@ -26,6 +26,40 @@ struct ast_id_entry {
 	struct Token id;
 };
 
+/** List of sources received from parser. */
+struct ast_source_list {
+	/** Head of the list. */
+	struct stailq head;
+	/** Length of the list. */
+	uint32_t len;
+};
+
+/** Element of the sources list, describing one entry of a FROM clause. */
+struct ast_source {
+	/** Link to the next element of the list. */
+	struct stailq_entry link;
+	/** Name of the table. Not set for subqueries. */
+	struct Token name;
+	/** Alias of the source, if any. */
+	struct Token alias;
+	/** Name of the index specified via INDEXED BY, if any. */
+	struct Token indexed_by;
+	/** SELECT statement of a subquery. */
+	struct Select *select;
+	/** Expression of a join's ON clause. */
+	struct Expr *join_on;
+	/** Column names of a join's USING clause. */
+	struct ast_id_list *join_using;
+	/** Arguments of a table-valued function. */
+	struct ExprList *func_args;
+	/** Type of join between this source and the previous one. */
+	int join_type;
+	/** True if the source is a table-valued function. */
+	bool is_tab_func;
+	/** True if scanning is not allowed for this source. */
+	bool disallow_scan;
+};
+
 /** Append an ID to ID list. */
 struct ast_id_list *
 ast_id_list_append(struct Parse *parser, struct ast_id_list *list,
@@ -34,3 +68,24 @@ ast_id_list_append(struct Parse *parser, struct ast_id_list *list,
 /** Convert `struct ast_id_list` to `struct IdList`. */
 struct IdList *
 id_list_from_ast(struct ast_id_list *list);
+
+/** Allocate a new, zero-initialized source. */
+struct ast_source *
+ast_source_new(struct Parse *parser);
+
+/** Destroy the resources owned by the source. */
+void
+ast_source_destroy(struct ast_source *src);
+
+/** Append a source to the sources list, creating the list if needed. */
+struct ast_source_list *
+ast_source_list_append(struct Parse *parser, struct ast_source_list *list,
+		       struct ast_source *src);
+
+/** Destroy the resources owned by the sources in the list. */
+void
+ast_source_list_destroy(struct ast_source_list *list);
+
+/** Convert `struct ast_source_list` to `struct SrcList`. */
+struct SrcList *
+src_list_from_ast(struct ast_source_list *list);

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -3273,19 +3273,13 @@ sqlSrcListDelete(struct SrcList *pList)
 }
 
 struct SrcList *
-sqlSrcListAppendFromTerm(struct Parse *pParse, struct SrcList *p,
-			 struct Token *pTable, struct Token *pAlias,
-			 struct Select *pSubquery, struct Expr *pOn,
-			 struct ast_id_list *join_using, int disallow_scan)
+sqlSrcListAppendFromTerm(struct SrcList *p, struct Token *pTable,
+			 struct Token *pAlias, struct Select *pSubquery,
+			 struct Expr *pOn, struct ast_id_list *join_using,
+			 int disallow_scan)
 {
 	struct SrcList_item *pItem;
-	if (p == NULL && (pOn != NULL || join_using != NULL)) {
-		diag_set(ClientError, ER_SQL_SYNTAX_WITH_POS,
-			 pParse->line_count, pParse->line_pos, "a JOIN clause "\
-			 "is required before ON and USING");
-		pParse->is_aborted = true;
-		goto append_from_error;
-	}
+	assert((pOn == NULL && join_using == NULL) || p != NULL);
 	p = sql_src_list_append(p, pTable);
 	assert(p->nSrc != 0);
 	pItem = &p->a[p->nSrc - 1];
@@ -3298,12 +3292,6 @@ sqlSrcListAppendFromTerm(struct Parse *pParse, struct SrcList *p,
 	pItem->pUsing = id_list_from_ast(join_using);
 	pItem->fg.disallow_scan = disallow_scan;
 	return p;
-
- append_from_error:
-	assert(p == 0);
-	sql_expr_delete(pOn);
-	sql_select_delete(pSubquery);
-	return 0;
 }
 
 /*
@@ -3352,33 +3340,6 @@ sqlSrcListFuncArgs(struct SrcList *p, struct ExprList *pList)
 		pItem->fg.isTabFunc = 1;
 	} else {
 		sql_expr_list_delete(pList);
-	}
-}
-
-/*
- * When building up a FROM clause in the parser, the join operator
- * is initially attached to the left operand.  But the code generator
- * expects the join operator to be on the right operand.  This routine
- * Shifts all join operators from left to right for an entire FROM
- * clause.
- *
- * Example: Suppose the join is like this:
- *
- *           A natural cross join B
- *
- * The operator is "natural cross join".  The A and B operands are stored
- * in p->a[0] and p->a[1], respectively.  The parser initially stores the
- * operator with A.  This routine shifts that operator over to B.
- */
-void
-sqlSrcListShiftJoinType(SrcList * p)
-{
-	if (p) {
-		int i;
-		for (i = p->nSrc - 1; i > 0; i--) {
-			p->a[i].fg.jointype = p->a[i - 1].fg.jointype;
-		}
-		p->a[0].fg.jointype = 0;
 	}
 }
 

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -3276,10 +3276,10 @@ struct SrcList *
 sqlSrcListAppendFromTerm(struct Parse *pParse, struct SrcList *p,
 			 struct Token *pTable, struct Token *pAlias,
 			 struct Select *pSubquery, struct Expr *pOn,
-			 struct IdList *pUsing, int disallow_scan)
+			 struct ast_id_list *join_using, int disallow_scan)
 {
 	struct SrcList_item *pItem;
-	if (!p && (pOn || pUsing)) {
+	if (p == NULL && (pOn != NULL || join_using != NULL)) {
 		diag_set(ClientError, ER_SQL_SYNTAX_WITH_POS,
 			 pParse->line_count, pParse->line_pos, "a JOIN clause "\
 			 "is required before ON and USING");
@@ -3295,14 +3295,13 @@ sqlSrcListAppendFromTerm(struct Parse *pParse, struct SrcList *p,
 	}
 	pItem->pSelect = pSubquery;
 	pItem->pOn = pOn;
-	pItem->pUsing = pUsing;
+	pItem->pUsing = id_list_from_ast(join_using);
 	pItem->fg.disallow_scan = disallow_scan;
 	return p;
 
  append_from_error:
 	assert(p == 0);
 	sql_expr_delete(pOn);
-	sqlIdListDelete(pUsing);
 	sql_select_delete(pSubquery);
 	return 0;
 }

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -1768,32 +1768,14 @@ sql_expr_list_append(struct ExprList *expr_list, struct Expr *expr)
 	return expr_list;
 }
 
-/*
- * pColumns and pExpr form a vector assignment which is part of the SET
- * clause of an UPDATE statement.  Like this:
- *
- *        (a,b,c) = (expr1,expr2,expr3)
- * Or:    (a,b,c) = (SELECT x,y,z FROM ....)
- *
- * For each term of the vector assignment, append new entries to the
- * expression list pList.  In the case of a subquery on the LHS, append
- * TK_SELECT_COLUMN expressions.
- */
-ExprList *
-sqlExprListAppendVector(Parse * pParse,	/* Parsing context */
-			    ExprList * pList,	/* List to which to append. Might be NULL */
-			    IdList * pColumns,	/* List of names of LHS of the assignment */
-			    Expr * pExpr	/* Vector expression to be appended. Might be NULL */
-    )
+struct ExprList *
+sqlExprListAppendVector(struct Parse *pParse, struct ExprList *pList,
+			struct ast_id_list *columns, struct Expr *pExpr)
 {
 	int n;
 	int i;
 	int iFirst = pList ? pList->nExpr : 0;
-	/* pColumns can only be NULL due to an OOM but an OOM will cause an
-	 * exit prior to this routine being invoked
-	 */
-	if (NEVER(pColumns == 0))
-		goto vector_append_error;
+	struct IdList *pColumns = id_list_from_ast(columns);
 	if (pExpr == 0)
 		goto vector_append_error;
 

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -1272,49 +1272,6 @@ sqlExprAssignVarNumber(Parse * pParse, Expr * pExpr, u32 n)
 	}
 }
 
-struct Expr *
-expr_new_variable(struct Parse *parse, const struct Token *spec,
-		  const struct Token *id)
-{
-	assert(spec != NULL && spec->n == 1);
-	uint32_t len = 1;
-	if (parse->parse_only) {
-		diag_set(ClientError, ER_SQL_PARSER_GENERIC_WITH_POS,
-			 parse->line_count, parse->line_pos,
-			 "bindings are not allowed in DDL");
-		parse->is_aborted = true;
-		return NULL;
-	}
-	if (id != NULL) {
-		assert(spec->z[0] != '?');
-		if (id->z - spec->z != 1) {
-			diag_set(ClientError, ER_SQL_UNKNOWN_TOKEN,
-				 parse->line_count, spec->z - parse->zTail + 1,
-				 tt_cstr(spec->z, spec->n));
-			parse->is_aborted = true;
-			return NULL;
-		}
-		if (spec->z[0] == '#' && sqlIsdigit(id->z[0])) {
-			diag_set(ClientError, ER_SQL_SYNTAX_NEAR_TOKEN,
-				 parse->line_count, tt_cstr(spec->z, spec->n));
-			parse->is_aborted = true;
-			return NULL;
-		}
-		len += id->n;
-	}
-	struct Expr *expr = sql_expr_new_empty(TK_VARIABLE, len + 1);
-	expr->type = FIELD_TYPE_BOOLEAN;
-	expr->flags = EP_Leaf;
-	expr->u.zToken = (char *)(expr + 1);
-	expr->u.zToken[0] = spec->z[0];
-	if (id != NULL)
-		memcpy(expr->u.zToken + 1, id->z, id->n);
-	expr->u.zToken[len] = '\0';
-
-	sqlExprAssignVarNumber(parse, expr, len);
-	return expr;
-}
-
 /*
  * Recursively delete an expression tree.
  */
@@ -1871,14 +1828,13 @@ sqlExprListSetName(Parse * pParse,	/* Parsing context */
 }
 
 void
-sqlExprListSetSpan(struct ExprList *pList, struct ExprSpan *pSpan)
+sqlExprListSetSpan(struct ExprList *pList, const char *str, uint32_t len)
 {
 	assert(pList != NULL);
 	struct ExprList_item *pItem = &pList->a[pList->nExpr - 1];
 	assert(pList->nExpr > 0);
-	assert(pItem->pExpr == pSpan->pExpr);
 	sql_xfree(pItem->zSpan);
-	pItem->zSpan = sql_xstrndup(pSpan->zStart, pSpan->zEnd - pSpan->zStart);
+	pItem->zSpan = sql_xstrndup(str, len);
 }
 
 /*

--- a/src/box/sql/main.c
+++ b/src/box/sql/main.c
@@ -314,7 +314,6 @@ sql_init_db(sql **out_db)
 
 	assert(sizeof(db->aLimit) == sizeof(aHardLimit));
 	memcpy(db->aLimit, aHardLimit, sizeof(db->aLimit));
-	db->aLimit[SQL_LIMIT_COMPOUND_SELECT] = SQL_DEFAULT_COMPOUND_SELECT;
 	db->szMmap = sqlGlobalConfig.szMmap;
 	db->nMaxSorterMmap = 0x7FFFFFFF;
 

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -402,7 +402,7 @@ ifexists(A) ::= .            {A = 0;}
 ///////////////////// The CREATE VIEW statement /////////////////////////////
 //
 cmd ::= createkw(X) VIEW ifnotexists(E) nm(Y) eidlist_opt(C)
-          AS select(S). {
+          AS select_old(S). {
   if (!pParse->parse_only) {
     create_view_def_init(&pParse->create_view_def, &Y, &X, C, S, E);
     pParse->initiateTTrans = true;
@@ -416,7 +416,7 @@ cmd ::= createkw(X) VIEW ifnotexists(E) nm(Y) eidlist_opt(C)
 
 //////////////////////// The SELECT statement /////////////////////////////////
 //
-cmd ::= select(X).  {
+cmd ::= select_old(X).  {
   SelectDest dest = {SRT_Output, 0, 0, 0, 0, 0, 0};
   if(pParse->parse_only) {
     diag_set(ClientError, ER_SQL_PARSER_GENERIC,
@@ -428,128 +428,81 @@ cmd ::= select(X).  {
   sql_select_delete(X);
 }
 
-%type select {Select*}
-%destructor select {sql_select_delete($$);}
-%type selectnowith {Select*}
-%destructor selectnowith {sql_select_delete($$);}
-%type oneselect {Select*}
-%destructor oneselect {sql_select_delete($$);}
-
-%include {
-  /**
-   * For a compound SELECT statement, make sure
-   * p->pPrior->pNext==p for all elements in the list. And make
-   * sure list length does not exceed SQL_MAX_COMPOUND_SELECT.
-   */
-  static void parserDoubleLinkSelect(Parse *pParse, Select *p){
-    if( p->pPrior ){
-      Select *pNext = 0, *pLoop;
-      int mxSelect, cnt = 0;
-      for(pLoop=p; pLoop; pNext=pLoop, pLoop=pLoop->pPrior, cnt++){
-        pLoop->pNext = pNext;
-        pLoop->selFlags |= SF_Compound;
-      }
-      if((p->selFlags & SF_MultiValue) == 0 &&
-         (mxSelect = sql_get()->aLimit[SQL_LIMIT_COMPOUND_SELECT]) > 0 &&
-         cnt > mxSelect) {
-          diag_set(ClientError, ER_SQL_PARSER_LIMIT, "The number of UNION or "\
-                   "EXCEPT or INTERSECT operations", cnt,
-                   sql_get()->aLimit[SQL_LIMIT_COMPOUND_SELECT]);
-         pParse->is_aborted = true;
-      }
-    }
-  }
+/**
+ * A temporary rule that converts `struct ast_select` values to `struct Select`.
+ */
+%type select_old {Select*}
+%destructor select_old {sql_select_delete($$);}
+select_old(A) ::= select(X). {
+  A = select_from_ast(pParse, X);
 }
 
+%type select {struct ast_select *}
+%destructor select {ast_select_list_destroy($$);}
+%type selectnowith {struct ast_select *}
+%destructor selectnowith {ast_select_list_destroy($$);}
+%type oneselect {struct ast_select *}
+%destructor oneselect {ast_select_list_destroy($$);}
+
 select(A) ::= with(W) selectnowith(X). {
-  Select *p = X;
-  if( p ){
-    p->pWith = W;
-    parserDoubleLinkSelect(pParse, p);
-  }else{
-    sqlWithDelete(W);
-  }
-  A = p; /*A-overwrites-W*/
+  A = X;
+  A->with = W;
 }
 
 selectnowith(A) ::= oneselect(A).
 
-selectnowith(A) ::= selectnowith(A) multiselect_op(Y) oneselect(Z).  {
-  Select *pRhs = Z;
-  Select *pLhs = A;
-  if( pRhs && pRhs->pPrior ){
-    SrcList *pFrom;
-    Token x;
-    x.n = 0;
-    parserDoubleLinkSelect(pParse, pRhs);
-    pFrom = sqlSrcListAppendFromTerm(0, 0, &x, pRhs, 0, 0, false);
-    pRhs = sqlSelectNew(pParse,0,pFrom,0,0,0,0,0,0,0);
+selectnowith(A) ::= selectnowith(X) multiselect_op(Y) oneselect(Z).  {
+  A = Z;
+  if (!rlist_empty(&Z->link)) {
+    struct ast_source *new = ast_source_new(pParse);
+    new->select = Z;
+    A = ast_select_new(pParse);
+    A->sources = ast_source_list_append(pParse, NULL, new);
   }
-  if( pRhs ){
-    pRhs->op = (u8)Y;
-    pRhs->pPrior = pLhs;
-    if( ALWAYS(pLhs) ) pLhs->selFlags &= ~SF_MultiValue;
-    pRhs->selFlags &= ~SF_MultiValue;
-    if( Y!=TK_ALL ) pParse->hasCompound = 1;
-  }else{
-    sql_select_delete(pLhs);
-  }
-  A = pRhs;
+  A->op = Y;
+  A->flags |= SF_Compound;
+  A->flags &= ~SF_MultiValue;
+  X->flags |= SF_Compound;
+  X->flags &= ~SF_MultiValue;
+  rlist_add(&X->link, &A->link);
+  if(Y != TK_ALL)
+    pParse->hasCompound = 1;
 }
-%type multiselect_op {int}
+%type multiselect_op {uint8_t}
 multiselect_op(A) ::= UNION(OP).             {A = @OP; /*A-overwrites-OP*/}
 multiselect_op(A) ::= UNION ALL.             {A = TK_ALL;}
 multiselect_op(A) ::= EXCEPT|INTERSECT(OP).  {A = @OP; /*A-overwrites-OP*/}
 
-oneselect(A) ::= SELECT(S) distinct(D) selcollist(W) from(X) where_opt(Y)
+oneselect(A) ::= SELECT distinct(D) selcollist(W) from(X) where_opt(Y)
                  groupby_opt(P) having_opt(Q) orderby_opt(Z) limit_opt(L). {
-#ifdef SQL_DEBUG
-  Token s = S; /*A-overwrites-S*/
-#endif
-  A = sqlSelectNew(pParse,W,X,Y,P,Q,Z,D,L.pLimit,L.pOffset);
-#ifdef SQL_DEBUG
-  /* Populate the Select.zSelName[] string that is used to help with
-  ** query planner debugging, to differentiate between multiple Select
-  ** objects in a complex query.
-  **
-  ** If the SELECT keyword is immediately followed by a C-style comment
-  ** then extract the first few alphanumeric characters from within that
-  ** comment to be the zSelName value.  Otherwise, the label is #N where
-  ** is an integer that is incremented with each SELECT statement seen.
-  */
-  if( A!=0 ){
-    const char *z = s.z+6;
-    int i;
-    sql_snprintf(sizeof(A->zSelName), A->zSelName, "#%d",
-                     ++pParse->nSelect);
-    while( z[0]==' ' ) z++;
-    if( z[0]=='/' && z[1]=='*' ){
-      z += 2;
-      while( z[0]==' ' ) z++;
-      for(i=0; sqlIsalnum(z[i]); i++){}
-      sql_snprintf(sizeof(A->zSelName), A->zSelName, "%.*s", i, z);
-    }
-  }
-#endif /* SQL_DEBUG */
+  A = ast_select_new(pParse);
+  A->columns = W;
+  A->sources = X;
+  A->where = Y;
+  A->group_by = P;
+  A->having = Q;
+  A->order_by = Z;
+  A->flags = D;
+  A->limit = L.pLimit;
+  A->offset = L.pOffset;
 }
 oneselect(A) ::= values(A).
 
-%type values {Select*}
-%destructor values {sql_select_delete($$);}
+%type values {struct ast_select *}
+%destructor values {ast_select_list_destroy($$);}
 values(A) ::= VALUES LP nexprlist(X) RP. {
-  A = sqlSelectNew(pParse,X,0,0,0,0,0,SF_Values,0,0);
+  A = ast_select_new(pParse);
+  A->columns = X;
+  A->flags = SF_Values;
 }
-values(A) ::= values(A) COMMA LP exprlist(Y) RP. {
-  Select *pRight, *pLeft = A;
-  pRight = sqlSelectNew(pParse,Y,0,0,0,0,0,SF_Values|SF_MultiValue,0,0);
-  if( ALWAYS(pLeft) ) pLeft->selFlags &= ~SF_MultiValue;
-  if( pRight ){
-    pRight->op = TK_ALL;
-    pRight->pPrior = pLeft;
-    A = pRight;
-  }else{
-    A = pLeft;
-  }
+values(A) ::= values(X) COMMA LP exprlist(Y) RP. {
+  X->flags |= SF_Compound;
+  X->flags &= ~SF_MultiValue;
+  A = ast_select_new(pParse);
+  A->columns = Y;
+  A->flags = SF_Values|SF_MultiValue|SF_Compound;
+  A->op = TK_ALL;
+  rlist_add(&X->link, &A->link);
 }
 
 // The "distinct" nonterminal is true (1) if the DISTINCT keyword is
@@ -598,12 +551,13 @@ as(X) ::= .            {X.n = 0; X.z = 0;}
 seqscan(X) ::= SEQSCAN.     {X = 0;}
 seqscan(X) ::= .            {X = 1;}
 
-%type from {SrcList*}
-%destructor from {sqlSrcListDelete($$);}
-
-from(A) ::= .                {A = sql_xmalloc0(sizeof(*A));}
+%type from {struct ast_source_list *}
+%destructor from {ast_source_list_destroy($$);}
+from(A) ::= . {
+  A = NULL;
+}
 from(A) ::= FROM source_list(X). {
-  A = src_list_from_ast(X);
+  A = X;
 }
 
 %type source_list {struct ast_source_list *}
@@ -623,14 +577,13 @@ source_list(A) ::= LP source_list(F) RP as(Z). {
     new->select = old->select;
     A = ast_source_list_append(pParse, NULL, new);
   } else {
-    struct SrcList *list = src_list_from_ast(F);
-    if (list != NULL) {
-      Select *pSubquery = sqlSelectNew(pParse,0,list,0,0,0,0,SF_NestedFrom,0,0);
-      struct ast_source *src = ast_source_new(pParse);
-      src->alias = Z;
-      src->select = pSubquery;
-      A = ast_source_list_append(pParse, NULL, src);
-    }
+    struct ast_select *subquery = ast_select_new(pParse);
+    subquery->sources = F;
+    subquery->flags = SF_NestedFrom;
+    struct ast_source *src = ast_source_new(pParse);
+    src->alias = Z;
+    src->select = subquery;
+    A = ast_source_list_append(pParse, NULL, src);
   }
 }
 source_list(A) ::= source_list(A) joinop(Y) source(X) on_opt(N) using_opt(U). {
@@ -653,17 +606,16 @@ source_list(A) ::= source_list(X) joinop(Y) LP source_list(F) RP as(Z) on_opt(N)
     new->join_using = U;
     A = ast_source_list_append(pParse, X, new);
   } else {
-    struct SrcList *list = src_list_from_ast(F);
-    if (list != NULL) {
-      Select *pSubquery = sqlSelectNew(pParse,0,list,0,0,0,0,SF_NestedFrom,0,0);
-      struct ast_source *src = ast_source_new(pParse);
-      src->alias = Z;
-      src->select = pSubquery;
-      src->join_type = Y;
-      src->join_on = N;
-      src->join_using = U;
-      A = ast_source_list_append(pParse, X, src);
-    }
+    struct ast_select *subquery = ast_select_new(pParse);
+    subquery->sources = F;
+    subquery->flags = SF_NestedFrom;
+    struct ast_source *src = ast_source_new(pParse);
+    src->alias = Z;
+    src->select = subquery;
+    src->join_type = Y;
+    src->join_on = N;
+    src->join_using = U;
+    A = ast_source_list_append(pParse, X, src);
   }
 }
 
@@ -883,7 +835,7 @@ setlist(A) ::= LP idlist(X) RP EQ expr(Y). {
 
 ////////////////////////// The INSERT command /////////////////////////////////
 //
-cmd ::= with(W) insert_cmd(R) INTO fullname(X) idlist_opt(F) select(S). {
+cmd ::= with(W) insert_cmd(R) INTO fullname(X) idlist_opt(F) select_old(S). {
   sqlWithPush(pParse, W, 1);
   sqlSubProgramsRemaining = SQL_MAX_COMPILING_TRIGGERS;
   /* Instruct SQL to initate Tarantool's transaction.  */
@@ -1353,12 +1305,12 @@ expr(A) ::= expr(A) in_op(N) LP exprlist(Y) RP(E). [IN] {
   }
   A.zEnd = &E.z[E.n];
 }
-expr(A) ::= LP(B) select(X) RP(E). {
+expr(A) ::= LP(B) select_old(X) RP(E). {
   spanSet(&A,&B,&E); /*A-overwrites-B*/
   A.pExpr = sqlPExpr(pParse, TK_SELECT, 0, 0);
   sqlPExprAddSelect(pParse, A.pExpr, X);
 }
-expr(A) ::= expr(A) in_op(N) LP select(Y) RP(E).  [IN] {
+expr(A) ::= expr(A) in_op(N) LP select_old(Y) RP(E).  [IN] {
   A.pExpr = sqlPExpr(pParse, TK_IN, A.pExpr, 0);
   sqlPExprAddSelect(pParse, A.pExpr, Y);
   exprNot(pParse, N, &A);
@@ -1374,7 +1326,7 @@ expr(A) ::= expr(A) in_op(N) nm(Y) paren_exprlist(E). [IN] {
   exprNot(pParse, N, &A);
   A.zEnd = &Y.z[Y.n];
 }
-expr(A) ::= EXISTS(B) LP select(Y) RP(E). {
+expr(A) ::= EXISTS(B) LP select_old(Y) RP(E). {
   Expr *p;
   spanSet(&A,&B,&E); /*A-overwrites-B*/
   p = A.pExpr = sqlPExpr(pParse, TK_EXISTS, 0, 0);
@@ -1630,7 +1582,7 @@ trigger_cmd(A) ::=
    }
 
 // INSERT
-trigger_cmd(A) ::= insert_cmd(R) INTO trnm(X) idlist_opt(F) select(S). {
+trigger_cmd(A) ::= insert_cmd(R) INTO trnm(X) idlist_opt(F) select_old(S). {
   /*A-overwrites-R. */
   A = sql_trigger_insert_step(&X, F, S, R);
 }
@@ -1641,7 +1593,7 @@ trigger_cmd(A) ::= DELETE FROM trnm(X) tridxby where_opt(Y). {
 }
 
 // SELECT
-trigger_cmd(A) ::= select(X). {
+trigger_cmd(A) ::= select_old(X). {
   /* A-overwrites-X. */
   A = sql_trigger_select_step(X);
 }
@@ -1789,10 +1741,10 @@ with(A) ::= . {A = 0;}
 with(A) ::= WITH wqlist(W).              { A = W; }
 with(A) ::= WITH RECURSIVE wqlist(W).    { A = W; }
 
-wqlist(A) ::= nm(X) eidlist_opt(Y) AS LP select(Z) RP. {
+wqlist(A) ::= nm(X) eidlist_opt(Y) AS LP select_old(Z) RP. {
   A = sqlWithAdd(pParse, 0, &X, Y, Z); /*A-overwrites-X*/
 }
-wqlist(A) ::= wqlist(A) COMMA nm(X) eidlist_opt(Y) AS LP select(Z) RP. {
+wqlist(A) ::= wqlist(A) COMMA nm(X) eidlist_opt(Y) AS LP select_old(Z) RP. {
   A = sqlWithAdd(pParse, A, &X, Y, Z);
 }
 

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -783,7 +783,7 @@ limit_opt(A) ::= LIMIT expr(X) COMMA expr(Y).
 
 /////////////////////////// The DELETE statement /////////////////////////////
 //
-cmd ::= with(C) DELETE FROM fullname(X) indexed_opt(I) where_opt(W). {
+cmd ::= with_old(C) DELETE FROM fullname(X) indexed_opt(I) where_opt(W). {
   sqlWithPush(pParse, C, 1);
   sqlSrcListIndexedBy(X, &I);
   sqlSubProgramsRemaining = SQL_MAX_COMPILING_TRIGGERS;
@@ -807,7 +807,7 @@ where_opt(A) ::= WHERE expr(X).       {A = X.pExpr;}
 
 ////////////////////////// The UPDATE command ////////////////////////////////
 //
-cmd ::= with(C) UPDATE orconf(R) fullname(X) indexed_opt(I) SET setlist(Y)
+cmd ::= with_old(C) UPDATE orconf(R) fullname(X) indexed_opt(I) SET setlist(Y)
         where_opt(W).  {
   sqlWithPush(pParse, C, 1);
   sqlSrcListIndexedBy(X, &I);
@@ -842,14 +842,15 @@ setlist(A) ::= LP idlist(X) RP EQ expr(Y). {
 
 ////////////////////////// The INSERT command /////////////////////////////////
 //
-cmd ::= with(W) insert_cmd(R) INTO fullname(X) idlist_opt(F) select_old(S). {
+cmd ::= with_old(W) insert_cmd(R) INTO fullname(X) idlist_opt(F)
+        select_old(S). {
   sqlWithPush(pParse, W, 1);
   sqlSubProgramsRemaining = SQL_MAX_COMPILING_TRIGGERS;
   /* Instruct SQL to initate Tarantool's transaction.  */
   pParse->initiateTTrans = true;
   sqlInsert(pParse, X, S, id_list_from_ast(F), R);
 }
-cmd ::= with(W) insert_cmd(R) INTO fullname(X) idlist_opt(F) DEFAULT VALUES.
+cmd ::= with_old(W) insert_cmd(R) INTO fullname(X) idlist_opt(F) DEFAULT VALUES.
 {
   sqlWithPush(pParse, W, 1);
   sqlSubProgramsRemaining = SQL_MAX_COMPILING_TRIGGERS;
@@ -1739,20 +1740,25 @@ cmd ::= ALTER TABLE nm(X) DROP CONSTRAINT nm(F) DOT nm(Z) CHECK. {
 }
 
 //////////////////////// COMMON TABLE EXPRESSIONS ////////////////////////////
-%type with {With*}
-%type wqlist {With*}
-%destructor with {sqlWithDelete($$);}
-%destructor wqlist {sqlWithDelete($$);}
+%type with_old {With*}
+%destructor with_old {sqlWithDelete($$);}
+with_old(A) ::= with(X). {
+  A = with_from_ast(pParse, X);
+}
 
+%type with {struct ast_with_list *}
+%destructor with {ast_with_destroy($$);}
 with(A) ::= . {A = 0;}
 with(A) ::= WITH wqlist(W).              { A = W; }
 with(A) ::= WITH RECURSIVE wqlist(W).    { A = W; }
 
-wqlist(A) ::= nm(X) eidlist_opt(Y) AS LP select_old(Z) RP. {
-  A = sqlWithAdd(pParse, 0, &X, Y, Z); /*A-overwrites-X*/
+%type wqlist {struct ast_with_list *}
+%destructor wqlist {ast_with_destroy($$);}
+wqlist(A) ::= nm(X) idlist_opt(Y) AS LP select(Z) RP. {
+  A = ast_with_list_append(pParse, NULL, &X, Y, Z);
 }
-wqlist(A) ::= wqlist(A) COMMA nm(X) eidlist_opt(Y) AS LP select_old(Z) RP. {
-  A = sqlWithAdd(pParse, A, &X, Y, Z);
+wqlist(A) ::= wqlist(A) COMMA nm(X) idlist_opt(Y) AS LP select(Z) RP. {
+  A = ast_with_list_append(pParse, A, &X, Y, Z);
 }
 
 ////////////////////////////// TYPE DECLARATION ///////////////////////////////

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -92,9 +92,12 @@ struct LimitVal {
 **
 **      UPDATE ON (a,b,c)
 **
-** Then the "b" IdList records the list "a,b,c".
+** Then the "b" records the list "a,b,c".
 */
-struct TrigEvent { int a; IdList * b; };
+struct TrigEvent {
+  int a;
+  struct ast_id_list *b;
+};
 
 /*
 ** Disable lookaside memory allocation for objects that might be
@@ -693,11 +696,9 @@ indexed_opt(A) ::= .                 {A.z=0; A.n=0;}
 indexed_opt(A) ::= INDEXED BY nm(X). {A = X;}
 indexed_opt(A) ::= NOT INDEXED.      {A.z=0; A.n=1;}
 
-%type using_opt {IdList*}
-%destructor using_opt {sqlIdListDelete($$);}
+%type using_opt {struct ast_id_list *}
 using_opt(U) ::= USING LP idlist(L) RP.  {U = L;}
 using_opt(U) ::= .                        {U = 0;}
-
 
 %type orderby_opt {ExprList*}
 %destructor orderby_opt {sql_expr_list_delete($$);}
@@ -854,7 +855,7 @@ cmd ::= with(W) insert_cmd(R) INTO fullname(X) idlist_opt(F) select(S). {
   sqlSubProgramsRemaining = SQL_MAX_COMPILING_TRIGGERS;
   /* Instruct SQL to initate Tarantool's transaction.  */
   pParse->initiateTTrans = true;
-  sqlInsert(pParse, X, S, F, R);
+  sqlInsert(pParse, X, S, id_list_from_ast(F), R);
 }
 cmd ::= with(W) insert_cmd(R) INTO fullname(X) idlist_opt(F) DEFAULT VALUES.
 {
@@ -862,26 +863,23 @@ cmd ::= with(W) insert_cmd(R) INTO fullname(X) idlist_opt(F) DEFAULT VALUES.
   sqlSubProgramsRemaining = SQL_MAX_COMPILING_TRIGGERS;
   /* Instruct SQL to initate Tarantool's transaction.  */
   pParse->initiateTTrans = true;
-  sqlInsert(pParse, X, 0, F, R);
+  sqlInsert(pParse, X, 0, id_list_from_ast(F), R);
 }
 
 %type insert_cmd {int}
 insert_cmd(A) ::= INSERT orconf(R).   {A = R;}
 insert_cmd(A) ::= REPLACE.            {A = ON_CONFLICT_ACTION_REPLACE;}
 
-%type idlist_opt {IdList*}
-%destructor idlist_opt {sqlIdListDelete($$);}
-%type idlist {IdList*}
-%destructor idlist {sqlIdListDelete($$);}
+%type idlist_opt {struct ast_id_list *}
+%type idlist {struct ast_id_list *}
 
 idlist_opt(A) ::= .                       {A = 0;}
 idlist_opt(A) ::= LP idlist(X) RP.    {A = X;}
 idlist(A) ::= idlist(A) COMMA nm(Y). {
-  A = sql_id_list_append(A, &Y);
+  A = ast_id_list_append(pParse, A, &Y);
 }
 idlist(A) ::= nm(Y). {
-  /* A-overwrites-Y. */
-  A = sql_id_list_append(NULL, &Y);
+  A = ast_id_list_append(pParse, NULL, &Y);
 }
 
 /////////////////////////// Expression Processing /////////////////////////////
@@ -1510,8 +1508,8 @@ cmd ::= createkw trigger_decl(A) BEGIN trigger_cmd_list(S) END(Z). {
 trigger_decl(A) ::= TRIGGER ifnotexists(NOERR) nm(B)
                     trigger_time(C) trigger_event(D)
                     ON fullname(E) foreach_clause when_clause(G). {
-  create_trigger_def_init(&pParse->create_trigger_def, E, &B, C, D.a, D.b, G,
-                          NOERR);
+  create_trigger_def_init(&pParse->create_trigger_def, E, &B, C, D.a,
+                          id_list_from_ast(D.b), G, NOERR);
   sql_trigger_begin(pParse);
   A = B; /*A-overwrites-T*/
 }
@@ -1523,7 +1521,6 @@ trigger_time(A) ::= INSTEAD OF.  { A = TK_INSTEAD;}
 trigger_time(A) ::= .            { A = TK_BEFORE; }
 
 %type trigger_event {struct TrigEvent}
-%destructor trigger_event {sqlIdListDelete($$.b);}
 trigger_event(A) ::= DELETE|INSERT(X).   {A.a = @X; /*A-overwrites-X*/ A.b = 0;}
 trigger_event(A) ::= UPDATE(X).          {A.a = @X; /*A-overwrites-X*/ A.b = 0;}
 trigger_event(A) ::= UPDATE OF idlist(X).{A.a = TK_UPDATE; A.b = X;}

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -81,8 +81,10 @@
 ** LIMIT clause of a SELECT statement.
 */
 struct LimitVal {
-  Expr *pLimit;    /* The LIMIT expression.  NULL if there is no limit */
-  Expr *pOffset;   /* The OFFSET expression.  NULL if there is none */
+  /** The LIMIT expression. NULL if there is no limit. */
+  struct ast_expr *limit;
+  /** The OFFSET expression. NULL if there is no offset. */
+  struct ast_expr *offset;
 };
 
 /*
@@ -303,7 +305,12 @@ cconsname(N) ::= . { N = Token_nil; }
  * tokens go to the next ccons instead.
  */
 ccons ::= DEFAULT expr(X). [COLLATE] {
-  sql_column_add_default(pParse, &X);
+  struct ExprSpan res;
+  struct Expr *e = expr_from_ast(pParse, X);
+  res.pExpr = e;
+  res.zStart = X->str;
+  res.zEnd = &X->str[X->len];
+  sql_column_add_default(pParse, &res);
 }
 
 // In addition to the type name, we also care about the primary key and
@@ -325,7 +332,7 @@ ccons ::= cconsname(N) UNIQUE. {
   sql_create_index(pParse);
 }
 
-ccons ::= cconsname(N) CHECK LP expr(X) RP. {
+ccons ::= cconsname(N) CHECK LP expr_old(X) RP. {
   create_ck_def_init(&pParse->create_ck_def, NULL, &N, &X);
   sql_create_check_contraint(pParse, true);
 }
@@ -347,13 +354,13 @@ tcons ::= cconsname(N) PRIMARY KEY LP col_list_with_autoinc(X) RP. {
                         SQL_INDEX_TYPE_CONSTRAINT_PK, SORT_ORDER_ASC, false);
   sqlAddPrimaryKey(pParse);
 }
-tcons ::= cconsname(N) UNIQUE LP sortlist(X) RP. {
+tcons ::= cconsname(N) UNIQUE LP sortlist_old(X) RP. {
   create_index_def_init(&pParse->create_index_def, NULL, &N, X,
                         SQL_INDEX_TYPE_CONSTRAINT_UNIQUE, SORT_ORDER_ASC,
                         false);
   sql_create_index(pParse);
 }
-tcons ::= cconsname(N) CHECK LP expr(X) RP. {
+tcons ::= cconsname(N) CHECK LP expr_old(X) RP. {
   create_ck_def_init(&pParse->create_ck_def, NULL, &N, &X);
   sql_create_check_contraint(pParse, false);
 }
@@ -369,7 +376,7 @@ tcons ::= cconsname(N) FOREIGN KEY LP eidlist(FA) RP
 %type onconf {int}
 %type index_onconf {int}
 %type orconf {int}
-%type resolvetype {int}
+%type resolvetype {enum on_conflict_action}
 onconf(A) ::= .                              {A = ON_CONFLICT_ACTION_ABORT;}
 onconf(A) ::= ON CONFLICT resolvetype(X).    {A = X;}
 orconf(A) ::= .                              {A = ON_CONFLICT_ACTION_DEFAULT;}
@@ -438,11 +445,8 @@ select_old(A) ::= select(X). {
 }
 
 %type select {struct ast_select *}
-%destructor select {ast_select_list_destroy($$);}
 %type selectnowith {struct ast_select *}
-%destructor selectnowith {ast_select_list_destroy($$);}
 %type oneselect {struct ast_select *}
-%destructor oneselect {ast_select_list_destroy($$);}
 
 select(A) ::= with(W) selectnowith(X). {
   A = X;
@@ -483,13 +487,12 @@ oneselect(A) ::= SELECT distinct(D) select_list(W) from(X) where_opt(Y)
   A->having = Q;
   A->order_by = Z;
   A->flags = D;
-  A->limit = L.pLimit;
-  A->offset = L.pOffset;
+  A->limit = L.limit;
+  A->offset = L.offset;
 }
 oneselect(A) ::= values(A).
 
 %type values {struct ast_select *}
-%destructor values {ast_select_list_destroy($$);}
 values(A) ::= VALUES LP nexprlist(X) RP. {
   A = ast_select_new(pParse);
   A->columns = X;
@@ -513,37 +516,37 @@ distinct(A) ::= DISTINCT.   {A = SF_Distinct;}
 distinct(A) ::= ALL.        {A = SF_All;}
 distinct(A) ::= .           {A = 0;}
 
-%type select_list {struct ExprList *}
-%destructor select_list {sql_expr_list_delete($$);}
+%type select_list {struct ast_expr_list *}
 select_list(A) ::= expr(X) as(Y). {
-  A = sql_expr_list_append(NULL, X.pExpr);
-  if(Y.n > 0)
-    sqlExprListSetName(pParse, A, &Y, 1);
-  sqlExprListSetSpan(A, &X);
+  A = ast_expr_list_append(pParse, NULL, X);
+  ast_expr_list_set_name(A, &Y);
+  A->is_select_list = true;
 }
-select_list(A) ::= STAR. {
-  A = sql_expr_list_append(NULL, sql_expr_new_anon(TK_ASTERISK));
+select_list(A) ::= STAR(X). {
+  struct ast_expr *expr = ast_expr_new(pParse, X.z, X.n, TK_ASTERISK);
+  A = ast_expr_list_append(pParse, NULL, expr);
+  A->is_select_list = true;
 }
-select_list(A) ::= nm(X) DOT STAR. {
-  struct Expr *pLeft = sql_expr_new_dequoted(TK_ID, &X);
-  Expr *pRight = sql_expr_new_anon(TK_ASTERISK);
-  Expr *pDot = sqlPExpr(pParse, TK_DOT, pLeft, pRight);
-  A = sql_expr_list_append(NULL, pDot);
+select_list(A) ::= nm(X) DOT STAR(Y). {
+  struct ast_expr *dot = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_DOT);
+  dot->left = ast_expr_new(pParse, X.z, X.n, TK_ID);
+  dot->right = ast_expr_new(pParse, Y.z, Y.n, TK_ASTERISK);
+  A = ast_expr_list_append(pParse, NULL, dot);
+  A->is_select_list = true;
 }
 select_list(A) ::= select_list(A) COMMA expr(X) as(Y). {
-  A = sql_expr_list_append(A, X.pExpr);
-  if(Y.n > 0)
-    sqlExprListSetName(pParse, A, &Y, 1);
-  sqlExprListSetSpan(A, &X);
+  A = ast_expr_list_append(pParse, A, X);
+  ast_expr_list_set_name(A, &Y);
 }
-select_list(A) ::= select_list(A) COMMA STAR. {
-  A = sql_expr_list_append(A, sql_expr_new_anon(TK_ASTERISK));
+select_list(A) ::= select_list(A) COMMA STAR(X). {
+  struct ast_expr *expr = ast_expr_new(pParse, X.z, X.n, TK_ASTERISK);
+  A = ast_expr_list_append(pParse, A, expr);
 }
-select_list(A) ::= select_list(A) COMMA nm(X) DOT STAR. {
-  struct Expr *pLeft = sql_expr_new_dequoted(TK_ID, &X);
-  Expr *pRight = sql_expr_new_anon(TK_ASTERISK);
-  Expr *pDot = sqlPExpr(pParse, TK_DOT, pLeft, pRight);
-  A = sql_expr_list_append(A, pDot);
+select_list(A) ::= select_list(A) COMMA nm(X) DOT STAR(Y). {
+  struct ast_expr *dot = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_DOT);
+  dot->left = ast_expr_new(pParse, X.z, X.n, TK_ID);
+  dot->right = ast_expr_new(pParse, Y.z, Y.n, TK_ASTERISK);
+  A = ast_expr_list_append(pParse, A, dot);
 }
 
 // An option "AS <id>" phrase that can follow one of the expressions that
@@ -559,7 +562,6 @@ seqscan(X) ::= SEQSCAN.     {X = 0;}
 seqscan(X) ::= .            {X = 1;}
 
 %type from {struct ast_source_list *}
-%destructor from {ast_source_list_destroy($$);}
 from(A) ::= . {
   A = NULL;
 }
@@ -568,7 +570,6 @@ from(A) ::= FROM source_list(X). {
 }
 
 %type source_list {struct ast_source_list *}
-%destructor source_list {ast_source_list_destroy($$);}
 source_list(A) ::= source(X). {
   A = ast_source_list_append(pParse, NULL, X);
 }
@@ -627,7 +628,6 @@ source_list(A) ::= source_list(X) joinop(Y) LP source_list(F) RP as(Z) on_opt(N)
 }
 
 %type source {struct ast_source *}
-%destructor source {ast_source_destroy($$);}
 source(A) ::= seqscan(X) nm(Y) as(Z) indexed_opt(I). {
   A = ast_source_new(pParse);
   A->name = Y;
@@ -668,9 +668,10 @@ joinop(X) ::= JOIN_KW(A) join_nm(B) JOIN.
 joinop(X) ::= JOIN_KW(A) join_nm(B) join_nm(C) JOIN.
                   {X = sqlJoinType(pParse,&A,&B,&C);/*X-overwrites-A*/}
 
-%type on_opt {Expr*}
-%destructor on_opt {sql_expr_delete($$);}
-on_opt(N) ::= ON expr(E).   {N = E.pExpr;}
+%type on_opt {struct ast_expr *}
+on_opt(N) ::= ON expr(E). {
+  N = E;
+}
 on_opt(N) ::= .             {N = 0;}
 
 // Note that this block abuses the Token type just a little. If there is
@@ -692,23 +693,33 @@ indexed_opt(A) ::= NOT INDEXED.      {A.z=0; A.n=1;}
 using_opt(U) ::= USING LP idlist(L) RP.  {U = L;}
 using_opt(U) ::= .                        {U = 0;}
 
-%type orderby_opt {ExprList*}
-%destructor orderby_opt {sql_expr_list_delete($$);}
+%type orderby_opt {struct ast_expr_list *}
 
 // the sortlist non-terminal stores a list of expression where each
 // expression is optionally followed by ASC or DESC to indicate the
 // sort order.
 //
-%type sortlist {ExprList*}
-%destructor sortlist {sql_expr_list_delete($$);}
+%type sortlist_old {ExprList*}
+%destructor sortlist_old {sql_expr_list_delete($$);}
 
 orderby_opt(A) ::= .                          {A = 0;}
 orderby_opt(A) ::= ORDER BY sortlist(X).      {A = X;}
+
+%type sortlist {struct ast_expr_list *}
 sortlist(A) ::= sortlist(A) COMMA expr(Y) sortorder(Z). {
+  A = ast_expr_list_append(pParse, A, Y);
+  ast_expr_list_set_order(A, Z);
+}
+sortlist(A) ::= expr(Y) sortorder(Z). {
+  A = ast_expr_list_append(pParse, NULL, Y);
+  ast_expr_list_set_order(A, Z);
+}
+
+sortlist_old(A) ::= sortlist_old(A) COMMA expr_old(Y) sortorder(Z). {
   A = sql_expr_list_append(A, Y.pExpr);
   sqlExprListSetSortOrder(A,Z);
 }
-sortlist(A) ::= expr(Y) sortorder(Z). {
+sortlist_old(A) ::= expr_old(Y) sortorder(Z). {
   /* A-overwrites-Y. */
   A = sql_expr_list_append(NULL, Y.pExpr);
   sqlExprListSetSortOrder(A,Z);
@@ -721,7 +732,7 @@ sortlist(A) ::= expr(Y) sortorder(Z). {
 %type col_list_with_autoinc {ExprList*}
 %destructor col_list_with_autoinc {sql_expr_list_delete($$);}
 
-col_list_with_autoinc(A) ::= col_list_with_autoinc(A) COMMA expr(Y)
+col_list_with_autoinc(A) ::= col_list_with_autoinc(A) COMMA expr_old(Y)
                              autoinc(I). {
   uint32_t fieldno;
   if (I == 1) {
@@ -733,7 +744,7 @@ col_list_with_autoinc(A) ::= col_list_with_autoinc(A) COMMA expr(Y)
   A = sql_expr_list_append(A, Y.pExpr);
 }
 
-col_list_with_autoinc(A) ::= expr(Y) autoinc(I). {
+col_list_with_autoinc(A) ::= expr_old(Y) autoinc(I). {
   if (I == 1) {
     uint32_t fieldno = 0;
     if (sql_fieldno_by_name(pParse, Y.pExpr, &fieldno) != 0)
@@ -751,39 +762,38 @@ sortorder(A) ::= ASC.           {A = SORT_ORDER_ASC;}
 sortorder(A) ::= DESC.          {A = SORT_ORDER_DESC;}
 sortorder(A) ::= .              {A = SORT_ORDER_UNDEF;}
 
-%type groupby_opt {ExprList*}
-%destructor groupby_opt {sql_expr_list_delete($$);}
+%type groupby_opt {struct ast_expr_list *}
 groupby_opt(A) ::= .                      {A = 0;}
 groupby_opt(A) ::= GROUP BY nexprlist(X). {A = X;}
 
-%type having_opt {Expr*}
-%destructor having_opt {sql_expr_delete($$);}
+%type having_opt {struct ast_expr *}
 having_opt(A) ::= .                {A = 0;}
-having_opt(A) ::= HAVING expr(X).  {A = X.pExpr;}
+having_opt(A) ::= HAVING expr(X). {
+  A = X;
+}
 
 %type limit_opt {struct LimitVal}
 
-// The destructor for limit_opt will never fire in the current grammar.
-// The limit_opt non-terminal only occurs at the end of a single production
-// rule for SELECT statements.  As soon as the rule that create the 
-// limit_opt non-terminal reduces, the SELECT statement rule will also
-// reduce.  So there is never a limit_opt non-terminal on the stack 
-// except as a transient.  So there is never anything to destroy.
-//
-//%destructor limit_opt {
-//  sqlExprDelete($$.pLimit);
-//  sqlExprDelete($$.pOffset);
-//}
-limit_opt(A) ::= .                    {A.pLimit = 0; A.pOffset = 0;}
-limit_opt(A) ::= LIMIT expr(X).       {A.pLimit = X.pExpr; A.pOffset = 0;}
-limit_opt(A) ::= LIMIT expr(X) OFFSET expr(Y). 
-                                      {A.pLimit = X.pExpr; A.pOffset = Y.pExpr;}
-limit_opt(A) ::= LIMIT expr(X) COMMA expr(Y). 
-                                      {A.pOffset = X.pExpr; A.pLimit = Y.pExpr;}
+limit_opt(A) ::= . {
+  A.limit = NULL;
+  A.offset = NULL;
+}
+limit_opt(A) ::= LIMIT expr(X). {
+  A.limit = X;
+  A.offset = NULL;
+}
+limit_opt(A) ::= LIMIT expr(X) OFFSET expr(Y). {
+  A.limit = X;
+  A.offset = Y;
+}
+limit_opt(A) ::= LIMIT expr(X) COMMA expr(Y). {
+  A.offset = X;
+  A.limit = Y;
+}
 
 /////////////////////////// The DELETE statement /////////////////////////////
 //
-cmd ::= with_old(C) DELETE FROM fullname(X) indexed_opt(I) where_opt(W). {
+cmd ::= with_old(C) DELETE FROM fullname(X) indexed_opt(I) where_opt_old(W). {
   sqlWithPush(pParse, C, 1);
   sqlSrcListIndexedBy(X, &I);
   sqlSubProgramsRemaining = SQL_MAX_COMPILING_TRIGGERS;
@@ -799,16 +809,22 @@ cmd ::= TRUNCATE TABLE fullname(X). {
   sql_table_truncate(pParse, X);
 }
 
-%type where_opt {Expr*}
-%destructor where_opt {sql_expr_delete($$);}
+%type where_opt_old {Expr*}
+%destructor where_opt_old {sql_expr_delete($$);}
+where_opt_old(A) ::= where_opt(X). {
+  A = expr_from_ast(pParse, X);
+}
 
+%type where_opt {struct ast_expr *}
 where_opt(A) ::= .                    {A = 0;}
-where_opt(A) ::= WHERE expr(X).       {A = X.pExpr;}
+where_opt(A) ::= WHERE expr(X). {
+  A = X;
+}
 
 ////////////////////////// The UPDATE command ////////////////////////////////
 //
 cmd ::= with_old(C) UPDATE orconf(R) fullname(X) indexed_opt(I) SET setlist(Y)
-        where_opt(W).  {
+        where_opt_old(W).  {
   sqlWithPush(pParse, C, 1);
   sqlSrcListIndexedBy(X, &I);
   if (Y != NULL && Y->nExpr > SQL_MAX_COLUMN) {
@@ -825,18 +841,18 @@ cmd ::= with_old(C) UPDATE orconf(R) fullname(X) indexed_opt(I) SET setlist(Y)
 %type setlist {ExprList*}
 %destructor setlist {sql_expr_list_delete($$);}
 
-setlist(A) ::= setlist(A) COMMA nm(X) EQ expr(Y). {
+setlist(A) ::= setlist(A) COMMA nm(X) EQ expr_old(Y). {
   A = sql_expr_list_append(A, Y.pExpr);
   sqlExprListSetName(pParse, A, &X, 1);
 }
-setlist(A) ::= setlist(A) COMMA LP idlist(X) RP EQ expr(Y). {
+setlist(A) ::= setlist(A) COMMA LP idlist(X) RP EQ expr_old(Y). {
   A = sqlExprListAppendVector(pParse, A, X, Y.pExpr);
 }
-setlist(A) ::= nm(X) EQ expr(Y). {
+setlist(A) ::= nm(X) EQ expr_old(Y). {
   A = sql_expr_list_append(NULL, Y.pExpr);
   sqlExprListSetName(pParse, A, &X, 1);
 }
-setlist(A) ::= LP idlist(X) RP EQ expr(Y). {
+setlist(A) ::= LP idlist(X) RP EQ expr_old(Y). {
   A = sqlExprListAppendVector(pParse, 0, X, Y.pExpr);
 }
 
@@ -878,520 +894,385 @@ idlist(A) ::= nm(Y). {
 /////////////////////////// Expression Processing /////////////////////////////
 //
 
-%type expr {ExprSpan}
-%destructor expr {sql_expr_delete($$.pExpr);}
-%type term {ExprSpan}
-%destructor term {sql_expr_delete($$.pExpr);}
-
-%include {
-  /* This is a utility routine used to set the ExprSpan.zStart and
-  ** ExprSpan.zEnd values of pOut so that the span covers the complete
-  ** range of text beginning with pStart and going to the end of pEnd.
-  */
-  static void spanSet(ExprSpan *pOut, Token *pStart, Token *pEnd){
-    pOut->zStart = pStart->z;
-    pOut->zEnd = &pEnd->z[pEnd->n];
-  }
-
-  /* Construct a new Expr object from a single identifier.  Use the
-  ** new Expr to populate pOut.  Set the span of pOut to be the identifier
-  ** that created the expression.
-  */
-  static void spanExpr(struct ExprSpan *pOut, int op, Token t){
-    struct Expr *p = NULL;
-    int name_sz = t.n + 1;
-    p = sql_xmalloc(sizeof(Expr) + name_sz);
-    memset(p, 0, sizeof(Expr));
-    switch (op) {
-    case TK_STRING:
-      p->type = FIELD_TYPE_STRING;
-      break;
-    case TK_BLOB:
-      p->type = FIELD_TYPE_VARBINARY;
-      break;
-    case TK_INTEGER:
-      p->type = FIELD_TYPE_INTEGER;
-      break;
-    case TK_FLOAT:
-      p->type = FIELD_TYPE_DOUBLE;
-      break;
-    case TK_DECIMAL:
-      p->type = FIELD_TYPE_DECIMAL;
-      break;
-    case TK_TRUE:
-    case TK_FALSE:
-    case TK_UNKNOWN:
-      p->type = FIELD_TYPE_BOOLEAN;
-      break;
-    default:
-      p->type = FIELD_TYPE_SCALAR;
-      break;
-    }
-    p->op = (u8)op;
-    p->flags = EP_Leaf;
-    p->iAgg = -1;
-    p->u.zToken = (char*)&p[1];
-    memcpy(p->u.zToken, t.z, t.n);
-    p->u.zToken[t.n] = '\0';
-    sqlDequote(p->u.zToken);
-    if (op == TK_ID || op == TK_COLLATE || op == TK_FUNCTION)
-      p->flags |= t.z[0] != '"' ? EP_Lookup2 : 0;
-#if SQL_MAX_EXPR_DEPTH>0
-    p->nHeight = 1;
-#endif  
-    pOut->pExpr = p;
-    pOut->zStart = t.z;
-    pOut->zEnd = &t.z[t.n];
-    return;
-  }
+%type expr_old {ExprSpan}
+%destructor expr_old {sql_expr_delete($$.pExpr);}
+expr_old(A) ::= expr(X). {
+  struct Expr *e = expr_from_ast(pParse, X);
+  A.pExpr = e;
+  A.zStart = X->str;
+  A.zEnd = &X->str[X->len];
 }
 
+%type expr {struct ast_expr *}
+%type term {struct ast_expr *}
 expr(A) ::= term(A).
-expr(A) ::= LP(B) expr(X) RP(E).
-            {spanSet(&A,&B,&E); /*A-overwrites-B*/  A.pExpr = X.pExpr;}
-term(A) ::= NULL(X).        {spanExpr(&A, @X, X);/*A-overwrites-X*/}
-expr(A) ::= id(X).          {spanExpr(&A, TK_ID, X); /*A-overwrites-X*/}
-expr(A) ::= JOIN_KW(X).     {spanExpr(&A, TK_ID, X); /*A-overwrites-X*/}
-expr(A) ::= nm(X) DOT nm(Y). {
-  struct Expr *temp1 = sql_expr_new_dequoted(TK_ID, &X);
-  struct Expr *temp2 = sql_expr_new_dequoted(TK_ID, &Y);
-  spanSet(&A,&X,&Y); /*A-overwrites-X*/
-  A.pExpr = sqlPExpr(pParse, TK_DOT, temp1, temp2);
+term(A) ::= NULL|BLOB|STRING|FALSE|TRUE|UNKNOWN|FLOAT|DECIMAL|INTEGER(X). {
+  A = ast_expr_new(pParse, X.z, X.n, @X);
 }
-term(A) ::= BLOB(X). {spanExpr(&A, @X, X);/*A-overwrites-X*/}
-term(A) ::= STRING(X).     {spanExpr(&A, @X, X);/*A-overwrites-X*/}
-term(A) ::= FALSE(X) . {spanExpr(&A, @X, X);/*A-overwrites-X*/}
-term(A) ::= TRUE(X) . {spanExpr(&A, @X, X);/*A-overwrites-X*/}
-term(A) ::= UNKNOWN(X) . {spanExpr(&A, @X, X);/*A-overwrites-X*/}
-term(A) ::= FLOAT(X). {spanExpr(&A, @X, X);/*A-overwrites-X*/}
-term(A) ::= DECIMAL(X) . {spanExpr(&A, @X, X);/*A-overwrites-X*/}
-term(A) ::= INTEGER(X). {
-  A.pExpr = sql_expr_new_dequoted(TK_INTEGER, &X);
-  A.pExpr->type = FIELD_TYPE_INTEGER;
-  A.zStart = X.z;
-  A.zEnd = X.z + X.n;
-  A.pExpr->flags |= EP_Leaf;
+expr(A) ::= LP(B) expr(X) RP(E). {
+  A = ast_expr_new(pParse, B.z, (E.z - B.z) + E.n, TK_PARENTHESES);
+  A->left = X;
+}
+expr(A) ::= id(X). {
+  A = ast_expr_new(pParse, X.z, X.n, TK_ID);
+}
+expr(A) ::= JOIN_KW(X). {
+  A = ast_expr_new(pParse, X.z, X.n, TK_ID);
+}
+expr(A) ::= nm(X) DOT nm(Y). {
+  A = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_DOT);
+  A->left = ast_expr_new(pParse, X.z, X.n, TK_ID);
+  A->right = ast_expr_new(pParse, Y.z, Y.n, TK_ID);
 }
 expr(A) ::= VARNUM(X). {
-  A.pExpr = expr_new_variable(pParse, &X, NULL);
-  spanSet(&A, &X, &X);
+  A = ast_expr_new(pParse, X.z, X.n, TK_VARIABLE);
 }
 expr(A) ::= COLON|VARIABLE(X) id(Y).     {
-  A.pExpr = expr_new_variable(pParse, &X, &Y);
-  spanSet(&A, &X, &Y);
+  A = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_VARIABLE);
+  A->left = ast_expr_new(pParse, Y.z, Y.n, TK_STRING);
 }
 expr(A) ::= COLON|VARIABLE(X) INTEGER(Y).     {
-  A.pExpr = expr_new_variable(pParse, &X, &Y);
-  spanSet(&A, &X, &Y);
+  A = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_VARIABLE);
+  A->left = ast_expr_new(pParse, Y.z, Y.n, TK_INTEGER);
 }
-expr(A) ::= expr(A) COLLATE id(C). {
-  A.pExpr = sqlExprAddCollateToken(A.pExpr, &C, 1);
-  A.zEnd = &C.z[C.n];
+expr(A) ::= expr(X) COLLATE id(C). {
+  A = ast_expr_new(pParse, X->str, (C.z - X->str) + C.n, TK_COLLATE);
+  A->left = X;
+  A->right = ast_expr_new(pParse, C.z, C.n, TK_ID);
 }
-
 expr(A) ::= CAST(X) LP expr(E) AS typedef(T) RP(Y). {
-  spanSet(&A,&X,&Y); /*A-overwrites-X*/
-  A.pExpr = sql_expr_new_dequoted(TK_CAST, NULL);
-  A.pExpr->type = T;
-  sqlExprAttachSubtrees(A.pExpr, E.pExpr, 0);
+  A = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_CAST);
+  A->type = T;
+  A->left = E;
 }
-
 expr(A) ::= expr(X) LB getlist(Y) RB(E). {
-  struct Expr *expr = sql_expr_new_anon(TK_GETITEM);
-  Y = sql_expr_list_append(Y, X.pExpr);
-  expr->x.pList = Y;
-  expr->type = FIELD_TYPE_ANY;
-  sqlExprSetHeightAndFlags(pParse, expr);
-  A.pExpr = expr;
-  A.zStart = X.zStart;
-  A.zEnd = &E.z[E.n];
+  A = ast_expr_new(pParse, X->str, (E.z - X->str) + E.n, TK_GETITEM);
+  A->left = X;
+  A->list = Y;
 }
 
+%type getlist {struct ast_expr_list *}
 getlist(A) ::= getlist(A) RB LB expr(X). {
-  A = sql_expr_list_append(A, X.pExpr);
+  A = ast_expr_list_append(pParse, A, X);
 }
 getlist(A) ::= expr(X). {
-  A = sql_expr_list_append(NULL, X.pExpr);
+  A = ast_expr_list_append(pParse, NULL, X);
 }
-
-%type getlist {ExprList *}
-%destructor getlist {sql_expr_list_delete($$);}
 
 expr(A) ::= LB(X) exprlist(Y) RB(E). {
-  struct Expr *expr = sql_expr_new_anon(TK_ARRAY);
-  expr->x.pList = Y;
-  expr->type = FIELD_TYPE_ARRAY;
-  sqlExprSetHeightAndFlags(pParse, expr);
-  A.pExpr = expr;
-  spanSet(&A, &X, &E);
+  A = ast_expr_new(pParse, X.z, (E.z - X.z) + E.n, TK_ARRAY);
+  A->list = Y;
 }
-
 expr(A) ::= LCB(X) maplist(Y) RCB(E). {
-  struct Expr *expr = sql_expr_new_anon(TK_MAP);
-  expr->x.pList = Y;
-  expr->type = FIELD_TYPE_MAP;
-  sqlExprSetHeightAndFlags(pParse, expr);
-  A.pExpr = expr;
-  spanSet(&A, &X, &E);
+  A = ast_expr_new(pParse, X.z, (E.z - X.z) + E.n, TK_MAP);
+  A->list = Y;
 }
 
+%type maplist {struct ast_expr_list *}
+%type nmaplist {struct ast_expr_list *}
 maplist(A) ::= nmaplist(A).
 maplist(A) ::= . {
   A = NULL;
 }
 nmaplist(A) ::= nmaplist(A) COMMA expr(X) COLON expr(Y). {
-  A = sql_expr_list_append(A, X.pExpr);
-  A = sql_expr_list_append(A, Y.pExpr);
+  A = ast_expr_list_append(pParse, A, X);
+  A = ast_expr_list_append(pParse, A, Y);
 }
 nmaplist(A) ::= expr(X) COLON expr(Y). {
-  A = sql_expr_list_append(NULL, X.pExpr);
-  A = sql_expr_list_append(A, Y.pExpr);
+  A = ast_expr_list_append(pParse, NULL, X);
+  A = ast_expr_list_append(pParse, A, Y);
 }
 
-%type maplist {ExprList *}
-%destructor maplist {sql_expr_list_delete($$);}
-%type nmaplist {ExprList *}
-%destructor nmaplist {sql_expr_list_delete($$);}
-
-expr(A) ::= TRIM(X) LP trim_operands(Y) RP(E). {
-  A.pExpr = sqlExprFunction(pParse, Y, &X);
-  spanSet(&A, &X, &E);
+expr(A) ::= TRIM(X) LP(B) trim_operands(Y) RP(E). {
+  A = ast_expr_new(pParse, X.z, (E.z - X.z) + E.n, TK_FUNCTION);
+  A->left = ast_expr_new(pParse, X.z, X.n, TK_STRING);
+  A->right = ast_expr_new(pParse, B.z, (E.z - B.z) + E.n, TK_VECTOR);
+  A->right->list = Y;
 }
 
-%type trim_operands {struct ExprList *}
-%destructor trim_operands {sql_expr_list_delete($$);}
-
+%type trim_operands {struct ast_expr_list *}
 trim_operands(A) ::= LEADING|TRAILING|BOTH(N) expr(Z) FROM expr(Y). {
-  A = sql_expr_list_append(NULL, Y.pExpr);
-  A = sql_expr_list_append(A, sql_expr_new_anon(@N));
-  A = sql_expr_list_append(A, Z.pExpr);
+  A = ast_expr_list_append(pParse, NULL, Y);
+  A = ast_expr_list_append(pParse, A, ast_expr_new(pParse, N.z, N.n, @N));
+  A = ast_expr_list_append(pParse, A, Z);
 }
-
 trim_operands(A) ::= LEADING|TRAILING|BOTH(N) FROM expr(Y). {
-  A = sql_expr_list_append(NULL, Y.pExpr);
-  A = sql_expr_list_append(A, sql_expr_new_anon(@N));
+  A = ast_expr_list_append(pParse, NULL, Y);
+  A = ast_expr_list_append(pParse, A, ast_expr_new(pParse, N.z, N.n, @N));
 }
-
 trim_operands(A) ::= expr(Z) FROM expr(Y). {
-  A = sql_expr_list_append(NULL, Y.pExpr);
-  A = sql_expr_list_append(A, Z.pExpr);
+  A = ast_expr_list_append(pParse, NULL, Y);
+  A = ast_expr_list_append(pParse, A, Z);
 }
-
 trim_operands(A) ::= expr(Y). {
-  A = sql_expr_list_append(NULL, Y.pExpr);
+  A = ast_expr_list_append(pParse, NULL, Y);
 }
 
-%type expr_optional {struct Expr *}
-%destructor expr_optional {sql_expr_delete($$);}
-
-expr_optional(A) ::= .        { A = NULL; }
-expr_optional(A) ::= expr(X). { A = X.pExpr; }
-
-expr(A) ::= id(X) LP distinct(D) exprlist(Y) RP(E). {
-  if (Y != NULL && Y->nExpr > SQL_MAX_FUNCTION_ARG){
-    const char *err =
-      tt_sprintf("Number of arguments to function %.*s", X.n, X.z);
-    diag_set(ClientError, ER_SQL_PARSER_LIMIT, err, Y->nExpr,
-             SQL_MAX_FUNCTION_ARG);
-    pParse->is_aborted = true;
-  }
-  A.pExpr = sqlExprFunction(pParse, Y, &X);
-  spanSet(&A,&X,&E);
-  if( D==SF_Distinct && A.pExpr ){
-    A.pExpr->flags |= EP_Distinct;
-  }
+expr(A) ::= id(X) LP(B) distinct(D) exprlist(Y) RP(E). {
+  A = ast_expr_new(pParse, X.z, (E.z - X.z) + E.n, TK_FUNCTION);
+  A->left = ast_expr_new(pParse, X.z, X.n, TK_STRING);
+  uint8_t op = D == SF_Distinct ? TK_DISTINCT : TK_VECTOR;
+  A->right = ast_expr_new(pParse, B.z, (E.z - B.z) + E.n, op);
+  A->right->list = Y;
 }
-
-/*
- * type_func(A) ::= DATE(A) .
- * type_func(A) ::= DATETIME(A) .
- */
-type_func(A) ::= CHAR(A) .
-expr(A) ::= type_func(X) LP distinct(D) exprlist(Y) RP(E). {
-  if (Y != NULL && Y->nExpr > SQL_MAX_FUNCTION_ARG){
-    const char *err =
-      tt_sprintf("Number of arguments to function %.*s", X.n, X.z);
-    diag_set(ClientError, ER_SQL_PARSER_LIMIT, err, Y->nExpr,
-             SQL_MAX_FUNCTION_ARG);
-    pParse->is_aborted = true;
-  }
-  A.pExpr = sqlExprFunction(pParse, Y, &X);
-  spanSet(&A,&X,&E);
-  if( D==SF_Distinct && A.pExpr ){
-    A.pExpr->flags |= EP_Distinct;
-  }
+expr(A) ::= CHAR(X) LP(B) distinct(D) exprlist(Y) RP(E). {
+  A = ast_expr_new(pParse, X.z, (E.z - X.z) + E.n, TK_FUNCTION);
+  A->left = ast_expr_new(pParse, X.z, X.n, TK_STRING);
+  uint8_t op = D == SF_Distinct ? TK_DISTINCT : TK_VECTOR;
+  A->right = ast_expr_new(pParse, B.z, (E.z - B.z) + E.n, op);
+  A->right->list = Y;
 }
-
 expr(A) ::= id(X) LP STAR RP(E). {
-  A.pExpr = sqlExprFunction(pParse, 0, &X);
-  spanSet(&A,&X,&E);
+  A = ast_expr_new(pParse, X.z, (E.z - X.z) + E.n, TK_FUNCTION);
+  A->left = ast_expr_new(pParse, X.z, X.n, TK_STRING);
 }
-/*
- * term(A) ::= CTIME_KW(OP). {
- *   A.pExpr = sqlExprFunction(pParse, 0, &OP);
- *   spanSet(&A, &OP, &OP);
- * }
- */
-
-%include {
-  /* This routine constructs a binary expression node out of two ExprSpan
-  ** objects and uses the result to populate a new ExprSpan object.
-  */
-  static void spanBinaryExpr(
-    Parse *pParse,      /* The parsing context.  Errors accumulate here */
-    int op,             /* The binary operation */
-    ExprSpan *pLeft,    /* The left operand, and output */
-    ExprSpan *pRight    /* The right operand */
-  ){
-    pLeft->pExpr = sqlPExpr(pParse, op, pLeft->pExpr, pRight->pExpr);
-    pLeft->zEnd = pRight->zEnd;
-  }
-
-  /* If doNot is true, then add a TK_NOT Expr-node wrapper around the
-  ** outside of *ppExpr.
-  */
-  static void exprNot(Parse *pParse, int doNot, ExprSpan *pSpan){
-    if( doNot ){
-      pSpan->pExpr = sqlPExpr(pParse, TK_NOT, pSpan->pExpr, 0);
-    }
-  }
-}
-
 expr(A) ::= LP(L) nexprlist(X) COMMA expr(Y) RP(R). {
-  ExprList *pList = sql_expr_list_append(X, Y.pExpr);
-  A.pExpr = sqlPExpr(pParse, TK_VECTOR, 0, 0);
-  if( A.pExpr ){
-    A.pExpr->x.pList = pList;
-    spanSet(&A, &L, &R);
-  }else{
-    sql_expr_list_delete(pList);
+  A = ast_expr_new(pParse, L.z, (R.z - L.z) + R.n, TK_VECTOR);
+  A->list = ast_expr_list_append(pParse, X, Y);
+}
+expr(A) ::= expr(X) AND(OP) expr(Y). {
+  A = ast_expr_new(pParse, X->str, (Y->str - X->str) + Y->len, @OP);
+  A->left = X;
+  A->right = Y;
+}
+expr(A) ::= expr(X) OR(OP) expr(Y). {
+  A = ast_expr_new(pParse, X->str, (Y->str - X->str) + Y->len, @OP);
+  A->left = X;
+  A->right = Y;
+}
+expr(A) ::= expr(X) LT|GT|GE|LE(OP) expr(Y). {
+  A = ast_expr_new(pParse, X->str, (Y->str - X->str) + Y->len, @OP);
+  A->left = X;
+  A->right = Y;
+}
+expr(A) ::= expr(X) EQ|NE(OP) expr(Y). {
+  A = ast_expr_new(pParse, X->str, (Y->str - X->str) + Y->len, @OP);
+  A->left = X;
+  A->right = Y;
+}
+expr(A) ::= expr(X) BITAND|BITOR|LSHIFT|RSHIFT(OP) expr(Y). {
+  A = ast_expr_new(pParse, X->str, (Y->str - X->str) + Y->len, @OP);
+  A->left = X;
+  A->right = Y;
+}
+expr(A) ::= expr(X) PLUS|MINUS(OP) expr(Y). {
+  A = ast_expr_new(pParse, X->str, (Y->str - X->str) + Y->len, @OP);
+  A->left = X;
+  A->right = Y;
+}
+expr(A) ::= expr(X) STAR|SLASH|REM(OP) expr(Y). {
+  A = ast_expr_new(pParse, X->str, (Y->str - X->str) + Y->len, @OP);
+  A->left = X;
+  A->right = Y;
+}
+expr(A) ::= expr(X) CONCAT(OP) expr(Y). {
+  A = ast_expr_new(pParse, X->str, (Y->str - X->str) + Y->len, @OP);
+  A->left = X;
+  A->right = Y;
+}
+expr(A) ::= expr(X) LIKE_KW|MATCH(OP) expr(Y). {
+  A = ast_expr_new(pParse, X->str, (Y->str - X->str) + Y->len, TK_FUNCTION);
+  A->left = ast_expr_new(pParse, OP.z, OP.n, TK_STRING);
+  A->right = ast_expr_new(pParse, X->str, (Y->str - X->str) + Y->len,
+                          TK_VECTOR);
+  A->right->list = ast_expr_list_append(pParse, NULL, Y);
+  A->right->list = ast_expr_list_append(pParse, A->right->list, X);
+}
+expr(A) ::= expr(X) NOT LIKE_KW|MATCH(OP) expr(Y). {
+  A = ast_expr_new(pParse, X->str, (Y->str - X->str) + Y->len, TK_NOT);
+  A->left = ast_expr_new(pParse, X->str, (Y->str - X->str) + Y->len,
+                         TK_FUNCTION);
+  A->left->left = ast_expr_new(pParse, OP.z, OP.n, TK_STRING);
+  A->left->right = ast_expr_new(pParse, X->str, (Y->str - X->str) + Y->len,
+                                TK_VECTOR);
+  A->left->right->list = ast_expr_list_append(pParse, NULL, Y);
+  A->left->right->list = ast_expr_list_append(pParse, A->left->right->list, X);
+}
+expr(A) ::= expr(X) LIKE_KW|MATCH(OP) expr(Y) ESCAPE expr(E). {
+  A = ast_expr_new(pParse, X->str, (E->str - X->str) + E->len, TK_FUNCTION);
+  A->left = ast_expr_new(pParse, OP.z, OP.n, TK_STRING);
+  A->right = ast_expr_new(pParse, X->str, (E->str - X->str) + E->len,
+                          TK_VECTOR);
+  A->right->list = ast_expr_list_append(pParse, NULL, Y);
+  A->right->list = ast_expr_list_append(pParse, A->right->list, X);
+  A->right->list = ast_expr_list_append(pParse, A->right->list, E);
+}
+expr(A) ::= expr(X) NOT LIKE_KW|MATCH(OP) expr(Y) ESCAPE expr(E). {
+  A = ast_expr_new(pParse, X->str, (E->str - X->str) + E->len, TK_NOT);
+  A->left = ast_expr_new(pParse, X->str, (E->str - X->str) + E->len,
+                         TK_FUNCTION);
+  A->left->left = ast_expr_new(pParse, OP.z, OP.n, TK_STRING);
+  A->left->right = ast_expr_new(pParse, X->str, (E->str - X->str) + E->len,
+                                TK_VECTOR);
+  A->left->right->list = ast_expr_list_append(pParse, NULL, Y);
+  A->left->right->list = ast_expr_list_append(pParse, A->left->right->list, X);
+  A->left->right->list = ast_expr_list_append(pParse, A->left->right->list, E);
+}
+expr(A) ::= expr(X) IS NULL(E). {
+  A = ast_expr_new(pParse, X->str, (E.z - X->str) + E.n, TK_ISNULL);
+  A->left = X;
+}
+expr(A) ::= expr(X) IS NOT NULL(E). {
+  A = ast_expr_new(pParse, X->str, (E.z - X->str) + E.n, TK_NOTNULL);
+  A->left = X;
+}
+expr(A) ::= NOT(B) expr(X). {
+  A = ast_expr_new(pParse, B.z, (X->str - B.z) + X->len, @B);
+  A->left = X;
+}
+expr(A) ::= BITNOT(B) expr(X). {
+  A = ast_expr_new(pParse, B.z, (X->str - B.z) + X->len, @B);
+  A->left = X;
+}
+expr(A) ::= MINUS(B) expr(X). [BITNOT] {
+  A = ast_expr_new(pParse, B.z, (X->str - B.z) + X->len, TK_UMINUS);
+  A->left = X;
+}
+expr(A) ::= PLUS(B) expr(X). [BITNOT] {
+  A = ast_expr_new(pParse, B.z, (X->str - B.z) + X->len, TK_UPLUS);
+  A->left = X;
+}
+expr(A) ::= expr(Z) BETWEEN(N) expr(X) AND expr(Y). {
+  A = ast_expr_new(pParse, Z->str, (Y->str - Z->str) + Y->len, @N);
+  A->left = Z;
+  A->list = ast_expr_list_append(pParse, NULL, X);
+  A->list = ast_expr_list_append(pParse, A->list, Y);
+}
+expr(A) ::= expr(Z) NOT BETWEEN(N) expr(X) AND expr(Y). {
+  A = ast_expr_new(pParse, Z->str, (Y->str - Z->str) + Y->len, TK_NOT);
+  A->left = ast_expr_new(pParse, Z->str, (Y->str - Z->str) + Y->len, @N);
+  A->left->left = Z;
+  A->left->list = ast_expr_list_append(pParse, NULL, X);
+  A->left->list = ast_expr_list_append(pParse, A->left->list, Y);
+}
+expr(A) ::= expr(X) IN LP(B) exprlist(Y) RP(E). {
+  A = ast_expr_new(pParse, X->str, (E.z - X->str) + E.n, TK_IN);
+  A->left = X;
+  A->right = ast_expr_new(pParse, B.z, (E.z - B.z) + E.n, TK_VECTOR);
+  A->right->list = Y;
+}
+expr(A) ::= expr(X) NOT IN LP(B) exprlist(Y) RP(E). {
+  A = ast_expr_new(pParse, X->str, (E.z - X->str) + E.n, TK_NOT);
+  A->left = ast_expr_new(pParse, X->str, (E.z - X->str) + E.n, TK_IN);
+  A->left->left = X;
+  A->left->right = ast_expr_new(pParse, B.z, (E.z - B.z) + E.n, TK_VECTOR);
+  A->left->right->list = Y;
+}
+expr(A) ::= expr(X) IN LP(B) select(Y) RP(E). {
+  A = ast_expr_new(pParse, X->str, (E.z - X->str) + E.n, TK_IN);
+  A->left = X;
+  A->right = ast_expr_new(pParse, B.z, (E.z - B.z) + E.n, TK_SELECT);
+  A->right->select = Y;
+}
+expr(A) ::= expr(X) NOT IN LP(B) select(Y) RP(E). {
+  A = ast_expr_new(pParse, X->str, (E.z - X->str) + E.n, TK_NOT);
+  A->left = ast_expr_new(pParse, X->str, (E.z - X->str) + E.n, TK_IN);
+  A->left->left = X;
+  A->left->right = ast_expr_new(pParse, B.z, (E.z - B.z) + E.n, TK_SELECT);
+  A->left->right->select = Y;
+}
+expr(A) ::= expr(X) IN nm(Y). {
+  struct ast_source *src = ast_source_new(pParse);
+  src->name = Y;
+  struct ast_select *select = ast_select_new(pParse);
+  select->sources = ast_source_list_append(pParse, NULL, src);
+  A = ast_expr_new(pParse, X->str, (Y.z - X->str) + Y.n, TK_IN);
+  A->left = X;
+  A->right = ast_expr_new(pParse, Y.z, Y.n, TK_SELECT);
+  A->right->select = select;
+}
+expr(A) ::= expr(X) IN nm(Y) LP exprlist(E) RP. {
+  struct ast_source *src = ast_source_new(pParse);
+  src->name = Y;
+  if (E != NULL) {
+    src->func_args = E;
+    src->is_tab_func = true;
   }
+  struct ast_select *select = ast_select_new(pParse);
+  select->sources = ast_source_list_append(pParse, NULL, src);
+  A = ast_expr_new(pParse, X->str, (Y.z - X->str) + Y.n, TK_IN);
+  A->left = X;
+  A->right = ast_expr_new(pParse, Y.z, Y.n, TK_SELECT);
+  A->right->select = select;
 }
-
-expr(A) ::= expr(A) AND(OP) expr(Y).    {spanBinaryExpr(pParse,@OP,&A,&Y);}
-expr(A) ::= expr(A) OR(OP) expr(Y).     {spanBinaryExpr(pParse,@OP,&A,&Y);}
-expr(A) ::= expr(A) LT|GT|GE|LE(OP) expr(Y).
-                                        {spanBinaryExpr(pParse,@OP,&A,&Y);}
-expr(A) ::= expr(A) EQ|NE(OP) expr(Y).  {spanBinaryExpr(pParse,@OP,&A,&Y);}
-expr(A) ::= expr(A) BITAND|BITOR|LSHIFT|RSHIFT(OP) expr(Y).
-                                        {spanBinaryExpr(pParse,@OP,&A,&Y);}
-expr(A) ::= expr(A) PLUS|MINUS(OP) expr(Y).
-                                        {spanBinaryExpr(pParse,@OP,&A,&Y);}
-expr(A) ::= expr(A) STAR|SLASH|REM(OP) expr(Y).
-                                        {spanBinaryExpr(pParse,@OP,&A,&Y);}
-expr(A) ::= expr(A) CONCAT(OP) expr(Y). {spanBinaryExpr(pParse,@OP,&A,&Y);}
-%type likeop {Token}
-likeop(A) ::= LIKE_KW|MATCH(X).     {A=X;/*A-overwrites-X*/}
-likeop(A) ::= NOT LIKE_KW|MATCH(X). {A=X; A.n|=0x80000000; /*A-overwrite-X*/}
-expr(A) ::= expr(A) likeop(OP) expr(Y).  [LIKE_KW]  {
-  ExprList *pList;
-  int bNot = OP.n & 0x80000000;
-  OP.n &= 0x7fffffff;
-  pList = sql_expr_list_append(NULL, Y.pExpr);
-  pList = sql_expr_list_append(pList, A.pExpr);
-  A.pExpr = sqlExprFunction(pParse, pList, &OP);
-  exprNot(pParse, bNot, &A);
-  A.zEnd = Y.zEnd;
+expr(A) ::= expr(X) NOT IN nm(Y). {
+  struct ast_source *src = ast_source_new(pParse);
+  src->name = Y;
+  struct ast_select *select = ast_select_new(pParse);
+  select->sources = ast_source_list_append(pParse, NULL, src);
+  A = ast_expr_new(pParse, X->str, (Y.z - X->str) + Y.n, TK_NOT);
+  A->left = ast_expr_new(pParse, X->str, (Y.z - X->str) + Y.n, TK_IN);
+  A->left->left = X;
+  A->left->right = ast_expr_new(pParse, Y.z, Y.n, TK_SELECT);
+  A->left->right->select = select;
 }
-expr(A) ::= expr(A) likeop(OP) expr(Y) ESCAPE expr(E).  [LIKE_KW]  {
-  ExprList *pList;
-  int bNot = OP.n & 0x80000000;
-  OP.n &= 0x7fffffff;
-  pList = sql_expr_list_append(NULL, Y.pExpr);
-  pList = sql_expr_list_append(pList, A.pExpr);
-  pList = sql_expr_list_append(pList, E.pExpr);
-  A.pExpr = sqlExprFunction(pParse, pList, &OP);
-  exprNot(pParse, bNot, &A);
-  A.zEnd = E.zEnd;
-}
-
-%include {
-  /* Construct an expression node for a unary postfix operator
-  */
-  static void spanUnaryPostfix(
-    Parse *pParse,         /* Parsing context to record errors */
-    int op,                /* The operator */
-    ExprSpan *pOperand,    /* The operand, and output */
-    Token *pPostOp         /* The operand token for setting the span */
-  ){
-    pOperand->pExpr = sqlPExpr(pParse, op, pOperand->pExpr, 0);
-    pOperand->zEnd = &pPostOp->z[pPostOp->n];
-  }                           
-}
-
-// Tokens TK_ISNULL and TK_NOTNULL defined in extra tokens and are identifiers
-// for operations IS NULL and IS NOT NULL.
-
-expr(A) ::= expr(A) IS NULL(E).   {spanUnaryPostfix(pParse,TK_ISNULL,&A,&E);}
-expr(A) ::= expr(A) IS NOT NULL(E).   {spanUnaryPostfix(pParse,TK_NOTNULL,&A,&E);}
-
-
-%include {
-  /* Construct an expression node for a unary prefix operator
-  */
-  static void spanUnaryPrefix(
-    ExprSpan *pOut,        /* Write the new expression node here */
-    Parse *pParse,         /* Parsing context to record errors */
-    int op,                /* The operator */
-    ExprSpan *pOperand,    /* The operand */
-    Token *pPreOp         /* The operand token for setting the span */
-  ){
-    pOut->zStart = pPreOp->z;
-    pOut->pExpr = sqlPExpr(pParse, op, pOperand->pExpr, 0);
-    pOut->zEnd = pOperand->zEnd;
+expr(A) ::= expr(X) NOT IN nm(Y) LP exprlist(E) RP. {
+  struct ast_source *src = ast_source_new(pParse);
+  src->name = Y;
+  if (E != NULL) {
+    src->func_args = E;
+    src->is_tab_func = true;
   }
+  struct ast_select *select = ast_select_new(pParse);
+  select->sources = ast_source_list_append(pParse, NULL, src);
+  A = ast_expr_new(pParse, X->str, (Y.z - X->str) + Y.n, TK_NOT);
+  A->left = ast_expr_new(pParse, X->str, (Y.z - X->str) + Y.n, TK_IN);
+  A->left->left = X;
+  A->left->right = ast_expr_new(pParse, Y.z, Y.n, TK_SELECT);
+  A->left->right->select = select;
+}
+expr(A) ::= LP(B) select(X) RP(E). {
+  A = ast_expr_new(pParse, B.z, (E.z - B.z) + E.n, TK_SELECT);
+  A->select = X;
+}
+expr(A) ::= EXISTS(B) LP select(Y) RP(E). {
+  A = ast_expr_new(pParse, B.z, (E.z - B.z) + E.n, TK_EXISTS);
+  A->select = Y;
+}
+expr(A) ::= CASE(C) case_exprlist(Y) END(E). {
+  A = ast_expr_new(pParse, C.z, (E.z - C.z) + E.n, TK_CASE);
+  A->list = Y;
+}
+expr(A) ::= CASE(C) expr(X) case_exprlist(Y) END(E). {
+  A = ast_expr_new(pParse, C.z, (E.z - C.z) + E.n, TK_CASE);
+  A->left = X;
+  A->list = Y;
 }
 
-
-
-expr(A) ::= NOT(B) expr(X).  
-              {spanUnaryPrefix(&A,pParse,@B,&X,&B);/*A-overwrites-B*/}
-expr(A) ::= BITNOT(B) expr(X).
-              {spanUnaryPrefix(&A,pParse,@B,&X,&B);/*A-overwrites-B*/}
-expr(A) ::= MINUS(B) expr(X). [BITNOT]
-              {spanUnaryPrefix(&A,pParse,TK_UMINUS,&X,&B);/*A-overwrites-B*/}
-expr(A) ::= PLUS(B) expr(X). [BITNOT]
-              {spanUnaryPrefix(&A,pParse,TK_UPLUS,&X,&B);/*A-overwrites-B*/}
-
-%type between_op {int}
-between_op(A) ::= BETWEEN.     {A = 0;}
-between_op(A) ::= NOT BETWEEN. {A = 1;}
-expr(A) ::= expr(A) between_op(N) expr(X) AND expr(Y). [BETWEEN] {
-  ExprList *pList = sql_expr_list_append(NULL, X.pExpr);
-  pList = sql_expr_list_append(pList, Y.pExpr);
-  A.pExpr = sqlPExpr(pParse, TK_BETWEEN, A.pExpr, 0);
-  if( A.pExpr ){
-    A.pExpr->x.pList = pList;
-  }else{
-    sql_expr_list_delete(pList);
-  } 
-  exprNot(pParse, N, &A);
-  A.zEnd = Y.zEnd;
+%type case_exprlist_when {struct ast_expr_list *}
+case_exprlist_when(A) ::= case_exprlist_when(A) WHEN expr(Y) THEN expr(Z). {
+  A = ast_expr_list_append(pParse, A, Y);
+  A = ast_expr_list_append(pParse, A, Z);
 }
-%type in_op {int}
-in_op(A) ::= IN.      {A = 0;}
-in_op(A) ::= NOT IN.  {A = 1;}
-expr(A) ::= expr(A) in_op(N) LP exprlist(Y) RP(E). [IN] {
-  if( Y==0 ){
-    /* Expressions of the form
-    **
-    **      expr1 IN ()
-    **      expr1 NOT IN ()
-    **
-    ** simplify to constants 0 (false) and 1 (true), respectively,
-    ** regardless of the value of expr1.
-    */
-    sql_expr_delete(A.pExpr);
-    int tk = N == 0 ? TK_FALSE : TK_TRUE;
-    A.pExpr = sql_expr_new_anon(tk);
-    A.pExpr->type = FIELD_TYPE_BOOLEAN;
-  }else if( Y->nExpr==1 ){
-    /* Expressions of the form:
-    **
-    **      expr1 IN (?1)
-    **      expr1 NOT IN (?2)
-    **
-    ** with exactly one value on the RHS can be simplified to something
-    ** like this:
-    **
-    **      expr1 == ?1
-    **      expr1 <> ?2
-    */
-    Expr *pRHS = Y->a[0].pExpr;
-    Y->a[0].pExpr = 0;
-    sql_expr_list_delete(Y);
-    A.pExpr = sqlPExpr(pParse, N ? TK_NE : TK_EQ, A.pExpr, pRHS);
-  }else{
-    A.pExpr = sqlPExpr(pParse, TK_IN, A.pExpr, 0);
-    if( A.pExpr ){
-      A.pExpr->x.pList = Y;
-      sqlExprSetHeightAndFlags(pParse, A.pExpr);
-    }else{
-      sql_expr_list_delete(Y);
-    }
-    exprNot(pParse, N, &A);
-  }
-  A.zEnd = &E.z[E.n];
-}
-expr(A) ::= LP(B) select_old(X) RP(E). {
-  spanSet(&A,&B,&E); /*A-overwrites-B*/
-  A.pExpr = sqlPExpr(pParse, TK_SELECT, 0, 0);
-  sqlPExprAddSelect(pParse, A.pExpr, X);
-}
-expr(A) ::= expr(A) in_op(N) LP select_old(Y) RP(E).  [IN] {
-  A.pExpr = sqlPExpr(pParse, TK_IN, A.pExpr, 0);
-  sqlPExprAddSelect(pParse, A.pExpr, Y);
-  exprNot(pParse, N, &A);
-  A.zEnd = &E.z[E.n];
-}
-expr(A) ::= expr(A) in_op(N) nm(Y) paren_exprlist(E). [IN] {
-  struct SrcList *pSrc = sql_src_list_append(NULL, &Y);
-  Select *pSelect = sqlSelectNew(pParse, 0,pSrc,0,0,0,0,0,0,0);
-  if(E != NULL)
-    sqlSrcListFuncArgs(pSelect != NULL ? pSrc : NULL, E);
-  A.pExpr = sqlPExpr(pParse, TK_IN, A.pExpr, 0);
-  sqlPExprAddSelect(pParse, A.pExpr, pSelect);
-  exprNot(pParse, N, &A);
-  A.zEnd = &Y.z[Y.n];
-}
-expr(A) ::= EXISTS(B) LP select_old(Y) RP(E). {
-  Expr *p;
-  spanSet(&A,&B,&E); /*A-overwrites-B*/
-  p = A.pExpr = sqlPExpr(pParse, TK_EXISTS, 0, 0);
-  sqlPExprAddSelect(pParse, p, Y);
+case_exprlist_when(A) ::= WHEN expr(Y) THEN expr(Z). {
+  A = ast_expr_list_append(pParse, NULL, Y);
+  A = ast_expr_list_append(pParse, A, Z);
 }
 
-/* CASE expressions */
-expr(A) ::= CASE(C) expr_optional(X) case_exprlist(Y) case_else(Z) END(E). {
-  spanSet(&A,&C,&E);  /*A-overwrites-C*/
-  A.pExpr = sqlPExpr(pParse, TK_CASE, X, 0);
-  if( A.pExpr ){
-    A.pExpr->x.pList = Z ? sql_expr_list_append(Y, Z) : Y;
-    sqlExprSetHeightAndFlags(pParse, A.pExpr);
-  }else{
-    sql_expr_list_delete(Y);
-    sql_expr_delete(Z);
-  }
+%type case_exprlist {struct ast_expr_list *}
+case_exprlist(A) ::= case_exprlist_when(A).
+case_exprlist(A) ::= case_exprlist_when(A) ELSE expr(X). {
+  A = ast_expr_list_append(pParse, A, X);
 }
-%type case_exprlist {ExprList*}
-%destructor case_exprlist {sql_expr_list_delete($$);}
-case_exprlist(A) ::= case_exprlist(A) WHEN expr(Y) THEN expr(Z). {
-  A = sql_expr_list_append(A, Y.pExpr);
-  A = sql_expr_list_append(A, Z.pExpr);
-}
-case_exprlist(A) ::= WHEN expr(Y) THEN expr(Z). {
-  A = sql_expr_list_append(NULL, Y.pExpr);
-  A = sql_expr_list_append(A, Z.pExpr);
-}
-%type case_else {Expr*}
-%destructor case_else {sql_expr_delete($$);}
-case_else(A) ::=  ELSE expr(X).         {A = X.pExpr;}
-case_else(A) ::=  .                     {A = 0;} 
 
-%type exprlist {ExprList*}
-%destructor exprlist {sql_expr_list_delete($$);}
-%type nexprlist {ExprList*}
-%destructor nexprlist {sql_expr_list_delete($$);}
+%type exprlist {struct ast_expr_list *}
+%type nexprlist {struct ast_expr_list *}
 
 exprlist(A) ::= nexprlist(A).
-exprlist(A) ::= .                            {A = 0;}
-nexprlist(A) ::= nexprlist(A) COMMA expr(Y).
-    {A = sql_expr_list_append(A, Y.pExpr);}
-nexprlist(A) ::= expr(Y).
-    {A = sql_expr_list_append(NULL, Y.pExpr); /*A-overwrites-Y*/}
-
-/* A paren_exprlist is an optional expression list contained inside
-** of parenthesis */
-%type paren_exprlist {ExprList*}
-%destructor paren_exprlist {sql_expr_list_delete($$);}
-paren_exprlist(A) ::= .   {A = 0;}
-paren_exprlist(A) ::= LP exprlist(X) RP.  {A = X;}
-
+exprlist(A) ::= . {
+  A = NULL;
+}
+nexprlist(A) ::= nexprlist(A) COMMA expr(Y). {
+  A = ast_expr_list_append(pParse, A, Y);
+}
+nexprlist(A) ::= expr(Y). {
+  A = ast_expr_list_append(pParse, NULL, Y);
+}
 
 ///////////////////////////// The CREATE INDEX command ///////////////////////
 //
 cmd ::= createkw uniqueflag(U) INDEX ifnotexists(NE) nm(X)
-        ON nm(Y) LP sortlist(Z) RP. {
+        ON nm(Y) LP sortlist_old(Z) RP. {
   struct SrcList *src_list = sql_src_list_append(NULL ,&Y);
   create_index_def_init(&pParse->create_index_def, src_list, &X, Z, U,
                         SORT_ORDER_ASC, NE);
@@ -1455,7 +1336,8 @@ cmd ::= DROP INDEX ifexists(E) nm(X) ON fullname(Y).   {
 ///////////////////////////// The SET SESSION command ////////////////////////
 //
 cmd ::= SET SESSION nm(X) EQ term(Y).  {
-    sql_setting_set(pParse,&X,Y.pExpr);
+    struct Expr *e = expr_from_ast(pParse, Y);
+    sql_setting_set(pParse, &X, e);
 }
 
 ///////////////////////////// The PRAGMA command /////////////////////////////
@@ -1469,7 +1351,7 @@ cmd ::= PRAGMA nm(X) LP nm(Y) RP.         {
 cmd ::= PRAGMA nm(X) LP nm(Y) DOT nm(Z) RP.  {
     sqlPragma(pParse,&X,&Y,&Z);
 }
-cmd ::= FUNCTION_KW(T) expr(E). {
+cmd ::= FUNCTION_KW(T) expr_old(E). {
   if (!pParse->is_expr) {
     diag_set(ClientError, ER_SQL_SYNTAX_NEAR_TOKEN, pParse->line_count,
              tt_cstr(T.z, T.n));
@@ -1529,7 +1411,9 @@ foreach_clause ::= FOR EACH ROW.
 %type when_clause {Expr*}
 %destructor when_clause {sql_expr_delete($$);}
 when_clause(A) ::= .             { A = 0; }
-when_clause(A) ::= WHEN expr(X). { A = X.pExpr; }
+when_clause(A) ::= WHEN expr_old(X). {
+  A = X.pExpr;
+}
 
 %type trigger_cmd_list {TriggerStep*}
 %destructor trigger_cmd_list {sqlDeleteTriggerStep($$);}
@@ -1581,7 +1465,7 @@ tridxby ::= NOT INDEXED. {
 %destructor trigger_cmd {sqlDeleteTriggerStep($$);}
 // UPDATE 
 trigger_cmd(A) ::=
-   UPDATE orconf(R) trnm(X) tridxby SET setlist(Y) where_opt(Z). {
+   UPDATE orconf(R) trnm(X) tridxby SET setlist(Y) where_opt_old(Z). {
      A = sql_trigger_update_step(&X, Y, Z, R);
      if (A == NULL) {
         pParse->is_aborted = true;
@@ -1596,7 +1480,7 @@ trigger_cmd(A) ::= insert_cmd(R) INTO trnm(X) idlist_opt(F) select_old(S). {
 }
 
 // DELETE
-trigger_cmd(A) ::= DELETE FROM trnm(X) tridxby where_opt(Y). {
+trigger_cmd(A) ::= DELETE FROM trnm(X) tridxby where_opt_old(Y). {
   A = sql_trigger_delete_step(&X, Y);
 }
 
@@ -1608,19 +1492,16 @@ trigger_cmd(A) ::= select_old(X). {
 
 // The special RAISE expression that may occur in trigger programs
 expr(A) ::= RAISE(X) LP IGNORE RP(Y).  {
-  spanSet(&A,&X,&Y);  /*A-overwrites-X*/
-  A.pExpr = sqlPExpr(pParse, TK_RAISE, 0, 0);
-  if( A.pExpr ){
-    A.pExpr->on_conflict_action = ON_CONFLICT_ACTION_IGNORE;
-  }
+  A = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_RAISE);
+  A->on_conflict_action = ON_CONFLICT_ACTION_IGNORE;
 }
 expr(A) ::= RAISE(X) LP raisetype(T) COMMA STRING(Z) RP(Y).  {
-  spanSet(&A,&X,&Y);  /*A-overwrites-X*/
-  A.pExpr = sql_expr_new_dequoted(TK_RAISE, &Z);
-  A.pExpr->on_conflict_action = (enum on_conflict_action) T;
+  A = ast_expr_new(pParse, X.z, (Y.z - X.z) + Y.n, TK_RAISE);
+  A->left = ast_expr_new(pParse, Z.z, Z.n, @Z);
+  A->on_conflict_action = T;
 }
 
-%type raisetype {int}
+%type raisetype {enum on_conflict_action}
 raisetype(A) ::= ROLLBACK.  {A = ON_CONFLICT_ACTION_ROLLBACK;}
 raisetype(A) ::= ABORT.     {A = ON_CONFLICT_ACTION_ABORT;}
 raisetype(A) ::= FAIL.      {A = ON_CONFLICT_ACTION_FAIL;}
@@ -1678,12 +1559,12 @@ cmd ::= alter_add_constraint(N) FOREIGN KEY LP eidlist(FA) RP REFERENCES
   sql_create_foreign_key(pParse);
 }
 
-cmd ::= alter_add_constraint(N) CHECK LP expr(X) RP. {
+cmd ::= alter_add_constraint(N) CHECK LP expr_old(X) RP. {
     create_ck_def_init(&pParse->create_ck_def, N.table_name, &N.name, &X);
     sql_create_check_contraint(pParse, false);
 }
 
-cmd ::= alter_add_constraint(N) unique_spec(U) LP sortlist(X) RP. {
+cmd ::= alter_add_constraint(N) unique_spec(U) LP sortlist_old(X) RP. {
   create_index_def_init(&pParse->create_index_def, N.table_name, &N.name, X, U,
                         SORT_ORDER_ASC, false);
   sql_create_index(pParse);
@@ -1747,13 +1628,11 @@ with_old(A) ::= with(X). {
 }
 
 %type with {struct ast_with_list *}
-%destructor with {ast_with_destroy($$);}
 with(A) ::= . {A = 0;}
 with(A) ::= WITH wqlist(W).              { A = W; }
 with(A) ::= WITH RECURSIVE wqlist(W).    { A = W; }
 
 %type wqlist {struct ast_with_list *}
-%destructor wqlist {ast_with_destroy($$);}
 wqlist(A) ::= nm(X) idlist_opt(Y) AS LP select(Z) RP. {
   A = ast_with_list_append(pParse, NULL, &X, Y, Z);
 }

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -482,7 +482,7 @@ selectnowith(A) ::= selectnowith(A) multiselect_op(Y) oneselect(Z).  {
     Token x;
     x.n = 0;
     parserDoubleLinkSelect(pParse, pRhs);
-    pFrom = sqlSrcListAppendFromTerm(pParse,0,0,&x,pRhs,0,0,false);
+    pFrom = sqlSrcListAppendFromTerm(0, 0, &x, pRhs, 0, 0, false);
     pRhs = sqlSelectNew(pParse,0,pFrom,0,0,0,0,0,0,0);
   }
   if( pRhs ){
@@ -598,63 +598,96 @@ as(X) ::= .            {X.n = 0; X.z = 0;}
 seqscan(X) ::= SEQSCAN.     {X = 0;}
 seqscan(X) ::= .            {X = 1;}
 
-%type seltablist {SrcList*}
-%destructor seltablist {sqlSrcListDelete($$);}
-%type stl_prefix {SrcList*}
-%destructor stl_prefix {sqlSrcListDelete($$);}
 %type from {SrcList*}
 %destructor from {sqlSrcListDelete($$);}
 
-// A complete FROM clause.
-//
 from(A) ::= .                {A = sql_xmalloc0(sizeof(*A));}
-from(A) ::= FROM seltablist(X). {
-  A = X;
-  sqlSrcListShiftJoinType(A);
+from(A) ::= FROM source_list(X). {
+  A = src_list_from_ast(X);
 }
 
-// "seltablist" is a "Select Table List" - the content of the FROM clause
-// in a SELECT statement.  "stl_prefix" is a prefix of this list.
-//
-stl_prefix(A) ::= seltablist(A) joinop(Y).    {
-   if( ALWAYS(A && A->nSrc>0) ) A->a[A->nSrc-1].fg.jointype = (u8)Y;
+%type source_list {struct ast_source_list *}
+%destructor source_list {ast_source_list_destroy($$);}
+source_list(A) ::= source(X). {
+  A = ast_source_list_append(pParse, NULL, X);
 }
-stl_prefix(A) ::= .                           {A = 0;}
-seltablist(A) ::= stl_prefix(A) seqscan(X) nm(Y) as(Z) indexed_opt(I)
-                  on_opt(N) using_opt(U). {
-  A = sqlSrcListAppendFromTerm(pParse,A,&Y,&Z,0,N,U,X);
-  sqlSrcListIndexedBy(A, &I);
-}
-seltablist(A) ::= stl_prefix(A) seqscan(X) nm(Y) LP exprlist(E) RP as(Z)
-                  on_opt(N) using_opt(U). {
-  A = sqlSrcListAppendFromTerm(pParse,A,&Y,&Z,0,N,U,X);
-  sqlSrcListFuncArgs(A, E);
-}
-seltablist(A) ::= stl_prefix(A) LP select(S) RP
-                  as(Z) on_opt(N) using_opt(U). {
-  A = sqlSrcListAppendFromTerm(pParse,A,0,&Z,S,N,U,false);
-}
-seltablist(A) ::= stl_prefix(A) LP seltablist(F) RP
-                  as(Z) on_opt(N) using_opt(U). {
-  if( A==0 && Z.n==0 && N==0 && U==0 ){
+source_list(A) ::= LP source_list(F) RP as(Z). {
+  if (Z.n == 0) {
     A = F;
-  }else if( F->nSrc==1 ){
-    A = sqlSrcListAppendFromTerm(pParse,A,0,&Z,0,N,U,false);
-    if( A ){
-      struct SrcList_item *pNew = &A->a[A->nSrc-1];
-      struct SrcList_item *pOld = F->a;
-      pNew->zName = pOld->zName;
-      pNew->pSelect = pOld->pSelect;
-      pOld->zName =  0;
-      pOld->pSelect = 0;
+  } else if (F->len == 1) {
+    struct ast_source *old = stailq_first_entry(&F->head, struct ast_source,
+                                                link);
+    struct ast_source *new = ast_source_new(pParse);
+    new->name = old->name;
+    new->alias = Z;
+    new->select = old->select;
+    A = ast_source_list_append(pParse, NULL, new);
+  } else {
+    struct SrcList *list = src_list_from_ast(F);
+    if (list != NULL) {
+      Select *pSubquery = sqlSelectNew(pParse,0,list,0,0,0,0,SF_NestedFrom,0,0);
+      struct ast_source *src = ast_source_new(pParse);
+      src->alias = Z;
+      src->select = pSubquery;
+      A = ast_source_list_append(pParse, NULL, src);
     }
-    sqlSrcListDelete(F);
-  }else{
-    Select *pSubquery;
-    sqlSrcListShiftJoinType(F);
-    pSubquery = sqlSelectNew(pParse,0,F,0,0,0,0,SF_NestedFrom,0,0);
-    A = sqlSrcListAppendFromTerm(pParse,A,0,&Z,pSubquery,N,U,false);
   }
+}
+source_list(A) ::= source_list(A) joinop(Y) source(X) on_opt(N) using_opt(U). {
+  X->join_type = Y;
+  X->join_on = N;
+  X->join_using = U;
+  A = ast_source_list_append(pParse, A, X);
+}
+source_list(A) ::= source_list(X) joinop(Y) LP source_list(F) RP as(Z) on_opt(N)
+                   using_opt(U). {
+  if (F->len == 1) {
+    struct ast_source *old = stailq_first_entry(&F->head, struct ast_source,
+                                                link);
+    struct ast_source *new = ast_source_new(pParse);
+    new->name = old->name;
+    new->alias = Z;
+    new->select = old->select;
+    new->join_type = Y;
+    new->join_on = N;
+    new->join_using = U;
+    A = ast_source_list_append(pParse, X, new);
+  } else {
+    struct SrcList *list = src_list_from_ast(F);
+    if (list != NULL) {
+      Select *pSubquery = sqlSelectNew(pParse,0,list,0,0,0,0,SF_NestedFrom,0,0);
+      struct ast_source *src = ast_source_new(pParse);
+      src->alias = Z;
+      src->select = pSubquery;
+      src->join_type = Y;
+      src->join_on = N;
+      src->join_using = U;
+      A = ast_source_list_append(pParse, X, src);
+    }
+  }
+}
+
+%type source {struct ast_source *}
+%destructor source {ast_source_destroy($$);}
+source(A) ::= seqscan(X) nm(Y) as(Z) indexed_opt(I). {
+  A = ast_source_new(pParse);
+  A->name = Y;
+  A->alias = Z;
+  A->indexed_by = I;
+  A->disallow_scan = X;
+}
+source(A) ::= seqscan(X) nm(Y) LP exprlist(E) RP as(Z). {
+  A = ast_source_new(pParse);
+  A->name = Y;
+  A->alias = Z;
+  A->func_args = E;
+  A->is_tab_func = true;
+  A->disallow_scan = X;
+}
+source(A) ::= LP select(S) RP as(Z). {
+  A = ast_source_new(pParse);
+  A->alias = Z;
+  A->select = S;
 }
 
 %type fullname {SrcList*}

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -473,7 +473,7 @@ multiselect_op(A) ::= UNION(OP).             {A = @OP; /*A-overwrites-OP*/}
 multiselect_op(A) ::= UNION ALL.             {A = TK_ALL;}
 multiselect_op(A) ::= EXCEPT|INTERSECT(OP).  {A = @OP; /*A-overwrites-OP*/}
 
-oneselect(A) ::= SELECT distinct(D) selcollist(W) from(X) where_opt(Y)
+oneselect(A) ::= SELECT distinct(D) select_list(W) from(X) where_opt(Y)
                  groupby_opt(P) having_opt(Q) orderby_opt(Z) limit_opt(L). {
   A = ast_select_new(pParse);
   A->columns = W;
@@ -513,28 +513,35 @@ distinct(A) ::= DISTINCT.   {A = SF_Distinct;}
 distinct(A) ::= ALL.        {A = SF_All;}
 distinct(A) ::= .           {A = 0;}
 
-// selcollist is a list of expressions that are to become the return
-// values of the SELECT statement.  The "*" in statements like
-// "SELECT * FROM ..." is encoded as a special expression with an
-// opcode of TK_ASTERISK.
-//
-%type selcollist {ExprList*}
-%destructor selcollist {sql_expr_list_delete($$);}
-%type sclp {ExprList*}
-%destructor sclp {sql_expr_list_delete($$);}
-sclp(A) ::= selcollist(A) COMMA.
-sclp(A) ::= .                                {A = 0;}
-selcollist(A) ::= sclp(A) expr(X) as(Y).     {
-   A = sql_expr_list_append(A, X.pExpr);
-   if( Y.n>0 ) sqlExprListSetName(pParse, A, &Y, 1);
-   sqlExprListSetSpan(A, &X);
+%type select_list {struct ExprList *}
+%destructor select_list {sql_expr_list_delete($$);}
+select_list(A) ::= expr(X) as(Y). {
+  A = sql_expr_list_append(NULL, X.pExpr);
+  if(Y.n > 0)
+    sqlExprListSetName(pParse, A, &Y, 1);
+  sqlExprListSetSpan(A, &X);
 }
-selcollist(A) ::= sclp(A) STAR. {
+select_list(A) ::= STAR. {
+  A = sql_expr_list_append(NULL, sql_expr_new_anon(TK_ASTERISK));
+}
+select_list(A) ::= nm(X) DOT STAR. {
+  struct Expr *pLeft = sql_expr_new_dequoted(TK_ID, &X);
+  Expr *pRight = sql_expr_new_anon(TK_ASTERISK);
+  Expr *pDot = sqlPExpr(pParse, TK_DOT, pLeft, pRight);
+  A = sql_expr_list_append(NULL, pDot);
+}
+select_list(A) ::= select_list(A) COMMA expr(X) as(Y). {
+  A = sql_expr_list_append(A, X.pExpr);
+  if(Y.n > 0)
+    sqlExprListSetName(pParse, A, &Y, 1);
+  sqlExprListSetSpan(A, &X);
+}
+select_list(A) ::= select_list(A) COMMA STAR. {
   A = sql_expr_list_append(A, sql_expr_new_anon(TK_ASTERISK));
 }
-selcollist(A) ::= sclp(A) nm(X) DOT STAR. {
+select_list(A) ::= select_list(A) COMMA nm(X) DOT STAR. {
   struct Expr *pLeft = sql_expr_new_dequoted(TK_ID, &X);
-  Expr *pRight = sqlPExpr(pParse, TK_ASTERISK, 0, 0);
+  Expr *pRight = sql_expr_new_anon(TK_ASTERISK);
   Expr *pDot = sqlPExpr(pParse, TK_DOT, pLeft, pRight);
   A = sql_expr_list_append(A, pDot);
 }

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -4482,12 +4482,12 @@ sqlIndexedByLookup(Parse * pParse, struct SrcList_item *pFrom)
 static int
 convertCompoundSelectToSubquery(Walker * pWalker, Select * p)
 {
+	(void)pWalker;
 	int i;
 	Select *pNew;
 	Select *pX;
 	struct ExprList_item *a;
 	SrcList *pNewSrc;
-	Parse *pParse;
 	Token dummy;
 
 	if (p->pPrior == 0)
@@ -4509,13 +4509,9 @@ convertCompoundSelectToSubquery(Walker * pWalker, Select * p)
 
 	/* If we reach this point, that means the transformation is required. */
 
-	pParse = pWalker->pParse;
 	pNew = sql_xmalloc0(sizeof(*pNew));
 	memset(&dummy, 0, sizeof(dummy));
-	pNewSrc = sqlSrcListAppendFromTerm(pParse, 0, 0, &dummy, pNew, 0, 0,
-					   false);
-	if (pNewSrc == 0)
-		return WRC_Abort;
+	pNewSrc = sqlSrcListAppendFromTerm(0, 0, &dummy, pNew, 0, 0, false);
 	*pNew = *p;
 	p->pSrc = pNewSrc;
 	struct Expr *expr = sql_expr_new_anon(TK_ASTERISK);

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1555,9 +1555,7 @@ typedef u64 Bitmask;
  * now be identified by a database name, a dot, then the table name: ID.ID.
  *
  * The jointype starts out showing the join type between the current table
- * and the next table on the list.  The parser builds the list this way.
- * But sqlSrcListShiftJoinType() later shifts the jointypes so that each
- * jointype expresses the join between the table and the previous table.
+ * and the previous table on the list.
  *
  * In the colUsed field, the high-order bit (bit 63) is set if the table
  * contains more than 63 columns and the 64-th or later column is used.
@@ -2897,10 +2895,10 @@ sql_src_list_append(struct SrcList *list, struct Token *name_token);
  * Return a new SrcList that encodes FROM with the new term added.
  */
 struct SrcList *
-sqlSrcListAppendFromTerm(struct Parse *pParse, struct SrcList *p,
-			 struct Token *pTable, struct Token *pAlias,
-			 struct Select *pSubquery, struct Expr *pOn,
-			 struct ast_id_list *join_using, int disallow_scan);
+sqlSrcListAppendFromTerm(struct SrcList *p, struct Token *pTable,
+			 struct Token *pAlias, struct Select *pSubquery,
+			 struct Expr *pOn, struct ast_id_list *join_using,
+			 int disallow_scan);
 
 /**
  * Add an INDEXED BY or NOT INDEXED clause to the most recently added element of
@@ -2917,7 +2915,6 @@ void
 sqlSrcListFuncArgs(struct SrcList *p, struct ExprList *pList);
 
 int sqlIndexedByLookup(Parse *, struct SrcList_item *);
-void sqlSrcListShiftJoinType(SrcList *);
 void sqlSrcListAssignCursors(Parse *, SrcList *);
 
 /** Delete an IdList. */

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2598,17 +2598,6 @@ struct ExprList *
 sqlExprListAppendVector(struct Parse *pParse, struct ExprList *pList,
 			struct ast_id_list *columns, struct Expr *pExpr);
 
-/**
- * Parse tokens as a name or a position of bound variable.
- *
- * @param parse Parse context.
- * @param spec Special symbol for bound variable.
- * @param id Name or position number of bound variable.
- */
-struct Expr *
-expr_new_variable(struct Parse *parse, const struct Token *spec,
-		  const struct Token *id);
-
 /** Return TRUE if expression is term, FALSE otherwise. */
 static inline bool
 sql_expr_is_term(const struct Expr *expr)
@@ -2634,7 +2623,7 @@ void sqlExprListSetName(Parse *, ExprList *, Token *, int);
  * expression list.
  */
 void
-sqlExprListSetSpan(struct ExprList *pList, struct ExprSpan *pSpan);
+sqlExprListSetSpan(struct ExprList *pList, const char *str, uint32_t len);
 
 u32 sqlExprListFlags(const ExprList *);
 

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -69,6 +69,7 @@
 
 #include "box/column_mask.h"
 #include "parse_def.h"
+#include "ast.h"
 #include "box/field_def.h"
 #include "box/func.h"
 #include "box/func_def.h"
@@ -2578,7 +2579,26 @@ sql_and_expr_new(struct Expr *left_expr, struct Expr *right_expr);
 
 Expr *sqlExprFunction(Parse *, ExprList *, Token *);
 void sqlExprAssignVarNumber(Parse *, Expr *, u32);
-ExprList *sqlExprListAppendVector(Parse *, ExprList *, IdList *, Expr *);
+
+/*
+ * pColumns and pExpr form a vector assignment which is part of the SET
+ * clause of an UPDATE statement.  Like this:
+ *
+ *        (a,b,c) = (expr1,expr2,expr3)
+ * Or:    (a,b,c) = (SELECT x,y,z FROM ....)
+ *
+ * For each term of the vector assignment, append new entries to the
+ * expression list pList.  In the case of a subquery on the LHS, append
+ * TK_SELECT_COLUMN expressions.
+ *
+ * @param pParse Parsing context.
+ * @param pList List to which to append. Might be NULL.
+ * @param columns List of names of LHS of the assignment.
+ * @param pExpr Vector expression to be appended. Might be NULL.
+ */
+struct ExprList *
+sqlExprListAppendVector(struct Parse *pParse, struct ExprList *pList,
+			struct ast_id_list *columns, struct Expr *pExpr);
 
 /**
  * Parse tokens as a name or a position of bound variable.
@@ -2870,7 +2890,7 @@ sql_src_list_append(struct SrcList *list, struct Token *name_token);
  * FROM clause. "pTable" is the name of the table in the FROM clause term. If
  * the term has an alias, then "pAlias" points to the alias token. If the term
  * is a subquery, then "pSubquery" is the SELECT statement that the subquery
- * encodes. The "pTable" is NULL for subqueries. The "pOn" and "pUsing"
+ * encodes. The "pTable" is NULL for subqueries. The "pOn" and "join_using"
  * parameters are the content of the ON and USING clauses. Flag disallow_scan
  * shows if scannig SELECT can be executed for this source.
  *
@@ -2880,7 +2900,7 @@ struct SrcList *
 sqlSrcListAppendFromTerm(struct Parse *pParse, struct SrcList *p,
 			 struct Token *pTable, struct Token *pAlias,
 			 struct Select *pSubquery, struct Expr *pOn,
-			 struct IdList *pUsing, int disallow_scan);
+			 struct ast_id_list *join_using, int disallow_scan);
 
 /**
  * Add an INDEXED BY or NOT INDEXED clause to the most recently added element of
@@ -3622,7 +3642,7 @@ sql_trigger_select_step(struct Select *select);
  * @retval Not NULL TriggerStep object on success.
  */
 struct TriggerStep *
-sql_trigger_insert_step(struct Token *table_name, struct IdList *column_list,
+sql_trigger_insert_step(struct Token *table_name, struct ast_id_list *columns,
 			struct Select *select, enum on_conflict_action orconf);
 
 /**

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -620,17 +620,6 @@ sql_bind_parameter_lindex(struct Vdbe *v, const char *zName, int nName);
 #define SQL_DEFAULT_RECURSIVE_TRIGGERS 0
 #endif
 
-/**
- * Default count of allowed compound selects.
- *
- * Tarantool: gh-2548, gh-3382: Fiber stack is 64KB by default,
- * so maximum number of entities should be less than 30 or stack
- * guard will be triggered (triggered with clang).
-*/
-#ifndef SQL_DEFAULT_COMPOUND_SELECT
-#define SQL_DEFAULT_COMPOUND_SELECT 30
-#endif
-
 /*
  * Macros to compute minimum and maximum of two numbers.
  */

--- a/src/box/sql/sqlLimit.h
+++ b/src/box/sql/sqlLimit.h
@@ -118,7 +118,7 @@ enum {
  * any limit on the number of terms in a compount SELECT.
  */
 #ifndef SQL_MAX_COMPOUND_SELECT
-#define SQL_MAX_COMPOUND_SELECT 50
+#define SQL_MAX_COMPOUND_SELECT 30
 #endif
 
 /*

--- a/src/box/sql/trigger.c
+++ b/src/box/sql/trigger.c
@@ -245,14 +245,14 @@ sql_trigger_step_new(u8 op, struct Token *target_name)
 }
 
 struct TriggerStep *
-sql_trigger_insert_step(struct Token *table_name, struct IdList *column_list,
+sql_trigger_insert_step(struct Token *table_name, struct ast_id_list *columns,
 			struct Select *select, enum on_conflict_action orconf)
 {
 	assert(select != NULL);
 	struct TriggerStep *trigger_step =
 		sql_trigger_step_new(TK_INSERT, table_name);
 	trigger_step->pSelect = sqlSelectDup(select, EXPRDUP_REDUCE);
-	trigger_step->pIdList = column_list;
+	trigger_step->pIdList = id_list_from_ast(columns);
 	trigger_step->orconf = orconf;
 	sql_select_delete(select);
 	return trigger_step;

--- a/test/sql-tap/join.test.lua
+++ b/test/sql-tap/join.test.lua
@@ -577,7 +577,8 @@ test:do_catchsql_test(
         SELECT * FROM t1 USING(a);
     ]], {
         -- <join-3.5>
-        1, "Syntax error at line 1 at or near position 34: a JOIN clause is required before ON and USING"
+        1, "At line 1 at or near position 26: keyword 'USING' is reserved. " ..
+        "Please use double quotes if 'USING' is an identifier."
         -- </join-3.5>
     })
 

--- a/test/sql-tap/misc1.test.lua
+++ b/test/sql-tap/misc1.test.lua
@@ -1062,7 +1062,7 @@ test:do_catchsql_test(
         VALUES(0,0x0MATCH#0;
     ]], {
         -- <misc1-21.2>
-        1, [[Syntax error at line 1 near '#']]
+        1, [[Syntax error at line 1 near ';']]
         -- </misc1-21.2>
     })
 

--- a/test/sql-tap/tkt3935.test.lua
+++ b/test/sql-tap/tkt3935.test.lua
@@ -57,7 +57,8 @@ test:do_catchsql_test(
         SELECT a FROM (t1) AS t ON b USING(a);
     ]], {
         -- <tkt3935.4>
-        1, "Syntax error at line 1 at or near position 46: a JOIN clause is required before ON and USING"
+        1, "At line 1 at or near position 33: keyword 'ON' is reserved. " ..
+        "Please use double quotes if 'ON' is an identifier."
         -- </tkt3935.4>
     })
 
@@ -67,7 +68,8 @@ test:do_catchsql_test(
         SELECT a FROM (t1) AS t ON b;
     ]], {
         -- <tkt3935.5>
-        1, "Syntax error at line 1 at or near position 37: a JOIN clause is required before ON and USING"
+        1, "At line 1 at or near position 33: keyword 'ON' is reserved. " ..
+        "Please use double quotes if 'ON' is an identifier."
         -- </tkt3935.5>
     })
 
@@ -77,7 +79,8 @@ test:do_catchsql_test(
         SELECT a FROM (SELECT * FROM t1) AS t ON b USING(a);
     ]], {
         -- <tkt3935.6>
-        1, "Syntax error at line 1 at or near position 60: a JOIN clause is required before ON and USING"
+        1, "At line 1 at or near position 47: keyword 'ON' is reserved. " ..
+        "Please use double quotes if 'ON' is an identifier."
         -- </tkt3935.6>
     })
 
@@ -87,7 +90,8 @@ test:do_catchsql_test(
         SELECT a FROM (SELECT * FROM t1) AS t ON b;
     ]], {
         -- <tkt3935.7>
-        1, "Syntax error at line 1 at or near position 51: a JOIN clause is required before ON and USING"
+        1, "At line 1 at or near position 47: keyword 'ON' is reserved. " ..
+        "Please use double quotes if 'ON' is an identifier."
         -- </tkt3935.7>
     })
 
@@ -97,7 +101,8 @@ test:do_catchsql_test(
         SELECT a FROM t1 AS t ON b;
     ]], {
         -- <tkt3935.8>
-        1, "Syntax error at line 1 at or near position 35: a JOIN clause is required before ON and USING"
+        1, "At line 1 at or near position 31: keyword 'ON' is reserved. " ..
+        "Please use double quotes if 'ON' is an identifier."
         -- </tkt3935.8>
     })
 
@@ -107,7 +112,8 @@ test:do_catchsql_test(
         SELECT a FROM t1 AS t ON b USING(a);
     ]], {
         -- <tkt3935.9>
-        1, "Syntax error at line 1 at or near position 44: a JOIN clause is required before ON and USING"
+        1, "At line 1 at or near position 31: keyword 'ON' is reserved. " ..
+        "Please use double quotes if 'ON' is an identifier."
         -- </tkt3935.9>
     })
 
@@ -117,7 +123,8 @@ test:do_catchsql_test(
         SELECT a FROM t1 AS t USING(a);
     ]], {
         -- <tkt3935.10>
-        1, "Syntax error at line 1 at or near position 39: a JOIN clause is required before ON and USING"
+        1, "At line 1 at or near position 31: keyword 'USING' is reserved. " ..
+        "Please use double quotes if 'USING' is an identifier."
         -- </tkt3935.10>
     })
 


### PR DESCRIPTION
This patch-set a set of structures, that will be used to describe basic objects, received from SQL parser.

This patch-set is mostly a refactoring, also contains some occasional refactoring to the `parse.y` file.

Part of #5485 