### PR TITLE
build: enable basic/digest auth in libcurl build

### DIFF
--- a/changelogs/unreleased/gh-12805-fix-proxy-auth.md
+++ b/changelogs/unreleased/gh-12805-fix-proxy-auth.md
@@ -1,0 +1,4 @@
+## bugfix/lua/http client
+
+* Fixed a regression of authorization on an HTTP proxy or a target HTTP(S) host
+  using the Basic algorithm (gh-12805).

--- a/cmake/BuildLibCURL.cmake
+++ b/cmake/BuildLibCURL.cmake
@@ -100,9 +100,21 @@ macro(curl_build)
     # Additionaly disable some more protocols.
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_SMB=ON")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_GOPHER=ON")
-    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_BASIC_AUTH=ON")
+
+    # Enable basic and digest auth methods, disable all the others.
+    #
+    # The built-in http client uses the libcurl's basic auth functionality, when
+    # proxy or target URI is in the https://user:pass@<...> form or when the
+    # `proxy_user_pwd` Lua API option is provided.
+    #
+    # The external smtp module may use the digest auth method.
+    #
+    # Enabling other auth methods would only add dead code, because the built-in
+    # http client has no API to use them. Also, kerberos/negotiate require a new
+    # GSSAPI dependency.
+    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_BASIC_AUTH=OFF")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_BEARER_AUTH=ON")
-    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_DIGEST_AUTH=ON")
+    list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_DIGEST_AUTH=OFF")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_KERBEROS_AUTH=ON")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_NEGOTIATE_AUTH=ON")
     list(APPEND LIBCURL_CMAKE_FLAGS "-DCURL_DISABLE_AWS=ON")


### PR DESCRIPTION
Enabling the Basic auth fixes a regression introduced in commit c9daf9bf079a ("cmake: reflect changes with CURL_DISABLE_CRYPTO_AUTH"), where the Basic authorization mechanism was mistakenly disabled.

The linked commit attempts to follow libcurl's commit [1] ("lib: add ability to disable auths individually"), where a generic `CURL_DISABLE_CRYPTO_AUTH` build option was replaced by the following ones:

* `CURL_DISABLE_DIGEST_AUTH`
* `CURL_DISABLE_KERBEROS_AUTH`
* `CURL_DISABLE_NEGOTIATE_AUTH`
* `CURL_DISABLE_AWS`

These ones were set to `ON`, which disables the corresponding auth algorithms.

However, libcurl's commit also adds two new build options that allow disabling functionality that was previously enabled unconditionally:

* `CURL_DISABLE_BASIC_AUTH`
* `CURL_DISABLE_BEARER_AUTH`

These options were set to `ON` in the linked tarantool commit as well.

As a result, tarantool's built-in http client is unable to handle the Basic algorithm for authorization on a proxy or a target host. So, it is enabled back by this commit.

## What exactly is repaired?

* Authorization on a proxy server using the `https_proxy=http://user:pass@<...>` environment variable (and similar ones, see [2]).
* Authorization on a proxy server using the `proxy_user_pwd` option from the http client's Lua API.
* Authorization on a target server using the `https://user:pass@<...>` URL scheme.

Digest is also enabled by this commit, but the reason is different. We can't use libcurl's Digest algorithm implementation with the built-in http client neither for a proxy nor for a target host. Our http client leaves `CURLOPT_HTTPAUTH` at its default, which is `CURLAUTH_BASIC`. It doesn't add `CURLAUTH_DIGEST` to the client-side supported auth methods.

However, there is an smtp client (implemented as a separate module, see [3]), which may use Digest once it is compiled into the library if the server supports it and if the `username`/`password` options are provided. `CURLOPT_HTTPAUTH`'s default is irrelevant here and Digest is used if possible.

The Digest algorithm doesn't need any new dependency; everything is in libcurl itself.

## Why not enable Bearer back as well?

libcurl's Bearer support just sets the `Authorization: Bearer <token>` header with the token provided with `CURLOPT_XOAUTH2_BEARER`, nothing else. The library doesn't provide any negotiation protocol support, so enabling it adds nothing without some negotiation code and related Lua API.

## Why not enable Kerberos/Negotiate?

They require a new GSSAPI dependency. Also, the use case is a bit specific: Active Directory, Kerberos-based SSO; mainly related to corporate environments. I would avoid enabling them until we see a real need. (And we also have to implement a Lua API to pass credentials to actually provide it as a feature of the built-in http client.)

## Why not enable AWS?

It doesn't require new dependencies, but it is vendor-specific and I would avoid enabling it until we see a real need. (And it also requires some Lua API in the http client.)

Fixes #12805

[1]: https://github.com/curl/curl/commit/e92edfbef64448ef461117769881f3ed776dec4e
[2]: https://curl.se/libcurl/c/libcurl-env.html
[3]: https://github.com/tarantool/smtp