### PR TITLE
sql: support `INSERT DEFAULT VALUES` in trigger

### DIFF
--- a/changelogs/unreleased/gh-12969-insert-defaults-in-trigger.md
+++ b/changelogs/unreleased/gh-12969-insert-defaults-in-trigger.md
@@ -1,0 +1,4 @@
+## feature/sql
+
+* The INSERT INTO TABLE DEFAULT VALUES statement is now supported
+  in SQL triggers (gh-12969).

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1478,6 +1478,10 @@ trigger_cmd(A) ::= insert_cmd(R) INTO trnm(X) idlist_opt(F) select_old(S). {
   /*A-overwrites-R. */
   A = sql_trigger_insert_step(&X, F, S, R);
 }
+trigger_cmd(A) ::= insert_cmd(R) INTO trnm(X) idlist_opt(F) DEFAULT VALUES. {
+  /*A-overwrites-R. */
+  A = sql_trigger_insert_step(&X, F, NULL, R);
+}
 
 // DELETE
 trigger_cmd(A) ::= DELETE FROM trnm(X) tridxby where_opt_old(Y). {

--- a/src/box/sql/trigger.c
+++ b/src/box/sql/trigger.c
@@ -248,7 +248,6 @@ struct TriggerStep *
 sql_trigger_insert_step(struct Token *table_name, struct ast_id_list *columns,
 			struct Select *select, enum on_conflict_action orconf)
 {
-	assert(select != NULL);
 	struct TriggerStep *trigger_step =
 		sql_trigger_step_new(TK_INSERT, table_name);
 	trigger_step->pSelect = sqlSelectDup(select, EXPRDUP_REDUCE);

--- a/test/sql-luatest/triggers_test.lua
+++ b/test/sql-luatest/triggers_test.lua
@@ -759,3 +759,50 @@ end
         box.execute([[DROP TABLE t2;]])
     end)
 end
+
+--
+-- Check that INSERT DEFAULT VALUES works as expected in trigger.
+--
+g.test_12969_insert_defaults_in_trigger = function(cg)
+    cg.server:exec(function()
+        box.execute([[CREATE TABLE t1(i INT PRIMARY KEY);]])
+        box.execute([[CREATE TABLE t2(i INT PRIMARY KEY AUTOINCREMENT,
+                      a STRING DEFAULT 'default string',
+                      b INT DEFAULT 123);]])
+        box.execute([[CREATE TRIGGER t1t AFTER INSERT ON t1
+                      FOR EACH ROW BEGIN INSERT INTO t2 DEFAULT VALUES; END;]])
+        box.execute([[INSERT INTO t1 VALUES(11), (22), (33), (44), (55);]])
+        local exp = {
+            {1, 'default string', 123},
+            {2, 'default string', 123},
+            {3, 'default string', 123},
+            {4, 'default string', 123},
+            {5, 'default string', 123},
+        }
+        local res = box.execute([[SELECT * FROM t2;]])
+        t.assert_equals(res.rows, exp)
+        box.execute([[DROP TRIGGER t1t;]])
+
+        box.execute([[CREATE TRIGGER t2t AFTER INSERT ON t1
+                      FOR EACH ROW BEGIN INSERT INTO t2(b) VALUES(1); END;]])
+        box.execute([[INSERT INTO t1 VALUES(66), (77), (88), (99), (100);]])
+        exp = {
+            {1, 'default string', 123},
+            {2, 'default string', 123},
+            {3, 'default string', 123},
+            {4, 'default string', 123},
+            {5, 'default string', 123},
+            {6, 'default string', 1},
+            {7, 'default string', 1},
+            {8, 'default string', 1},
+            {9, 'default string', 1},
+            {10, 'default string', 1},
+        }
+        res = box.execute([[SELECT * FROM t2;]])
+        t.assert_equals(res.rows, exp)
+        box.execute([[DROP TRIGGER t2t;]])
+
+        box.execute([[DROP TABLE t2;]])
+        box.execute([[DROP TABLE t1;]])
+    end)
+end


### PR DESCRIPTION
This patch adds support for the `INSERT INTO table DEFAULT VALUES` statement for SQL triggers.

Closes #12969

@TarantoolBot document
Title: Support `INSERT INTO table DEFAULT VALUES` in SQL triggers

SQL triggers now support the INSERT INTO table DEFAULT VALUES statement. Note that this is primarily a parser change, as prior to this patch, it was possible to insert default values into all but one column by inserting into a single column, for example:
```SQL
CREATE TABLE t1(i INT PRIMARY KEY);
CREATE TABLE t2(i INT PRIMARY KEY AUTOINCREMENT, a INT DEFAULT 1,
                b INT DEFAULT 2, c INT DEFAULT 3);
CREATE TRIGGER t1t AFTER INSERT ON t1 FOR EACH ROW BEGIN
    INSERT INTO t2(i) VALUES (NULL); END;
```