### PR TITLE
Enable read view in application threads

### DIFF
--- a/changelogs/unreleased/gh-12951-app-threads-read-view.md
+++ b/changelogs/unreleased/gh-12951-app-threads-read-view.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* Application threads can now use a database read view opened in the main
+  thread (gh-12951).

--- a/src/box/errcode.h
+++ b/src/box/errcode.h
@@ -449,6 +449,7 @@ struct errcode_record {
 	_(ER_NO_SUCH_THREAD_GROUP, 302,		"Thread group does not exist", "thread_group", STRING) \
 	_(ER_XLOG_NOT_FOUND, 303,		"xlog file not found", "vclock", STRING) \
 	_(ER_RECOVERY_POINT_TXN_LAST_ROW, 304,	"Last row of recovery point transaction should not be local") \
+	_(ER_NO_SUCH_READ_VIEW, 305,		"Read view was not found by id") \
 	TEST_ERROR_CODES(_) /** This one should be last. */
 
 /*

--- a/src/box/lua/init.c
+++ b/src/box/lua/init.c
@@ -238,6 +238,7 @@ static const char * const lua_sources_minimal[] = {
 	"box/net_replicaset", "internal.net.replicaset", net_replicaset_lua,
 	"box/app_threads", "experimental.threads", app_threads_lua,
 	"box/recovery_point_manager", NULL, recovery_point_manager_lua,
+	"box/read_view", NULL, read_view_lua,
 	/*
 	 * To support tarantool-only types with checks, the module
 	 * must be loaded after decimal and datetime lua modules
@@ -342,7 +343,6 @@ static const char * const lua_sources_minimal[] = {
 static const char * const lua_sources_main[] = {
 	"box/session", NULL, session_lua,
 	"box/schema", NULL, schema_lua,
-	"box/read_view", NULL, read_view_lua,
 	"box/healthcheck", "internal.healthcheck", healthcheck_lua,
 	"box/healthcheck_defaults", "internal.healthcheck.defaults",
 	healthcheck_defaults_lua,
@@ -1097,6 +1097,7 @@ box_lua_init_minimal(struct lua_State *L)
 	box_lua_call_init(L);
 	box_lua_iproto_init(L);
 	box_lua_trigger_init(L);
+	box_lua_read_view_init(L);
 
 	luaopen_key_def(L);
 	lua_pop(L, 1);
@@ -1145,7 +1146,6 @@ box_lua_init(struct lua_State *L)
 	box_lua_index_init(L);
 	box_lua_space_init(L);
 	box_lua_sequence_init(L);
-	box_lua_read_view_init(L);
 	box_lua_misc_init(L);
 	box_lua_info_init(L);
 	box_lua_stat_init(L);

--- a/src/box/lua/iproto.lua
+++ b/src/box/lua/iproto.lua
@@ -1,10 +1,5 @@
-local ffi = require('ffi')
+local fiber = require('fiber')
 local utils = require('internal.utils')
-
-ffi.cdef[[
-    bool
-    cord_is_main(void);
-]]
 
 local may_register_funcs = true
 
@@ -21,7 +16,7 @@ box.iproto.export = function(func_name, func)
     end
 end
 
-if ffi.C.cord_is_main() then
+if fiber._internal.cord_is_main then
 
 --
 -- box.iproto.export() may be called in the main thread before the IPROTO

--- a/src/box/lua/net_box.lua
+++ b/src/box/lua/net_box.lua
@@ -1377,13 +1377,8 @@ function this_module.timeout(timeout, ...)
     }, {__index = this_module})
 end
 
-ffi.cdef[[
-    bool
-    cord_is_main(void);
-]]
-
 -- net.box.self is available in the main thread only
-if ffi.C.cord_is_main() then
+if fiber._internal.cord_is_main then
 
 local function rollback()
     if rawget(box, 'rollback') ~= nil then

--- a/src/box/lua/net_replicaset.lua
+++ b/src/box/lua/net_replicaset.lua
@@ -1,12 +1,6 @@
-local ffi = require('ffi')
 local fiber = require('fiber')
 local net_box = require('net.box')
 local uri_lib = require('uri')
-
-ffi.cdef[[
-    bool
-    cord_is_main(void);
-]]
 
 -- The constant is copy-paste from tarantool/src/lua/socket.lua.
 local TIMEOUT_INFINITY = 500 * 365 * 86400
@@ -381,7 +375,7 @@ local function get_connect_cfg(replicaset_name, opts)
     opts = opts or {}
     check_options(opts, connect_opts_template, 'opts')
 
-    if not ffi.C.cord_is_main() then
+    if not fiber._internal.cord_is_main then
         error('config is available only in main thread', 0)
     end
 

--- a/src/box/lua/read_view.c
+++ b/src/box/lua/read_view.c
@@ -12,8 +12,11 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 
+#include "diag.h"
+#include "error.h"
 #include "fiber.h"
 #include "port.h"
 #include "box/index.h"
@@ -35,7 +38,7 @@ static bool box_read_view_ffi = true;
 TWEAK_BOOL(box_read_view_ffi);
 
 /** Lua ctype ID of struct read_view_handle pointer. */
-static uint32_t CTID_STRUCT_READ_VIEW_HANDLE;
+static __thread uint32_t CTID_STRUCT_READ_VIEW_HANDLE;
 
 /** Get a read view handle from Lua stack. */
 static inline struct read_view_handle *
@@ -49,7 +52,7 @@ lbox_check_read_view_handle(struct lua_State *L, int idx)
 }
 
 /** Lua ctype ID of struct space_read_view_handle pointer. */
-static uint32_t CTID_STRUCT_SPACE_READ_VIEW_HANDLE;
+static __thread uint32_t CTID_STRUCT_SPACE_READ_VIEW_HANDLE;
 
 /** Get a space read view handle from Lua stack. */
 static inline struct space_read_view_handle *
@@ -91,7 +94,7 @@ lbox_check_index_read_view_iterator(struct lua_State *L, int idx)
  * the Lua stack.
  */
 static void
-lbox_push_read_view(struct lua_State *L, const struct read_view *rv)
+lbox_push_read_view_info(struct lua_State *L, const struct read_view *rv)
 {
 	lua_newtable(L);
 	luaL_pushuint64(L, rv->id);
@@ -109,11 +112,11 @@ lbox_push_read_view(struct lua_State *L, const struct read_view *rv)
 }
 
 /**
- * Helper function for lbox_read_view_open() that pushes a table for the given
+ * Helper function for lbox_new_read_view() that pushes a table for the given
  * index read view to the Lua stack.
  */
 static void
-lbox_read_view_push_index(struct lua_State *L,
+lbox_push_index_read_view(struct lua_State *L,
 			  struct index_read_view *index,
 			  struct space_read_view_handle *space)
 {
@@ -140,11 +143,11 @@ lbox_read_view_push_index(struct lua_State *L,
 }
 
 /**
- * Helper function for lbox_read_view_open() that pushes a table for the given
+ * Helper function for lbox_new_read_view() that pushes a table for the given
  * space read view to the Lua stack.
  */
 static void
-lbox_read_view_push_space(struct lua_State *L,
+lbox_push_space_read_view(struct lua_State *L,
 			  struct space_read_view_handle *space)
 {
 	lua_newtable(L);
@@ -158,7 +161,7 @@ lbox_read_view_push_space(struct lua_State *L,
 			space_read_view_index(space->ptr, i);
 		if (index == NULL)
 			continue;
-		lbox_read_view_push_index(L, index, space);
+		lbox_push_index_read_view(L, index, space);
 		lua_pushvalue(L, -1);
 		lua_rawseti(L, -3, i);
 		lua_setfield(L, -2, index->def->name);
@@ -167,9 +170,9 @@ lbox_read_view_push_space(struct lua_State *L,
 }
 
 /**
- * Opens a database read view.
- * Takes the new read view name (string).
- * On success, returns a table that has the following structure:
+ * Creates a read view handle and pushes a table with the following structure
+ * to the Lua stack:
+ *
  * {
  *     -- Read view handle (cdata).
  *     _crv = <cdata:struct read_view_handle *>,
@@ -206,14 +209,46 @@ lbox_read_view_push_space(struct lua_State *L,
  *     }
  * }
  *
+ * Returns 0 on success. On failure, sets diag and returns -1.
+ */
+static int
+lbox_new_read_view(struct lua_State *L, struct read_view *rv)
+{
+	struct read_view_handle *rvh = read_view_handle_new(rv);
+	if (rvh == NULL)
+		return -1;
+
+	/* Create a read view table. */
+	lbox_push_read_view_info(L, rv);
+
+	*(struct read_view_handle **)luaL_pushcdata(
+		L, CTID_STRUCT_READ_VIEW_HANDLE) = rvh;
+	lua_setfield(L, -2, "_crv");
+
+	/* Create a space table. */
+	lua_newtable(L);
+	struct space_read_view_handle *space;
+	read_view_foreach_space(space, rvh) {
+		lbox_push_space_read_view(L, space);
+		lua_pushvalue(L, -1);
+		lua_rawseti(L, -3, space->ptr->id);
+		lua_setfield(L, -2, space->ptr->name);
+	}
+	lua_setfield(L, -2, "space");
+
+	return 0;
+}
+
+/**
+ * Opens a database read view.
+ * Takes the new read view name (string).
  * On error, raises a Lua exception.
  */
 static int
 lbox_read_view_open(struct lua_State *L)
 {
+	assert(cord_is_main());
 	const char *name = luaL_checkstring(L, 1);
-
-	/* Open a read view. */
 	struct read_view_opts opts;
 	read_view_opts_create(&opts);
 	opts.name = name;
@@ -225,30 +260,87 @@ lbox_read_view_open(struct lua_State *L)
 	struct read_view *rv = read_view_new(&opts);
 	if (rv == NULL)
 		return luaT_error_at(L, 2);
-	struct read_view_handle *rvh = read_view_handle_new(rv);
-	if (rvh == NULL) {
+	if (lbox_new_read_view(L, rv) != 0) {
 		read_view_delete(rv);
 		return luaT_error_at(L, 2);
 	}
+	return 1;
+}
 
-	/* Create a space table. */
-	lua_newtable(L);
-	struct space_read_view_handle *space;
-	read_view_foreach_space(space, rvh) {
-		lbox_read_view_push_space(L, space);
-		lua_pushvalue(L, -1);
-		lua_rawseti(L, -3, space->ptr->id);
-		lua_setfield(L, -2, space->ptr->name);
+/**
+ * Pushes a pointer to the given read view encoded as a %p-formatted string
+ * to the Lua stack. See also lbox_check_read_view_ptr_str.
+ */
+static void
+lbox_push_read_view_ptr_str(struct lua_State *L, struct read_view *rv)
+{
+	lua_pushfstring(L, "%p", rv);
+}
+
+/**
+ * Returns a pointer to a read view encoded as a %p-formatted string at
+ * the given index in the Lua stack. See also lbox_push_read_view_ptr_str.
+ */
+static struct read_view *
+lbox_check_read_view_ptr_str(struct lua_State *L, int idx)
+{
+	struct read_view *rv = NULL;
+	VERIFY(sscanf(luaL_checkstring(L, idx), "%p", &rv) == 1);
+	return rv;
+}
+
+/**
+ * Increments the usage counter of a read view.
+ * Takes a read view id.
+ * Returns a pointer to the read view encoded as a %p-formatted string.
+ * On error, raises a Lua exception.
+ */
+static int
+lbox_read_view_acquire(struct lua_State *L)
+{
+	assert(cord_is_main());
+	uint64_t id = luaL_checkuint64(L, 1);
+	struct read_view *rv = read_view_by_id(id);
+	if (rv == NULL || rv->is_close_pending) {
+		diag_set(ClientError, ER_NO_SUCH_READ_VIEW);
+		return luaT_error(L);
 	}
+	if (rv->is_system) {
+		diag_set(ClientError, ER_READ_VIEW_BUSY);
+		return luaT_error(L);
+	}
+	read_view_pin(rv);
+	lbox_push_read_view_ptr_str(L, rv);
+	return 1;
+}
 
-	/* Push the read view table and set rv._crv and rv.space. */
-	lbox_push_read_view(L, rv);
-	lua_replace(L, 1);
-	lua_setfield(L, 1, "space");
-	*(struct read_view_handle **)luaL_pushcdata(
-		L, CTID_STRUCT_READ_VIEW_HANDLE) = rvh;
-	lua_setfield(L, 1, "_crv");
-	lua_settop(L, 1);
+/**
+ * Decrements the usage counter of a read view and deletes the read view
+ * if it was closed and has no more users.
+ * Takes a pointer to a read view encoded as a %p-formatted string.
+ */
+static int
+lbox_read_view_release(struct lua_State *L)
+{
+	assert(cord_is_main());
+	struct read_view *rv = lbox_check_read_view_ptr_str(L, 1);
+	read_view_unpin(rv);
+	if (rv->pin_count == 0 && rv->is_close_pending)
+		read_view_delete(rv);
+	return 0;
+}
+
+/**
+ * Reuses an existing database read view.
+ * Takes a pointer to a read view encoded as a %p-formatted string.
+ * On error, raises a Lua exception.
+ */
+static int
+lbox_read_view_reuse(struct lua_State *L)
+{
+	struct read_view *rv = lbox_check_read_view_ptr_str(L, 1);
+	if (lbox_new_read_view(L, rv) != 0)
+		return luaT_error_at(L, 2);
 	return 1;
 }
 
@@ -258,7 +350,7 @@ lbox_read_view_list_cb(struct read_view *rv, void *arg)
 	struct lua_State *L = (struct lua_State *)arg;
 	assert(lua_gettop(L) >= 1);
 	assert(lua_type(L, -1) == LUA_TTABLE);
-	lbox_push_read_view(L, rv);
+	lbox_push_read_view_info(L, rv);
 	lua_rawseti(L, -2, lua_objlen(L, -2) + 1);
 	return true;
 }
@@ -270,6 +362,7 @@ lbox_read_view_list_cb(struct read_view *rv, void *arg)
 static int
 lbox_read_view_list(struct lua_State *L)
 {
+	assert(cord_is_main());
 	lua_newtable(L);
 	read_view_foreach(lbox_read_view_list_cb, L);
 	return 1;
@@ -277,24 +370,37 @@ lbox_read_view_list(struct lua_State *L)
 
 /**
  * Given a read view object (a table that has the 'id' field), pushes
- * the read view status string ('open' or 'closed') to the Lua stack.
+ * the read view status string ('open', 'closed', 'close_pending') to
+ * the Lua stack.
  */
 static int
 lbox_read_view_status(struct lua_State *L)
 {
+	assert(cord_is_main());
 	lua_getfield(L, 1, "id");
 	uint64_t id = luaL_checkuint64(L, -1);
 	struct read_view *rv = read_view_by_id(id);
-	if (rv == NULL)
+	if (rv == NULL) {
 		lua_pushliteral(L, "closed");
-	else
+	} else if (rv->is_close_pending) {
+		lua_pushliteral(L, "close_pending");
+	} else {
 		lua_pushliteral(L, "open");
+	}
 	return 1;
 }
 
 /**
  * Closes a database read view by the given handle cdata.
  * Logs a warning if the second argument is true.
+ *
+ * The behavior of this function differs between the main thread and
+ * application threads:
+ *  - The main thread closes the core read view if it has no users,
+ *    otherwise it marks the read view as "close pending" to be closed
+ *    as soon as the last user is gone.
+ *  - An application thread returns a pointer to the core read view
+ *    to be passed to the main thread for release.
  */
 static int
 lbox_read_view_close(struct lua_State *L)
@@ -307,8 +413,18 @@ lbox_read_view_close(struct lua_State *L)
 			 (unsigned long long)rv->id, rv->name);
 	}
 	read_view_handle_delete(rvh);
-	read_view_delete(rv);
-	return 0;
+	if (cord_is_main()) {
+		assert(!rv->is_close_pending);
+		if (rv->pin_count == 0) {
+			read_view_delete(rv);
+		} else {
+			rv->is_close_pending = true;
+		}
+		return 0;
+	} else {
+		lbox_push_read_view_ptr_str(L, rv);
+		return 1;
+	}
 }
 
 /**
@@ -513,6 +629,9 @@ box_lua_read_view_init(struct lua_State *L)
 	int rc;
 	const struct luaL_Reg module_methods[] = {
 		{"open", lbox_read_view_open},
+		{"acquire", lbox_read_view_acquire},
+		{"release", lbox_read_view_release},
+		{"reuse", lbox_read_view_reuse},
 		{"list", lbox_read_view_list},
 		{"status", lbox_read_view_status},
 		{"close", lbox_read_view_close},

--- a/src/box/lua/read_view.lua
+++ b/src/box/lua/read_view.lua
@@ -1,6 +1,9 @@
 local fun = require('fun')
 local utils = require('internal.utils')
 
+local fiber = require('fiber')
+local threads = require('experimental.threads')
+
 local check_index_arg = box.internal.check_index_arg
 local check_param_table = utils.check_param_table
 local check_primary_index = box.internal.check_primary_index
@@ -64,9 +67,15 @@ local iterator_pos_end = ffi.new('const char *[1]')
 
 local internal = box.internal.read_view
 
+if fiber._internal.cord_is_main then
+    threads.export('box.internal.read_view.acquire', internal.acquire)
+    threads.export('box.internal.read_view.release', internal.release)
+end
+
 -- box.read_view.open() options template.
 local READ_VIEW_OPTIONS_TEMPLATE = {
     name = 'string',
+    id = 'number',
 }
 
 local function check_read_view_arg(rv, method, level)
@@ -173,7 +182,6 @@ local read_view_registry = setmetatable({}, {__mode = 'v'})
 --
 local function register_read_view(rv)
     assert(rv.id ~= nil)
-    assert(read_view_registry[rv.id] == nil)
     assert(getmetatable(rv) == nil)
     setmetatable(rv, read_view_mt)
     read_view_registry[rv.id] = rv
@@ -189,6 +197,10 @@ box.read_view = {}
 -- the most recent read view will always be last.
 --
 function box.read_view.list()
+    if not fiber._internal.cord_is_main then
+        box.error(box.error.UNSUPPORTED, 'Application thread',
+                  'listing read views', 2)
+    end
     local list = {}
     for _, rv in ipairs(internal.list()) do
         local registered_rv = read_view_registry[rv.id]
@@ -204,22 +216,82 @@ function box.read_view.list()
     return list
 end
 
+--
+-- Wrapper around internal.close() that, if called in an application thread,
+-- sends a request to release the read view to the main thread.
+--
+local function read_view_close(crv, warn)
+    local ptr = internal.close(crv, warn)
+    if ptr ~= nil then
+        assert(not fiber._internal.cord_is_main)
+        -- threads.call() yields while we can't yield in this function
+        -- because it may be called by the garbage collector.
+        fiber.new(threads.call, 'tx', 'box.internal.read_view.release', {ptr})
+    end
+end
+
 local function read_view_gc(crv)
-    internal.close(crv, true)
+    read_view_close(crv, true)
 end
 
 --
--- Opens a new read view.
+-- Opens a new or reuses an existing read view.
 --
 -- Takes an optional argument that contains a table of read view options.
 -- Returns a read view object on success. On error, raises an exception.
 --
 -- Available options:
---  - 'name' - read view name. If omitted 'unknown' is used.
+--  - 'name' - new read view name
+--  - 'id' - id of the read view to reuse
+--
+-- Notes:
+--  - 'name' and 'id' can't be used together.
+--  - 'name' may be omitted, in which case it defaults to 'unknown'.
+--  - A new read view may be created only in the main thread.
+--  - Reusing a read view may cause a fiber yield.
 --
 function box.read_view.open(opts)
+    opts = opts or {}
     check_param_table(opts, READ_VIEW_OPTIONS_TEMPLATE, 2)
-    local rv = internal.open(opts and opts.name or 'unknown')
+    if opts.id ~= nil and opts.name ~= nil then
+        box.error(box.error.ILLEGAL_PARAMS, "options parameter 'name' " ..
+                  "should not be used with 'id'", 2)
+    end
+    local rv
+    if opts.id ~= nil then
+        -- If the read view is already in the thread-local registry and
+        -- it has an active handle, there's no need to create a new one.
+        rv = read_view_registry[opts.id]
+        if rv ~= nil and rv._crv ~= nil then
+            return rv
+        end
+        -- Ask the main thread to pin the read view with the given id
+        -- and create a local handle for it.
+        local ret = utils.call_at(2, threads.call, 'tx',
+                                  'box.internal.read_view.acquire', {opts.id})
+        -- We should never get here when called from the main thread because
+        -- the read view registry maintained by the main thread is supposed to
+        -- store all usable read views.
+        assert(not fiber._internal.cord_is_main)
+        local ptr = ret[1][1]
+        local ok
+        ok, ret = pcall(internal.reuse, ptr)
+        if not ok then
+            -- Don't forget to unpin the read view on error.
+            threads.call('tx', 'box.internal.read_view.release', {ptr})
+            box.error(ret, 2)
+        end
+        rv = ret
+        -- Reset the status field because application threads can't call
+        -- internal.status.
+        rv.status = 'open'
+    else
+        if not fiber._internal.cord_is_main then
+            box.error(box.error.UNSUPPORTED, 'Application thread',
+                      'creating a new read view', 2)
+        end
+        rv = internal.open(opts.name or 'unknown')
+    end
     setmetatable(rv.space, read_view_space_list_mt)
     for space_id, space in pairs(rv.space) do
         if type(space_id) == 'number' then
@@ -250,7 +322,7 @@ end
 --  - 'timestamp' - fiber.clock() at the time of read view open.
 --  - 'vclock' - box.info.vclock at the time of read view open.
 --  - 'signature' - box.info.signature at the time of read view open.
---  - 'status' - 'open' or 'closed'.
+--  - 'status' - 'open', 'closed', or 'close_pending'.
 --
 function read_view_methods:info()
     check_read_view_arg(self, 'info', 2)
@@ -275,7 +347,7 @@ read_view_mt.__serialize = read_view_methods.info
 --
 function read_view_methods:close()
     check_read_view_arg(self, 'close', 2)
-    if self.status == 'closed' then
+    if self.status ~= 'open' then
         box.error(box.error.READ_VIEW_CLOSED, 2)
     end
     if self._crv == nil then
@@ -290,9 +362,14 @@ function read_view_methods:close()
             index._cspace = nil
         end
     end
-    internal.close(self._crv)
+    read_view_close(self._crv)
     ffi.gc(self._crv, nil)
     self._crv = nil
+    if not fiber._internal.cord_is_main then
+        -- Reset the status field because application threads can't call
+        -- internal.status.
+        self.status = 'closed'
+    end
 end
 
 --

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -95,10 +95,6 @@ ffi.cdef[[
     ssize_t
     box_index_count(uint32_t space_id, uint32_t index_id, int type,
                     const char *key, const char *key_end);
-    size_t
-    box_region_used(void);
-    void
-    box_region_truncate(size_t size);
     bool
     box_txn();
     int64_t
@@ -117,67 +113,6 @@ ffi.cdef[[
 
     box_txn_savepoint_t *
     box_txn_savepoint();
-
-    struct port {
-        const struct port_vtab *vtab;
-        char pad[74];
-    };
-
-    enum port_c_entry_type {
-        PORT_C_ENTRY_UNKNOWN,
-        PORT_C_ENTRY_NULL,
-        PORT_C_ENTRY_DOUBLE,
-        PORT_C_ENTRY_TUPLE,
-        PORT_C_ENTRY_STR,
-        PORT_C_ENTRY_BOOL,
-        PORT_C_ENTRY_MP,
-        PORT_C_ENTRY_MP_OBJECT,
-        PORT_C_ENTRY_MP_ITERABLE,
-    };
-
-    struct port_c_iterator;
-
-    typedef void
-    (*port_c_iterator_create_f)(void *data, struct port_c_iterator *it);
-
-    struct port_c_iterable {
-        port_c_iterator_create_f iterator_create;
-        void *data;
-    };
-
-    struct port_c_entry {
-        struct port_c_entry *next;
-        enum port_c_entry_type type;
-        union {
-            double number;
-            struct tuple *tuple;
-            bool boolean;
-            struct {
-                const char *data;
-                uint32_t size;
-            } str;
-            struct {
-                const char *data;
-                uint32_t size;
-                union {
-                    struct tuple_format *mp_format;
-                    struct mp_ctx *mp_ctx;
-                };
-            } mp;
-            struct port_c_iterable iterable;
-        };
-    };
-
-    struct port_c {
-        const struct port_vtab *vtab;
-        struct port_c_entry *first;
-        struct port_c_entry *last;
-        struct port_c_entry first_entry;
-        int size;
-    };
-
-    void
-    port_destroy(struct port *port);
 
     int
     box_index_tuple_position(uint32_t space_id, uint32_t index_id,

--- a/src/box/lua/utils.lua
+++ b/src/box/lua/utils.lua
@@ -1,4 +1,73 @@
+local ffi = require('ffi')
 local msgpack = require('msgpack')
+
+ffi.cdef([[
+    size_t
+    box_region_used(void);
+    void
+    box_region_truncate(size_t size);
+
+    struct port {
+        const struct port_vtab *vtab;
+        char pad[74];
+    };
+
+    enum port_c_entry_type {
+        PORT_C_ENTRY_UNKNOWN,
+        PORT_C_ENTRY_NULL,
+        PORT_C_ENTRY_DOUBLE,
+        PORT_C_ENTRY_TUPLE,
+        PORT_C_ENTRY_STR,
+        PORT_C_ENTRY_BOOL,
+        PORT_C_ENTRY_MP,
+        PORT_C_ENTRY_MP_OBJECT,
+        PORT_C_ENTRY_MP_ITERABLE,
+    };
+
+    struct port_c_iterator;
+
+    typedef void
+    (*port_c_iterator_create_f)(void *data, struct port_c_iterator *it);
+
+    struct port_c_iterable {
+        port_c_iterator_create_f iterator_create;
+        void *data;
+    };
+
+    struct port_c_entry {
+        struct port_c_entry *next;
+        enum port_c_entry_type type;
+        union {
+            double number;
+            struct tuple *tuple;
+            bool boolean;
+            struct {
+                const char *data;
+                uint32_t size;
+            } str;
+            struct {
+                const char *data;
+                uint32_t size;
+                union {
+                    struct tuple_format *mp_format;
+                    struct mp_ctx *mp_ctx;
+                };
+            } mp;
+            struct port_c_iterable iterable;
+        };
+    };
+
+    struct port_c {
+        const struct port_vtab *vtab;
+        struct port_c_entry *first;
+        struct port_c_entry *last;
+        struct port_c_entry first_entry;
+        int size;
+    };
+
+    void
+    port_destroy(struct port *port);
+]])
 
 -- performance fixup for hot functions
 local is_tuple = box.tuple.is

--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -17,6 +17,7 @@
 #include "engine.h"
 #include "error.h"
 #include "errcode.h"
+#include "errinj.h"
 #include "fiber.h"
 #include "field_def.h"
 #include "index.h"
@@ -222,10 +223,13 @@ read_view_unregister(struct read_view *rv)
 struct read_view *
 read_view_new(const struct read_view_opts *opts)
 {
+	assert(cord_is_main());
 	struct read_view *rv = xmalloc(sizeof(*rv));
 	rv->id = next_read_view_id++;
 	assert(opts->name != NULL);
 	rv->name = xstrdup(opts->name);
+	rv->pin_count = 0;
+	rv->is_close_pending = false;
 	rv->is_system = opts->is_system;
 	rv->disable_decompression = opts->disable_decompression;
 	rv->timestamp = ev_monotonic_now(loop());
@@ -259,6 +263,8 @@ fail:
 void
 read_view_delete(struct read_view *rv)
 {
+	assert(cord_is_main());
+	assert(rv->pin_count == 0);
 	read_view_unregister(rv);
 	struct space_read_view *space_rv, *next_space_rv;
 	rlist_foreach_entry_safe(space_rv, &rv->spaces, link,
@@ -279,6 +285,7 @@ read_view_delete(struct read_view *rv)
 struct read_view *
 read_view_by_id(uint64_t id)
 {
+	assert(cord_is_main());
 	struct mh_i64ptr_t *h = read_views;
 	if (h == NULL)
 		return NULL;
@@ -291,6 +298,7 @@ read_view_by_id(uint64_t id)
 bool
 read_view_foreach(read_view_foreach_f cb, void *arg)
 {
+	assert(cord_is_main());
 	struct mh_i64ptr_t *h = read_views;
 	if (h == NULL)
 		return true;
@@ -306,6 +314,10 @@ read_view_foreach(read_view_foreach_f cb, void *arg)
 struct read_view_handle *
 read_view_handle_new(struct read_view *rv)
 {
+	ERROR_INJECT(ERRINJ_READ_VIEW_HANDLE_NEW, {
+		diag_set(ClientError, ER_INJECTION, "read view handle new");
+		return NULL;
+	});
 	struct read_view_handle *h = xmalloc(sizeof(*h));
 	h->ptr = rv;
 	h->owner = cord();

--- a/src/box/read_view.h
+++ b/src/box/read_view.h
@@ -5,6 +5,7 @@
  */
 #pragma once
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -122,6 +123,16 @@ struct read_view {
 	uint64_t id;
 	/** Read view name. Used for introspection. */
 	char *name;
+	/**
+	 * Number of users referring to this read view.
+	 * A read view must not be deleted until it's 0.
+	 */
+	int pin_count;
+	/**
+	 * Set if the read view should be closed as soon as the last user stops
+	 * using it (pin_count hits 0).
+	 */
+	bool is_close_pending;
 	/**
 	 * Set if this read view is needed for system purposes (for example, to
 	 * make a checkpoint). Initialized with read_view_opts::is_system.
@@ -257,6 +268,19 @@ read_view_new(const struct read_view_opts *opts);
  */
 void
 read_view_delete(struct read_view *rv);
+
+static inline void
+read_view_pin(struct read_view *rv)
+{
+	rv->pin_count++;
+}
+
+static inline void
+read_view_unpin(struct read_view *rv)
+{
+	assert(rv->pin_count > 0);
+	rv->pin_count--;
+}
 
 /**
  * Looks up an open read view by id.

--- a/src/lib/core/errinj.h
+++ b/src/lib/core/errinj.h
@@ -124,6 +124,7 @@ struct errinj {
 	_(ERRINJ_NETBOX_IO_ERROR, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_RAFT_PROMOTE_DELAY, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_RAFT_WAIT_TERM_PERSISTED_DELAY, ERRINJ_BOOL, {.bparam = false}) \
+	_(ERRINJ_READ_VIEW_HANDLE_NEW, ERRINJ_BOOL, {.bparam = false}) \
 	_(ERRINJ_RELAY_BREAK_LSN, ERRINJ_INT, {.iparam = -1}) \
 	_(ERRINJ_RELAY_EXIT_DELAY, ERRINJ_DOUBLE, {.dparam = 0}) \
 	_(ERRINJ_RELAY_FASTER_THAN_TX, ERRINJ_BOOL, {.bparam = false}) \

--- a/src/lua/fiber.lua
+++ b/src/lua/fiber.lua
@@ -11,6 +11,8 @@ double
 fiber_clock(void);
 int64_t
 fiber_clock64(void);
+bool
+cord_is_main(void);
 ]]
 local C = ffi.C
 
@@ -94,6 +96,7 @@ fiber._internal = fiber._internal or {}
 fiber._internal.schedule_task = worker_schedule_task
 fiber._internal.set_system = fiber_set_system
 fiber._internal.set_managed_shutdown = fiber_set_managed_shutdown
+fiber._internal.cord_is_main = ffi.C.cord_is_main()
 
 setmetatable(fiber, {__serialize = function(self)
     local res = table.copy(self)

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -1,5 +1,6 @@
 -- log.lua
 --
+local fiber = require('fiber')
 local ffi = require('ffi')
 ffi.cdef[[
     typedef void (*sayfunc_t)(int level, const char *filename, int line,
@@ -72,9 +73,6 @@ ffi.cdef[[
     extern void
     log_write_flightrec_from_lua(int level, const char *filename, int line,
                                  ...);
-
-    bool
-    cord_is_main(void);
 ]]
 
 local S_WARN = ffi.C.S_WARN
@@ -482,7 +480,7 @@ log_main = {
     new = log_new,
 }
 
-if ffi.C.cord_is_main() then
+if fiber._internal.cord_is_main then
     log_main.rotate = log_rotate
     log_main.pid = log_pid
     log_main.level = set_log_level

--- a/test/box-luatest/read_view_test.lua
+++ b/test/box-luatest/read_view_test.lua
@@ -75,6 +75,12 @@ g.test_invalid_opts = function(cg)
         t.assert_error_msg_equals(
             "options parameter 'name' should be of type string",
             box.read_view.open, {name = 42})
+        t.assert_error_msg_equals(
+            "options parameter 'id' should be of type number",
+            box.read_view.open, {id = 'foo'})
+        t.assert_error_msg_equals(
+            "options parameter 'name' should not be used with 'id'",
+            box.read_view.open, {name = 'foo', id = 42})
     end)
 end
 
@@ -2655,3 +2661,334 @@ g_mvcc.test_count_cleaner = function(cg)
         rv:close()
     end, {cg.params.func_index})
 end
+
+local g_threads = t.group('read_view.threads')
+
+g_threads.before_all(function(cg)
+    cg.server = server:new({
+        box_cfg = {app_threads = 4},
+        net_box_credentials = {user = 'admin'}
+    })
+    cg.server:start()
+end)
+
+g_threads.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g_threads.after_each(function(cg)
+    -- If there's a stray read view left from a failing test, make sure it's
+    -- gone. To do that, first collect garbage in all application threads,
+    -- then collect garbage in the main thread and check the read view list.
+    -- Note, we might need to retry the last step because read views are
+    -- unpinned by application threads asynchronously.
+    for i = 1, cg.server.box_cfg.app_threads do
+        cg.server:exec(function()
+        for _ = 1, 5 do collectgarbage('collect') end
+        end, {}, {_thread_id = i})
+    end
+    cg.server:exec(function()
+        t.helpers.retrying({}, function()
+            collectgarbage('collect')
+            t.assert_equals(box.read_view.list(), {})
+        end)
+    end)
+end)
+
+g_threads.test_unsupported = function(cg)
+    cg.server:exec(function()
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'UNSUPPORTED',
+            message = 'Application thread does not support ' ..
+                      'listing read views',
+        }, box.read_view.list)
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'UNSUPPORTED',
+            message = 'Application thread does not support ' ..
+                      'creating a new read view',
+        }, box.read_view.open)
+    end, {}, {_thread_id = 1})
+end
+
+g_threads.test_reuse_in_main_thread = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local rv = box.read_view.open()
+        local id = rv.id
+
+        -- Reopening a read view with the same id doesn't create a new handle.
+        t.assert_equals(box.read_view.open({id = id}), rv)
+
+        -- Try to reuse a closed read view that's still in the registry.
+        rv:close()
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'NO_SUCH_READ_VIEW',
+        }, box.read_view.open, {id = id})
+
+        -- Try to reuse a read view that has been garbage-collected.
+        rv = nil -- luacheck: ignore
+        for _ = 1, 5 do collectgarbage('collect') end
+        t.assert_equals(box.read_view.list(), {})
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'NO_SUCH_READ_VIEW',
+        }, box.read_view.open, {id = id})
+
+        -- Try to reuse a system read view.
+        t.assert_equals(box.read_view.list(), {})
+        box.space._schema:delete('dummy')
+        local f = fiber.new(box.snapshot)
+        f:set_joinable(true)
+        fiber.yield()
+        rv = box.read_view.list()[1]
+        t.assert_covers(rv, {is_system = true, name = 'checkpoint'})
+        id = rv.id
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'READ_VIEW_BUSY',
+        }, box.read_view.open, {id = id})
+
+        -- Try to reuse a system read view whose handle was removed from
+        -- the registry by the garbage collector.
+        rv = nil -- luacheck: ignore
+        for _ = 1, 5 do collectgarbage('collect') end
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'READ_VIEW_BUSY',
+        }, box.read_view.open, {id = id})
+        t.assert_equals({f:join()}, {true, 'ok'})
+    end)
+end
+
+g_threads.test_reuse_in_app_thread = function(cg)
+    local id = cg.server:exec(function()
+        local rv = box.read_view.open()
+        rawset(_G, 'test_rv', rv)
+        return rv.id
+    end)
+    cg.server:exec(function(id)
+        local rv = box.read_view.open({id = id})
+        t.assert_equals(rv.id, id)
+        t.assert_equals(rv.status, 'open')
+
+        -- Reopening a read view with the same id shouldn't create
+        -- a new handle.
+        t.assert_equals(box.read_view.open({id = id}), rv)
+
+        -- It should be possible to reuse the original id again after
+        -- the old handle was closed.
+        rv:close()
+        t.assert_equals(rv.status, 'closed')
+        local rv2 = box.read_view.open({id = id})
+        t.assert_not_equals(rv2, rv)
+        t.assert_equals(rv2.id, id)
+        t.assert_equals(rv2.status, 'open')
+        rv2:close()
+        t.assert_equals(rv2.status, 'closed')
+    end, {id}, {_thread_id = 1})
+    cg.server:exec(function()
+        local rv = rawget(_G, 'test_rv')
+        rv:close()
+    end)
+
+    -- Try to reuse a closed read view that's still in the registry.
+    cg.server:exec(function(id)
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'NO_SUCH_READ_VIEW',
+        }, box.read_view.open, {id = id})
+    end, {id}, {_thread_id = 1})
+
+    -- Try to reuse a read view that has been garbage-collected.
+    cg.server:exec(function()
+        rawset(_G, 'test_rv', nil)
+        for _ = 1, 5 do collectgarbage('collect') end
+        t.assert_equals(box.read_view.list(), {})
+    end)
+    cg.server:exec(function(id)
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'NO_SUCH_READ_VIEW',
+        }, box.read_view.open, {id = id})
+    end, {id}, {_thread_id = 1})
+end
+
+g_threads.after_test('test_reuse_in_app_thread', function(cg)
+    cg.server:exec(function()
+        rawset(_G, 'test_rv', nil)
+    end)
+end)
+
+g_threads.test_reuse_error_after_acquire = function(cg)
+    -- Check that if an application thread fails to create a read view handle,
+    -- the read view is released in the main thread.
+    t.tarantool.skip_if_not_debug()
+    cg.server:exec(function()
+        local threads = require('experimental.threads')
+        local rv = box.read_view.open()
+        t.assert_equals(rv.status, 'open')
+        box.error.injection.set('ERRINJ_READ_VIEW_HANDLE_NEW', true)
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'INJECTION',
+            details = 'read view handle new',
+        }, threads.eval, 'app', [[box.read_view.open({id = ...})]], {rv.id})
+        rv:close()
+        t.assert_equals(rv.status, 'closed')
+    end)
+end
+
+g_threads.after_test('test_reuse_error_after_acquire', function(cg)
+    cg.server:exec(function()
+        box.error.injection.set('ERRINJ_READ_VIEW_HANDLE_NEW', false)
+    end)
+end)
+
+g_threads.test_close_pending = function(cg)
+    -- Check that a read view isn't deleted until every thread using it
+    -- closes it.
+    cg.server:exec(function()
+        local threads = require('experimental.threads')
+        local rv = box.read_view.open()
+        threads.eval('app', [[
+            rawset(_G, 'test_rv', box.read_view.open({id = ...}))
+        ]], {rv.id}, {target = 'all'})
+        rv:close()
+        t.assert_equals(rv.status, 'close_pending')
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'READ_VIEW_CLOSED',
+        }, rv.close, rv)
+
+        -- The read view is still usable in application threads.
+        t.assert_equals(threads.eval('app', [[
+            local rv = rawget(_G, 'test_rv')
+            return rv.id, rv.status
+        ]], {}, {target = 'any'}), {{rv.id, 'open'}})
+
+        -- However, if an application thread closes the read view,
+        -- it won't be able to reopen it.
+        threads.eval('app', [[
+            local rv = rawget(_G, 'test_rv')
+            rawset(_G, 'test_rv', nil)
+            rv:close()
+        ]], {}, {target = 1})
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'NO_SUCH_READ_VIEW',
+        }, threads.eval, 'app', [[
+            box.read_view.open({id = ...})
+        ]], {rv.id}, {target = 1})
+
+        -- The read view status doesn't change after it's removed from
+        -- the local registry by the garbage collector.
+        rv = nil -- luacheck: ignore
+        for _ = 1, 5 do collectgarbage('collect') end
+        rv = box.read_view.list()[1]
+        t.assert_equals(rv.status, 'close_pending')
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'READ_VIEW_CLOSED',
+        }, rv.close, rv)
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'NO_SUCH_READ_VIEW',
+        }, threads.eval, 'app', [[
+            box.read_view.open({id = ...})
+        ]], {rv.id}, {target = 1})
+
+        -- The read view is deleted as soon as all threads close it.
+        for i = 2, box.cfg.app_threads do
+            threads.eval('app', [[
+                local rv = rawget(_G, 'test_rv')
+                rawset(_G, 'test_rv', nil)
+                rv:close()
+            ]], {}, {target = i})
+        end
+        t.helpers.retrying({}, function()
+            t.assert_equals(rv.status, 'closed')
+        end)
+        rv = nil -- luacheck: ignore
+        for _ = 1, 5 do collectgarbage('collect') end
+        t.assert_equals(box.read_view.list(), {})
+    end)
+end
+
+g_threads.after_test('test_close_pending', function(cg)
+    cg.server:exec(function()
+        local threads = require('experimental.threads')
+        threads.eval('app', [[rawset(_G, 'test_rv', nil)]], {},
+                     {target = 'all'})
+    end)
+end)
+
+g_threads.test_gc = function(cg)
+    -- Check that read view handles closed by the garbage collector release
+    -- the backing read view in the main thread.
+    local rv_id, rv_name = cg.server:exec(function()
+        local threads = require('experimental.threads')
+        local rv = box.read_view.open({name = 'test_gc_in_threads'})
+        threads.eval('app', [[box.read_view.open({id = ...})]], {rv.id})
+        rv:close()
+        t.assert_equals(rv.status, 'close_pending')
+        threads.eval('app', [[for i = 1, 5 do collectgarbage('collect') end]])
+        t.helpers.retrying({}, function()
+            t.assert_equals(rv.status, 'closed')
+        end)
+        return rv.id, rv.name
+    end)
+    for thread_id = 1, cg.server.box_cfg.app_threads do
+        local fmt = "app%d/.*W> read view %d .'%s'. was not properly closed"
+        local pattern = string.format(fmt, thread_id, rv_id, rv_name)
+        t.assert(cg.server:grep_log(pattern))
+    end
+end
+
+g_threads.test_data_access = function(cg)
+    cg.server:exec(function()
+        local threads = require('experimental.threads')
+        local s = box.schema.space.create('test', {
+            format = {{'a', 'unsigned'}, {'b', 'string'}},
+        })
+        s:create_index('primary')
+        s:create_index('secondary', {parts = {'b'}})
+        s:insert({1, 'a'})
+        s:insert({2, 'b'})
+        s:insert({3, 'c'})
+        local rv = box.read_view.open()
+        s:replace({2, 'abc'})
+        s:insert({4, 'd'})
+        local function eval(expr)
+            return unpack(unpack(threads.eval('app', [[
+                local rv = box.read_view.open({id = ...})
+            ]] .. expr, {rv.id}, {target = 'any'})))
+        end
+        local ret
+        ret = eval([[return rv.space.test:count()]])
+        t.assert_equals(ret, 3)
+        ret = eval([[return rv.space.test:select({2}, {iterator = 'ge'})]])
+        t.assert_equals(ret, {{2, 'b'}, {3, 'c'}})
+        t.assert_equals(ret[1]:tomap({names_only = true}), {a = 2, b = 'b'})
+        ret = eval([[return rv.space.test.index.secondary:get('a')]])
+        t.assert_equals(ret, {1, 'a'})
+        t.assert_equals(ret:tomap({names_only = true}), {a = 1, b = 'a'})
+        ret = eval([[
+            local fun = require('fun')
+            return fun.totable(rv.space.test:pairs())
+        ]])
+        t.assert_equals(ret, {{1, 'a'}, {2, 'b'}, {3, 'c'}})
+        t.assert_equals(ret[3]:tomap({names_only = true}), {a = 3, b = 'c'})
+        eval([[rv:close()]])
+    end)
+end
+
+g_threads.after_test('test_data_access', function(cg)
+    cg.server:exec(function()
+        if box.space.test ~= nil then
+            box.space.test:drop()
+        end
+    end)
+end)

--- a/test/box/error.result
+++ b/test/box/error.result
@@ -513,6 +513,7 @@ t;
  |   302: box.error.NO_SUCH_THREAD_GROUP
  |   303: box.error.XLOG_NOT_FOUND
  |   304: box.error.RECOVERY_POINT_TXN_LAST_ROW
+ |   305: box.error.NO_SUCH_READ_VIEW
  | ...
 
 test_run:cmd("setopt delimiter ''");


### PR DESCRIPTION
A database read view can now be accessed from an application thread. To do that, you need to pass the read view id to the thread where it's going to be used and open the read view by id there, for example:

```lua
local threads = require('experimental.threads')

box.cfg{app_threads = 1}

box.schema.space.create('test')
box.space.test:create_index('primary')
box.space.test:replace({1, 'x'})
box.space.test:replace({2, 'y'})
box.space.test:replace({3, 'z'})

local rv = box.read_view.open({name = 'shared_read_view'})
threads.eval('app', [[
    local rv = box.read_view.open({id = ...})
    return rv.space.test:select()
]], {rv.id})
```

Note, a new read view still can be created only in the main thread - calling `box.read_view.open()` without an id in an application thread would fail. Also, application threads can't use `box.read_view.list()`.

If a read view is used in an application thread, closing it in the main thread will not delete the read view immediately: instead the read view will be switch to the `close_pending` state. Just like a closed read view, a read view in the `close_pending` state can't be used in the main thread or reopened in another thread. However, it still can be used in the application threads where it was opened before it switched to this state. Once the last thread using the read view closes it (or the read view object is closed implicitly by the Lua garbage collector), the read view will be deleted globally.

Closes #12951