### PR TITLE
config: allow unset unused context env vars

### DIFF
--- a/changelogs/unreleased/gh-10436-unset-unused-context-env.md
+++ b/changelogs/unreleased/gh-10436-unset-unused-context-env.md
@@ -1,0 +1,6 @@
+## bugfix/config
+
+* Unused `config.context` variables that cannot be read (an unset
+  environment variable or an unreadable file) no longer prevent an
+  instance from starting. A warning is logged for each such variable
+  (gh-10436).

--- a/src/box/lua/config/configdata.lua
+++ b/src/box/lua/config/configdata.lua
@@ -1074,7 +1074,7 @@ local function new(iconfig, cconfig, instance_name)
     iconfig = instance_config:normalize(
         instance_config:apply_vars(iconfig, vars))
     iconfig_def = instance_config:normalize(
-        instance_config:apply_vars(iconfig_def, vars))
+        instance_config:apply_vars(iconfig_def, vars, {warn = true}))
 
     local replicaset_uuid = instance_config:get(iconfig_def,
         'database.replicaset_uuid')

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -266,16 +266,23 @@ local function instance_uri(self, iconfig, advertise_type, opts)
     return uri
 end
 
-local function apply_vars_f(data, w, vars)
-    if data ~= nil and type(data) == 'string' then
-        return (data:gsub('{{ *(.-) *}}', function(var_name)
-            if vars[var_name] ~= nil then
-                return vars[var_name]
-            end
-            w.error(('Unknown variable %q'):format(var_name))
-        end))
+-- Substitute {{ var_name }} tokens in a string. ctx.vars holds the
+-- static template variables; ctx.context resolves
+-- config.context.<name> on demand, raising on a read failure.
+local function apply_vars_f(data, w, ctx)
+    if type(data) ~= 'string' then
+        return data
     end
-    return data
+    return (data:gsub('{{ *(.-) *}}', function(var_name)
+        if ctx.vars[var_name] ~= nil then
+            return ctx.vars[var_name]
+        end
+        local name = var_name:match('^context%.(.+)$')
+        if name ~= nil then
+            return ctx.context(name, w)
+        end
+        w.error(('Unknown variable %q'):format(var_name))
+    end))
 end
 
 -- The file path is interpreted as relative to `process.work_dir`.
@@ -304,7 +311,8 @@ local function prepare_file_path(self, iconfig, path)
 end
 
 -- Read a config.context[name] variable depending on its "from"
--- type.
+-- type. Returns (true, value) on success or (false, err_msg) on a
+-- read failure (an unset 'env' variable or an unreadable 'file').
 local function read_context_var_noexc(base_dir, def)
     -- Scalar shorthand: the value is defined right in
     -- config.context.
@@ -318,41 +326,85 @@ local function read_context_var_noexc(base_dir, def)
         return true, def
     end
     -- Record form: resolve the value from env/file.
+    local ok, value
     if def.from == 'env' then
-        local value = os.getenv(def.env)
+        value = os.getenv(def.env)
         if value == nil then
-            return false, ('no %q environment variable'):format(def.env)
+            value = ('no %q environment variable'):format(def.env)
+            ok = false
+        else
+            ok = true
         end
-        return true, value
     elseif def.from == 'file' then
         local path = file.rebase_file_path(base_dir, def.file)
-        return pcall(file.universal_read, path, 'file')
+        ok, value = pcall(file.universal_read, path, 'file')
     else
         assert(false)
     end
+    if ok and def.rstrip then
+        value = value:rstrip()
+    end
+    return ok, value
 end
 
-local function apply_vars(self, iconfig, vars)
+-- opts.warn, when true, logs a warning for each declared
+-- config.context variable that is unreferenced and cannot be read
+-- (such variables no longer abort startup; referenced ones still do).
+-- Set only for the real apply, not the defaults-only one, to avoid
+-- duplicate warnings (see build_iconfig() in configdata.lua).
+local function apply_vars(self, iconfig, vars, opts)
     vars = table.copy(vars)
 
     local base_dir = self:base_dir(iconfig)
+    local context_vars = self:get(iconfig, 'config.context') or {}
 
-    -- Read config.context.* variables and add them into the
-    -- variables list.
-    local context_vars = self:get(iconfig, 'config.context')
-    for name, def in pairs(context_vars or {}) do
-        local ok, res = read_context_var_noexc(base_dir, def)
-        if not ok then
-            error(('Unable to read config.context.%s variable value: ' ..
-                '%s'):format(name, res), 0)
+    -- Names of the config.context variables that got referenced.
+    local used = {}
+    -- Per-call cache of resolved variables ({ok, res} by name).
+    local cache = {}
+
+    -- Read a declared config.context.<name>, at most once per call.
+    local function resolve_cached(name)
+        local cached = cache[name]
+        if cached == nil then
+            cached = {read_context_var_noexc(base_dir, context_vars[name])}
+            cache[name] = cached
         end
-        if type(def) == 'table' and def.rstrip then
-            res = res:rstrip()
-        end
-        vars['context.' .. name] = res
+        return cached[1], cached[2]
     end
 
-    return self:map(iconfig, apply_vars_f, vars)
+    -- Resolve a config.context.<name> reference, raising if it is
+    -- declared but cannot be read.
+    local function context(name, w)
+        used[name] = true
+        if context_vars[name] == nil then
+            w.error(('Unknown variable "context.%s"'):format(name))
+        end
+        local ok, res = resolve_cached(name)
+        if not ok then
+            w.error(('Unable to read config.context.%s variable value: %s')
+                :format(name, res))
+        end
+        return res
+    end
+
+    local res = self:map(iconfig, apply_vars_f,
+                         {vars = vars, context = context})
+
+    -- Warn about unreferenced variables that can't be read.
+    if opts ~= nil and opts.warn then
+        for name in pairs(context_vars) do
+            if not used[name] then
+                local ok, err = resolve_cached(name)
+                if not ok then
+                    log.warn(('config.context.%s: cannot read the variable ' ..
+                        'value: %s, it is left unset'):format(name, err))
+                end
+            end
+        end
+    end
+
+    return res
 end
 
 local function feedback_apply_default_if(_data, _w)

--- a/test/config-luatest/gh_10436_unset_env_var_test.lua
+++ b/test/config-luatest/gh_10436_unset_env_var_test.lua
@@ -1,0 +1,231 @@
+local t = require('luatest')
+local yaml = require('yaml')
+local treegen = require('luatest.treegen')
+local justrun = require('luatest.justrun')
+local cluster_config = require('internal.config.cluster_config')
+local helpers = require('test.config-luatest.helpers')
+
+local g = helpers.group()
+
+-- Verify the given configuration option.
+local function verify_option(option, exp)
+    return loadstring(([[
+        local t = require('luatest')
+        local config = require('config')
+
+        t.assert_equals(config:info().status, 'ready')
+        t.assert_equals(config:get(%q), %q)
+    ]]):format(option, exp))
+end
+
+-- Unset env var of an unreferenced context variable must not
+-- prevent startup.
+g.test_unused_unset_env_context_var_starts = function(g)
+    helpers.success_case(g, {
+        options = {
+            ['config.context'] = {
+                myvar = {
+                    from = 'env',
+                    env = 'MYVAR_UNSET_ENV',
+                },
+            },
+        },
+        verify = function()
+            local config = require('config')
+            t.assert_equals(config:info().status, 'ready')
+        end,
+    })
+end
+
+-- The exact ticket config: two unreferenced env context vars, both
+-- unset. The instance must start.
+g.test_ticket_config_two_unused_unset_env_vars = function(g)
+    helpers.success_case(g, {
+        options = {
+            ['config.context'] = {
+                dbadmin_password = {
+                    from = 'env',
+                    env = 'DBADMIN_PASSWORD',
+                },
+                sampleuser_password = {
+                    from = 'env',
+                    env = 'SAMPLEUSER_PASSWORD',
+                },
+            },
+        },
+        verify = function()
+            local config = require('config')
+            t.assert_equals(config:info().status, 'ready')
+        end,
+    })
+end
+
+-- An unreferenced unset env context var must produce a warning. The
+-- warning is logged before box.cfg(), so it goes to stderr (not the
+-- box log file); run the instance via justrun and grep its stderr.
+g.test_unused_unset_env_context_var_warns = function()
+    local dir = treegen.prepare_directory({}, {})
+    local config = table.deepcopy(helpers.simple_config)
+    cluster_config:set(config, 'config.context', {
+        myvar = {from = 'env', env = 'MYVAR_UNSET_ENV'},
+    })
+    cluster_config:set(config, 'app.file', 'main.lua')
+    treegen.write_file(dir, 'config.yaml', yaml.encode(config))
+    -- The instance starts successfully; exit right after so that
+    -- justrun collects the full stderr and returns.
+    treegen.write_file(dir, 'main.lua', 'os.exit(0)')
+
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, {},
+        {'--name', 'instance-001', '--config', 'config.yaml'}, opts)
+    t.assert_equals(res.exit_code, 0)
+    t.assert_str_contains(res.stderr, 'config.context.myvar: cannot read ' ..
+        'the variable value: no "MYVAR_UNSET_ENV" environment variable, ' ..
+        'it is left unset')
+end
+
+-- A referenced context var with an unset env var must still fail
+-- startup (existing error contract).
+g.test_referenced_unset_env_context_var_fails = function()
+    helpers.failure_case({
+        options = {
+            ['config.context'] = {
+                myvar = {
+                    from = 'env',
+                    env = 'MYVAR_UNSET_ENV',
+                },
+            },
+            ['process.title'] = '{{ context.myvar }}',
+        },
+        exp_err = table.concat({
+            'Unable to read config.context.myvar variable value',
+            'no "MYVAR_UNSET_ENV" environment variable',
+        }, ': '),
+    })
+end
+
+-- A referenced context var with a set env var is substituted.
+g.test_referenced_set_env_context_var_works = function(g)
+    helpers.success_case(g, {
+        env = {
+            ['MYVAR_SET_ENV'] = 'needle',
+        },
+        options = {
+            ['config.context'] = {
+                myvar = {
+                    from = 'env',
+                    env = 'MYVAR_SET_ENV',
+                },
+            },
+            ['process.title'] = '{{ context.myvar }}',
+        },
+        verify = verify_option('process.title', 'needle'),
+    })
+end
+
+-- A referenced env var with rstrip = true is resolved and stripped.
+g.test_referenced_set_env_context_var_rstrip = function(g)
+    helpers.success_case(g, {
+        env = {
+            ['MYVAR_SET_ENV'] = 'needle   ',
+        },
+        options = {
+            ['config.context'] = {
+                myvar = {
+                    from = 'env',
+                    env = 'MYVAR_SET_ENV',
+                    rstrip = true,
+                },
+            },
+            ['process.title'] = '{{ context.myvar }}',
+        },
+        verify = verify_option('process.title', 'needle'),
+    })
+end
+
+-- Lazy resolution: start with the env var unset and unreferenced,
+-- then set it and reference it on reload -- reload must succeed.
+g.test_lazy_env_context_var_set_before_reference = function(g)
+    helpers.reload_success_case(g, {
+        options = {
+            ['config.context'] = {
+                myvar = {
+                    from = 'env',
+                    env = 'MYVAR_LAZY_ENV',
+                },
+            },
+        },
+        verify = function()
+            local config = require('config')
+            t.assert_equals(config:info().status, 'ready')
+            os.setenv('MYVAR_LAZY_ENV', 'needle')
+        end,
+        options_2 = {
+            ['config.context'] = {
+                myvar = {
+                    from = 'env',
+                    env = 'MYVAR_LAZY_ENV',
+                },
+            },
+            ['process.title'] = '{{ context.myvar }}',
+        },
+        verify_2 = verify_option('process.title', 'needle'),
+    })
+end
+
+-- A missing file of an unreferenced 'file' context var must not
+-- prevent startup (same relaxation as for unset env vars).
+g.test_unused_missing_file_context_var_starts = function(g)
+    helpers.success_case(g, {
+        options = {
+            ['config.context'] = {
+                myvar = {
+                    from = 'file',
+                    file = 'no_such_file.txt',
+                },
+            },
+        },
+        verify = function()
+            local config = require('config')
+            t.assert_equals(config:info().status, 'ready')
+        end,
+    })
+end
+
+-- An unreferenced unreadable 'file' context var must warn on stderr
+-- (logged before box.cfg(), so use justrun; see the env case above).
+g.test_unused_missing_file_context_var_warns = function()
+    local dir = treegen.prepare_directory({}, {})
+    local config = table.deepcopy(helpers.simple_config)
+    cluster_config:set(config, 'config.context', {
+        myvar = {from = 'file', file = 'no_such_file.txt'},
+    })
+    cluster_config:set(config, 'app.file', 'main.lua')
+    treegen.write_file(dir, 'config.yaml', yaml.encode(config))
+    treegen.write_file(dir, 'main.lua', 'os.exit(0)')
+
+    local opts = {nojson = true, stderr = true}
+    local res = justrun.tarantool(dir, {},
+        {'--name', 'instance-001', '--config', 'config.yaml'}, opts)
+    t.assert_equals(res.exit_code, 0)
+    t.assert_str_contains(res.stderr, 'config.context.myvar: cannot read ' ..
+        'the variable value: Unable to open file')
+end
+
+-- A referenced 'file' context var with a missing file must still
+-- fail startup (existing error contract).
+g.test_referenced_missing_file_context_var_fails = function()
+    helpers.failure_case({
+        options = {
+            ['config.context'] = {
+                myvar = {
+                    from = 'file',
+                    file = 'no_such_file.txt',
+                },
+            },
+            ['process.title'] = '{{ context.myvar }}',
+        },
+        exp_err = 'Unable to read config.context.myvar variable value: ' ..
+            'Unable to open file',
+    })
+end


### PR DESCRIPTION
Do not fail configuration startup when an environment variable declared in config.context is unset but never referenced. Resolve such variables lazily and log a warning when they remain unused.

Keep reporting an error if an unset variable is referenced by a configuration template.

Closes #10436

NO_DOC=bugfix