### PR TITLE
cmake: bump luzer to a new version

### DIFF
--- a/cmake/BuildLuzer.cmake
+++ b/cmake/BuildLuzer.cmake
@@ -25,7 +25,7 @@ list(APPEND LUZER_CMAKE_FLAGS
 
 ExternalProject_Add(bundled-luzer
   GIT_REPOSITORY https://github.com/ligurio/luzer
-  GIT_TAG aae4bbde656a9ef464cc1532c92a420a9d438219
+  GIT_TAG f67ca86c83443599eb4f4d235f9a52770ba8b003
   GIT_PROGRESS TRUE
   GIT_SHALLOW FALSE
   SOURCE_DIR ${LUZER_DIR}/source


### PR DESCRIPTION
The patch bumps luzer to a new version that contains fixes and other changes [1]:

- docs: fix a typo for luzer.path
- luzer/tests: fix a test for LuaJIT friendly mode
- ci: enable parallel mode for testing
- cmake: update SetHwArchString()
- luzer/tests: refactoring
- luzer: refactoring getting symbols location
- luzer: fix an error due to unused jit_status
- luzer: use CMAKE_SHARED_LIBRARY_SUFFIX
- cmake: refactor searching libraries and executable
- luzer: add macOS ARM64 support
- rockspec: propagate CMake options
- rockspec: fix propagating variables
- cmake: fix clang error
- cmake: rename variable
- cmake: raise an error if the library was not found
- luzer: suppress unsigned integer overflow in lhash
- cmake: fix possible corruption on copying library
- luzer: fix a signal handler
- luzer: disable parasite instrumentation in metrics
- cmake: support building on i386
- cmake: print details about found Lua

1. https://github.com/ligurio/luzer/compare/aae4bbde656a9ef464cc1532c92a420a9d438219...f67ca86c83443599eb4f4d235f9a52770ba8b003

NO_CHANGELOG=build
NO_DOC=build
NO_TEST=build
NO_DEPS_UPDATE