### PR TITLE
box: refactor read view Lua internals

### DIFF
--- a/src/box/index.h
+++ b/src/box/index.h
@@ -752,7 +752,7 @@ struct index_read_view_vtab {
 	 * If the key isn't found, the data is set to NULL.
 	 *
 	 * Note, unless the read_view_opts::disable_decompression flag was set
-	 * at read_view_open, the returned data may be allocated on the fiber
+	 * at read_view_new, the returned data may be allocated on the fiber
 	 * region, and the user is supposed to call region_truncate after using
 	 * the data.
 	 *
@@ -820,7 +820,7 @@ struct index_read_view_iterator_base {
 	 * On EOF the data is set to NULL.
 	 *
 	 * Note, unless the read_view_opts::disable_decompression flag was set
-	 * at read_view_open, the returned data may be allocated on the fiber
+	 * at read_view_new, the returned data may be allocated on the fiber
 	 * region, and the user is supposed to call region_truncate after using
 	 * the data.
 	 *

--- a/src/box/lua/read_view.c
+++ b/src/box/lua/read_view.c
@@ -37,6 +37,17 @@ TWEAK_BOOL(box_read_view_ffi);
 /** Lua ctype ID of struct space_read_view_handle pointer. */
 static uint32_t CTID_STRUCT_SPACE_READ_VIEW_HANDLE;
 
+/** Get a space read view handle from Lua stack. */
+static inline struct space_read_view_handle *
+lbox_check_space_read_view_handle(struct lua_State *L, int idx)
+{
+	assert(CTID_STRUCT_SPACE_READ_VIEW_HANDLE != 0);
+	uint32_t ctypeid;
+	void *cdata = luaL_checkcdata(L, idx, &ctypeid);
+	assert(ctypeid == CTID_STRUCT_SPACE_READ_VIEW_HANDLE);
+	return *(struct space_read_view_handle **)cdata;
+}
+
 /**
  * Wrapper around a database read view object pushed to Lua as user data.
  */
@@ -63,54 +74,6 @@ lbox_check_read_view(struct lua_State *L, int idx)
 }
 
 /**
- * Wrapper around an index read view object pushed to Lua as user data.
- */
-struct lbox_index_read_view {
-	/** Space which this index belongs to. */
-	struct space_read_view_handle *space;
-	/* Ordinal number of this index in the space. */
-	uint32_t index_id;
-	/**
-	 * Pointer to the read view that owns this index.
-	 * The wrapped object is valid if and only if it hasn't been closed.
-	 */
-	struct lbox_read_view *read_view;
-	/**
-	 * Reference to the read view that owns this index.
-	 * It protects the Lua read view object from garbage collection.
-	 */
-	int read_view_ref;
-};
-
-/** Type name of lbox_index_read_view Lua user data. */
-static const char lbox_index_read_view_typename[] = "box.read_view.index";
-
-/** Get an index read view from Lua stack. */
-static inline struct lbox_index_read_view *
-lbox_check_index_read_view(struct lua_State *L, int idx)
-{
-	return luaL_checkudata(L, idx, lbox_index_read_view_typename);
-}
-
-/** Get an index read view from Lua stack. Raise if it's closed. */
-static struct lbox_index_read_view *
-lbox_check_open_index_read_view_at(struct lua_State *L, int idx, int level)
-{
-	struct lbox_index_read_view *rv = lbox_check_index_read_view(L, idx);
-	if (rv->read_view->is_closed) {
-		diag_set(ClientError, ER_READ_VIEW_CLOSED);
-		luaT_error_at(L, level);
-	}
-	return rv;
-}
-
-static inline struct lbox_index_read_view *
-lbox_check_open_index_read_view(struct lua_State *L, int idx)
-{
-	return lbox_check_open_index_read_view_at(L, idx, 1);
-}
-
-/**
  * Wrapper around an index read view iterator object pushed to Lua as user
  * data.
  */
@@ -119,22 +82,6 @@ struct lbox_index_read_view_iterator {
 	struct index_read_view_iterator obj;
 	/** Space which the iterated index belongs to. */
 	struct space_read_view_handle *space;
-	/**
-	 * Pointer to the read view that owns this iterator.
-	 * The wrapped object is valid if and only if it hasn't been closed.
-	 */
-	struct lbox_read_view *read_view;
-	/**
-	 * Reference to the read view that owns this iterator.
-	 * It protects the Lua read view object from garbage collection.
-	 */
-	int read_view_ref;
-	/**
-	 * Reference to the iterator key.
-	 * An iterator assumes that the key stays valid throughout its lifetime
-	 * so we copy the encoded key to Lua memory.
-	 */
-	int key_ref;
 	/** Number of tuples returned so far. */
 	uint64_t count;
 };
@@ -148,19 +95,6 @@ static inline struct lbox_index_read_view_iterator *
 lbox_check_index_read_view_iterator(struct lua_State *L, int idx)
 {
 	return luaL_checkudata(L, idx, lbox_index_read_view_iterator_typename);
-}
-
-/** Get an index read view iterator from Lua stack. Raise if it's closed. */
-static struct lbox_index_read_view_iterator *
-lbox_check_open_index_read_view_iterator(struct lua_State *L, int idx)
-{
-	struct lbox_index_read_view_iterator *it =
-		lbox_check_index_read_view_iterator(L, idx);
-	if (it->read_view->is_closed) {
-		diag_set(ClientError, ER_READ_VIEW_CLOSED);
-		luaT_error(L);
-	}
-	return it;
 }
 
 /**
@@ -188,36 +122,17 @@ lbox_push_read_view(struct lua_State *L, const struct read_view *rv)
 /**
  * Helper function for lbox_read_view_open() that pushes a table for the given
  * index read view to the Lua stack.
- *
- * 'rv_idx' is the index of 'rv' in the Lua stack.
  */
 static void
-lbox_read_view_push_index(struct lua_State *L, int rv_idx,
-			  struct lbox_read_view *rv,
+lbox_read_view_push_index(struct lua_State *L,
 			  struct index_read_view *index,
 			  struct space_read_view_handle *space)
 {
-	assert(rv_idx >= 0);
 	lua_newtable(L);
 	lua_pushinteger(L, index->def->iid);
 	lua_setfield(L, -2, "id");
 	lua_pushstring(L, index->def->name);
 	lua_setfield(L, -2, "name");
-
-	/* Allocate a userdata object for the new index read view. */
-	struct lbox_index_read_view *u = lua_newuserdata(L, sizeof(*rv));
-	u->space = space;
-	u->index_id = index->def->iid;
-	u->read_view = rv;
-	u->read_view_ref = LUA_NOREF;
-	luaL_getmetatable(L, lbox_index_read_view_typename);
-	lua_setmetatable(L, -2);
-
-	/* Take a reference to the read view object. */
-	lua_pushvalue(L, rv_idx);
-	u->read_view_ref = luaL_ref(L, LUA_REGISTRYINDEX);
-
-	lua_setfield(L, -2, "_impl");
 
 	*(struct space_read_view_handle **)luaL_pushcdata(
 		L, CTID_STRUCT_SPACE_READ_VIEW_HANDLE) = space;
@@ -238,12 +153,9 @@ lbox_read_view_push_index(struct lua_State *L, int rv_idx,
 /**
  * Helper function for lbox_read_view_open() that pushes a table for the given
  * space read view to the Lua stack.
- *
- * 'rv_idx' is the index of 'rv' in the Lua stack.
  */
 static void
-lbox_read_view_push_space(struct lua_State *L, int rv_idx,
-			  struct lbox_read_view *rv,
+lbox_read_view_push_space(struct lua_State *L,
 			  struct space_read_view_handle *space)
 {
 	lua_newtable(L);
@@ -257,7 +169,7 @@ lbox_read_view_push_space(struct lua_State *L, int rv_idx,
 			space_read_view_index(space->ptr, i);
 		if (index == NULL)
 			continue;
-		lbox_read_view_push_index(L, rv_idx, rv, index, space);
+		lbox_read_view_push_index(L, index, space);
 		lua_pushvalue(L, -1);
 		lua_rawseti(L, -3, i);
 		lua_setfield(L, -2, index->def->name);
@@ -290,11 +202,7 @@ lbox_read_view_push_space(struct lua_State *L, int rv_idx,
  *             -- Table of space indexes, keyed by space id and name.
  *             index = {
  *                 [id] = {
- *                     -- Index read view implementation.
- *                     -- Represented by struct lbox_index_read_view.
- *                     _impl = <userdata:box.read_view.index>,
- *
- *                     -- lbox_index_read_view->space exported for FFI.
+ *                     -- Space read view handle (cdata).
  *                     _cspace = <cdata:struct space_read_view_handle *>,
  *
  *                     -- Set if FFI should be used for this index.
@@ -322,7 +230,6 @@ lbox_read_view_open(struct lua_State *L)
 	rv->is_closed = true;
 	luaL_getmetatable(L, lbox_read_view_typename);
 	lua_setmetatable(L, -2);
-	int rv_idx = lua_gettop(L);
 
 	/* Open a read view. */
 	struct read_view_opts opts;
@@ -346,7 +253,7 @@ lbox_read_view_open(struct lua_State *L)
 	lua_newtable(L);
 	struct space_read_view_handle *space;
 	read_view_foreach_space(space, rv->handle) {
-		lbox_read_view_push_space(L, rv_idx, rv, space);
+		lbox_read_view_push_space(L, space);
 		lua_pushvalue(L, -1);
 		lua_rawseti(L, -3, space->ptr->id);
 		lua_setfield(L, -2, space->ptr->name);
@@ -435,33 +342,22 @@ lbox_read_view_close(struct lua_State *L)
 }
 
 /**
- * Frees an index read view.
- * Drops a reference to the database read view.
- */
-static int
-lbox_index_read_view_gc(struct lua_State *L)
-{
-	struct lbox_index_read_view *rv = lbox_check_index_read_view(L, 1);
-	luaL_unref(L, LUA_REGISTRYINDEX, rv->read_view_ref);
-	TRASH(rv);
-	return 0;
-}
-
-/**
  * Gets a tuple by key from an index read view.
- * Expects the key (tuple or Lua array) as the second argument.
+ * Takes space read view handle, index id, and key (tuple or Lua array).
  * Returns a tuple or nil on success. On error, raises a Lua exception.
  */
 static int
 lbox_index_read_view_get(struct lua_State *L)
 {
-	struct lbox_index_read_view *rv = lbox_check_open_index_read_view(L, 1);
+	struct space_read_view_handle *space =
+		lbox_check_space_read_view_handle(L, 1);
+	uint32_t index_id = luaL_checkinteger(L, 2);
 	struct region *region = &fiber()->gc;
 	size_t region_svp = region_used(region);
 	size_t key_len;
-	const char *key = lbox_encode_tuple_on_gc(L, 2, &key_len);
+	const char *key = lbox_encode_tuple_on_gc(L, 3, &key_len);
 	struct tuple *tuple;
-	int rc = box_index_read_view_get(rv->space, rv->index_id,
+	int rc = box_index_read_view_get(space, index_id,
 					 key, key + key_len, &tuple);
 	region_truncate(region, region_svp);
 	if (rc != 0)
@@ -470,19 +366,22 @@ lbox_index_read_view_get(struct lua_State *L)
 }
 
 /**
- * Count tuples in an index read view. Takes iterator type and key.
+ * Counts tuples in an index read view.
+ * Takes space read view handle, index id, iterator type, and key.
  * Returns a number. On error, raises a Lua exception.
  */
 static int
 lbox_index_read_view_count(struct lua_State *L)
 {
-	struct lbox_index_read_view *rv = lbox_check_open_index_read_view(L, 1);
-	int iterator = luaL_checkinteger(L, 2);
+	struct space_read_view_handle *space =
+		lbox_check_space_read_view_handle(L, 1);
+	uint32_t index_id = luaL_checkinteger(L, 2);
+	int iterator = luaL_checkinteger(L, 3);
 	struct region *region = &fiber()->gc;
 	size_t region_svp = region_used(region);
 	size_t key_len;
-	const char *key = lbox_encode_tuple_on_gc(L, 3, &key_len);
-	ssize_t count = box_index_read_view_count(rv->space, rv->index_id,
+	const char *key = lbox_encode_tuple_on_gc(L, 4, &key_len);
+	ssize_t count = box_index_read_view_count(space, index_id,
 						  iterator, key, key + key_len);
 	region_truncate(region, region_svp);
 	if (count < 0)
@@ -494,40 +393,45 @@ lbox_index_read_view_count(struct lua_State *L)
 /** Specialization of lbox_normalize_position for read views. */
 static int
 lbox_read_view_normalize_position(lua_State *L, int idx,
-				  struct lbox_index_read_view *rv,
+				  struct space_read_view_handle *space,
+				  uint32_t index_id,
 				  const char **packed_pos,
 				  const char **packed_pos_end)
 {
-	struct index_read_view *index = space_read_view_index(rv->space->ptr,
-							      rv->index_id);
+	struct index_read_view *index = space_read_view_index(space->ptr,
+							      index_id);
 	return lbox_normalize_position(L, idx, index->def->cmp_def, packed_pos,
 				       packed_pos_end);
 }
 
 /**
  * Selects tuples from an index read view.
- * Takes iterator type, offset, limit, key, position and fetch_pos.
+ * Takes space read view handle, index id, iterator type, offset, limit,
+ * key, position, and fetch_pos.
  * Returns an array of tuples and string with packed position if fetch_pos is
  * true on success. On error, raises a Lua exception.
  */
 static int
 lbox_index_read_view_select(struct lua_State *L)
 {
-	struct lbox_index_read_view *rv = lbox_check_open_index_read_view(L, 1);
-	int iterator = luaL_checkinteger(L, 2);
-	uint32_t offset = luaL_checkinteger(L, 3);
-	uint32_t limit = luaL_checkinteger(L, 4);
+	struct space_read_view_handle *space =
+		lbox_check_space_read_view_handle(L, 1);
+	uint32_t index_id = luaL_checkinteger(L, 2);
+	int iterator = luaL_checkinteger(L, 3);
+	uint32_t offset = luaL_checkinteger(L, 4);
+	uint32_t limit = luaL_checkinteger(L, 5);
 	struct region *region = &fiber()->gc;
 	size_t region_svp = region_used(region);
 	size_t key_len;
-	const char *key = lbox_encode_tuple_on_gc(L, 5, &key_len);
+	const char *key = lbox_encode_tuple_on_gc(L, 6, &key_len);
 	const char *packed_pos, *packed_pos_end;
-	bool fetch_pos = lua_toboolean(L, 7);
-	if (lbox_read_view_normalize_position(L, 6, rv, &packed_pos,
+	bool fetch_pos = lua_toboolean(L, 8);
+	if (lbox_read_view_normalize_position(L, 7, space, index_id,
+					      &packed_pos,
 					      &packed_pos_end) != 0)
 		goto fail;
 	struct port port;
-	int rc = box_index_read_view_select(rv->space, rv->index_id, iterator,
+	int rc = box_index_read_view_select(space, index_id, iterator,
 					    offset, limit, key, key + key_len,
 					    &packed_pos, &packed_pos_end,
 					    fetch_pos, &port);
@@ -556,10 +460,8 @@ lbox_index_read_view_iterator_gc(struct lua_State *L)
 {
 	struct lbox_index_read_view_iterator *it =
 		lbox_check_index_read_view_iterator(L, 1);
-	if (it->read_view != NULL)
+	if (it->space != NULL)
 		box_index_read_view_iterator_destroy(&it->obj);
-	luaL_unref(L, LUA_REGISTRYINDEX, it->read_view_ref);
-	luaL_unref(L, LUA_REGISTRYINDEX, it->key_ref);
 	return 0;
 }
 
@@ -572,7 +474,7 @@ static int
 lbox_index_read_view_iterator_next(struct lua_State *L)
 {
 	struct lbox_index_read_view_iterator *it =
-		lbox_check_open_index_read_view_iterator(L, 1);
+		lbox_check_index_read_view_iterator(L, 1);
 	struct tuple *tuple;
 	if (box_index_read_view_iterator_next(&it->obj, it->space, &tuple) != 0)
 		return luaT_error(L);
@@ -585,15 +487,17 @@ lbox_index_read_view_iterator_next(struct lua_State *L)
 
 /**
  * Creates an iterator over an index read view.
- * Takes iterator type, key and position.
+ * Takes space read view handle, index id, iterator type, key, position,
+ * and offset.
  * Returns an iterator object on success. On error, raises a Lua exception.
  */
 static int
 lbox_index_read_view_iterator(struct lua_State *L)
 {
-	struct lbox_index_read_view *rv =
-		lbox_check_open_index_read_view_at(L, 1, 2);
-	int iterator = luaL_checkinteger(L, 2);
+	struct space_read_view_handle *space =
+		lbox_check_space_read_view_handle(L, 1);
+	uint32_t index_id = luaL_checkinteger(L, 2);
+	int iterator = luaL_checkinteger(L, 3);
 
 	/*
 	 * Store the key on Lua memory, because the iterator implementation
@@ -602,36 +506,30 @@ lbox_index_read_view_iterator(struct lua_State *L)
 	struct region *region = &fiber()->gc;
 	size_t region_svp = region_used(region);
 	size_t key_len;
-	const char *key = lbox_encode_tuple_on_gc(L, 3, &key_len);
+	const char *key = lbox_encode_tuple_on_gc(L, 4, &key_len);
 	lua_pushlstring(L, key, key_len);
 	key = lua_tostring(L, -1);
 	const char *packed_pos, *packed_pos_end;
-	if (lbox_read_view_normalize_position(L, 4, rv, &packed_pos,
+	if (lbox_read_view_normalize_position(L, 5, space, index_id,
+					      &packed_pos,
 					      &packed_pos_end) != 0)
 		goto error;
-	uint32_t offset = luaL_checkinteger(L, 5);
+	uint32_t offset = luaL_checkinteger(L, 6);
 
 	/* Allocate a userdata object for the new iterator. */
 	struct lbox_index_read_view_iterator *it =
 			lua_newuserdata(L, sizeof(*it));
-	it->read_view = NULL;
-	it->read_view_ref = LUA_NOREF;
-	it->key_ref = LUA_NOREF;
+	it->space = NULL;
 	it->count = 0;
 	luaL_getmetatable(L, lbox_index_read_view_iterator_typename);
 	lua_setmetatable(L, -2);
 
 	/* Initialize the userdata object. */
 	if (box_index_read_view_create_iterator_with_offset(
-			rv->space, rv->index_id, iterator, key, key + key_len,
+			space, index_id, iterator, key, key + key_len,
 			packed_pos, packed_pos_end, offset, &it->obj) != 0)
 		goto error;
-	it->space = rv->space;
-	it->read_view = rv->read_view;
-	lua_rawgeti(L, LUA_REGISTRYINDEX, rv->read_view_ref);
-	it->read_view_ref = luaL_ref(L, LUA_REGISTRYINDEX);
-	lua_pushvalue(L, -2);
-	it->key_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+	it->space = space;
 	region_truncate(region, region_svp);
 	return 1;
 error:
@@ -646,7 +544,11 @@ box_lua_read_view_init(struct lua_State *L)
 		{"open", lbox_read_view_open },
 		{"list", lbox_read_view_list},
 		{"status", lbox_read_view_status},
-		{ NULL, NULL }
+		{"index_get", lbox_index_read_view_get},
+		{"index_count", lbox_index_read_view_count},
+		{"index_select", lbox_index_read_view_select},
+		{"index_iterator", lbox_index_read_view_iterator},
+		{ NULL, NULL}
 	};
 	luaL_findtable(L, LUA_GLOBALSINDEX, "box.internal.read_view", 0);
 	luaL_setfuncs(L, module_methods, 0);
@@ -658,17 +560,6 @@ box_lua_read_view_init(struct lua_State *L)
 		{ NULL, NULL }
 	};
 	luaL_register_type(L, lbox_read_view_typename, read_view_methods);
-
-	const struct luaL_Reg index_read_view_methods[] = {
-		{"__gc", lbox_index_read_view_gc },
-		{"get", lbox_index_read_view_get },
-		{"count", lbox_index_read_view_count },
-		{"select", lbox_index_read_view_select },
-		{"iterator", lbox_index_read_view_iterator },
-		{ NULL, NULL }
-	};
-	luaL_register_type(L, lbox_index_read_view_typename,
-			   index_read_view_methods);
 
 	const struct luaL_Reg index_read_view_iterator_methods[] = {
 		{"__gc", lbox_index_read_view_iterator_gc },

--- a/src/box/lua/read_view.c
+++ b/src/box/lua/read_view.c
@@ -53,7 +53,7 @@ lbox_check_space_read_view_handle(struct lua_State *L, int idx)
  */
 struct lbox_read_view {
 	/** Wrapped database read view object. */
-	struct read_view obj;
+	struct read_view *ptr;
 	/** Read view handle. */
 	struct read_view_handle *handle;
 	/**
@@ -227,6 +227,8 @@ lbox_read_view_open(struct lua_State *L)
 
 	/* Allocate a userdata object for the new read view. */
 	struct lbox_read_view *rv = lua_newuserdata(L, sizeof(*rv));
+	rv->ptr = NULL;
+	rv->handle = NULL;
 	rv->is_closed = true;
 	luaL_getmetatable(L, lbox_read_view_typename);
 	lua_setmetatable(L, -2);
@@ -240,11 +242,12 @@ lbox_read_view_open(struct lua_State *L)
 	opts.enable_field_names = true;
 	opts.enable_space_upgrade = true;
 	opts.enable_data_temporary_spaces = true;
-	if (read_view_open(&rv->obj, &opts) != 0)
+	rv->ptr = read_view_new(&opts);
+	if (rv->ptr == NULL)
 		return luaT_error_at(L, 2);
-	rv->handle = read_view_handle_new(&rv->obj);
+	rv->handle = read_view_handle_new(rv->ptr);
 	if (rv->handle == NULL) {
-		read_view_close(&rv->obj);
+		read_view_delete(rv->ptr);
 		return luaT_error_at(L, 2);
 	}
 	rv->is_closed = false;
@@ -260,7 +263,7 @@ lbox_read_view_open(struct lua_State *L)
 	}
 
 	/* Push the read view table and set rv._impl and rv.space. */
-	lbox_push_read_view(L, &rv->obj);
+	lbox_push_read_view(L, rv->ptr);
 	lua_replace(L, 1);
 	lua_setfield(L, 1, "space");
 	lua_setfield(L, 1, "_impl");
@@ -318,9 +321,9 @@ lbox_read_view_gc(struct lua_State *L)
 	struct lbox_read_view *rv = lbox_check_read_view(L, 1);
 	if (!rv->is_closed) {
 		say_warn("read view %llu ('%s') was not properly closed",
-			 (unsigned long long)rv->obj.id, rv->obj.name);
+			 (unsigned long long)rv->ptr->id, rv->ptr->name);
 		read_view_handle_delete(rv->handle);
-		read_view_close(&rv->obj);
+		read_view_delete(rv->ptr);
 	}
 	TRASH(rv);
 	return 0;
@@ -335,7 +338,7 @@ lbox_read_view_close(struct lua_State *L)
 	struct lbox_read_view *rv = lbox_check_read_view(L, 1);
 	if (!rv->is_closed) {
 		read_view_handle_delete(rv->handle);
-		read_view_close(&rv->obj);
+		read_view_delete(rv->ptr);
 		rv->is_closed = true;
 	}
 	return 0;

--- a/src/box/lua/read_view.c
+++ b/src/box/lua/read_view.c
@@ -34,6 +34,20 @@
 static bool box_read_view_ffi = true;
 TWEAK_BOOL(box_read_view_ffi);
 
+/** Lua ctype ID of struct read_view_handle pointer. */
+static uint32_t CTID_STRUCT_READ_VIEW_HANDLE;
+
+/** Get a read view handle from Lua stack. */
+static inline struct read_view_handle *
+lbox_check_read_view_handle(struct lua_State *L, int idx)
+{
+	assert(CTID_STRUCT_READ_VIEW_HANDLE != 0);
+	uint32_t ctypeid;
+	void *cdata = luaL_checkcdata(L, idx, &ctypeid);
+	assert(ctypeid == CTID_STRUCT_READ_VIEW_HANDLE);
+	return *(struct read_view_handle **)cdata;
+}
+
 /** Lua ctype ID of struct space_read_view_handle pointer. */
 static uint32_t CTID_STRUCT_SPACE_READ_VIEW_HANDLE;
 
@@ -46,31 +60,6 @@ lbox_check_space_read_view_handle(struct lua_State *L, int idx)
 	void *cdata = luaL_checkcdata(L, idx, &ctypeid);
 	assert(ctypeid == CTID_STRUCT_SPACE_READ_VIEW_HANDLE);
 	return *(struct space_read_view_handle **)cdata;
-}
-
-/**
- * Wrapper around a database read view object pushed to Lua as user data.
- */
-struct lbox_read_view {
-	/** Wrapped database read view object. */
-	struct read_view *ptr;
-	/** Read view handle. */
-	struct read_view_handle *handle;
-	/**
-	 * Set to true if the read view was closed.
-	 * If set, the wrapped object is invalid and must not be used.
-	 */
-	bool is_closed;
-};
-
-/** Type name of lbox_read_view Lua user data. */
-static const char lbox_read_view_typename[] = "box.read_view";
-
-/** Get a database read view from Lua stack. */
-static struct lbox_read_view *
-lbox_check_read_view(struct lua_State *L, int idx)
-{
-	return luaL_checkudata(L, idx, lbox_read_view_typename);
 }
 
 /**
@@ -182,9 +171,8 @@ lbox_read_view_push_space(struct lua_State *L,
  * Takes the new read view name (string).
  * On success, returns a table that has the following structure:
  * {
- *     -- Read view implementation.
- *     -- Represented by struct lbox_read_view.
- *     _impl = <userdata:box.read_view>,
+ *     -- Read view handle (cdata).
+ *     _crv = <cdata:struct read_view_handle *>,
  *
  *     id = <number>,                            -- read view id
  *     name = <string>,                          -- read view name
@@ -225,14 +213,6 @@ lbox_read_view_open(struct lua_State *L)
 {
 	const char *name = luaL_checkstring(L, 1);
 
-	/* Allocate a userdata object for the new read view. */
-	struct lbox_read_view *rv = lua_newuserdata(L, sizeof(*rv));
-	rv->ptr = NULL;
-	rv->handle = NULL;
-	rv->is_closed = true;
-	luaL_getmetatable(L, lbox_read_view_typename);
-	lua_setmetatable(L, -2);
-
 	/* Open a read view. */
 	struct read_view_opts opts;
 	read_view_opts_create(&opts);
@@ -242,31 +222,32 @@ lbox_read_view_open(struct lua_State *L)
 	opts.enable_field_names = true;
 	opts.enable_space_upgrade = true;
 	opts.enable_data_temporary_spaces = true;
-	rv->ptr = read_view_new(&opts);
-	if (rv->ptr == NULL)
+	struct read_view *rv = read_view_new(&opts);
+	if (rv == NULL)
 		return luaT_error_at(L, 2);
-	rv->handle = read_view_handle_new(rv->ptr);
-	if (rv->handle == NULL) {
-		read_view_delete(rv->ptr);
+	struct read_view_handle *rvh = read_view_handle_new(rv);
+	if (rvh == NULL) {
+		read_view_delete(rv);
 		return luaT_error_at(L, 2);
 	}
-	rv->is_closed = false;
 
 	/* Create a space table. */
 	lua_newtable(L);
 	struct space_read_view_handle *space;
-	read_view_foreach_space(space, rv->handle) {
+	read_view_foreach_space(space, rvh) {
 		lbox_read_view_push_space(L, space);
 		lua_pushvalue(L, -1);
 		lua_rawseti(L, -3, space->ptr->id);
 		lua_setfield(L, -2, space->ptr->name);
 	}
 
-	/* Push the read view table and set rv._impl and rv.space. */
-	lbox_push_read_view(L, rv->ptr);
+	/* Push the read view table and set rv._crv and rv.space. */
+	lbox_push_read_view(L, rv);
 	lua_replace(L, 1);
 	lua_setfield(L, 1, "space");
-	lua_setfield(L, 1, "_impl");
+	*(struct read_view_handle **)luaL_pushcdata(
+		L, CTID_STRUCT_READ_VIEW_HANDLE) = rvh;
+	lua_setfield(L, 1, "_crv");
 	lua_settop(L, 1);
 	return 1;
 }
@@ -312,35 +293,21 @@ lbox_read_view_status(struct lua_State *L)
 }
 
 /**
- * Frees a database read view.
- * If the read view is still open, closes it and logs a warning.
- */
-static int
-lbox_read_view_gc(struct lua_State *L)
-{
-	struct lbox_read_view *rv = lbox_check_read_view(L, 1);
-	if (!rv->is_closed) {
-		say_warn("read view %llu ('%s') was not properly closed",
-			 (unsigned long long)rv->ptr->id, rv->ptr->name);
-		read_view_handle_delete(rv->handle);
-		read_view_delete(rv->ptr);
-	}
-	TRASH(rv);
-	return 0;
-}
-
-/**
- * Closes a database read view unless it's already closed.
+ * Closes a database read view by the given handle cdata.
+ * Logs a warning if the second argument is true.
  */
 static int
 lbox_read_view_close(struct lua_State *L)
 {
-	struct lbox_read_view *rv = lbox_check_read_view(L, 1);
-	if (!rv->is_closed) {
-		read_view_handle_delete(rv->handle);
-		read_view_delete(rv->ptr);
-		rv->is_closed = true;
+	struct read_view_handle *rvh = lbox_check_read_view_handle(L, 1);
+	struct read_view *rv = rvh->ptr;
+	bool warn = lua_toboolean(L, 2);
+	if (warn) {
+		say_warn("read view %llu ('%s') was not properly closed",
+			 (unsigned long long)rv->id, rv->name);
 	}
+	read_view_handle_delete(rvh);
+	read_view_delete(rv);
 	return 0;
 }
 
@@ -543,10 +510,12 @@ error:
 void
 box_lua_read_view_init(struct lua_State *L)
 {
+	int rc;
 	const struct luaL_Reg module_methods[] = {
-		{"open", lbox_read_view_open },
+		{"open", lbox_read_view_open},
 		{"list", lbox_read_view_list},
 		{"status", lbox_read_view_status},
+		{"close", lbox_read_view_close},
 		{"index_get", lbox_index_read_view_get},
 		{"index_count", lbox_index_read_view_count},
 		{"index_select", lbox_index_read_view_select},
@@ -557,13 +526,6 @@ box_lua_read_view_init(struct lua_State *L)
 	luaL_setfuncs(L, module_methods, 0);
 	lua_pop(L, 1);
 
-	const struct luaL_Reg read_view_methods[] = {
-		{"__gc", lbox_read_view_gc },
-		{"close", lbox_read_view_close },
-		{ NULL, NULL }
-	};
-	luaL_register_type(L, lbox_read_view_typename, read_view_methods);
-
 	const struct luaL_Reg index_read_view_iterator_methods[] = {
 		{"__gc", lbox_index_read_view_iterator_gc },
 		{"next", lbox_index_read_view_iterator_next },
@@ -572,7 +534,14 @@ box_lua_read_view_init(struct lua_State *L)
 	luaL_register_type(L, lbox_index_read_view_iterator_typename,
 			   index_read_view_iterator_methods);
 
-	int rc = luaL_cdef(L, "struct space_read_view_handle;");
+	rc = luaL_cdef(L, "struct read_view_handle;");
+	assert(rc == 0);
+	(void)rc;
+	CTID_STRUCT_READ_VIEW_HANDLE = luaL_ctypeid(
+		L, "struct read_view_handle *");
+	assert(CTID_STRUCT_READ_VIEW_HANDLE != 0);
+
+	rc = luaL_cdef(L, "struct space_read_view_handle;");
 	assert(rc == 0);
 	(void)rc;
 	CTID_STRUCT_SPACE_READ_VIEW_HANDLE = luaL_ctypeid(

--- a/src/box/lua/read_view.lua
+++ b/src/box/lua/read_view.lua
@@ -204,6 +204,10 @@ function box.read_view.list()
     return list
 end
 
+local function read_view_gc(crv)
+    internal.close(crv, true)
+end
+
 --
 -- Opens a new read view.
 --
@@ -234,6 +238,7 @@ function box.read_view.open(opts)
             end
         end
     end
+    ffi.gc(rv._crv, read_view_gc)
     return register_read_view(rv)
 end
 
@@ -273,7 +278,7 @@ function read_view_methods:close()
     if self.status == 'closed' then
         box.error(box.error.READ_VIEW_CLOSED, 2)
     end
-    if self._impl == nil then
+    if self._crv == nil then
         -- System read view. Can't be closed.
         box.error(box.error.READ_VIEW_BUSY, 2)
     end
@@ -285,7 +290,9 @@ function read_view_methods:close()
             index._cspace = nil
         end
     end
-    self._impl:close()
+    internal.close(self._crv)
+    ffi.gc(self._crv, nil)
+    self._crv = nil
 end
 
 --

--- a/src/box/lua/read_view.lua
+++ b/src/box/lua/read_view.lua
@@ -227,6 +227,9 @@ function box.read_view.open(opts)
                     else
                         setmetatable(index, read_view_index_mt_luac)
                     end
+                    -- Keep a reference to the read view to make sure
+                    -- it won't go away while the index is in use.
+                    index._rv = rv
                 end
             end
         end
@@ -303,10 +306,9 @@ local function keify(key)
 end
 
 --
--- Checks if the given index read view is open. Used by the FFI API.
--- (The Lua C API has this check implemented in C.)
+-- Checks if the given index read view is open.
 --
-local function check_index_read_view_is_open_ffi(index)
+local function check_index_read_view_is_open(index)
     if index._cspace == nil then
         box.error(box.error.READ_VIEW_CLOSED, 3)
     end
@@ -348,13 +350,14 @@ end
 --
 function read_view_index_methods_luac:get(key)
     check_index_arg(self, 'get', 2)
+    check_index_read_view_is_open(self)
     key = keify(key)
-    return self._impl:get(key)
+    return internal.index_get(self._cspace, self.id, key)
 end
 
 function read_view_index_methods_ffi:get(key)
     check_index_arg(self, 'get', 2)
-    check_index_read_view_is_open_ffi(self)
+    check_index_read_view_is_open(self)
     local ibuf = cord_ibuf_take()
     local raw_key, raw_key_end = tuple_encode(ibuf, key)
     local ok = builtin.box_index_read_view_get(
@@ -378,14 +381,15 @@ end
 --
 function read_view_index_methods_luac:count(key, opts)
     check_index_arg(self, 'count', 2)
+    check_index_read_view_is_open(self)
     key = keify(key)
     local itype = check_iterator_type(opts, #key == 0, 2)
-    return self._impl:count(itype, key)
+    return internal.index_count(self._cspace, self.id, itype, key)
 end
 
 function read_view_index_methods_ffi:count(key, opts)
     check_index_arg(self, 'count', 2)
-    check_index_read_view_is_open_ffi(self)
+    check_index_read_view_is_open(self)
     local ibuf = cord_ibuf_take()
     local raw_key, raw_key_end = tuple_encode(ibuf, key)
     local key_is_nil = raw_key + 1 >= raw_key_end
@@ -412,16 +416,18 @@ end
 --
 function read_view_index_methods_luac:select(key, opts)
     check_index_arg(self, 'select', 2)
+    check_index_read_view_is_open(self)
     key = keify(key)
     local key_is_nil = #key == 0
     local iterator, offset, limit, after, fetch_pos =
         check_select_opts(opts, key_is_nil, 2)
-    return self._impl:select(iterator, offset, limit, key, after, fetch_pos)
+    return internal.index_select(self._cspace, self.id, iterator,
+                                 offset, limit, key, after, fetch_pos)
 end
 
 function read_view_index_methods_ffi:select(key, opts)
     check_index_arg(self, 'select', 2)
-    check_index_read_view_is_open_ffi(self)
+    check_index_read_view_is_open(self)
     local region_svp = builtin.box_region_used()
     local ibuf = cord_ibuf_take()
     local raw_key, raw_key_end = tuple_encode(ibuf, key)
@@ -454,21 +460,34 @@ function read_view_index_methods_ffi:select(key, opts)
     return ret, pos
 end
 
+local function iterator_next_luac(it)
+    check_index_read_view_is_open(it.index)
+    return it.impl:next()
+end
+
 --
 -- Creates an iterator over an index read view, given key and iterator type.
 -- Returns a 'gen, param, state' triplet, suitable for a 'for' loop.
 --
 function read_view_index_methods_luac:pairs(key, opts)
     check_index_arg(self, 'pairs', 2)
+    check_index_read_view_is_open(self)
     key = keify(key)
     local key_is_nil = #key == 0
     local iterator, after, offset = check_pairs_opts(opts, key_is_nil, 2)
-    local it = self._impl:iterator(iterator, key, after, offset)
-    return it.next, it
+    local it = internal.index_iterator(self._cspace, self.id, iterator,
+                                       key, after, offset)
+    return iterator_next_luac, {
+        -- Keep references to the index and the search key to make sure
+        -- they won't go away while the iterator is in use.
+        index = self,
+        key = key,
+        impl = it,
+    }
 end
 
 local function iterator_next_ffi(it, count)
-    check_index_read_view_is_open_ffi(it.index)
+    check_index_read_view_is_open(it.index)
     if builtin.box_index_read_view_iterator_next(
             it.cdata, it.index._cspace, ptuple) ~= 0 then
         box.error(box.error.last(), 2)
@@ -479,7 +498,7 @@ end
 
 function read_view_index_methods_ffi:pairs(key, opts)
     check_index_arg(self, 'pairs', 2)
-    check_index_read_view_is_open_ffi(self)
+    check_index_read_view_is_open(self)
     local region_svp = builtin.box_region_used()
     local ibuf = cord_ibuf_take()
     local raw_key, raw_key_end = tuple_encode(ibuf, key)
@@ -514,7 +533,7 @@ end
 
 function read_view_index_methods_common:quantile(level, begin_key, end_key)
     check_index_arg(self, 'quantile', 2)
-    check_index_read_view_is_open_ffi(self)
+    check_index_read_view_is_open(self)
     if level == nil then
         box.error(box.error.ILLEGAL_PARAMS,
                   'Usage: index:quantile(level[, begin_key, end_key])', 2)
@@ -557,7 +576,7 @@ end
 
 function read_view_index_methods_common:tuple_pos(tuple)
     check_index_arg(self, 'tuple_pos', 2)
-    check_index_read_view_is_open_ffi(self)
+    check_index_read_view_is_open(self)
     local region_svp = builtin.box_region_used()
     local ibuf = cord_ibuf_take()
     local data, data_end = tuple_encode(ibuf, tuple)
@@ -576,7 +595,7 @@ end
 
 function read_view_index_methods_common:offset_of(key, opts)
     check_index_arg(self, 'offset_of', 2)
-    check_index_read_view_is_open_ffi(self)
+    check_index_read_view_is_open(self)
     key = keify(key)
     local itype = check_iterator_type(opts, #key == 0, 2)
     if itype == box.index.EQ then

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -1027,7 +1027,7 @@ checkpoint_write_tuple(struct xlog *l, uint32_t space_id, uint32_t group_id,
 
 struct checkpoint {
 	/** Database read view written to the snapshot file. */
-	struct read_view rv;
+	struct read_view *rv;
 	/** Snapshot writer thread. */
 	struct cord cord;
 	/** The vclock of the snapshot file. */
@@ -1154,19 +1154,15 @@ checkpoint_dump_sort_data(
 static struct checkpoint *
 checkpoint_new(struct memtx_engine *memtx, const struct box_checkpoint *box)
 {
-	struct checkpoint *ckpt = (struct checkpoint *)malloc(sizeof(*ckpt));
-	if (ckpt == NULL) {
-		diag_set(OutOfMemory, sizeof(*ckpt), "malloc",
-			 "struct checkpoint");
-		return NULL;
-	}
+	struct checkpoint *ckpt = (struct checkpoint *)xmalloc(sizeof(*ckpt));
 	struct read_view_opts rv_opts;
 	read_view_opts_create(&rv_opts);
 	rv_opts.name = "checkpoint";
 	rv_opts.is_system = true;
 	rv_opts.filter_space = checkpoint_space_filter;
 	rv_opts.filter_index = checkpoint_index_filter;
-	if (read_view_open(&ckpt->rv, &rv_opts) != 0) {
+	ckpt->rv = read_view_new(&rv_opts);
+	if (ckpt->rv == NULL) {
 		free(ckpt);
 		return NULL;
 	}
@@ -1190,7 +1186,7 @@ checkpoint_delete(struct checkpoint *ckpt)
 {
 	if (ckpt->sort_data_writer != NULL)
 		memtx_sort_data_writer_delete(ckpt->sort_data_writer);
-	read_view_close(&ckpt->rv);
+	read_view_delete(ckpt->rv);
 	xdir_destroy(&ckpt->dir);
 	free(ckpt);
 }
@@ -1339,7 +1335,7 @@ checkpoint_f(va_list ap)
 	if (ckpt->sort_data_writer != NULL &&
 	    memtx_sort_data_writer_create_file(ckpt->sort_data_writer,
 					       snap->filename, &ckpt->vclock,
-					       &INSTANCE_UUID, &ckpt->rv) != 0)
+					       &INSTANCE_UUID, ckpt->rv) != 0)
 		return -1;
 
 	struct mh_i32_t *temp_space_ids = mh_i32_new();
@@ -1355,7 +1351,7 @@ checkpoint_f(va_list ap)
 	});
 	ERROR_INJECT(ERRINJ_SNAP_SKIP_ALL_ROWS, goto done);
 	struct space_read_view *space_rv;
-	read_view_foreach_space(space_rv, &ckpt->rv) {
+	read_view_foreach_space(space_rv, ckpt->rv) {
 		FiberGCChecker gc_check;
 		bool skip = false;
 		ERROR_INJECT(ERRINJ_SNAP_SKIP_DDL_ROWS, {
@@ -1648,7 +1644,7 @@ memtx_engine_backup(struct engine *engine, const struct vclock *vclock,
 
 struct memtx_join_ctx {
 	/** Database read view sent to the replica. */
-	struct read_view rv;
+	struct read_view *rv;
 	struct xstream *stream;
 };
 
@@ -1685,21 +1681,16 @@ memtx_engine_prepare_join(struct engine *engine, struct engine_join_ctx *arg)
 {
 	if (arg->cursor != NULL)
 		return 0;
-
 	struct memtx_join_ctx *ctx =
-		(struct memtx_join_ctx *)malloc(sizeof(*ctx));
-	if (ctx == NULL) {
-		diag_set(OutOfMemory, sizeof(*ctx),
-			 "malloc", "struct memtx_join_ctx");
-		return -1;
-	}
+		(struct memtx_join_ctx *)xmalloc(sizeof(*ctx));
 	struct read_view_opts rv_opts;
 	read_view_opts_create(&rv_opts);
 	rv_opts.name = "join";
 	rv_opts.is_system = true;
 	rv_opts.filter_space = memtx_join_space_filter;
 	rv_opts.filter_index = primary_index_filter;
-	if (read_view_open(&ctx->rv, &rv_opts) != 0) {
+	ctx->rv = read_view_new(&rv_opts);
+	if (ctx->rv == NULL) {
 		free(ctx);
 		return -1;
 	}
@@ -1734,7 +1725,7 @@ memtx_join_f(va_list ap)
 	struct memtx_join_ctx *ctx = va_arg(ap, struct memtx_join_ctx *);
 	struct mh_i32_t *temp_space_ids = mh_i32_new();
 	struct space_read_view *space_rv;
-	read_view_foreach_space(space_rv, &ctx->rv) {
+	read_view_foreach_space(space_rv, ctx->rv) {
 		FiberGCChecker gc_check;
 		struct index_read_view *index_rv =
 			space_read_view_index(space_rv, 0);
@@ -1799,7 +1790,7 @@ memtx_engine_complete_join(struct engine *engine, struct engine_join_ctx *arg)
 
 	struct memtx_join_ctx *ctx =
 		(struct memtx_join_ctx *)arg->data[engine->id];
-	read_view_close(&ctx->rv);
+	read_view_delete(ctx->rv);
 	free(ctx);
 }
 

--- a/src/box/memtx_engine.h
+++ b/src/box/memtx_engine.h
@@ -308,7 +308,7 @@ memtx_prepare_result_tuple(struct space *space, struct tuple **result);
  * This function performs two tasks:
  *
  *  1. Eliminates dirty tuples using the provided snapshot cleaner created
- *     at read_view_open. If the given tuple should be skipped, the data is
+ *     at read_view_new. If the given tuple should be skipped, the data is
  *     set to NULL.
  *
  *  2. Decompresses tuples if required, unless the disable_decompression flag

--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -219,9 +219,10 @@ read_view_unregister(struct read_view *rv)
 	}
 }
 
-int
-read_view_open(struct read_view *rv, const struct read_view_opts *opts)
+struct read_view *
+read_view_new(const struct read_view_opts *opts)
 {
+	struct read_view *rv = xmalloc(sizeof(*rv));
 	rv->id = next_read_view_id++;
 	assert(opts->name != NULL);
 	rv->name = xstrdup(opts->name);
@@ -231,6 +232,7 @@ read_view_open(struct read_view *rv, const struct read_view_opts *opts)
 	vclock_copy(&rv->vclock, box_vclock);
 	rlist_create(&rv->engines);
 	rlist_create(&rv->spaces);
+	rv->ctx = NULL;
 	read_view_register(rv);
 	struct engine *engine;
 	engine_foreach(engine) {
@@ -248,14 +250,14 @@ read_view_open(struct read_view *rv, const struct read_view_opts *opts)
 	};
 	if (space_foreach(read_view_add_space_cb, &add_space_cb_arg) != 0)
 		goto fail;
-	return 0;
+	return rv;
 fail:
-	read_view_close(rv);
-	return -1;
+	read_view_delete(rv);
+	return NULL;
 }
 
 void
-read_view_close(struct read_view *rv)
+read_view_delete(struct read_view *rv)
 {
 	read_view_unregister(rv);
 	struct space_read_view *space_rv, *next_space_rv;
@@ -271,6 +273,7 @@ read_view_close(struct read_view *rv)
 	}
 	free(rv->name);
 	TRASH(rv);
+	free(rv);
 }
 
 struct read_view *

--- a/src/box/read_view.h
+++ b/src/box/read_view.h
@@ -140,6 +140,11 @@ struct read_view {
 	struct rlist engines;
 	/** List of space read views, linked by space_read_view::link. */
 	struct rlist spaces;
+	/**
+	 * Extra context attached to the read view.
+	 * Used by the raw read view API in Tarantol EE.
+	 */
+	void *ctx;
 };
 
 /**
@@ -242,16 +247,16 @@ read_view_opts_create(struct read_view_opts *opts);
  *
  * Engines that don't support read view creation are silently skipped.
  *
- * Returns 0 on success. On error, returns -1 and sets diag.
+ * On error, returns NULL and sets diag.
  */
-int
-read_view_open(struct read_view *rv, const struct read_view_opts *opts);
+struct read_view *
+read_view_new(const struct read_view_opts *opts);
 
 /**
  * Closes a database read view.
  */
 void
-read_view_close(struct read_view *rv);
+read_view_delete(struct read_view *rv);
 
 /**
  * Looks up an open read view by id.

--- a/test/box-luatest/read_view_test.lua
+++ b/test/box-luatest/read_view_test.lua
@@ -597,8 +597,8 @@ g.test_index_ref = function(cg)
     cg.server:exec(function()
         local weak = setmetatable({}, {__mode = 'v'})
         local rv = box.read_view.open()
-        local idx = rv.space._space.index.primary._impl -- luacheck: ignore
-        weak.rv = rv._impl
+        local idx = rv.space._space.index.primary -- luacheck: ignore
+        weak.rv = rv
         rv = nil -- luacheck: ignore
         for _ = 1, 5 do collectgarbage('collect') end
         t.assert_is_not(weak.rv, nil)
@@ -615,7 +615,7 @@ g.test_iterator_ref = function(cg)
         local rv = box.read_view.open()
         local idx = rv.space._space.index.primary
         local gen, param, state = idx:pairs() -- luacheck: ignore
-        weak.rv = rv._impl
+        weak.rv = rv
         rv = nil -- luacheck: ignore
         idx = nil -- luacheck: ignore
         for _ = 1, 5 do collectgarbage('collect') end


### PR DESCRIPTION
In order to facilitate further development of the read view Lua module aimed at making it available in application threads, let's do some refactoring:
- Drop `lbox_index_read_view` wrapper. We don't really need it because we can use `index._cspace` directly instead.
- Store `read_view` by pointer instead of embedding it. This will help us implement a handle in Lua, which doesn't own a read view.
- Replace `lbox_read_view` userdata with `read_view_handle` cdata. After the done refactoring, there's no need in userdata anymore. Besides, it lets us move the `__gc` read view callback to Lua code, which will help us handle garbage collection in application threads (an application thread needs to dispatch this callback to the main thread, which can currently only be done in Lua code).

Needed for #12951