### PR TITLE
memtx: store the rollback info as the engine savepoint

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6488,15 +6488,6 @@ box_storage_free(void)
 	wal_free();
 	iproto_free();
 	txn_limbo_free();
-
-	/*
-	 * We free the transactions from the limbo queue above.
-	 * Free the remained transactions here.
-	 */
-	struct txn *txn, *tmp;
-	rlist_foreach_entry_safe(txn, &txns, in_txns, tmp)
-		txn_free(txn);
-
 	replication_free();
 	gc_free();
 	engine_free();

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6568,6 +6568,7 @@ box_storage_shutdown()
 		diag_log();
 		panic("cannot gracefully shutdown iproto");
 	}
+	wal_shutdown();
 	replication_shutdown();
 	box_raft_shutdown();
 	txn_limbo_shutdown();

--- a/src/box/journal.h
+++ b/src/box/journal.h
@@ -395,6 +395,14 @@ journal_create(struct journal *journal, journal_submit_f submit,
 	journal->commit_checkpoint = commit_checkpoint;
 }
 
+static inline void
+journal_override_submit_method(struct journal *journal,
+			       journal_submit_f new_submit)
+{
+	assert(journal->submit != NULL);
+	journal->submit = new_submit;
+}
+
 static inline bool
 journal_is_initialized(struct journal *journal)
 {

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -836,12 +836,16 @@ memtx_engine_commit(struct engine *engine, struct txn *txn)
 			assert(stmt->space->engine == engine);
 			memtx_tx_history_commit_stmt(stmt);
 		}
-		if (stmt->engine_savepoint != NULL) {
+		struct memtx_stmt_rollback_info *undo =
+			(typeof(undo))stmt->engine_savepoint;
+		if (undo != NULL) {
 			struct space *space = stmt->space;
-			struct tuple *old_tuple = stmt->rollback_info.old_tuple;
+			struct tuple *old_tuple = undo->old_tuple;
 			if (space->upgrade != NULL && old_tuple != NULL)
 				memtx_space_upgrade_untrack_tuple(
 						space->upgrade, old_tuple);
+			/* Not going to be required anymore. */
+			memtx_stmt_rollback_info_delete(undo);
 		}
 	}
 }
@@ -852,10 +856,19 @@ memtx_engine_rollback_statement(struct engine *engine, struct txn *txn,
 {
 	(void)engine;
 	(void)txn;
-	struct tuple *old_tuple = stmt->rollback_info.old_tuple;
-	struct tuple *new_tuple = stmt->rollback_info.new_tuple;
-	if (old_tuple == NULL && new_tuple == NULL)
+	/* Only roll back the changes if they were made. */
+	if (stmt->engine_savepoint == NULL)
 		return;
+	struct memtx_stmt_rollback_info *undo =
+		(typeof(undo))stmt->engine_savepoint;
+	auto destroy_rollback_info = make_scoped_guard([&]() {
+		/* Not going to be required once used below. */
+		memtx_stmt_rollback_info_delete(undo);
+	});
+	struct tuple *old_tuple = undo->old_tuple;
+	struct tuple *new_tuple = undo->new_tuple;
+	/* The savepoint is only set if anything has changed. */
+	assert(old_tuple != NULL || new_tuple != NULL);
 	struct space *space = stmt->space;
 	if (space == NULL) {
 		/* The space was deleted. Nothing to rollback. */
@@ -863,10 +876,6 @@ memtx_engine_rollback_statement(struct engine *engine, struct txn *txn,
 	}
 	struct memtx_space *memtx_space = (struct memtx_space *)space;
 	uint32_t index_count;
-
-	/* Only roll back the changes if they were made. */
-	if (stmt->engine_savepoint == NULL)
-		return;
 
 	if (space->upgrade != NULL && new_tuple != NULL)
 		memtx_space_upgrade_untrack_tuple(space->upgrade, new_tuple);

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -42,6 +42,8 @@
 #include "xlog.h"
 #include "salad/stailq.h"
 #include "sysalloc.h"
+#include "trivia/util.h"
+#include "tuple.h"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -54,7 +56,6 @@ struct info_handler;
 struct iterator;
 struct fiber;
 struct read_view_tuple;
-struct tuple;
 struct tuple_format;
 struct memtx_tx_snapshot_cleaner;
 
@@ -180,6 +181,65 @@ struct memtx_engine {
 		struct memtx_sort_data_reader *sort_data_reader;
 	} recovery;
 };
+
+/**
+ * Structure which contains pointers to the tuples,
+ * that are used in rollback.
+ */
+struct memtx_stmt_rollback_info {
+	/* The deleted tuple (NULL if no tuple deleted).*/
+	struct tuple *old_tuple;
+	/* The inserted tuple (NULL if no tuple inserted). */
+	struct tuple *new_tuple;
+};
+
+/**
+ * Allocate and zero-initialize a rollback info on the region.
+ */
+static inline struct memtx_stmt_rollback_info *
+memtx_stmt_rollback_info_new(struct region *region)
+{
+	struct memtx_stmt_rollback_info *undo =
+		xregion_alloc_object(region, typeof(*undo));
+	memset(undo, 0, sizeof(*undo));
+	return undo;
+}
+
+/**
+ * Unref the tuples referenced by the rollback info.
+ */
+static inline void
+memtx_stmt_rollback_info_delete(struct memtx_stmt_rollback_info *undo)
+{
+	if (undo->old_tuple != NULL)
+		tuple_unref(undo->old_tuple);
+	if (undo->new_tuple != NULL)
+		tuple_unref(undo->new_tuple);
+}
+
+/**
+ * Add a deleted tuple to the rollback info.
+ */
+static inline void
+memtx_stmt_rollback_info_add_old_tuple(struct memtx_stmt_rollback_info *undo,
+				       struct tuple *old_tuple)
+{
+	assert(undo->old_tuple == NULL);
+	undo->old_tuple = old_tuple;
+	tuple_ref(old_tuple);
+}
+
+/**
+ * Set the new tuple in the rollback info.
+ */
+static inline void
+memtx_stmt_rollback_info_set_new_tuple(struct memtx_stmt_rollback_info *undo,
+				       struct tuple *new_tuple)
+{
+	assert(undo->new_tuple == NULL);
+	undo->new_tuple = new_tuple;
+	tuple_ref(new_tuple);
+}
 
 struct memtx_gc_task;
 

--- a/src/box/memtx_space.c
+++ b/src/box/memtx_space.c
@@ -342,6 +342,25 @@ memtx_space_prepare_index_tuple(struct tuple_format *format,
 }
 
 /**
+ * Prepare the MemTX statement rollback info:
+ * set, ref tuples and set the savepoint.
+ */
+static void
+memtx_set_replace_rollback_info(struct txn_stmt *stmt,
+				struct tuple *old_index_tuple,
+				struct tuple *new_index_tuple,
+				struct region *region)
+{
+	struct memtx_stmt_rollback_info *undo =
+		memtx_stmt_rollback_info_new(region);
+	if (old_index_tuple != NULL)
+		memtx_stmt_rollback_info_add_old_tuple(undo, old_index_tuple);
+	if (new_index_tuple != NULL)
+		memtx_stmt_rollback_info_set_new_tuple(undo, new_index_tuple);
+	stmt->engine_savepoint = undo;
+}
+
+/**
  * Take actions required after replace in space is finished:
  * - set transactional information
  * - track new tuple in space upgrade
@@ -355,8 +374,10 @@ memtx_space_complete_replace(struct space *space, struct txn *txn,
 		memtx_space_upgrade_track_tuple(space->upgrade,
 						new_index_tuple);
 	struct txn_stmt *stmt = txn_current_stmt(txn);
-	txn_stmt_prepare_rollback_info(stmt, old_index_tuple, new_index_tuple);
-	stmt->engine_savepoint = stmt;
+	struct region *region = tx_region_acquire(txn);
+	memtx_set_replace_rollback_info(stmt, old_index_tuple,
+					new_index_tuple, region);
+	tx_region_release(txn, TX_ALLOC_SYSTEM);
 }
 
 static int

--- a/src/box/memtx_tx.c
+++ b/src/box/memtx_tx.c
@@ -2861,11 +2861,13 @@ memtx_tx_history_rollback_deleted_story(struct txn_stmt *stmt)
  *    also removed their stories on DDL, so here we should roll them back
  *    without stories if they have failed to commit.
  */
-void
+static void
 memtx_tx_history_rollback_empty_stmt(struct txn_stmt *stmt)
 {
-	struct tuple *old_tuple = stmt->rollback_info.old_tuple;
-	struct tuple *new_tuple = stmt->rollback_info.new_tuple;
+	struct memtx_stmt_rollback_info *undo =
+		(typeof(undo))stmt->engine_savepoint;
+	struct tuple *old_tuple = undo->old_tuple;
+	struct tuple *new_tuple = undo->new_tuple;
 	if (!stmt->txn->is_schema_changed && stmt->txn->psn == 0)
 		return;
 	if (stmt->space->def->opts.is_ephemeral ||
@@ -2892,7 +2894,9 @@ memtx_tx_history_rollback_stmt(struct txn_stmt *stmt)
 {
 	/* Consistency asserts. */
 	if (stmt->add_story != NULL) {
-		assert(stmt->add_story->tuple == stmt->rollback_info.new_tuple);
+		struct memtx_stmt_rollback_info *undo =
+			(typeof(undo))stmt->engine_savepoint;
+		assert(stmt->add_story->tuple == undo->new_tuple);
 		assert(stmt->add_story->add_psn == stmt->txn->psn);
 	}
 	if (stmt->del_story != NULL)
@@ -3585,15 +3589,24 @@ memtx_tx_invalidate_space(struct space *space, struct txn *ddl_owner)
 	 * they won't be rolled back because we already did it. Moreover, they
 	 * could access the old space that is going to be deleted leading to
 	 * use-after-free.
+	 *
+	 * Skip oneselves as we could be invalidating the space during rollback,
+	 * so our status can be TXN_ABORTED too.
 	 */
 	struct txn *txn;
 	rlist_foreach_entry(txn, &txns, in_txns) {
-		if (txn->status != TXN_ABORTED || txn->psn != 0)
+		if (txn == ddl_owner ||
+		    txn->status != TXN_ABORTED || txn->psn != 0)
 			continue;
 		struct txn_stmt *stmt;
 		stailq_foreach_entry(stmt, &txn->stmts, next) {
-			if (stmt->space == space)
+			if (stmt->space == space) {
+				struct memtx_stmt_rollback_info *undo =
+					(typeof(undo))stmt->engine_savepoint;
+				if (undo != NULL)
+					memtx_stmt_rollback_info_delete(undo);
 				stmt->engine_savepoint = NULL;
+			}
 		}
 	}
 

--- a/src/box/txn.c
+++ b/src/box/txn.c
@@ -305,8 +305,6 @@ txn_stmt_new(struct txn *txn, uint16_t type)
 	stmt->new_tuple = NULL;
 	stmt->min_key = NULL;
 	stmt->max_key = NULL;
-	stmt->rollback_info.old_tuple = NULL;
-	stmt->rollback_info.new_tuple = NULL;
 	stmt->add_story = NULL;
 	stmt->del_story = NULL;
 	stmt->next_in_del_list = NULL;
@@ -329,22 +327,6 @@ txn_stmt_destroy(struct txn_stmt *stmt)
 		tuple_unref(stmt->old_tuple);
 	if (stmt->new_tuple != NULL)
 		tuple_unref(stmt->new_tuple);
-	if (stmt->rollback_info.old_tuple != NULL)
-		tuple_unref(stmt->rollback_info.old_tuple);
-	if (stmt->rollback_info.new_tuple != NULL)
-		tuple_unref(stmt->rollback_info.new_tuple);
-}
-
-void
-txn_stmt_prepare_rollback_info(struct txn_stmt *stmt, struct tuple *old_tuple,
-			       struct tuple *new_tuple)
-{
-	stmt->rollback_info.old_tuple = old_tuple;
-	if (stmt->rollback_info.old_tuple != NULL)
-		tuple_ref(stmt->rollback_info.old_tuple);
-	stmt->rollback_info.new_tuple = new_tuple;
-	if (stmt->rollback_info.new_tuple != NULL)
-		tuple_ref(stmt->rollback_info.new_tuple);
 }
 
 void

--- a/src/box/txn.h
+++ b/src/box/txn.h
@@ -289,17 +289,6 @@ enum txn_status {
 	TXN_ABORTED,
 };
 
-
-/**
- * Structure which contains pointers to the tuples,
- * that are used in rollback. Currently used only in
- * memxt engine.
- */
-struct txn_stmt_rollback_info {
-	struct tuple *old_tuple;
-	struct tuple *new_tuple;
-};
-
 /**
  * A single statement of a multi-statement
  * transaction: undo and redo info.
@@ -320,8 +309,6 @@ struct txn_stmt {
 	const char *min_key;
 	/** The last Arrow inserted key (MP_ARRAY, allocated on txn). */
 	const char *max_key;
-	/** Structure, which contains tuples for rollback. */
-	struct txn_stmt_rollback_info rollback_info;
 	/**
 	 * If new_tuple != NULL and this transaction was not prepared,
 	 * this member holds added story of the new_tuple.
@@ -851,14 +838,6 @@ txn_stmt_on_rollback(struct txn_stmt *stmt, struct trigger *trigger)
 	txn_stmt_init_triggers(stmt);
 	trigger_add(&stmt->on_rollback, trigger);
 }
-
-/**
- * Save and ref @a old_tuple and @a new_tuple in special structure
- * inside @a stmt. Later this tuples will be used in case of rollback.
- */
-void
-txn_stmt_prepare_rollback_info(struct txn_stmt *stmt, struct tuple *old_tuple,
-			       struct tuple *new_tuple);
 
 /**
  * Save @a old_tuple and @a new_tuple of replace in @a stmt.

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -1128,4 +1128,5 @@ void
 txn_limbo_shutdown(void)
 {
 	txn_limbo_stop(&txn_limbo);
+	txn_limbo_queue_shutdown(&txn_limbo.queue);
 }

--- a/src/box/txn_limbo_queue.c
+++ b/src/box/txn_limbo_queue.c
@@ -926,12 +926,16 @@ void
 txn_limbo_queue_destroy(struct txn_limbo_queue *queue)
 {
 	fiber_cond_destroy(&queue->cond);
-	struct txn_limbo_entry *entry;
-	while (!rlist_empty(&queue->entries)) {
-		entry = rlist_shift_entry(&queue->entries,
-					  typeof(*entry), in_queue);
-		entry->txn->limbo_entry = NULL;
-		txn_free(entry->txn);
-	}
+	/* Should be emptied during shutdown. */
+	assert(rlist_empty(&queue->entries));
 	TRASH(queue);
+}
+
+void
+txn_limbo_queue_shutdown(struct txn_limbo_queue *queue)
+{
+	while (!txn_limbo_queue_is_empty(queue)) {
+		struct txn_limbo_entry *e = txn_limbo_queue_last_entry(queue);
+		txn_limbo_queue_complete_fail(queue, e, TXN_SIGNATURE_ROLLBACK);
+	}
 }

--- a/src/box/txn_limbo_queue.h
+++ b/src/box/txn_limbo_queue.h
@@ -294,6 +294,10 @@ txn_limbo_queue_create(struct txn_limbo_queue *queue);
 void
 txn_limbo_queue_destroy(struct txn_limbo_queue *queue);
 
+/** Rollback all transactions in the queue. */
+void
+txn_limbo_queue_shutdown(struct txn_limbo_queue *queue);
+
 #if defined(__cplusplus)
 }
 #endif /* defined(__cplusplus) */

--- a/src/box/wal.c
+++ b/src/box/wal.c
@@ -71,6 +71,10 @@ RLIST_HEAD(wal_on_write);
 static int
 wal_write_async(struct journal *, struct journal_entry *);
 
+/** Override of the method always setting the ER_SHUTDOWN. */
+static int
+wal_write_fail_async(struct journal *journal, struct journal_entry *entry);
+
 static int
 wal_write_none_async(struct journal *, struct journal_entry *);
 
@@ -661,20 +665,31 @@ wal_enable(void)
 }
 
 void
+wal_shutdown(void)
+{
+	/*
+	 * Abort new WAL write requests.
+	 *
+	 * The callback is called in the TX thread, so it's safe to
+	 * override it here (this function is called from TX too).
+	 */
+	struct wal_writer *writer = &wal_writer_singleton;
+	journal_override_submit_method(&writer->base, wal_write_fail_async);
+	/* Handle the requests remained.  */
+	VERIFY(journal_sync(NULL) == 0);
+}
+
+void
 wal_free(void)
 {
 	struct wal_writer *writer = &wal_writer_singleton;
-
 	cbus_stop_loop(&writer->wal_pipe);
 	cpipe_destroy(&writer->wal_pipe);
-
 	if (cord_join(&writer->cord)) {
 		/* We can't recover from this in any reasonable way. */
 		panic_syserror("WAL writer: thread join failed");
 	}
-
 	trigger_destroy(&wal_on_write);
-
 	wal_writer_destroy(writer);
 }
 
@@ -1575,6 +1590,17 @@ wal_write_async(struct journal *journal, struct journal_entry *entry)
 
 fail:
 	assert(entry->res == JOURNAL_ENTRY_ERR_UNKNOWN);
+	return -1;
+}
+
+static int
+wal_write_fail_async(struct journal *journal, struct journal_entry *entry)
+{
+	VERIFY(entry->res == JOURNAL_ENTRY_ERR_UNKNOWN);
+	struct wal_writer *writer = (struct wal_writer *)journal;
+	say_error("Aborting transaction %lld during shutdown",
+		  (long long)vclock_sum(&writer->vclock));
+	diag_set(ClientError, ER_SHUTDOWN);
 	return -1;
 }
 

--- a/src/box/wal.h
+++ b/src/box/wal.h
@@ -118,6 +118,12 @@ int
 wal_enable(void);
 
 /**
+ * Stop handling new write requests and handle the remaining ones.
+ */
+void
+wal_shutdown(void);
+
+/**
  * Stop WAL thread and free WAL writer resources.
  */
 void

--- a/src/main.cc
+++ b/src/main.cc
@@ -194,6 +194,17 @@ tarantool_exit(int code)
 	 * After on_shutdown fiber completes, we will never wake up again.
 	 */
 	fiber_set_system(fiber(), true);
+	/*
+	 * This is the end for the fiber effectively, it's never going to
+	 * die nor to return to the os.exit() caller. Let's call on_stop
+	 * triggers of the fiber here. This can do the following:
+	 *
+	 * 1. If there's an active transaction, it's rolled back and freed.
+	 * 2. Puts a cord buffer if it has been taken and not freed yet.
+	 * 3. Destroy a session created on demand.
+	 * 4. Drops a reference to a fiber storage if created in the caller.
+	 */
+	fiber_on_stop(fiber());
 	while (true)
 		fiber_sleep(TIMEOUT_INFINITY);
 }

--- a/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
+++ b/test/box-luatest/gh_6150_memtx_tx_memory_monitoring_test.lua
@@ -5,13 +5,15 @@ local g = t.group()
 
 -- Sizes of objects from transaction manager.
 -- Please update them, if you changed the relevant structures.
-local SIZE_OF_STMT = 160
+local SIZE_OF_STMT = 144
 -- Size of story with one link (for spaces with 1 index).
 local SIZE_OF_STORY = 152
 -- Size of tuple with 2 number fields
 local SIZE_OF_TUPLE = 9
 -- Size of xrow for tuples with 2 number fields
 local SIZE_OF_XROW = 163
+-- Size of rollback info.
+local SIZE_OF_UNDO = 16
 -- Tracker can allocate additional memory, be careful!
 local SIZE_OF_READ_TRACKER = 48
 local SIZE_OF_POINT_TRACKER = 80
@@ -97,9 +99,9 @@ g.test_simple = function()
                 ["max"] = SIZE_OF_STMT,
             },
             ["system"] = {
-                ["total"] = SIZE_OF_XROW,
-                ["max"] = SIZE_OF_XROW,
-                ["avg"] = math.floor(SIZE_OF_XROW / 2),
+                ["total"] = SIZE_OF_XROW + SIZE_OF_UNDO,
+                ["max"] = SIZE_OF_XROW + SIZE_OF_UNDO,
+                ["avg"] = math.floor((SIZE_OF_XROW + SIZE_OF_UNDO) / 2),
             }
         },
         ["mvcc"] = {
@@ -121,8 +123,9 @@ g.test_simple = function()
                 ["total"] = SIZE_OF_STMT,
             },
             ["system"] = {
-                ["total"] = SIZE_OF_XROW,
-                ["avg"] = math.floor(SIZE_OF_XROW / 2) + 1,
+                ["total"] = SIZE_OF_XROW + SIZE_OF_UNDO,
+                ["avg"] = math.floor((SIZE_OF_XROW +
+                                      SIZE_OF_UNDO) / 2) + 1,
             }
         },
         ["mvcc"] = {
@@ -149,9 +152,9 @@ g.test_simple = function()
                 ["max"] = SIZE_OF_STMT,
             },
             ["system"] = {
-                ["total"] = SIZE_OF_XROW,
-                ["avg"] = math.floor(SIZE_OF_XROW / 2),
-                ["max"] = SIZE_OF_XROW,
+                ["total"] = SIZE_OF_XROW + SIZE_OF_UNDO,
+                ["avg"] = math.floor((SIZE_OF_XROW + SIZE_OF_UNDO) / 2),
+                ["max"] = SIZE_OF_XROW + SIZE_OF_UNDO,
             }
         },
         ["mvcc"] = {
@@ -176,9 +179,10 @@ g.test_simple = function()
                 ["max"] = -1 * SIZE_OF_STMT,
             },
             ["system"] = {
-                ["total"] = -2 * SIZE_OF_XROW,
-                ["avg"] = -1 * math.floor(SIZE_OF_XROW / 2),
-                ["max"] = -1 * SIZE_OF_XROW,
+                ["total"] = -2 * (SIZE_OF_XROW + SIZE_OF_UNDO),
+                ["avg"] = -1 * math.floor((SIZE_OF_XROW +
+                                           SIZE_OF_UNDO) / 2),
+                ["max"] = -1 * (SIZE_OF_XROW + SIZE_OF_UNDO),
             }
         },
         ["mvcc"] = {
@@ -202,9 +206,9 @@ g.test_simple = function()
                 ["max"] = -1 * SIZE_OF_STMT,
             },
             ["system"] = {
-                ["total"] = -1 * SIZE_OF_XROW,
-                ["avg"] = -1 * SIZE_OF_XROW,
-                ["max"] = -1 * SIZE_OF_XROW,
+                ["total"] = -1 * (SIZE_OF_XROW + SIZE_OF_UNDO),
+                ["avg"] = -1 * (SIZE_OF_XROW + SIZE_OF_UNDO),
+                ["max"] = -1 * (SIZE_OF_XROW + SIZE_OF_UNDO),
             },
         },
         ["mvcc"] = {
@@ -418,9 +422,9 @@ g.test_conflict = function()
                 ["total"] = SIZE_OF_STMT,
             },
             ["system"] = {
-                ["max"] = SIZE_OF_XROW,
-                ["avg"] = math.floor(SIZE_OF_XROW / 2),
-                ["total"] = SIZE_OF_XROW,
+                ["max"] = SIZE_OF_XROW + SIZE_OF_UNDO,
+                ["avg"] = math.floor((SIZE_OF_XROW + SIZE_OF_UNDO) / 2),
+                ["total"] = SIZE_OF_XROW + SIZE_OF_UNDO,
             },
         },
         ["mvcc"] = {


### PR DESCRIPTION
The `engine_savepoint` is used to just specify if a change had been made during operation execution and its values had only two useful states: NULL and non-NULL, and a pointer to the `struct txn_stmt` was used to achieve the non-null value. At the same time we had a MemTX-specific rollback info structure stored in the `struct txn`.

Let's save the pointer to the rollback info in the `engine_savepoint` instead. This will allow to simplify performing actions on the range delete commit and rollback: a generic code can be used for regular replaces and the range delete then.

Using the transaction region to allocate the old tuples could affect the performance of requests replacing tuples, so the patch is checked for a possible regression. The difference in performance of replaces in the MemTX tree measured using the 1mops_write.lua test found to be statistically negligible (checked with the patched 1mops_write.lua from #12896 with insert_ratio=0.001):

```
              Base         Patched
1mops_master  1347383 rps  1345134 rps
```

Part of #11335