### PR TITLE
[backport 2.11] box: build fix with recent gcc/glibc

### DIFF
--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -2979,7 +2979,7 @@ luaT_netbox_transport_start(struct lua_State *L)
 	struct netbox_transport *transport = luaT_check_netbox_transport(L, 1);
 	assert(transport->worker == NULL);
 	assert(transport->coro_ref == LUA_NOREF);
-	assert(transport->self_ref = LUA_NOREF);
+	assert(transport->self_ref == LUA_NOREF);
 	struct lua_State *fiber_L = lua_newthread(L);
 	transport->coro_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 	transport->self_ref = luaL_ref(L, LUA_REGISTRYINDEX);

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -3296,7 +3296,7 @@ sql_set_boolean_option(int id, bool value)
 static int
 sql_set_string_option(int id, const char *value)
 {
-	assert(sql_session_opts[id - SESSION_SETTING_SQL_BEGIN].field_type =
+	assert(sql_session_opts[id - SESSION_SETTING_SQL_BEGIN].field_type ==
 	       FIELD_TYPE_STRING);
 	assert(id == SESSION_SETTING_SQL_DEFAULT_ENGINE);
 	(void)id;


### PR DESCRIPTION
*(This is a backport of PR #12314 to `release/2.11`, a future 2.11.10 release.)*

----

There are couple of errors like below and assertions where '=' is
used instead of '=='.