### PR TITLE
config: warn on execute grant without lua_call

### DIFF
--- a/changelogs/unreleased/gh-12830-warn-execute-without-lua-call.md
+++ b/changelogs/unreleased/gh-12830-warn-execute-without-lua-call.md
@@ -1,0 +1,5 @@
+## feature/config
+
+* Added a warning when a user or role is granted the `execute` permission
+  without the `lua_call` privilege, since it implicitly allows calling
+  permissive global functions (i.e. `box.session.su()`) (gh-12830).

--- a/src/box/lua/config/applier/credentials.lua
+++ b/src/box/lua/config/applier/credentials.lua
@@ -234,6 +234,22 @@ local function privileges_from_config(config_data)
     return intermediate
 end
 
+-- Check whether the config grants the 'execute' permission on the universe.
+-- Such a grant allows the subject to call all global functions, including
+-- box.session.su(), which is a frequently overlooked privilege escalation.
+local function has_dangerous_universe_execute(config_data)
+    for _, priv in ipairs(config_data.privileges or {}) do
+        if priv.universe then
+            for _, perm in ipairs(priv.permissions) do
+                if perm == 'execute' then
+                    return true
+                end
+            end
+        end
+    end
+    return false
+end
+
 -- Intermediate representation is basically a set, so this function subtracts
 -- `current` from `target`.
 -- Return privileges that are present in `target` but not in `current` as
@@ -531,6 +547,8 @@ local function sync_privileges(credentials, obj_to_sync)
     config._aboard:each(function(_key, alert)
         if alert._trait == 'missed_privilege' then
             alert._trait = 'missed_privilege_obsolete'
+        elseif obj_to_sync == nil and alert._trait == 'dangerous_execute' then
+            alert._trait = 'dangerous_execute_obsolete'
         end
     end)
 
@@ -547,6 +565,20 @@ local function sync_privileges(credentials, obj_to_sync)
         end
 
         local box_privileges = privileges_from_box(name)
+
+        if has_dangerous_universe_execute(config_privileges) then
+            local msg = ('credentials: %s %q is granted the execute ' ..
+                'permission on the universe. It allows calling all global ' ..
+                'functions, including box.session.su(). Consider granting ' ..
+                'execute only on the lua_call object type instead.'):format(
+                role_or_user, name)
+            config._aboard:set({
+                type = 'warn',
+                message = msg,
+                _trait = 'dangerous_execute',
+            }, {key = 'dangerous_execute/' .. role_or_user .. '/' .. name})
+        end
+
         config_privileges = privileges_from_config(config_privileges)
 
         local grants = privileges_subtract(config_privileges, box_privileges)
@@ -631,7 +663,8 @@ local function sync_privileges(credentials, obj_to_sync)
 
     -- Drop obsolete missed_privilege alerts.
     config._aboard:drop_if(function(_key, alert)
-        return alert._trait == 'missed_privilege_obsolete'
+        return alert._trait == 'missed_privilege_obsolete' or
+               alert._trait == 'dangerous_execute_obsolete'
     end)
 end
 

--- a/test/config-luatest/gh_12830_execute_without_lua_call_warning_test.lua
+++ b/test/config-luatest/gh_12830_execute_without_lua_call_warning_test.lua
@@ -1,0 +1,176 @@
+local t = require('luatest')
+local helpers = require('test.config-luatest.helpers')
+
+local g = helpers.group()
+
+local WARN_PATTERN = 'execute only on the lua_call object type instead.'
+
+-- Collect gh-12830 warning messages. Runs on the server.
+local function find_warnings(pattern)
+    local config = require('config')
+    local res = {}
+    for _, alert in ipairs(config:info().alerts) do
+        if alert.type == 'warn' and alert.message:find(pattern, 1, true) then
+            table.insert(res, alert.message)
+        end
+    end
+    return res
+end
+
+-- Build a config granting one privilege to each {subject, privilege} pair.
+local function privs(...)
+    local config = {}
+    for _, pair in ipairs({...}) do
+        config[pair[1]] = {privileges = {pair[2]}}
+    end
+    return config
+end
+
+-- Shortcut for a single subject.
+local function priv(subject, privilege)
+    return privs({subject, privilege})
+end
+
+-- Verifier asserting the exact number of gh-12830 warnings on the server.
+local function expect_warnings(count)
+    return {
+        verify = function(pattern, find_warnings, count)
+            local warns = loadstring(find_warnings)(pattern)
+            t.assert_equals(#warns, count,
+                ('expected %d warning(s), got: %s'):format(count,
+                    require('json').encode(warns)))
+            return warns
+        end,
+        verify_args = {WARN_PATTERN, string.dump(find_warnings), count},
+    }
+end
+
+local function assert_warning_exists(config)
+    local exp = expect_warnings(1)
+    helpers.success_case(g, {
+        options = config,
+        verify = exp.verify,
+        verify_args = exp.verify_args,
+    })
+end
+
+local function assert_warning_not_exists(config)
+    local exp = expect_warnings(0)
+    helpers.success_case(g, {
+        options = config,
+        verify = exp.verify,
+        verify_args = exp.verify_args,
+    })
+end
+
+-- Run reload_success_case: `count` warnings for `config`, none for `config2`.
+local function check_reload(config, count, config2)
+    local exp = expect_warnings(count)
+    local none = expect_warnings(0)
+    helpers.reload_success_case(g, {
+        options = config,
+        options_2 = config2,
+        verify = exp.verify,
+        verify_args = exp.verify_args,
+        verify_2 = none.verify,
+        verify_args_2 = none.verify_args,
+    })
+end
+
+-- execute + universe -> one warning.
+g.test_universe_execute_warns = function()
+    assert_warning_exists(priv('credentials.users.alice',
+        {permissions = {'execute'}, universe = true}))
+end
+
+-- lua_call: [all] without a universe grant does not warn.
+g.test_lua_call_all_no_warning = function()
+    assert_warning_not_exists(priv('credentials.users.alice',
+        {permissions = {'execute'}, lua_call = {'all'}}))
+end
+
+-- A concrete lua_call list does not warn.
+g.test_lua_call_named_no_warning = function()
+    assert_warning_not_exists(priv('credentials.users.alice',
+        {permissions = {'execute'}, lua_call = {'foo'}}))
+end
+
+-- A universe grant is unsafe even when lua_call is also configured.
+g.test_universe_execute_with_lua_call_named_warns = function()
+    assert_warning_exists(priv('credentials.users.alice',
+        {permissions = {'execute'}, universe = true, lua_call = {'foo'}}))
+end
+
+-- A universe grant is unsafe even when lua_call is also configured.
+g.test_universe_execute_with_lua_call_all_warns = function()
+    assert_warning_exists(priv('credentials.users.alice',
+        {permissions = {'execute'}, universe = true, lua_call = {'all'}}))
+end
+
+-- Creating a configured function does not drop the universe warning.
+g.test_warning_remains_after_delayed_function_creation = function()
+    local exp = expect_warnings(1)
+    helpers.success_case(g, {
+        options = priv('credentials.users.alice', {
+            permissions = {'execute'},
+            universe = true,
+            functions = {'late_func'},
+        }),
+        verify = exp.verify,
+        verify_args = exp.verify_args,
+    })
+    g.server:exec(function()
+        box.schema.func.create('late_func')
+    end)
+    g.server:exec(exp.verify, exp.verify_args)
+end
+
+-- Non-execute permissions on the universe do not warn.
+g.test_non_execute_universe_no_warning = function()
+    assert_warning_not_exists(priv('credentials.users.alice',
+        {permissions = {'read', 'write'}, universe = true}))
+end
+
+-- The warning fires for roles too.
+g.test_role_universe_execute_warns = function()
+    assert_warning_exists(priv('credentials.roles.myrole',
+        {permissions = {'execute'}, universe = true}))
+end
+
+-- Narrowing to lua_call on reload drops the warning.
+g.test_warning_dropped_on_reload = function()
+    check_reload(
+        priv('credentials.users.alice',
+            {permissions = {'execute'}, universe = true}), 1,
+        priv('credentials.users.alice',
+            {permissions = {'execute'}, lua_call = {'all'}}))
+end
+
+-- Removing the privilege on reload drops the warning.
+g.test_warning_dropped_when_privilege_removed = function()
+    check_reload(
+        priv('credentials.users.alice',
+            {permissions = {'execute'}, universe = true}), 1,
+        priv('credentials.users.alice',
+            {permissions = {'read'}, spaces = {'_priv'}}))
+end
+
+-- Each risky subject gets its own distinct alert (per-subject key).
+g.test_multiple_subjects_multiple_warnings = function()
+    local exp = expect_warnings(2)
+    local config = privs(
+        {'credentials.users.alice',
+            {permissions = {'execute'}, universe = true}},
+        {'credentials.roles.myrole',
+            {permissions = {'execute'}, universe = true}})
+    helpers.success_case(g, {
+        options = config,
+        verify = function(pattern, find_warnings, count)
+            local warns = loadstring(find_warnings)(pattern)
+            t.assert_equals(#warns, count)
+            -- The two alerts must be distinct.
+            t.assert_not_equals(warns[1], warns[2])
+        end,
+        verify_args = exp.verify_args,
+    })
+end


### PR DESCRIPTION
Granting the 'execute' permission on the universe (permissions: [execute] + universe: true) lets a user or role call all global functions, including box.session.su(). This is easy to write by accident and is a non-obvious privilege escalation.

Emit a warning alert for such grants. It is dropped once the config is fixed on reload, either by narrowing the grant via lua_call or by removing the privilege.

Closes #12830

@TarantoolBot document
Title: Warning on execute privilege without lua_call

When a user or role is granted the `execute` permission on the universe without a `lua_call` restriction, the declarative config now raises a warning alert. Such a grant allows calling all global Lua functions, including `box.session.su()`. Narrow the grant down with the `lua_call` privilege to silence the warning.