### PR TITLE
sql: fix behaviour of anonymous variables in statements with bind variables

### DIFF
--- a/changelogs/unreleased/gh-12733-fix-behaviout-of-anonymous-variables.md
+++ b/changelogs/unreleased/gh-12733-fix-behaviout-of-anonymous-variables.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed a wrong behaviour of anonymous variables
+  in sql statement with bind variables (gh-12733).

--- a/src/box/bind.c
+++ b/src/box/bind.c
@@ -173,12 +173,20 @@ sql_bind_list_decode(const char *data, struct sql_bind **out_bind)
 	return bind_count;
 }
 
+void
+set_bind_variables_in_vdbe(struct Vdbe *stmt, const char **bind_names,
+			   uint32_t *bind_names_len, uint32_t bind_count)
+{
+	sql_set_bind_variables_in_vdbe(stmt, bind_names,
+				       bind_names_len, bind_count);
+}
+
 int
 sql_bind_column(struct Vdbe *stmt, const struct sql_bind *p, uint32_t pos)
 {
 	if (p->name != NULL) {
-		pos = sql_bind_parameter_lindex(stmt, p->name, p->name_len);
-		if (pos == 0) {
+		if (sql_bind_parameter_lindex(stmt, p->name,
+					      p->name_len) == 0) {
 			diag_set(ClientError, ER_SQL_BIND_NOT_FOUND,
 				 sql_bind_name(p));
 			return -1;

--- a/src/box/bind.h
+++ b/src/box/bind.h
@@ -131,6 +131,13 @@ int
 sql_bind_column(struct Vdbe *stmt, const struct sql_bind *p, uint32_t pos);
 
 /**
+ * Put names and lens of names of bind_variables in vdbe.
+ */
+void
+set_bind_variables_in_vdbe(struct Vdbe *stmt, const char **bind_names,
+			   uint32_t *bind_names_len, uint32_t bind_count);
+
+/**
  * Bind parameter values to the prepared statement.
  * @param stmt Prepared statement.
  * @param bind Parameters to bind.
@@ -144,10 +151,18 @@ sql_bind(struct Vdbe *stmt, const struct sql_bind *bind, uint32_t bind_count)
 {
 	assert(stmt != NULL);
 	uint32_t pos = 1;
+	const char **bind_names = (const char **) xmalloc(sizeof(char *) *
+							  bind_count);
+	uint32_t *bind_names_len = (uint32_t *) xmalloc(sizeof(uint32_t) *
+							  bind_count);
 	for (uint32_t i = 0; i < bind_count; pos = ++i + 1) {
+		bind_names[i] = bind[i].name;
+		bind_names_len[i] = bind[i].name_len;
 		if (sql_bind_column(stmt, &bind[i], pos) != 0)
 			return -1;
 	}
+	set_bind_variables_in_vdbe(stmt, bind_names,
+				   bind_names_len, bind_count);
 	return 0;
 }
 

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -488,6 +488,14 @@ sql_unbind(struct Vdbe *stmt);
 void
 sql_reset_autoinc_id_list(struct Vdbe *stmt);
 
+/**
+ * Put names and lens of names of bind_variables in vdbe.
+ */
+void
+sql_set_bind_variables_in_vdbe(struct Vdbe *stmt, const char **bind_names,
+			       uint32_t *bind_names_len,
+			       uint32_t bind_count);
+
 /** Perform double parameter binding for the sql statement. */
 int
 sql_bind_double(struct Vdbe *v, int i, double value);

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -353,11 +353,30 @@ vdbe_field_ref_fetch(struct vdbe_field_ref *field_ref, uint32_t fieldno,
 }
 
 /*
+ * Return number of same bind variable.
+ * Returns 0 if no same bind_variable.
+ */
+static inline uint32_t
+vdbe_find_bind_names(Vdbe *p, const char *p4_name)
+{
+	for (uint32_t i = 0; i < p->count_bind_names; i++) {
+		if (p->bind_names[i] != NULL) {
+			if (strncmp(p->bind_names[i], p4_name,
+				    p->bind_names_len[i]) == 0) {
+				return (++i);
+			}
+		}
+	}
+	return 0;
+}
+
+/*
  * Execute as much of a VDBE program as we can.
  * This is the core of sql_step().
  */
 int sqlVdbeExec(Vdbe *p)
 {
+	ynVar last_p1 = 0;
 	Op *aOp = p->aOp;          /* Copy of p->aOp */
 	Op *pOp = aOp;             /* Current operation */
 #if defined(SQL_DEBUG)
@@ -405,6 +424,19 @@ int sqlVdbeExec(Vdbe *p)
 			printf("VDBE Trace:\n");
 	}
 #endif
+	for (pOp = &aOp[p->pc]; pOp < &aOp[p->nOp]; pOp++) {
+		if (pOp->opcode == OP_Variable) {
+			if (pOp->p4.z != NULL) {
+				uint32_t p1 =
+					vdbe_find_bind_names(p, pOp->p4.z);
+				if (p1 > 0)
+					pOp->p1 = p1;
+			} else {
+				pOp->p1 = last_p1 + 1;
+			}
+			last_p1 = pOp->p1;
+		}
+	}
 	for(pOp=&aOp[p->pc]; 1; pOp++) {
 		/* Errors are detected by individual opcodes, with an immediate
 		 * jumps to abort_due_to_error.
@@ -861,9 +893,8 @@ case OP_Blob: {                /* out2 */
  */
 case OP_Variable: {            /* out2 */
 	Mem *pVar;       /* Value being transferred */
+	assert(pOp->p1 > 0);
 
-	assert(pOp->p1>0 && pOp->p1<=p->nVar);
-	assert(pOp->p4.z==0 || pOp->p4.z==sqlVListNumToName(p->pVList,pOp->p1));
 	pVar = &p->aVar[pOp->p1 - 1];
 	if (sqlVdbeMemTooBig(pVar)) {
 		goto too_big;
@@ -1717,7 +1748,6 @@ case OP_And:              /* same as TK_AND, in1, in2, out3 */
 case OP_Or: {             /* same as TK_OR, in1, in2, out3 */
 	int v1;    /* Left operand:  0==FALSE, 1==TRUE, 2==UNKNOWN or NULL */
 	int v2;    /* Right operand: 0==FALSE, 1==TRUE, 2==UNKNOWN or NULL */
-
 	pIn1 = &aMem[pOp->p1];
 	if (mem_is_null(pIn1)) {
 		v1 = 2;
@@ -4315,7 +4345,6 @@ case OP_Expire: {
 case OP_Init: {          /* jump */
 	char *zTrace;
 	int i;
-
 	/* If the P4 argument is not NULL, then it must be an SQL comment string.
 	 * The "--" string is broken up to prevent false-positives with srcck1.c.
 	 *
@@ -4519,6 +4548,9 @@ default: {          /* This is really OP_Noop and OP_Explain */
 	/* If we reach this point, it means that execution is finished with
 	 * an error of some kind.
 	 */
+	free(p->bind_names);
+	free(p->bind_names_len);
+	p->count_bind_names = 0;
 abort_due_to_error:
 	rc = -1;
 	p->is_aborted = true;

--- a/src/box/sql/vdbeInt.h
+++ b/src/box/sql/vdbeInt.h
@@ -306,6 +306,12 @@ struct Vdbe {
 	struct txn_savepoint *anonymous_savepoint;
 	/* The statement ID in the prepared statement cache. */
 	uint32_t id;
+	/*Count of bind variables. */
+	uint32_t count_bind_names;
+	/*Array with names of bind variables. */
+	const char **bind_names;
+	/*Array with lens of names of bind variables. */
+	uint32_t *bind_names_len;
 };
 
 /*

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -394,6 +394,15 @@ sql_reset_autoinc_id_list(struct Vdbe *v)
 	stailq_create(&v->autoinc_id_list);
 }
 
+void
+sql_set_bind_variables_in_vdbe(struct Vdbe *stmt, const char **bind_names,
+			       uint32_t *bind_names_len, uint32_t bind_count)
+{
+	stmt->bind_names = bind_names;
+	stmt->bind_names_len = bind_names_len;
+	stmt->count_bind_names = bind_count;
+}
+
 int
 sql_bind_double(struct Vdbe *p, int i, double rValue)
 {

--- a/test/sql-luatest/bind_test.lua
+++ b/test/sql-luatest/bind_test.lua
@@ -29,6 +29,14 @@ g.test_bind_2 = function()
     t.assert_equals(err.message, res)
 end
 
+g.test_bind_4 = function()
+    g.server:exec(function()
+        local sql = [[SELECT :a, :a, ?, :b;]]
+        local res = box.execute(sql, {{[':a'] = 1}, {[':b'] = 2}})
+        t.assert_equals(res.rows, {{1, 1, 2, 2}})
+    end)
+end
+
 g = t.group("bind2", {{remote = true}, {remote = false}})
 
 g.before_all(function(cg)
@@ -170,6 +178,7 @@ g.test_3401_box_execute_parameter_binding = function(cg)
         parameters[1][100] = 200
         local ok = pcall(_G.execute, 'SELECT ?', parameters)
         t.assert_equals(ok, false)
+
         parameters = {}
         parameters[1] = {}
         parameters[1][':value'] = {kek = 300}


### PR DESCRIPTION
…ables

This patch fixes rows with next sql statements.

Prior to this patch:
```
tarantool> box.execute([[SELECT :a, :a, ?, :b]], {{[':a'] = 1}, {[':b'] = 2}})
---
  rows:
  - [1, 1, null, 2]
...
```
After this patch:
```
tarantool> box.execute([[SELECT :a, :a, ?, :b]], {{[':a'] = 1}, {[':b'] = 2}})
---
  rows:
  - [1, 1, 2, 2]
...
```

Part of #12733

NO_DOC=bugfix