### PR TITLE
box: expose index DDL format changes

### DIFF
--- a/changelogs/unreleased/gh-11564-index-ddl-format-visible.md
+++ b/changelogs/unreleased/gh-11564-index-ddl-format-visible.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed space formats not reflecting nullability changes made by index DDL
+  (gh-11564).

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -28,7 +28,6 @@ local normalize_txn_isolation_level = box.internal.normalize_txn_isolation_level
 local normalize_constraint = box.internal.tuple_format.normalize_constraint
 local normalize_foreign_key = box.internal.tuple_format.normalize_foreign_key
 local normalize_format = box.internal.tuple_format.normalize_format
-local denormalize_format = box.internal.tuple_format.denormalize_format
 
 local DEFAULT_ORIGIN = ''
 -- We use the field ID instead of the field name so we don't need to upgrade
@@ -505,7 +504,7 @@ function box.schema.space.format(id, format)
     end
 
     if format == nil then
-        return denormalize_format(tuple.format)
+        return box.space[id].format_object:totable()
     else
         check_param(format, 'format', 'table', 2)
         format = normalize_format(id, tuple.name, format, 2)

--- a/src/box/lua/tuple_format.c
+++ b/src/box/lua/tuple_format.c
@@ -109,6 +109,58 @@ lbox_tuple_format_tostring(struct lua_State *L)
 	return 1;
 }
 
+/*
+ * Update explicitly declared fields with their effective runtime
+ * type and nullability, which also include constraints imposed by
+ * indexes (index DDL can narrow both the field type and the
+ * nullability action).
+ */
+static void
+tuple_format_update_effective_fields(struct lua_State *L,
+				     struct tuple_format *format,
+				     int format_idx)
+{
+	if (tuple_format_field_count(format) == 0)
+		return;
+	uint32_t field_count = lua_objlen(L, format_idx);
+	assert(field_count <= tuple_format_field_count(format));
+	for (uint32_t i = 0; i < field_count; ++i) {
+		/* Get the field definition from the serialized format table. */
+		lua_rawgeti(L, format_idx, i + 1);
+		assert(lua_istable(L, -1));
+		struct tuple_field *field = tuple_format_field(format, i);
+		lua_pushstring(L, field_type_strs[field->type]);
+		lua_setfield(L, -2, "type");
+		if (field_type_is_fixed_decimal[field->type]) {
+			luaL_pushint64(L, field->type_params.scale);
+			lua_setfield(L, -2, "scale");
+		}
+		/*
+		 * Preserve fields where is_nullable/nullable_action was
+		 * omitted by the user, but keep both properties in sync
+		 * with the effective nullable action when present, so
+		 * they never end up conflicting.
+		 */
+		lua_getfield(L, -1, "is_nullable");
+		bool has_is_nullable = !lua_isnil(L, -1);
+		lua_pop(L, 1);
+		lua_getfield(L, -1, "nullable_action");
+		bool has_nullable_action = !lua_isnil(L, -1);
+		lua_pop(L, 1);
+		if (has_is_nullable) {
+			lua_pushboolean(L, action_is_nullable(
+						field->nullable_action));
+			lua_setfield(L, -2, "is_nullable");
+		}
+		if (has_nullable_action) {
+			lua_pushstring(L, on_conflict_action_strs[
+						field->nullable_action]);
+			lua_setfield(L, -2, "nullable_action");
+		}
+		lua_pop(L, 1);
+	}
+}
+
 int
 box_tuple_format_serialize_impl(struct lua_State *L,
 				struct tuple_format *format)
@@ -120,6 +172,7 @@ box_tuple_format_serialize_impl(struct lua_State *L,
 
 	const char *data = format->data;
 	luamp_decode(L, luaL_msgpack_default, &data);
+	tuple_format_update_effective_fields(L, format, lua_gettop(L));
 	luaL_findtable(L, LUA_GLOBALSINDEX, "box.internal.tuple_format", 1);
 	lua_getfield(L, -1, "denormalize_format");
 	lua_remove(L, -2);

--- a/test/box-luatest/gh_11564_index_ddl_format_test.lua
+++ b/test/box-luatest/gh_11564_index_ddl_format_test.lua
@@ -1,0 +1,262 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    if cg.server ~= nil then
+        cg.server:drop()
+        cg.server = nil
+    end
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+-- Create space 'test' with a primary index; the 'value' field is
+-- declared with the given is_nullable value, or an options table
+-- ({is_nullable, nullable_action, type}) for less common cases.
+local function create_test_space(cg, opts)
+    if type(opts) ~= 'table' then
+        opts = {is_nullable = opts}
+    end
+    cg.server:exec(function(opts)
+        local space = box.schema.space.create('test')
+        space:format({
+            {name = 'id', type = 'unsigned'},
+            {name = 'value', type = opts.type or 'unsigned',
+             is_nullable = opts.is_nullable,
+             nullable_action = opts.nullable_action,
+             scale = opts.scale},
+        })
+        space:create_index('pk')
+    end, {opts})
+end
+
+-- Create a secondary index on the 'value' field with the given
+-- is_nullable value, or an options table ({is_nullable, type}) for
+-- less common cases.
+local function create_index(cg, name, opts)
+    if type(opts) ~= 'table' then
+        opts = {is_nullable = opts}
+    end
+    cg.server:exec(function(name, opts)
+        box.space.test:create_index(name, {
+            parts = {{field = 'value', is_nullable = opts.is_nullable,
+                      type = opts.type, scale = opts.scale}},
+        })
+    end, {name, opts})
+end
+
+local function alter_index(cg, name, is_nullable)
+    cg.server:exec(function(name, is_nullable)
+        box.space.test.index[name]:alter({
+            parts = {{field = 'value', is_nullable = is_nullable}},
+        })
+    end, {name, is_nullable})
+end
+
+local function drop_index(cg, name)
+    cg.server:exec(function(name)
+        box.space.test.index[name]:drop()
+    end, {name})
+end
+
+-- Assert that both public format views (space:format() and
+-- space.format_object) report the given is_nullable for a field.
+local function assert_field_nullable(cg, field_no, expected)
+    cg.server:exec(function(field_no, expected)
+        local space = box.space.test
+        t.assert_equals(space:format()[field_no].is_nullable, expected)
+        t.assert_equals(
+            space.format_object:totable()[field_no].is_nullable, expected)
+    end, {field_no, expected})
+end
+
+-- Assert that a field's is_nullable option is absent (not exported)
+-- in both public format views.
+local function assert_field_nullable_absent(cg, field_no)
+    cg.server:exec(function(field_no)
+        local space = box.space.test
+        t.assert_equals(space:format()[field_no].is_nullable, nil)
+        t.assert_equals(
+            space.format_object:totable()[field_no].is_nullable, nil)
+    end, {field_no})
+end
+
+-- Assert that both public format views report the given type for a
+-- field.
+local function assert_field_type(cg, field_no, expected)
+    cg.server:exec(function(field_no, expected)
+        local space = box.space.test
+        t.assert_equals(space:format()[field_no].type, expected)
+        t.assert_equals(
+            space.format_object:totable()[field_no].type, expected)
+    end, {field_no, expected})
+end
+
+local function assert_field_scale(cg, field_no, expected)
+    cg.server:exec(function(field_no, expected)
+        local space = box.space.test
+        t.assert_equals(space:format()[field_no].scale, expected)
+        t.assert_equals(
+            space.format_object:totable()[field_no].scale, expected)
+    end, {field_no, expected})
+end
+
+-- Assert that replacing a tuple with NULL in the nullable field
+-- succeeds, consistently with the reported nullable format.
+local function assert_null_replace_ok(cg)
+    cg.server:exec(function()
+        local space = box.space.test
+        space:replace{1, box.NULL}
+        space:delete{1}
+    end)
+end
+
+-- Assert that replacing/validating a tuple with NULL fails,
+-- consistently with the reported non-nullable format.
+local function assert_null_replace_fails(cg)
+    cg.server:exec(function()
+        local space = box.space.test
+        local expected = {
+            type = 'ClientError',
+            code = box.error.FIELD_TYPE,
+            message = 'Tuple field 2 (value) type does not match one ' ..
+                      'required by operation: expected unsigned, got nil',
+        }
+        t.assert_error_covers(expected, space.replace, space, {1, box.NULL})
+        t.assert_error_covers(expected, space.format_object.validate,
+                               space.format_object, {1, box.NULL})
+    end)
+end
+
+-- Create a non-nullable secondary index on a nullable field: the
+-- reported format must become non-nullable, and NULL must be rejected.
+g.test_index_create_makes_nullable_visible_false = function(cg)
+    create_test_space(cg, true)
+    assert_field_nullable(cg, 2, true)
+
+    create_index(cg, 'value', false)
+
+    assert_field_nullable(cg, 2, false)
+    assert_null_replace_fails(cg)
+end
+
+-- Alter a non-nullable index to nullable: the reported format must
+-- become nullable again, and NULL must be accepted.
+g.test_index_alter_to_nullable_makes_visible_true = function(cg)
+    create_test_space(cg, true)
+    create_index(cg, 'value', false)
+    assert_field_nullable(cg, 2, false)
+
+    alter_index(cg, 'value', true)
+
+    assert_field_nullable(cg, 2, true)
+    assert_null_replace_ok(cg)
+end
+
+-- Drop a non-nullable index that was tightening a nullable field: the
+-- reported format must be restored to nullable.
+g.test_index_drop_restores_nullable = function(cg)
+    create_test_space(cg, true)
+    create_index(cg, 'value', false)
+    assert_field_nullable(cg, 2, false)
+
+    drop_index(cg, 'value')
+
+    assert_field_nullable(cg, 2, true)
+    assert_null_replace_ok(cg)
+end
+
+-- Two non-nullable indexes on the same nullable field: dropping one
+-- must not restore nullability; dropping the last one must.
+g.test_multiple_non_nullable_indexes = function(cg)
+    create_test_space(cg, true)
+    create_index(cg, 'sk1', false)
+    create_index(cg, 'sk2', false)
+    assert_field_nullable(cg, 2, false)
+
+    drop_index(cg, 'sk1')
+    assert_field_nullable(cg, 2, false)
+
+    drop_index(cg, 'sk2')
+    assert_field_nullable(cg, 2, true)
+end
+
+-- A field without an explicit is_nullable in the original format must
+-- stay absent in both views, even after a non-nullable index.
+g.test_omitted_is_nullable_stays_absent = function(cg)
+    create_test_space(cg, nil)
+
+    create_index(cg, 'value', false)
+
+    assert_field_nullable_absent(cg, 1)
+    assert_field_nullable_absent(cg, 2)
+end
+
+-- is_nullable and nullable_action must stay consistent with each
+-- other after an index narrows the effective nullable action.
+g.test_nullable_action_stays_consistent_with_is_nullable = function(cg)
+    create_test_space(cg, {is_nullable = true, nullable_action = 'none'})
+    create_index(cg, 'sk', false)
+
+    cg.server:exec(function()
+        local space = box.space.test
+        local exported = space:format()
+        t.assert_equals(exported[2].is_nullable, false)
+        t.assert_equals(exported[2].nullable_action, 'default')
+        space:format(exported)
+    end)
+end
+
+-- An index can narrow a field's reported type too, not just its
+-- nullability, and the type must revert once the index is dropped.
+g.test_index_narrows_reported_type = function(cg)
+    create_test_space(cg, {type = 'any'})
+    assert_field_type(cg, 2, 'any')
+
+    create_index(cg, 'sk', {type = 'unsigned'})
+    assert_field_type(cg, 2, 'unsigned')
+
+    cg.server:exec(function()
+        t.assert_error_covers(
+            {type = 'ClientError', code = box.error.FIELD_TYPE},
+            box.space.test.replace, box.space.test, {1, 'string'})
+    end)
+
+    drop_index(cg, 'sk')
+    assert_field_type(cg, 2, 'any')
+end
+
+g.test_index_narrows_reported_type_params = function(cg)
+    create_test_space(cg, {type = 'any'})
+
+    create_index(cg, 'sk', {type = 'decimal32', scale = 2})
+    assert_field_type(cg, 2, 'decimal32')
+    assert_field_scale(cg, 2, 2)
+
+    cg.server:exec(function()
+        local space = box.space.test
+        space:format(space:format())
+    end)
+end
+
+g.test_names_only_tuple_format_serialize = function()
+    local format = box.internal.tuple_format.new({
+        {name = 'a', type = 'unsigned'},
+    }, true)
+    t.assert_equals(format:totable(), {
+        {name = 'a', type = 'unsigned'},
+    })
+end

--- a/test/box-luatest/gh_11564_index_ddl_format_test.lua
+++ b/test/box-luatest/gh_11564_index_ddl_format_test.lua
@@ -1,0 +1,308 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    if cg.server ~= nil then
+        cg.server:drop()
+        cg.server = nil
+    end
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+-- Assert that both public format views (space:format() and
+-- space.format_object) report the given is_nullable for a field.
+local function assert_field_nullable(cg, field_no, expected)
+    cg.server:exec(function(field_no, expected)
+        local space = box.space.test
+        t.assert_equals(space:format()[field_no].is_nullable, expected)
+        t.assert_equals(
+            space.format_object:totable()[field_no].is_nullable, expected)
+    end, {field_no, expected})
+end
+
+-- Assert that a field's is_nullable option is absent (not exported)
+-- in both public format views.
+local function assert_field_nullable_absent(cg, field_no)
+    cg.server:exec(function(field_no)
+        local space = box.space.test
+        t.assert_equals(space:format()[field_no].is_nullable, nil)
+        t.assert_equals(
+            space.format_object:totable()[field_no].is_nullable, nil)
+    end, {field_no})
+end
+
+-- Assert that both public format views report the given type for a
+-- field.
+local function assert_field_type(cg, field_no, expected)
+    cg.server:exec(function(field_no, expected)
+        local space = box.space.test
+        t.assert_equals(space:format()[field_no].type, expected)
+        t.assert_equals(
+            space.format_object:totable()[field_no].type, expected)
+    end, {field_no, expected})
+end
+
+local function assert_field_scale(cg, field_no, expected)
+    cg.server:exec(function(field_no, expected)
+        local space = box.space.test
+        t.assert_equals(space:format()[field_no].scale, expected)
+        t.assert_equals(
+            space.format_object:totable()[field_no].scale, expected)
+    end, {field_no, expected})
+end
+
+-- Assert that replacing a tuple with NULL in the nullable field
+-- succeeds, consistently with the reported nullable format.
+local function assert_null_replace_ok(cg)
+    cg.server:exec(function()
+        local space = box.space.test
+        space:replace{1, box.NULL}
+        space:delete{1}
+    end)
+end
+
+-- Assert that replacing/validating a tuple with NULL fails,
+-- consistently with the reported non-nullable format.
+local function assert_null_replace_fails(cg)
+    cg.server:exec(function()
+        local space = box.space.test
+        local expected = {
+            type = 'ClientError',
+            code = box.error.FIELD_TYPE,
+            message = 'Tuple field 2 (value) type does not match one ' ..
+                      'required by operation: expected unsigned, got nil',
+        }
+        t.assert_error_covers(expected, space.replace, space, {1, box.NULL})
+        t.assert_error_covers(expected, space.format_object.validate,
+                               space.format_object, {1, box.NULL})
+    end)
+end
+
+-- Create a non-nullable secondary index on a nullable field: the
+-- reported format must become non-nullable, and NULL must be rejected.
+g.test_index_create_makes_nullable_visible_false = function(cg)
+    cg.server:exec(function()
+        local space = box.schema.space.create('test')
+        space:format({
+            {name = 'id', type = 'unsigned'},
+            {name = 'value', type = 'unsigned', is_nullable = true},
+        })
+        space:create_index('pk')
+    end)
+    assert_field_nullable(cg, 2, true)
+
+    cg.server:exec(function()
+        box.space.test:create_index('value', {
+            parts = {{field = 'value', is_nullable = false}},
+        })
+    end)
+
+    assert_field_nullable(cg, 2, false)
+    assert_null_replace_fails(cg)
+end
+
+-- Alter a non-nullable index to nullable: the reported format must
+-- become nullable again, and NULL must be accepted.
+g.test_index_alter_to_nullable_makes_visible_true = function(cg)
+    cg.server:exec(function()
+        local space = box.schema.space.create('test')
+        space:format({
+            {name = 'id', type = 'unsigned'},
+            {name = 'value', type = 'unsigned', is_nullable = true},
+        })
+        space:create_index('pk')
+        space:create_index('value', {
+            parts = {{field = 'value', is_nullable = false}},
+        })
+    end)
+    assert_field_nullable(cg, 2, false)
+
+    cg.server:exec(function()
+        box.space.test.index.value:alter({
+            parts = {{field = 'value', is_nullable = true}},
+        })
+    end)
+
+    assert_field_nullable(cg, 2, true)
+    assert_null_replace_ok(cg)
+end
+
+-- Drop a non-nullable index that was tightening a nullable field: the
+-- reported format must be restored to nullable.
+g.test_index_drop_restores_nullable = function(cg)
+    cg.server:exec(function()
+        local space = box.schema.space.create('test')
+        space:format({
+            {name = 'id', type = 'unsigned'},
+            {name = 'value', type = 'unsigned', is_nullable = true},
+        })
+        space:create_index('pk')
+        space:create_index('value', {
+            parts = {{field = 'value', is_nullable = false}},
+        })
+    end)
+    assert_field_nullable(cg, 2, false)
+
+    cg.server:exec(function()
+        box.space.test.index.value:drop()
+    end)
+
+    assert_field_nullable(cg, 2, true)
+    assert_null_replace_ok(cg)
+end
+
+-- Two non-nullable indexes on the same nullable field: dropping one
+-- must not restore nullability; dropping the last one must.
+g.test_multiple_non_nullable_indexes = function(cg)
+    cg.server:exec(function()
+        local space = box.schema.space.create('test')
+        space:format({
+            {name = 'id', type = 'unsigned'},
+            {name = 'value', type = 'unsigned', is_nullable = true},
+        })
+        space:create_index('pk')
+        space:create_index('sk1', {
+            parts = {{field = 'value', is_nullable = false}},
+        })
+        space:create_index('sk2', {
+            parts = {{field = 'value', is_nullable = false}},
+        })
+    end)
+    assert_field_nullable(cg, 2, false)
+
+    cg.server:exec(function()
+        box.space.test.index.sk1:drop()
+    end)
+    assert_field_nullable(cg, 2, false)
+
+    cg.server:exec(function()
+        box.space.test.index.sk2:drop()
+    end)
+    assert_field_nullable(cg, 2, true)
+end
+
+-- A field without an explicit is_nullable in the original format must
+-- stay absent in both views, even after a non-nullable index.
+g.test_omitted_is_nullable_stays_absent = function(cg)
+    cg.server:exec(function()
+        local space = box.schema.space.create('test')
+        space:format({
+            {name = 'id', type = 'unsigned'},
+            {name = 'value', type = 'unsigned'},
+        })
+        space:create_index('pk')
+    end)
+
+    cg.server:exec(function()
+        box.space.test:create_index('value', {
+            parts = {{field = 'value', is_nullable = false}},
+        })
+    end)
+
+    assert_field_nullable_absent(cg, 1)
+    assert_field_nullable_absent(cg, 2)
+end
+
+-- is_nullable and nullable_action must stay consistent with each
+-- other after an index narrows the effective nullable action.
+g.test_nullable_action_stays_consistent_with_is_nullable = function(cg)
+    cg.server:exec(function()
+        local space = box.schema.space.create('test')
+        space:format({
+            {name = 'id', type = 'unsigned'},
+            {name = 'value', type = 'unsigned', is_nullable = true,
+             nullable_action = 'none'},
+        })
+        space:create_index('pk')
+        space:create_index('sk', {
+            parts = {{field = 'value', is_nullable = false}},
+        })
+    end)
+
+    cg.server:exec(function()
+        local space = box.space.test
+        local exported = space:format()
+        t.assert_equals(exported[2].is_nullable, false)
+        t.assert_equals(exported[2].nullable_action, 'default')
+        space:format(exported)
+    end)
+end
+
+-- An index can narrow a field's reported type too, not just its
+-- nullability, and the type must revert once the index is dropped.
+g.test_index_narrows_reported_type = function(cg)
+    cg.server:exec(function()
+        local space = box.schema.space.create('test')
+        space:format({
+            {name = 'id', type = 'unsigned'},
+            {name = 'value', type = 'any'},
+        })
+        space:create_index('pk')
+    end)
+    assert_field_type(cg, 2, 'any')
+
+    cg.server:exec(function()
+        box.space.test:create_index('sk', {
+            parts = {{field = 'value', type = 'unsigned'}},
+        })
+    end)
+    assert_field_type(cg, 2, 'unsigned')
+
+    cg.server:exec(function()
+        t.assert_error_covers(
+            {type = 'ClientError', code = box.error.FIELD_TYPE},
+            box.space.test.replace, box.space.test, {1, 'string'})
+    end)
+
+    cg.server:exec(function()
+        box.space.test.index.sk:drop()
+    end)
+    assert_field_type(cg, 2, 'any')
+end
+
+g.test_index_narrows_reported_type_params = function(cg)
+    cg.server:exec(function()
+        local space = box.schema.space.create('test')
+        space:format({
+            {name = 'id', type = 'unsigned'},
+            {name = 'value', type = 'any'},
+        })
+        space:create_index('pk')
+    end)
+
+    cg.server:exec(function()
+        box.space.test:create_index('sk', {
+            parts = {{field = 'value', type = 'decimal32', scale = 2}},
+        })
+    end)
+    assert_field_type(cg, 2, 'decimal32')
+    assert_field_scale(cg, 2, 2)
+
+    cg.server:exec(function()
+        local space = box.space.test
+        space:format(space:format())
+    end)
+end
+
+g.test_names_only_tuple_format_serialize = function()
+    local format = box.internal.tuple_format.new({
+        {name = 'a', type = 'unsigned'},
+    }, true)
+    t.assert_equals(format:totable(), {
+        {name = 'a', type = 'unsigned'},
+    })
+end

--- a/test/box-luatest/gh_6042_uuid_and_scalar_test.lua
+++ b/test/box-luatest/gh_6042_uuid_and_scalar_test.lua
@@ -58,7 +58,7 @@ g.test_uuid_scalar = function()
 
         s = box.schema.space.create('a', {format = {{'u', 'scalar'}}})
         _ = s:create_index('i', {parts = {{'u', 'uuid'}}})
-        t.assert_equals(s:format()[1].type, 'scalar')
+        t.assert_equals(s:format()[1].type, 'uuid')
         t.assert_equals(s.index[0].parts[1].type, 'uuid')
         s:drop()
     end)

--- a/test/box-luatest/gh_9120_space_drop_rollback_test.lua
+++ b/test/box-luatest/gh_9120_space_drop_rollback_test.lua
@@ -93,7 +93,7 @@ g.test_sophisticated_transaction = function(cg)
         t.assert(s == box.space.test)
 
         -- The space format and contents still the same.
-        t.assert_equals(s:format(), {{name = 'id', type = 'any'}})
+        t.assert_equals(s:format(), {{name = 'id', type = 'unsigned'}})
         t.assert_equals(s:select(), {{1, 1}})
     end)
 end

--- a/test/engine-luatest/gh_6436_field_constraint_test.lua
+++ b/test/engine-luatest/gh_6436_field_constraint_test.lua
@@ -274,7 +274,7 @@ g.test_wrong_field_constraint = function(cg)
         local func_id = box.func.field_constr1.id
         t.assert_equals(box.space.test:format(),
                         { {constraint = {field_constr1 = func_id},
-                           name = "id1", type = "any"},
+                           name = "id1", type = "unsigned"}, -- cause of pk
                           {name = "id2", type = "any"} })
     end)
 end
@@ -522,7 +522,7 @@ g.test_field_constraint_integrity = function(cg)
 
         t.assert_equals(s:select{}, {{1, 2, 300}, {100, 2, 3}})
         t.assert_equals(s:format(),
-            { {name = "id1", type = "any"},
+            { {name = "id1", type = "unsigned"},
               {constraint = {field_constr2 = box.func.field_constr2.id},
                name = "id2", type = "any"}
             })

--- a/test/engine/ddl.result
+++ b/test/engine/ddl.result
@@ -775,8 +775,8 @@ s:format(format)
 ...
 s:format()
 ---
-- [{'name': 'field1', 'type': 'unsigned'}, {'name': 'field2', 'type': 'num'}, {'name': 'field3',
-    'type': 'str'}, {'name': 'field4', 'type': '*'}]
+- [{'name': 'field1', 'type': 'unsigned'}, {'name': 'field2', 'type': 'unsigned'},
+  {'name': 'field3', 'type': 'string'}, {'name': 'field4', 'type': 'any'}]
 ...
 s:replace{1, 2, '3', {4, 4, 4}}
 ---
@@ -1632,7 +1632,7 @@ s:format(format)
 ...
 s:format()
 ---
-- [{'name': 'field1', 'type': 'any'}]
+- [{'name': 'field1', 'type': 'unsigned'}]
 ...
 format[1].type = 'unsigned'
 ---
@@ -2009,8 +2009,8 @@ sk4 = s:create_index('sk4', {parts = {{3, 'number'}}})
 ...
 s:format()
 ---
-- [{'name': 'field1', 'type': 'unsigned'}, {'name': 'field2', 'type': 'scalar'}, {
-    'name': 'field3', 'type': 'integer'}]
+- [{'name': 'field1', 'type': 'unsigned'}, {'name': 'field2', 'type': 'unsigned'},
+  {'name': 'field3', 'type': 'integer'}]
 ...
 s:replace{1, '100', -20.2}
 ---


### PR DESCRIPTION
Make space:format() and space.format_object report effective field nullability after index DDL. Add coverage for create, alter, drop, and multiple-index cases.

Closes #11564

NO_DOC=bugfix