### PR TITLE
xrow_update: fix out-of-bounds '#' by a JSON path

### DIFF
--- a/changelogs/unreleased/gh-noticket-update-bar-delete-oob.md
+++ b/changelogs/unreleased/gh-noticket-update-bar-delete-oob.md
@@ -1,0 +1,6 @@
+## bugfix/core
+
+* Fixed an out-of-bounds access in the `#` update operation applied by a JSON
+  path. The number of fields to delete was not bounded by the array being
+  updated, and the size of a deleted map key was assumed to be the length of
+  the key in the path.

--- a/src/box/xrow_update_bar.c
+++ b/src/box/xrow_update_bar.c
@@ -55,11 +55,11 @@ xrow_update_bar_finish(struct xrow_update_field *field)
  * @param field Field to locate in.
  * @param[out] key_len_or_index One parameter for two values,
  *        depending on where the target point is located: in an
- *        array or a map. In case of map it is size of a key
- *        before the found point. It is used to find range of the
- *        both key and value in '#' operation to drop the pair.
- *        In case of array it is index of the array element to be
- *        able to check how many fields are left for deletion.
+ *        array or a map. In case of map it is length of the key
+ *        as it is written in the JSON path, which is not the size
+ *        of its MsgPack encoding. In case of array it is index of
+ *        the array element to be able to check how many fields are
+ *        left for deletion.
  *
  * @retval 0 Success.
  * @retval -1 Not found or invalid JSON.
@@ -272,7 +272,7 @@ xrow_update_op_do_nop_delete(struct xrow_update_op *op,
 	if (mp_typeof(*field->bar.parent) == MP_ARRAY) {
 		const char *tmp = field->bar.parent;
 		uint32_t size = mp_decode_array(&tmp);
-		if (key_len_or_index + op->arg.del.count > size)
+		if ((uint64_t) key_len_or_index + op->arg.del.count > size)
 			op->arg.del.count = size - key_len_or_index;
 		const char *end = field->bar.point + field->bar.point_size;
 		for (uint32_t i = 1; i < op->arg.del.count; ++i)
@@ -281,10 +281,26 @@ xrow_update_op_do_nop_delete(struct xrow_update_op *op,
 	} else {
 		if (op->arg.del.count != 1)
 			return xrow_update_err_delete1(op);
-		/* Take key size into account to delete it too. */
-		key_len_or_index = mp_sizeof_str(key_len_or_index);
-		field->bar.point -= key_len_or_index;
-		field->bar.point_size += key_len_or_index;
+		/*
+		 * Take key size into account to delete it too. The key
+		 * length can't be taken from the path token: a numeric
+		 * token matches an integer key, and a string key may use
+		 * any of the MsgPack string encodings. Walk the map up to
+		 * the found value instead.
+		 */
+		const char *tmp = field->bar.parent;
+		uint32_t size = mp_decode_map(&tmp);
+		const char *key = tmp;
+		for (uint32_t i = 0; i < size; ++i) {
+			key = tmp;
+			mp_next(&tmp);
+			if (tmp == field->bar.point)
+				break;
+			mp_next(&tmp);
+		}
+		assert(tmp == field->bar.point);
+		field->bar.point_size += field->bar.point - key;
+		field->bar.point = key;
 	}
 	return xrow_update_bar_finish(field);
 }

--- a/test/box-luatest/tuple_update_bar_delete_test.lua
+++ b/test/box-luatest/tuple_update_bar_delete_test.lua
@@ -1,0 +1,42 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+-- Check that '#' by a JSON path does not read past the updated field.
+g.test_delete_by_json_path = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('pk')
+
+        -- The number of fields to delete is not bounded by the array.
+        s:insert({1, {10, 20, 30}})
+        t.assert_equals(s:update(1, {{'#', '[2][2]', 4294967295}}):totable(),
+                        {1, {10}})
+
+        -- A numeric path step matches an integer map key, whose size is
+        -- not the size of a string of the same length.
+        local map = setmetatable({[2] = 'v', [3] = 'w'},
+                                 {__serialize = 'map'})
+        s:replace({1, map})
+        t.assert_equals(s:update(1, {{'#', '[2][2]', 1}}):totable(),
+                        {1, {[3] = 'w'}})
+    end)
+end


### PR DESCRIPTION
xrow_update_op_do_nop_delete() derives the byte range to drop from the path token and the delete count, and neither one is bounded by the field being updated. In the array branch the clamp adds an int index to a uint32_t count, so `{'#', '[2][2]', 4294967295}` wraps the sum and the mp_next() loop runs off the end of the tuple. In the map branch the key size is taken as mp_sizeof_str() of the path index, which is not the size of an integer map key, so `{'#', '[2][2]', 1}` on a map moves the deletion point in front of the key.

Widen the array clamp to 64 bits, the way xrow_update_op_do_array_delete() already does it, and locate the map key by walking the map up to the found value rather than reconstructing its encoding. Both bounds then come from the MsgPack at hand, so no caller has to pre-validate the count or the path. On a RelWithDebInfo build the first case segfaults inside mp_next(), and the second returns `[1, {3: "\0"}]` where `[1, {3: 'w'}]` is expected.