### PR TITLE
Adding a meta-field to a fiber

### DIFF
--- a/changelogs/unreleased/gh-12998-adding-metadata-field-in-fiber.md
+++ b/changelogs/unreleased/gh-12998-adding-metadata-field-in-fiber.md
@@ -1,0 +1,4 @@
+* Now struct fiber includes a map-type field
+  for context that is inherited when a new fiber is created.
+  The command get_cnt() is used to retrieve the metadata,
+  set_cnt() is used to modify it.

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1060,6 +1060,7 @@ fiber_recycle(struct fiber *fiber)
 	memset(&fiber->storage, 0, sizeof(fiber->storage));
 	fiber->storage.lua.storage_ref = FIBER_LUA_NOREF;
 	fiber->storage.lua.fid_ref = FIBER_LUA_NOREF;
+	fiber->cnt_ref = FIBER_LUA_NOREF;
 	unregister_fid(fiber);
 	fiber->fid = 0;
 	fiber->gc_initial_size = 0;
@@ -1556,6 +1557,7 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 		memset(fiber, 0, sizeof(struct fiber));
 		fiber->storage.lua.storage_ref = FIBER_LUA_NOREF;
 		fiber->storage.lua.fid_ref = FIBER_LUA_NOREF;
+		fiber->cnt_ref = FIBER_LUA_NOREF;
 
 		fiber_stack_create(fiber, fiber_attr, &cord()->slabc);
 		coro_create(&fiber->ctx, fiber_loop, NULL,
@@ -1574,6 +1576,7 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 	fiber->f = f;
 	fiber->fid = cord->next_fid;
 	fiber_set_name(fiber, name);
+	fiber->cnt_ref = FIBER_LUA_NOREF;
 	register_fid(fiber);
 	fiber->max_slice = zero_slice;
 	fiber->csw = 0;

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -677,6 +677,10 @@ struct fiber {
 	int csw;
 	/** Fiber id. */
 	uint64_t fid;
+	/** Reference on fiber metadata. */
+	int cnt_ref;
+	/** Len on fiber metadata. */
+	size_t cnt_len;
 	/** Fiber flags */
 	uint32_t flags;
 	struct clock_stat clock_stat;

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -39,6 +39,10 @@
 
 #include <lua.h>
 #include <lauxlib.h>
+#include "lua/msgpack.h" /* luaL_msgpack_default */
+#include "mpstream/mpstream.h"
+#include "cord_buf.h"
+#include <small/ibuf.h>
 
 static_assert(FIBER_LUA_NOREF == LUA_NOREF, "FIBER_LUA_NOREF is ok");
 
@@ -100,8 +104,15 @@ static int
 lbox_fiber_on_stop(struct trigger *trigger, void *event)
 {
 	struct fiber *f = event;
-	luaL_unref(tarantool_L, LUA_REGISTRYINDEX, f->storage.lua.storage_ref);
-	f->storage.lua.storage_ref = FIBER_LUA_NOREF;
+	if (f->storage.lua.storage_ref != FIBER_LUA_NOREF) {
+		luaL_unref(tarantool_L, LUA_REGISTRYINDEX,
+			   f->storage.lua.storage_ref);
+		f->storage.lua.storage_ref = FIBER_LUA_NOREF;
+	}
+	if (f->cnt_ref != FIBER_LUA_NOREF) {
+		luaL_unref(tarantool_L, LUA_REGISTRYINDEX, f->cnt_ref);
+		f->cnt_ref = FIBER_LUA_NOREF;
+	}
 	trigger_clear(trigger);
 	free(trigger);
 	return 0;
@@ -169,6 +180,27 @@ lbox_checkfiber(struct lua_State *L, int index)
 		luaT_error(L);
 	}
 	return f;
+}
+
+/**
+ * Puts fiber metadata in Lua stack.
+ */
+static int
+lbox_fiber_get_cnt(struct lua_State *L)
+{
+	struct fiber *f;
+	if (lua_gettop(L) == 0)
+		f = fiber();
+	else
+		f = lbox_checkfiber(L, 1);
+	if (f->cnt_ref == FIBER_LUA_NOREF) {
+		lua_pushnil(L);
+	} else {
+		lua_rawgeti(L, LUA_REGISTRYINDEX, f->cnt_ref);
+		const char *cnt = lua_tolstring(L, -1, &f->cnt_len);
+		luamp_decode(L, luaL_msgpack_default, &cnt);
+	}
+	return 1;
 }
 
 static int
@@ -475,6 +507,19 @@ fiber_create(struct lua_State *L)
 	int coro_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
 	struct fiber *f = fiber_new("lua", lua_fiber_run_f);
+
+	if (f == NULL) {
+		luaL_unref(L, LUA_REGISTRYINDEX, coro_ref);
+		luaT_error(L);
+	}
+	struct fiber *fib = fiber();
+	if (fib->cnt_ref != FIBER_LUA_NOREF) {
+		f->cnt_len = fib->cnt_len;
+		lua_rawgeti(L, LUA_REGISTRYINDEX, fib->cnt_ref);
+		f->cnt_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+	} else {
+		f->cnt_ref = FIBER_LUA_NOREF;
+	}
 #ifdef ENABLE_BACKTRACE
 	if (fiber_parent_backtrace_is_enabled()) {
 		struct fiber *parent = fiber();
@@ -663,6 +708,49 @@ lbox_fiber_name(struct lua_State *L)
 		lua_pushstring(L, fiber_name(f));
 		return 1;
 	}
+}
+
+/*
+ * This function encodes context of type map from lua stack,
+ * puts it in lua storage and save in fiber ref on cnt and its len.
+ */
+static int
+lbox_fiber_set_cnt(struct lua_State *L)
+{
+	struct fiber *f = fiber();
+	if (lua_type(L, 1) == LUA_TUSERDATA) {
+		f = lbox_checkfiber(L, 1);
+	}
+	if (f->flags & FIBER_IS_DEAD) {
+		diag_set(IllegalParams, "the fiber is dead");
+		luaT_error(L);
+	}
+	int index = lua_gettop(L);
+	if (index < 1)
+		return luaL_error(L, "msgpack.encode: a Lua object expected");
+
+	struct ibuf *buf = cord_ibuf_take();
+	struct mpstream stream;
+	mpstream_init(&stream, buf, ibuf_reserve_cb, ibuf_alloc_cb,
+		      luamp_error, L);
+	luamp_encode(L, luaL_msgpack_default, &stream, index);
+	mpstream_flush(&stream);
+
+	if (f->cnt_ref != FIBER_LUA_NOREF) {
+		luaL_unref(tarantool_L, LUA_REGISTRYINDEX, f->cnt_ref);
+	} else {
+		struct trigger *on_stop = xmalloc(sizeof(*on_stop));
+		trigger_create(on_stop, lbox_fiber_on_stop, NULL,
+			       (trigger_f0)free);
+		trigger_add(&f->on_stop, on_stop);
+	}
+	size_t cnt_len = ibuf_used(buf);
+	lua_pushlstring(L, buf->buf, cnt_len);
+	f->cnt_len = cnt_len;
+	int cnt_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+	f->cnt_ref = cnt_ref;
+	cord_ibuf_drop(buf);
+	return 0;
 }
 
 static int
@@ -1063,6 +1151,8 @@ lbox_fiber_set_max_slice(struct lua_State *L)
 }
 
 static const struct luaL_Reg lbox_fiber_meta [] = {
+	{"get_cnt", lbox_fiber_get_cnt},
+	{"set_cnt", lbox_fiber_set_cnt},
 	{"id", lbox_fiber_id},
 	{"name", lbox_fiber_name},
 	{"cancel", lbox_fiber_cancel},
@@ -1095,6 +1185,8 @@ static const struct luaL_Reg fiberlib[] = {
 	{"sleep", lbox_fiber_sleep},
 	{"yield", lbox_fiber_yield},
 	{"self", lbox_fiber_self},
+	{"get_cnt", lbox_fiber_get_cnt},
+	{"set_cnt", lbox_fiber_set_cnt},
 	{"id", lbox_fiber_id},
 	{"find", lbox_fiber_find},
 	{"kill", lbox_fiber_cancel},

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -96,6 +96,8 @@ local special_fields = {
     "line",
     "cord_name",
     "fiber_name",
+    "fiber_get_cnt",
+    "fiber_set_cnt",
     "fiber_id",
     "error_msg"
 }

--- a/test/app-luatest/fiber_test.lua
+++ b/test/app-luatest/fiber_test.lua
@@ -96,3 +96,58 @@ g.test_gh_10196_no_hang_on_self_join = function()
         message = 'cannot join itself',
     })
 end
+
+g.test_check_distribution_meta_data_in_fiber = function()
+    local f = fiber.self()
+
+    local res, err = f:get_cnt()
+    t.assert_equals(res, nil)
+    t.assert_equals(err, nil)
+
+    local sleep = function() require('fiber').sleep(500) end
+    local f_new = fiber.new(sleep)
+    res, err = f_new:get_cnt()
+    t.assert_equals(res, nil)
+    t.assert_equals(err, nil)
+    f_new:cancel()
+
+    local f_create = fiber.create(sleep)
+    res, err = f_create:get_cnt()
+    t.assert_equals(res, nil)
+    t.assert_equals(err, nil)
+    f_create:cancel()
+
+    local exp = {id = 0, a = 1, b = '2'}
+    f:set_cnt(exp)
+    res = f:get_cnt()
+    t.assert_equals(res, exp)
+
+    f_new = fiber.new(sleep)
+    res = f_new:get_cnt()
+    t.assert_equals(res, exp)
+
+    f_create = fiber.create(sleep)
+    res = f_create:get_cnt()
+    t.assert_equals(res, exp)
+
+    local exp_new = {c = 'llll'}
+    f_new:set_cnt(exp_new)
+    res = f_new:get_cnt()
+    t.assert_equals(res, exp_new)
+    res = f:get_cnt()
+    t.assert_equals(res, exp)
+    res = f_create:get_cnt()
+    t.assert_equals(res, exp)
+
+    local exp_create = {p = 0}
+    f_create:set_cnt(exp_create)
+    res = f_create:get_cnt()
+    t.assert_equals(res, exp_create)
+    res = f:get_cnt()
+    t.assert_equals(res, exp)
+    res = f_new:get_cnt()
+    t.assert_equals(res, exp_new)
+
+    f_new:cancel()
+    f_create:cancel()
+end


### PR DESCRIPTION
After this patch struct fiber includes a map-type field for metadata that is inherited when a new fiber is created. The command get_meta() is used to retrieve the metadata, get_meta() is used to modify it.

Part of #12998