### PR TITLE
util: fix off-by-one write in str_escape_inplace

### DIFF
--- a/changelogs/unreleased/gh-noticket-escape-inplace-oob.md
+++ b/changelogs/unreleased/gh-noticket-escape-inplace-oob.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed a one-byte out-of-bounds write in the in-place log message escaping
+  helper (`syslog_escape_inplace()` and the JSON variants) that happened when
+  the escaped message filled the log buffer exactly.

--- a/src/lib/core/util.c
+++ b/src/lib/core/util.c
@@ -384,8 +384,8 @@ str_escape_inplace(char *buf, int size, str_escape_char_f escape_func)
 	}
 
 	/* Write the null terminator. */
-	assert(total + 1 <= size); /* Guaranteed by the loop above. */
-	buf[total + 1] = '\0';
+	assert(total < size); /* Guaranteed by the loop above. */
+	buf[total] = '\0';
 
 	/* Write the escaped string from the end to the beginning. */
 	char *pw = buf + total;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -207,6 +207,10 @@ create_unit_test(PREFIX interval
                  SOURCES interval.c core_test_utils.c
                  LIBRARIES core unit
 )
+create_unit_test(PREFIX escape_inplace
+                 SOURCES escape_inplace.c core_test_utils.c
+                 LIBRARIES core unit
+)
 create_unit_test(PREFIX bps_tree
                  SOURCES bps_tree.cc
                  LIBRARIES unit small misc

--- a/test/unit/escape_inplace.c
+++ b/test/unit/escape_inplace.c
@@ -1,0 +1,73 @@
+#include "trivia/util.h"
+#include <stdlib.h>
+#include <string.h>
+
+#define UNIT_TAP_COMPATIBLE 1
+#include "unit.h"
+
+typedef int
+(*escape_inplace_f)(char *buf, int size);
+
+/*
+ * The escape helpers truncate the input so the escaped result plus the null
+ * terminator fit into the buffer, and they must never write past buf[size - 1].
+ * A run of characters that need no escaping fills the buffer up to size - 1
+ * bytes - the largest value the length cap allows - which is exactly the case
+ * where an off-by-one terminator write lands one byte past the end.
+ */
+static void
+test_no_overflow(escape_inplace_f escape, const char *name, int size)
+{
+	plan(2);
+	const unsigned char guard = 0x5a;
+	/* One extra byte we own to catch a write past buf[size - 1]. */
+	char *buf = xmalloc(size + 1);
+	memset(buf, 'a', size - 1);
+	buf[size - 1] = '\0';
+	buf[size] = guard;
+
+	int rc = escape(buf, size);
+	is(rc, size - 1, "%s size %d: escaped length fits the buffer",
+	   name, size);
+	is((unsigned char)buf[size], guard, "%s size %d: no write past the end",
+	   name, size);
+
+	free(buf);
+	check_plan();
+}
+
+/* Content that needs no escaping must pass through unchanged. */
+static void
+test_plain_passthrough(escape_inplace_f escape, const char *name)
+{
+	plan(2);
+	const char *src = "hello";
+	int len = strlen(src);
+	char buf[16];
+	memcpy(buf, src, len + 1);
+
+	int rc = escape(buf, sizeof(buf));
+	is(rc, len, "%s: length unchanged", name);
+	ok(memcmp(buf, src, len) == 0, "%s: bytes unchanged", name);
+
+	check_plan();
+}
+
+int
+main(void)
+{
+	plan(8);
+	header();
+
+	const int sizes[] = {2, 5, 8, 16};
+	for (size_t i = 0; i < lengthof(sizes); i++)
+		test_no_overflow(syslog_escape_inplace, "syslog", sizes[i]);
+	test_no_overflow(json_escape_inplace, "json", 8);
+	test_no_overflow(json_syslog_escape_inplace, "json_syslog", 8);
+
+	test_plain_passthrough(syslog_escape_inplace, "syslog");
+	test_plain_passthrough(json_escape_inplace, "json");
+
+	footer();
+	return check_plan();
+}


### PR DESCRIPTION
str_escape_inplace() fills the escaped output into buf[0..total-1] and then writes the terminating null at buf[total + 1]. The measuring loop only stops once total + esc_len >= size, so total reaches size - 1 when the escaped content fills the buffer, and that terminator lands on buf[size], one byte past the end. The guard assert is total + 1 <= size, which is size <= size, so it never catches the write in debug builds either.

Terminate at buf[total] and match the assert to total < size. The escaped bytes and the returned length stay the same, so callers that consume the returned length (say_format_plain feeding syslog) keep identical output, and all three inplace escapers get the fix at once. The added unit test drives total to size - 1 and checks a guard byte past the buffer end.