### PR TITLE
Synchronous Promote - Part 6 - Preparatory bug fixes

### DIFF
--- a/changelogs/unreleased/gh-10040-read-only-promote-infinite-wait.md
+++ b/changelogs/unreleased/gh-10040-read-only-promote-infinite-wait.md
@@ -1,0 +1,6 @@
+## bugfix/raft
+
+* Fixed a bug where `box.ctl.promote()` could hang indefinitely on
+  a read-only instance, even if the election was won and the
+  synchronous transaction queue was claimed successfully
+  (gh-10040).

--- a/changelogs/unreleased/gh-12972-bootstrap-synchro-queue-claim.md
+++ b/changelogs/unreleased/gh-12972-bootstrap-synchro-queue-claim.md
@@ -1,0 +1,6 @@
+## bugfix/raft
+
+* Fixed a bug where `box.cfg()` on a freshly bootstrapped instance with
+  `election_mode` set to `'candidate'` or `'manual'` could sometimes return
+  with the instance in a read-only state for some time afterwards, even
+  when no read-only mode was explicitly configured (gh-12972).

--- a/changelogs/unreleased/gh-13066-txn-races-with-promote-wal-write.md
+++ b/changelogs/unreleased/gh-13066-txn-races-with-promote-wal-write.md
@@ -1,0 +1,5 @@
+## bugfix/replication
+
+* Fixed a debug-build crash that could happen when a quorum of acks was
+  collected for a synchronous transaction while a `PROMOTE` or `DEMOTE` was
+  being written to the journal (gh-13066).

--- a/changelogs/unreleased/gh-13085-qsync-confirm-after-rollback.md
+++ b/changelogs/unreleased/gh-13085-qsync-confirm-after-rollback.md
@@ -1,0 +1,5 @@
+## bugfix/raft
+
+* Fixed a bug where an old leader could rejoin with a new one while having
+  mismatched data, and this would remain undetected. This could happen when
+  synchronous transactions are rolled back due to a timeout (gh-13085).

--- a/changelogs/unreleased/gh-13095-qsync-data-mismatch.md
+++ b/changelogs/unreleased/gh-13095-qsync-data-mismatch.md
@@ -1,0 +1,7 @@
+## bugfix/raft
+
+* Fixed a bug where a synchronous transaction, temporarily blocked because the
+  synchronous transaction queue was full (`replication.synchro_queue_max_size`
+  was reached), during a leader change or a timeout
+  (`replication.synchro_timeout`) could be rolled back, but then appear again
+  and even be committed (locally after a restart or on another node) (gh-13095).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -3083,31 +3083,46 @@ box_check_promote(void) {
 }
 
 /**
- * Wait until this instance becomes writable, as long as it remains the Raft
- * leader.
+ * Wait until this instance claims the limbo. Usually it means the node
+ * becomes writable, but not necessarily. It might, for example, have
+ * box.cfg.read_only = true and still claim the limbo successfully.
  */
 static int
-box_wait_for_rw_while_leader(struct raft *raft)
+box_wait_for_limbo_claim(struct raft *raft)
 {
 	assert(is_box_configured);
 	double deadline = ev_monotonic_now(loop()) +
 		replication_synchro_timeout;
-	while (box_is_ro()) {
+	bool is_timed_out = false;
+	while (txn_limbo.state != TXN_LIMBO_STATE_LEADER) {
 		if (raft->state != RAFT_STATE_LEADER) {
 			diag_set(ClientError, ER_INTERFERING_ELECTIONS);
 			return -1;
 		}
-		struct trigger on_update;
-		trigger_create(&on_update, fiber_wakeup_trigger_cb,
-			       fiber(), NULL);
-		raft_on_update(raft, &on_update);
-		int rc = fiber_cond_wait_deadline(&ro_cond, deadline);
-		trigger_clear(&on_update);
-		if (rc != 0)
+		if (fiber_is_cancelled()) {
+			diag_set(FiberIsCancelled);
 			return -1;
+		}
+		if (is_timed_out) {
+			diag_set(TimedOut);
+			return -1;
+		}
+		/*
+		 * Raft updates are covered by the limbo updates. Enough to
+		 * subscribe to the latter to get notified about the former too.
+		 */
+		struct trigger on_state_update;
+		trigger_create(&on_state_update, fiber_wakeup_trigger_cb,
+			       fiber(), NULL);
+		trigger_add(&txn_limbo.on_state_update, &on_state_update);
+		/*
+		 * Even if timed out, firstly check the limbo and raft states -
+		 * perhaps they are right already.
+		 */
+		is_timed_out = fiber_yield_deadline(deadline);
+		trigger_clear(&on_state_update);
 	}
 	assert(raft->state == RAFT_STATE_LEADER);
-	assert(!box_is_ro());
 	return 0;
 }
 
@@ -3134,7 +3149,7 @@ box_promote(void)
 	if (box_raft_try_promote() != 0)
 		return -1;
 	assert(raft->state == RAFT_STATE_LEADER);
-	return box_wait_for_rw_while_leader(raft);
+	return box_wait_for_limbo_claim(raft);
 }
 
 int

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6082,18 +6082,12 @@ box_cfg_xc(void)
 		 * should take the control over the situation and start a new
 		 * term immediately.
 		 */
-		int rc = box_raft_try_promote();
-		if (raft->leader != instance_id && raft->leader != 0) {
-			/*
-			 * It was promoted and is a single registered node -
-			 * there can't be another leader or a new term bump.
-			 */
-			panic("Bootstrap master couldn't elect self as a "
-			      "leader. Leader is %u, term is %llu",
-			      raft->leader, (long long)raft->volatile_term);
+		int rc = box_promote();
+		if (rc != 0) {
+			diag_log();
+			panic("Bootstrap master couldn't claim the synchronous "
+			      "transaction queue");
 		}
-		assert(rc == 0);
-		(void)rc;
 	}
 
 	/* box.cfg.read_only is not read yet. */

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -287,7 +287,6 @@ txn_limbo_create(struct txn_limbo *limbo, struct raft *raft)
 	txn_limbo_queue_create(&limbo->queue);
 	vclock_create(&limbo->promote_term_map);
 	latch_create(&limbo->state_latch);
-	limbo->svp_confirmed_lsn = -1;
 	limbo->raft = raft;
 	limbo->term = 1;
 	limbo->worker = fiber_new_system("txn_limbo_worker",
@@ -505,18 +504,21 @@ txn_limbo_wait_complete(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 	assert(!txn_limbo_entry_is_complete(entry));
 	assert(entry->lsn >= 0);
 	txn_limbo_lock(limbo);
-	if (limbo->state != TXN_LIMBO_STATE_LEADER) {
+	/*
+	 * The latch might have been taken over from a PROMOTE/DEMOTE WAL write
+	 * covering this entry. Then the entry is already completed by now.
+	 */
+	if (txn_limbo_entry_is_complete(entry) ||
+	    limbo->state != TXN_LIMBO_STATE_LEADER) {
 		txn_limbo_unlock(limbo);
-		do {
+		while (!txn_limbo_entry_is_complete(entry))
 			fiber_yield();
-		} while (!txn_limbo_entry_is_complete(entry));
 		if (entry->state == TXN_LIMBO_ENTRY_ROLLBACK) {
 			diag_set(ClientError, ER_SYNC_ROLLBACK);
 			return TXN_LIMBO_WAIT_ENTRY_FAIL_COMPLETE;
 		}
 		return TXN_LIMBO_WAIT_ENTRY_SUCCESS;
 	}
-	assert(!txn_limbo_entry_is_complete(entry));
 	txn_limbo_write_rollback(limbo, entry->lsn);
 	txn_limbo_queue_apply_rollback(&limbo->queue, entry->lsn,
 				       TXN_SIGNATURE_QUORUM_TIMEOUT);
@@ -926,11 +928,8 @@ txn_limbo_req_prepare(struct txn_limbo *limbo,
 		break;
 	case IPROTO_RAFT_PROMOTE:
 	case IPROTO_RAFT_DEMOTE: {
-		assert(limbo->svp_confirmed_lsn == -1);
 		assert(!limbo->is_transition_in_progress);
 		limbo->is_transition_in_progress = true;
-		limbo->svp_confirmed_lsn = limbo->queue.volatile_confirmed_lsn;
-		limbo->queue.volatile_confirmed_lsn = req->promote.lsn;
 		txn_limbo_update_system_spaces_is_sync_state(
 			limbo, req, /*is_rollback=*/false);
 		txn_limbo_update_state(limbo);
@@ -953,11 +952,8 @@ txn_limbo_req_rollback(struct txn_limbo *limbo,
 	case IPROTO_RAFT_PROMOTE:
 	case IPROTO_RAFT_DEMOTE: {
 		assert(limbo->is_in_rollback);
-		assert(limbo->svp_confirmed_lsn >= 0);
 		assert(limbo->is_transition_in_progress);
 		limbo->is_transition_in_progress = false;
-		limbo->queue.volatile_confirmed_lsn = limbo->svp_confirmed_lsn;
-		limbo->svp_confirmed_lsn = -1;
 		txn_limbo_update_system_spaces_is_sync_state(
 			limbo, req, /*is_rollback=*/true);
 		limbo->is_in_rollback = false;
@@ -1011,11 +1007,9 @@ txn_limbo_req_commit_promote_demote(struct txn_limbo *limbo,
 	txn_limbo_assert_locked(limbo);
 	assert(req->type == IPROTO_RAFT_PROMOTE ||
 	       req->type == IPROTO_RAFT_DEMOTE);
-	assert(limbo->svp_confirmed_lsn >= 0);
 	assert(limbo->is_in_rollback);
 	assert(limbo->is_transition_in_progress);
 	limbo->is_transition_in_progress = false;
-	limbo->svp_confirmed_lsn = -1;
 	limbo->is_in_rollback = false;
 
 	uint64_t term = req->promote.term;

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -296,6 +296,7 @@ txn_limbo_create(struct txn_limbo *limbo, struct raft *raft)
 {
 	memset(limbo, 0, sizeof(*limbo));
 	limbo->state = TXN_LIMBO_STATE_INACTIVE;
+	rlist_create(&limbo->on_state_update);
 	limbo->is_in_recovery = true;
 	txn_limbo_queue_create(&limbo->queue);
 	vclock_create(&limbo->promote_term_map);
@@ -345,6 +346,12 @@ make_leader:
 make_inactive:
 	limbo->state = TXN_LIMBO_STATE_INACTIVE;
 end:
+	/*
+	 * Run before the ro summary update. A trigger might need to finish
+	 * setting things up before the new state's effects, such as the box
+	 * becoming writable, can be observed.
+	 */
+	trigger_run(&limbo->on_state_update, limbo);
 	box_update_ro_summary();
 }
 
@@ -431,6 +438,7 @@ static inline void
 txn_limbo_destroy(struct txn_limbo *limbo)
 {
 	trigger_clear(&limbo->on_ack);
+	trigger_destroy(&limbo->on_state_update);
 	txn_limbo_queue_destroy(&limbo->queue);
 	TRASH(limbo);
 }

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -1071,9 +1071,8 @@ void
 txn_limbo_on_parameters_change(struct txn_limbo *limbo)
 {
 	/* The replication_synchro_quorum value may have changed. */
-	if (txn_limbo_is_owned_by_current_instance(limbo) &&
-	    txn_limbo_queue_bump_volatile_confirm(&limbo->queue))
-		fiber_wakeup(limbo->worker);
+	txn_limbo_queue_bump_volatile_confirm(&limbo->queue);
+	fiber_wakeup(limbo->worker);
 	/*
 	 * Wakeup all the others - timed out will rollback. Also
 	 * there can be non-transactional waiters, such as CONFIRM

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -183,7 +183,8 @@ static void
 txn_limbo_unfence(struct txn_limbo *limbo)
 {
 	txn_limbo_assert_locked(limbo);
-	txn_limbo_queue_unfence(&limbo->queue);
+	if (txn_limbo_queue_unfence(&limbo->queue))
+		fiber_wakeup(limbo->worker);
 }
 
 /**
@@ -1062,8 +1063,7 @@ void
 txn_limbo_on_parameters_change(struct txn_limbo *limbo)
 {
 	/* The replication_synchro_quorum value may have changed. */
-	if (!limbo->queue.is_fenced &&
-	    txn_limbo_is_owned_by_current_instance(limbo) &&
+	if (txn_limbo_is_owned_by_current_instance(limbo) &&
 	    txn_limbo_queue_bump_volatile_confirm(&limbo->queue))
 		fiber_wakeup(limbo->worker);
 	/*

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -738,6 +738,18 @@ txn_limbo_filter_promote_demote(struct txn_limbo *limbo,
 	assert(limbo->do_validate);
 	assert(iproto_type_is_promote_request(req->type));
 	/*
+	 * Need all LSNs to be known. They are used to determine whether the
+	 * request is safe to apply, below in the filtering logic.
+	 *
+	 * The queue is fenced off during the wait, so no new txns appearing
+	 * in parallel would prolong the waiting.
+	 */
+	txn_limbo_fence(limbo);
+	int rc = txn_limbo_queue_wait_writes_finished(&limbo->queue);
+	txn_limbo_unfence(limbo);
+	if (rc != 0)
+		return -1;
+	/*
 	 * PROMOTE might be claiming an unclaimed limbo. But DEMOTE can't be
 	 * unclaiming a nobody-owned limbo.
 	 */
@@ -850,12 +862,6 @@ txn_limbo_filter_request(struct txn_limbo *limbo,
 	txn_limbo_assert_locked(limbo);
 	if (!limbo->do_validate)
 		return 0;
-	/*
-	 * Need all LSNs to be known. They will be used to determine whether
-	 * filtered request is safe to apply.
-	 */
-	if (txn_limbo_queue_wait_writes_finished(&limbo->queue) < 0)
-		return -1;
 	switch (req->type) {
 	case IPROTO_RAFT_CONFIRM:
 		return txn_limbo_filter_confirm(limbo, req);
@@ -904,33 +910,24 @@ txn_limbo_req_prepare(struct txn_limbo *limbo,
 		      const struct synchro_request *req)
 {
 	txn_limbo_assert_locked(limbo);
-	/*
-	 * Guard against new transactions appearing during WAL write. It is
-	 * necessary because otherwise when PROMOTE/DEMOTE would be done and it
-	 * would see a txn without LSN in the limbo, it couldn't tell whether
-	 * the transaction should be confirmed or rolled back. It could be
-	 * delivered to the PROMOTE/DEMOTE initiator even before than to the
-	 * local TX thread, or could be not.
-	 *
-	 * CONFIRM and ROLLBACK need this guard only during  the filter stage.
-	 * Because the filter needs to see all the transactions LSNs to work
-	 * correctly.
-	 */
-	txn_limbo_fence(limbo);
-	if (txn_limbo_filter_request(limbo, req) < 0) {
-		txn_limbo_unfence(limbo);
+	if (txn_limbo_filter_request(limbo, req) < 0)
 		return -1;
-	}
 	/* Prepare for request execution and fine-grained filtering. */
 	switch (req->type) {
 	case IPROTO_RAFT_CONFIRM:
 	case IPROTO_RAFT_ROLLBACK:
-		txn_limbo_unfence(limbo);
 		break;
 	case IPROTO_RAFT_PROMOTE:
 	case IPROTO_RAFT_DEMOTE: {
 		assert(!limbo->is_transition_in_progress);
 		limbo->is_transition_in_progress = true;
+		/*
+		 * Guard against new transactions appearing during the WAL
+		 * write. Otherwise a txn written right after the PROMOTE
+		 * must be rolled back by this PROMOTE, but it can't be, because
+		 * it would be written after it.
+		 */
+		txn_limbo_fence(limbo);
 		txn_limbo_update_system_spaces_is_sync_state(
 			limbo, req, /*is_rollback=*/false);
 		txn_limbo_update_state(limbo);

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -172,6 +172,20 @@ txn_limbo_ack(struct txn_limbo *limbo, uint32_t replica_id, int64_t lsn)
 		fiber_wakeup(limbo->worker);
 }
 
+static void
+txn_limbo_fence(struct txn_limbo *limbo)
+{
+	txn_limbo_assert_locked(limbo);
+	txn_limbo_queue_fence(&limbo->queue);
+}
+
+static void
+txn_limbo_unfence(struct txn_limbo *limbo)
+{
+	txn_limbo_assert_locked(limbo);
+	txn_limbo_queue_unfence(&limbo->queue);
+}
+
 /**
  * Write a confirmation entry to the WAL. After it's written all the
  * transactions waiting for confirmation may be finished.
@@ -181,7 +195,7 @@ txn_limbo_write_confirm(struct txn_limbo *limbo, int64_t lsn)
 {
 	txn_limbo_assert_locked(limbo);
 	assert(lsn > limbo->queue.confirmed_lsn);
-	assert(!limbo->is_in_rollback);
+	assert(!limbo->queue.is_fenced);
 	struct synchro_request req = {
 		.type = IPROTO_RAFT_CONFIRM,
 		.queue_owner_id = limbo->queue.owner_id,
@@ -201,8 +215,7 @@ txn_limbo_write_rollback(struct txn_limbo *limbo, int64_t lsn)
 {
 	txn_limbo_assert_locked(limbo);
 	assert(lsn > limbo->queue.confirmed_lsn);
-	assert(!limbo->is_in_rollback);
-	limbo->is_in_rollback = true;
+	assert(limbo->queue.is_fenced);
 	struct synchro_request req = {
 		.type = IPROTO_RAFT_ROLLBACK,
 		.queue_owner_id = limbo->queue.owner_id,
@@ -211,7 +224,6 @@ txn_limbo_write_rollback(struct txn_limbo *limbo, int64_t lsn)
 		},
 	};
 	synchro_request_write_or_panic(&req);
-	limbo->is_in_rollback = false;
 }
 
 static int
@@ -222,7 +234,7 @@ txn_limbo_worker_bump_confirmed_lsn(struct txn_limbo *limbo)
 	assert(queue->volatile_confirmed_lsn >= queue->confirmed_lsn);
 	while (limbo->state == TXN_LIMBO_STATE_LEADER &&
 	       queue->volatile_confirmed_lsn > queue->confirmed_lsn) {
-		if (limbo->is_in_rollback)
+		if (queue->is_fenced)
 			return -1;
 		/* It can get bumped again while we are writing. */
 		int64_t lsn = queue->volatile_confirmed_lsn;
@@ -451,18 +463,6 @@ int
 txn_limbo_submit(struct txn_limbo *limbo, uint32_t id, struct txn *txn,
 		 size_t approx_len)
 {
-	if (limbo->is_in_rollback) {
-		/*
-		 * Cascading rollback. It is impossible to commit the
-		 * transaction, because if there is an existing rollback in
-		 * progress, it should rollback this one too for the sake of
-		 * 'reversed rollback order' rule. On the other hand the
-		 * rollback can't be postponed until after WAL write as well -
-		 * it should be done right now. See in the limbo comments why.
-		 */
-		diag_set(ClientError, ER_SYNC_ROLLBACK);
-		return -1;
-	}
 	return txn_limbo_queue_submit(&limbo->queue, id == 0 ? instance_id : id,
 				      txn, approx_len);
 }
@@ -519,11 +519,13 @@ txn_limbo_wait_complete(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 		}
 		return TXN_LIMBO_WAIT_ENTRY_SUCCESS;
 	}
+	txn_limbo_fence(limbo);
 	txn_limbo_write_rollback(limbo, entry->lsn);
 	txn_limbo_queue_apply_rollback(&limbo->queue, entry->lsn,
 				       TXN_SIGNATURE_QUORUM_TIMEOUT);
 	assert(txn_limbo_entry_is_complete(entry));
 	assert(entry->state == TXN_LIMBO_ENTRY_ROLLBACK);
+	txn_limbo_unfence(limbo);
 	txn_limbo_unlock(limbo);
 	diag_set(ClientError, ER_SYNC_QUORUM_TIMEOUT);
 	return TXN_LIMBO_WAIT_ENTRY_FAIL_COMPLETE;
@@ -914,17 +916,16 @@ txn_limbo_req_prepare(struct txn_limbo *limbo,
 	 * Because the filter needs to see all the transactions LSNs to work
 	 * correctly.
 	 */
-	assert(!limbo->is_in_rollback);
-	limbo->is_in_rollback = true;
+	txn_limbo_fence(limbo);
 	if (txn_limbo_filter_request(limbo, req) < 0) {
-		limbo->is_in_rollback = false;
+		txn_limbo_unfence(limbo);
 		return -1;
 	}
 	/* Prepare for request execution and fine-grained filtering. */
 	switch (req->type) {
 	case IPROTO_RAFT_CONFIRM:
 	case IPROTO_RAFT_ROLLBACK:
-		limbo->is_in_rollback = false;
+		txn_limbo_unfence(limbo);
 		break;
 	case IPROTO_RAFT_PROMOTE:
 	case IPROTO_RAFT_DEMOTE: {
@@ -951,12 +952,11 @@ txn_limbo_req_rollback(struct txn_limbo *limbo,
 	switch (req->type) {
 	case IPROTO_RAFT_PROMOTE:
 	case IPROTO_RAFT_DEMOTE: {
-		assert(limbo->is_in_rollback);
 		assert(limbo->is_transition_in_progress);
 		limbo->is_transition_in_progress = false;
 		txn_limbo_update_system_spaces_is_sync_state(
 			limbo, req, /*is_rollback=*/true);
-		limbo->is_in_rollback = false;
+		txn_limbo_unfence(limbo);
 		txn_limbo_update_state(limbo);
 		break;
 	}
@@ -1007,10 +1007,8 @@ txn_limbo_req_commit_promote_demote(struct txn_limbo *limbo,
 	txn_limbo_assert_locked(limbo);
 	assert(req->type == IPROTO_RAFT_PROMOTE ||
 	       req->type == IPROTO_RAFT_DEMOTE);
-	assert(limbo->is_in_rollback);
 	assert(limbo->is_transition_in_progress);
 	limbo->is_transition_in_progress = false;
-	limbo->is_in_rollback = false;
 
 	uint64_t term = req->promote.term;
 	uint32_t origin = req->origin_id;
@@ -1031,6 +1029,7 @@ txn_limbo_req_commit_promote_demote(struct txn_limbo *limbo,
 		new_owner = req->origin_id;
 	}
 	txn_limbo_queue_transfer_ownership(&limbo->queue, new_owner, lsn);
+	txn_limbo_unfence(limbo);
 	txn_limbo_update_state(limbo);
 }
 
@@ -1066,9 +1065,9 @@ void
 txn_limbo_on_parameters_change(struct txn_limbo *limbo)
 {
 	/* The replication_synchro_quorum value may have changed. */
-	if (!limbo->is_in_rollback &&
+	if (!limbo->queue.is_fenced &&
 	    txn_limbo_is_owned_by_current_instance(limbo) &&
-	     txn_limbo_queue_bump_volatile_confirm(&limbo->queue))
+	    txn_limbo_queue_bump_volatile_confirm(&limbo->queue))
 		fiber_wakeup(limbo->worker);
 	/*
 	 * Wakeup all the others - timed out will rollback. Also

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -130,6 +130,25 @@ txn_limbo_assert_locked(struct txn_limbo *limbo)
 	VERIFY(latch_is_locked(&limbo->state_latch));
 }
 
+/**
+ * Validate correctness of the limbo state. The function helps to catch
+ * state-breaking changes early, instead of continuing execution and either
+ * leaving the broken state unnoticed or crashing later in some distantly
+ * related place which usually complicates debug a lot.
+ */
+static void
+txn_limbo_assert_consistent(struct txn_limbo *limbo)
+{
+#ifndef NDEBUG
+	struct txn_limbo_queue *queue = &limbo->queue;
+	VERIFY(queue->confirmed_lsn ==
+	       vclock_get(&queue->confirmed_vclock, queue->owner_id));
+	VERIFY(queue->volatile_confirmed_lsn >= queue->confirmed_lsn);
+#else
+	(void)limbo;
+#endif
+}
+
 static int64_t
 txn_limbo_replica_confirmed_lsn(const struct txn_limbo *limbo,
 				uint32_t replica_id)
@@ -1066,8 +1085,10 @@ txn_limbo_process(struct txn_limbo *limbo, const struct synchro_request *req)
 void
 txn_limbo_on_parameters_change(struct txn_limbo *limbo)
 {
+	txn_limbo_assert_consistent(limbo);
 	/* The replication_synchro_quorum value may have changed. */
 	txn_limbo_queue_bump_volatile_confirm(&limbo->queue);
+	txn_limbo_assert_consistent(limbo);
 	fiber_wakeup(limbo->worker);
 	/*
 	 * Wakeup all the others - timed out will rollback. Also

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -885,33 +885,31 @@ txn_limbo_filter_request(struct txn_limbo *limbo,
 }
 
 /**
- * Update the state of synchronous replication for system spaces.
+ * Update the state of synchronous replication for system spaces to match the
+ * limbo state: they are synchronous while the queue has an owner.
+ *
+ * The request, when not NULL, is an in-progress PROMOTE/DEMOTE whose outcome
+ * is applied optimistically, before its WAL write: a PROMOTE is about to
+ * claim the ownership, a DEMOTE is about to drop it. A WAL failure restores
+ * the actual state via the rollback.
  */
 static void
 txn_limbo_update_system_spaces_is_sync_state(struct txn_limbo *limbo,
-					     const struct synchro_request *req,
-					     bool is_rollback)
+					     const struct synchro_request *req)
 {
 	txn_limbo_assert_locked(limbo);
-	/* Do not enable synchronous replication during bootstrap. */
-	if (req->origin_id == REPLICA_ID_NIL)
-		return;
-	uint16_t req_type = req->type;
-	assert(req_type == IPROTO_RAFT_PROMOTE ||
-	       req_type == IPROTO_RAFT_DEMOTE);
-	bool is_promote = req_type == IPROTO_RAFT_PROMOTE;
-	/* Synchronous replication is already enabled. */
-	if (is_promote && limbo->queue.owner_id != REPLICA_ID_NIL)
-		return;
-	/* Synchronous replication is already disabled. */
-	if (!is_promote && limbo->queue.owner_id == REPLICA_ID_NIL) {
-		assert(!is_rollback);
-		return;
+	bool is_sync;
+	if (req != NULL) {
+		assert(req->type == IPROTO_RAFT_PROMOTE ||
+		       req->type == IPROTO_RAFT_DEMOTE);
+		/* Bootstrap entries do not enable synchronous replication. */
+		if (req->origin_id == REPLICA_ID_NIL)
+			return;
+		is_sync = req->type == IPROTO_RAFT_PROMOTE;
+	} else {
+		is_sync = limbo->queue.owner_id != REPLICA_ID_NIL;
 	}
-	/* Flip operation types for a rollback. */
-	if (is_rollback)
-		is_promote = !is_promote;
-	system_spaces_update_is_sync_state(is_promote);
+	system_spaces_update_is_sync_state(is_sync);
 }
 
 int
@@ -937,8 +935,7 @@ txn_limbo_req_prepare(struct txn_limbo *limbo,
 		 * it would be written after it.
 		 */
 		txn_limbo_fence(limbo);
-		txn_limbo_update_system_spaces_is_sync_state(
-			limbo, req, /*is_rollback=*/false);
+		txn_limbo_update_system_spaces_is_sync_state(limbo, req);
 		txn_limbo_update_state(limbo);
 		break;
 	}
@@ -960,8 +957,7 @@ txn_limbo_req_rollback(struct txn_limbo *limbo,
 	case IPROTO_RAFT_DEMOTE: {
 		assert(limbo->is_transition_in_progress);
 		limbo->is_transition_in_progress = false;
-		txn_limbo_update_system_spaces_is_sync_state(
-			limbo, req, /*is_rollback=*/true);
+		txn_limbo_update_system_spaces_is_sync_state(limbo, NULL);
 		txn_limbo_unfence(limbo);
 		txn_limbo_update_state(limbo);
 		break;

--- a/src/box/txn_limbo.c
+++ b/src/box/txn_limbo.c
@@ -124,6 +124,21 @@ synchro_request_write_or_panic(const struct synchro_request *req)
 	      synchro_request_str(req));
 }
 
+/**
+ * Prepare a request which is never supposed to fail its preparation. These are
+ * supposed to be locally made requests originating from limbo's own state.
+ */
+static void
+txn_limbo_req_prepare_or_panic(struct txn_limbo *limbo,
+			       const struct synchro_request *req)
+{
+	if (txn_limbo_req_prepare(limbo, req) == 0)
+		return;
+	diag_log();
+	panic("Could not prepare a synchro request: %s",
+	      synchro_request_str(req));
+}
+
 static void
 txn_limbo_assert_locked(struct txn_limbo *limbo)
 {
@@ -206,46 +221,6 @@ txn_limbo_unfence(struct txn_limbo *limbo)
 		fiber_wakeup(limbo->worker);
 }
 
-/**
- * Write a confirmation entry to the WAL. After it's written all the
- * transactions waiting for confirmation may be finished.
- */
-static int
-txn_limbo_write_confirm(struct txn_limbo *limbo, int64_t lsn)
-{
-	txn_limbo_assert_locked(limbo);
-	assert(lsn > limbo->queue.confirmed_lsn);
-	assert(!limbo->queue.is_fenced);
-	struct synchro_request req = {
-		.type = IPROTO_RAFT_CONFIRM,
-		.queue_owner_id = limbo->queue.owner_id,
-		.confirm = {
-			.lsn = lsn
-		},
-	};
-	return synchro_request_write(&req);
-}
-
-/**
- * Write a rollback message to WAL. After it's written all the transactions
- * following the current one and waiting for confirmation must be rolled back.
- */
-static void
-txn_limbo_write_rollback(struct txn_limbo *limbo, int64_t lsn)
-{
-	txn_limbo_assert_locked(limbo);
-	assert(lsn > limbo->queue.confirmed_lsn);
-	assert(limbo->queue.is_fenced);
-	struct synchro_request req = {
-		.type = IPROTO_RAFT_ROLLBACK,
-		.queue_owner_id = limbo->queue.owner_id,
-		.rollback = {
-			.lsn = lsn
-		},
-	};
-	synchro_request_write_or_panic(&req);
-}
-
 static int
 txn_limbo_worker_bump_confirmed_lsn(struct txn_limbo *limbo)
 {
@@ -257,13 +232,22 @@ txn_limbo_worker_bump_confirmed_lsn(struct txn_limbo *limbo)
 		if (queue->is_fenced)
 			return -1;
 		/* It can get bumped again while we are writing. */
-		int64_t lsn = queue->volatile_confirmed_lsn;
-		if (txn_limbo_write_confirm(limbo, lsn) != 0) {
+		struct synchro_request req = {
+			.type = IPROTO_RAFT_CONFIRM,
+			.origin_id = instance_id,
+			.queue_owner_id = queue->owner_id,
+			.confirm = {
+				.lsn = queue->volatile_confirmed_lsn,
+			},
+		};
+		txn_limbo_req_prepare_or_panic(limbo, &req);
+		if (synchro_request_write(&req) != 0) {
 			diag_log();
+			txn_limbo_req_rollback(limbo, &req);
 			return -1;
 		}
 		ERROR_INJECT_YIELD(ERRINJ_TXN_LIMBO_WORKER_DELAY);
-		txn_limbo_queue_apply_confirm(queue, lsn);
+		txn_limbo_req_commit(limbo, &req);
 	}
 	assert(queue->volatile_confirmed_lsn >= queue->confirmed_lsn);
 	return 0;
@@ -548,9 +532,17 @@ txn_limbo_wait_complete(struct txn_limbo *limbo, struct txn_limbo_entry *entry)
 		return TXN_LIMBO_WAIT_ENTRY_SUCCESS;
 	}
 	txn_limbo_fence(limbo);
-	txn_limbo_write_rollback(limbo, entry->lsn);
-	txn_limbo_queue_apply_rollback(&limbo->queue, entry->lsn,
-				       TXN_SIGNATURE_QUORUM_TIMEOUT);
+	struct synchro_request req = {
+		.type = IPROTO_RAFT_ROLLBACK,
+		.origin_id = instance_id,
+		.queue_owner_id = limbo->queue.owner_id,
+		.rollback = {
+			.lsn = entry->lsn,
+		},
+	};
+	txn_limbo_req_prepare_or_panic(limbo, &req);
+	synchro_request_write_or_panic(&req);
+	txn_limbo_req_commit(limbo, &req);
 	assert(txn_limbo_entry_is_complete(entry));
 	assert(entry->state == TXN_LIMBO_ENTRY_ROLLBACK);
 	txn_limbo_unfence(limbo);
@@ -958,10 +950,6 @@ txn_limbo_req_prepare(struct txn_limbo *limbo,
 		txn_limbo_update_state(limbo);
 		break;
 	}
-	/*
-	 * XXX: ideally all requests should go through req_* methods. To unify
-	 * their work from applier and locally.
-	 */
 	}
 	return 0;
 }
@@ -981,10 +969,6 @@ txn_limbo_req_rollback(struct txn_limbo *limbo,
 		txn_limbo_update_state(limbo);
 		break;
 	}
-	/*
-	 * XXX: ideally all requests should go through req_* methods. To unify
-	 * their work from applier and locally.
-	 */
 	default: {
 		break;
 	}
@@ -1016,8 +1000,14 @@ txn_limbo_req_commit_rollback(struct txn_limbo *limbo, const struct synchro_requ
 	 */
 	if (req->queue_owner_id != limbo->queue.owner_id)
 		return;
+	/*
+	 * A locally created rollback is a quorum timeout. A received one means
+	 * the same has happened on the queue owner.
+	 */
+	int64_t signature = req->origin_id == instance_id ?
+		TXN_SIGNATURE_QUORUM_TIMEOUT : TXN_SIGNATURE_SYNC_ROLLBACK;
 	txn_limbo_queue_apply_rollback(&limbo->queue, req->rollback.lsn,
-				       TXN_SIGNATURE_SYNC_ROLLBACK);
+				       signature);
 }
 
 /** Commit IPROTO_RAFT_PROMOTE/DEMOTE request. */

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -81,6 +81,11 @@ enum txn_limbo_state {
 struct txn_limbo {
 	/** Limbo state. */
 	enum txn_limbo_state state;
+	/**
+	 * Triggers run on every event which might update the limbo state. Even
+	 * when the state didn't actually change.
+	 */
+	struct rlist on_state_update;
 	/** Synchronous transactions and other ones depending on them. */
 	struct txn_limbo_queue queue;
 	/**

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -111,23 +111,6 @@ struct txn_limbo {
 	/** To linearize any sort of state changes. */
 	struct latch state_latch;
 	/**
-	 * Whether the limbo is in rollback mode. The meaning is exactly the
-	 * same as for the similar WAL flag. In theory this should be deleted
-	 * if the limbo will be ever moved to WAL thread. It would reuse the WAL
-	 * flag.
-	 * It is a sign to immediately rollback all new limbo entries, if there
-	 * is an existing rollback in progress. This technique is called
-	 * 'cascading rollback'. Cascading rollback does not allow to write to
-	 * WAL anything new so as not to violate the 'reversed rollback order'
-	 * rule.
-	 * Without cascading rollback it could happen, that the limbo would
-	 * start writing ROLLBACK to WAL, then a new transaction would be added
-	 * to limbo and sent to WAL too. In the result the new transaction would
-	 * be stored in WAL after ROLLBACK, and yet it should be rolled back too
-	 * by the 'reversed rollback order' rule - contradiction.
-	 */
-	bool is_in_rollback;
-	/**
 	 * If there is an ongoing PROMOTE being applied. It is not immediate at
 	 * least because it needs to be written into the journal.
 	 */

--- a/src/box/txn_limbo.h
+++ b/src/box/txn_limbo.h
@@ -145,11 +145,6 @@ struct txn_limbo {
 	 */
 	bool saw_promote;
 	/**
-	 * Savepoint of confirmed LSN. To rollback to in case the current
-	 * synchro command (promote/demote/...) fails.
-	 */
-	int64_t svp_confirmed_lsn;
-	/**
 	 * Whether this instance validates incoming synchro requests. When the
 	 * setting is on, the instance only allows CONFIRM/ROLLBACK from the
 	 * limbo owner, tracks PROMOTE/DEMOTE term and owner_id consistency.

--- a/src/box/txn_limbo_queue.c
+++ b/src/box/txn_limbo_queue.c
@@ -609,6 +609,27 @@ txn_limbo_queue_get_lsn_range(struct txn_limbo_queue *queue, int64_t *first_lsn,
 	*last_lsn = last->lsn;
 }
 
+/**
+ * Bump the confirmed LSN of the queue to the given one, if it is bigger. The
+ * volatile confirmed LSN is bumped along when it gets behind. That can happen
+ * when the CONFIRM was made with a smaller quorum than known locally - then
+ * the volatile LSN is collecting acks by a bigger quorum. Or when the acks
+ * simply didn't arrive yet - they always reach the queue owner first, and the
+ * other nodes see them later, sometimes never, like the leaf replicas having
+ * no subscribers of their own. The volatile LSN must be bumped forward to
+ * keep it being the present or the future of the confirmed LSN.
+ */
+static void
+txn_limbo_queue_bump_confirmed_lsn(struct txn_limbo_queue *queue, int64_t lsn)
+{
+	if (queue->confirmed_lsn >= lsn)
+		return;
+	queue->confirmed_lsn = lsn;
+	vclock_follow(&queue->confirmed_vclock, queue->owner_id, lsn);
+	if (queue->volatile_confirmed_lsn < lsn)
+		queue->volatile_confirmed_lsn = lsn;
+}
+
 void
 txn_limbo_queue_apply_confirm(struct txn_limbo_queue *queue, int64_t lsn)
 {
@@ -644,13 +665,10 @@ txn_limbo_queue_apply_confirm(struct txn_limbo_queue *queue, int64_t lsn)
 				 * matching this txn exactly. Making an illusion
 				 * like each txn has its own confirmation.
 				 */
-				if (queue->confirmed_lsn < e->lsn) {
-					queue->confirmed_lsn = e->lsn;
-					vclock_follow(&queue->confirmed_vclock,
-						      queue->owner_id, e->lsn);
-				} else {
-					assert(queue->confirmed_lsn == lsn);
-				}
+				assert(queue->confirmed_lsn < e->lsn ||
+				       queue->confirmed_lsn == lsn);
+				txn_limbo_queue_bump_confirmed_lsn(queue,
+								   e->lsn);
 			}
 		} else if (e->txn->signature == TXN_SIGNATURE_UNKNOWN) {
 			/*
@@ -695,21 +713,7 @@ txn_limbo_queue_apply_confirm(struct txn_limbo_queue *queue, int64_t lsn)
 		}
 		txn_limbo_queue_complete_success(queue, e);
 	}
-	if (queue->confirmed_lsn < lsn) {
-		queue->confirmed_lsn = lsn;
-		vclock_follow(&queue->confirmed_vclock, queue->owner_id, lsn);
-	}
-	if (queue->confirmed_lsn > queue->volatile_confirmed_lsn) {
-		/*
-		 * This can happen when CONFIRM was made with a smaller quorum
-		 * than known right now. Then the volatile LSN is collecting
-		 * acks by a bigger quorum and can actually be smaller. Bump it
-		 * forward when this happens to keep the invariant of the
-		 * volatile LSN being the present or the future of the confirmed
-		 * LSN.
-		 */
-		queue->volatile_confirmed_lsn = queue->confirmed_lsn;
-	}
+	txn_limbo_queue_bump_confirmed_lsn(queue, lsn);
 	if (queue_was_full && !txn_limbo_queue_is_full(queue))
 		fiber_cond_broadcast(&queue->cond);
 }

--- a/src/box/txn_limbo_queue.c
+++ b/src/box/txn_limbo_queue.c
@@ -788,6 +788,16 @@ txn_limbo_queue_ack(struct txn_limbo_queue *queue, uint32_t replica_id,
 bool
 txn_limbo_queue_bump_volatile_confirm(struct txn_limbo_queue *queue)
 {
+	if (queue->is_fenced) {
+		/*
+		 * Bumping the volatile LSN during fencing can mistakenly bump
+		 * it to an LSN which is actually rolled back, while the
+		 * rollback isn't finished yet (is being written to WAL, for
+		 * example). This might lead to the same LSN being confirmed and
+		 * rolled back at the same time.
+		 */
+		return false;
+	}
 	if (queue->entry_to_confirm == NULL ||
 	    queue->entry_to_confirm->lsn == -1)
 		return false;
@@ -837,11 +847,12 @@ txn_limbo_queue_fence(struct txn_limbo_queue *queue)
 	queue->is_fenced = true;
 }
 
-void
+bool
 txn_limbo_queue_unfence(struct txn_limbo_queue *queue)
 {
 	assert(queue->is_fenced);
 	queue->is_fenced = false;
+	return txn_limbo_queue_bump_volatile_confirm(queue);
 }
 
 int

--- a/src/box/txn_limbo_queue.c
+++ b/src/box/txn_limbo_queue.c
@@ -250,6 +250,18 @@ txn_limbo_queue_submit(struct txn_limbo_queue *queue, uint32_t origin_id,
 	 */
 	assert(txn->signature == TXN_SIGNATURE_UNKNOWN);
 	assert(txn->status == TXN_PREPARED);
+	if (queue->is_fenced) {
+		/*
+		 * Cascading rollback. It is impossible to commit the
+		 * transaction, because if there is an existing rollback in
+		 * progress, it should rollback this one too for the sake of
+		 * 'reversed rollback order' rule. On the other hand the
+		 * rollback can't be postponed until after WAL write as well -
+		 * it should be done right now. See in the queue comments why.
+		 */
+		diag_set(ClientError, ER_SYNC_ROLLBACK);
+		return -1;
+	}
 	if (queue->owner_id == REPLICA_ID_NIL) {
 		diag_set(ClientError, ER_SYNC_QUEUE_UNCLAIMED);
 		return -1;
@@ -721,6 +733,8 @@ void
 txn_limbo_queue_transfer_ownership(struct txn_limbo_queue *queue,
 				   uint32_t new_owner_id, int64_t border_lsn)
 {
+	/* New transactions can't be coming during the ownership switch. */
+	assert(queue->is_fenced);
 	txn_limbo_queue_apply_confirm(queue, border_lsn);
 	txn_limbo_queue_apply_rollback(queue, border_lsn + 1,
 				       TXN_SIGNATURE_SYNC_ROLLBACK);
@@ -814,6 +828,20 @@ txn_limbo_queue_bump_volatile_confirm(struct txn_limbo_queue *queue)
 	assert(max_assigned_lsn >= queue->volatile_confirmed_lsn);
 	queue->volatile_confirmed_lsn = max_assigned_lsn;
 	return true;
+}
+
+void
+txn_limbo_queue_fence(struct txn_limbo_queue *queue)
+{
+	assert(!queue->is_fenced);
+	queue->is_fenced = true;
+}
+
+void
+txn_limbo_queue_unfence(struct txn_limbo_queue *queue)
+{
+	assert(queue->is_fenced);
+	queue->is_fenced = false;
 }
 
 int

--- a/src/box/txn_limbo_queue.c
+++ b/src/box/txn_limbo_queue.c
@@ -318,6 +318,22 @@ txn_limbo_queue_submit(struct txn_limbo_queue *queue, uint32_t origin_id,
 		/* Could be a spurious wakeup. */
 		if (txn_limbo_queue_is_full(queue))
 			continue;
+		/*
+		 * While the fence is up, transactions can't proceed to WAL.
+		 * The fencing ending might result in these txns being rolled
+		 * back, and that would be too late if they were already
+		 * written into WAL.
+		 *
+		 * Note that fencing doesn't necessarily mean the transaction
+		 * will be rolled back. For example, the fence might be raised
+		 * for the time of a PROMOTE WAL write, which then might fail,
+		 * and the fence would be lifted without rolling anything back.
+		 *
+		 * This is why the transaction needs to continue waiting. Can't
+		 * act until the situation is clear.
+		 */
+		if (queue->is_fenced)
+			continue;
 		if (txn_limbo_queue_first_entry(queue) == e)
 			break;
 		struct txn_limbo_entry *prev = rlist_prev_entry(e, in_queue);
@@ -852,6 +868,12 @@ txn_limbo_queue_unfence(struct txn_limbo_queue *queue)
 {
 	assert(queue->is_fenced);
 	queue->is_fenced = false;
+	/*
+	 * The parked transactions, if any survived the synchro request, need to
+	 * re-evaluate their situation. Nothing else might wake them up if the
+	 * request didn't touch them.
+	 */
+	fiber_cond_broadcast(&queue->cond);
 	return txn_limbo_queue_bump_volatile_confirm(queue);
 }
 

--- a/src/box/txn_limbo_queue.h
+++ b/src/box/txn_limbo_queue.h
@@ -276,8 +276,11 @@ txn_limbo_queue_bump_volatile_confirm(struct txn_limbo_queue *queue);
 void
 txn_limbo_queue_fence(struct txn_limbo_queue *queue);
 
-/** Lift the fence. */
-void
+/**
+ * Lift the fence and check if there is any work unblocked for processing, like
+ * a volatile confirmed LSN bump.
+ */
+bool
 txn_limbo_queue_unfence(struct txn_limbo_queue *queue);
 
 /**

--- a/src/box/txn_limbo_queue.h
+++ b/src/box/txn_limbo_queue.h
@@ -155,6 +155,11 @@ struct txn_limbo_queue {
 	 */
 	int ack_count;
 	/**
+	 * Whether the queue is fenced off from new confirmations and
+	 * transactions.
+	 */
+	bool is_fenced;
+	/**
 	 * The time that the latest successfully confirmed entry waited for
 	 * quorum.
 	 */
@@ -266,6 +271,14 @@ txn_limbo_queue_ack(struct txn_limbo_queue *queue, uint32_t replica_id,
 /** Try to bump the volatile confirmed LSN. */
 bool
 txn_limbo_queue_bump_volatile_confirm(struct txn_limbo_queue *queue);
+
+/** Fence the queue off from new confirmations and transactions. */
+void
+txn_limbo_queue_fence(struct txn_limbo_queue *queue);
+
+/** Lift the fence. */
+void
+txn_limbo_queue_unfence(struct txn_limbo_queue *queue);
 
 /**
  * Wait until the last transaction in the queue is finished and get its result.

--- a/test/replication-luatest/gh_10040_promote_wait_limbo_test.lua
+++ b/test/replication-luatest/gh_10040_promote_wait_limbo_test.lua
@@ -75,11 +75,15 @@ g.test_promote_waits_for_quorum = function(cg)
 end
 
 g.test_promote_aborts_wait_when_not_leader = function(cg)
+    t.tarantool.skip_if_not_debug()
     cg.master:exec(function()
         local fiber = require('fiber')
         box.ctl.demote()
         t.assert_equals(box.info.election.leader, 0)
-        box.cfg{read_only = true}
+        --
+        -- Block the next WAL write batch.
+        --
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
         local is_promote_finished = false
         local f = fiber.new(function()
             local ok, err = pcall(box.ctl.promote)
@@ -87,25 +91,80 @@ g.test_promote_aborts_wait_when_not_leader = function(cg)
             return {ok, err}
         end)
         f:set_joinable(true)
+        --
+        -- Step the WAL writes one by one until the PROMOTE request gets
+        -- stuck in its own WAL write. The steps before it are the Raft term
+        -- and vote persistence of the elections.
+        --
         t.helpers.retrying({timeout = 60}, function()
-            local info = box.info
-            t.assert_equals(info.election.leader, info.id)
-            t.assert_equals(info.election.term, info.synchro.queue.term)
-            t.assert_equals(info.synchro.queue.owner, info.id)
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
         end)
-        t.assert(box.info.ro)
+        while not box.info.synchro.queue.busy do
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+            t.helpers.retrying({timeout = 60}, function()
+                t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+            end)
+        end
+        --
+        -- The elections are won, but the limbo can't get claimed - the
+        -- PROMOTE is not going anywhere.
+        --
+        t.assert_equals(box.info.election.state, 'leader')
         t.assert_not(is_promote_finished)
-        box.ctl.demote()
-        local ok, err = f:join(60)
+        --
+        -- Losing the leadership aborts the wait. Can't use
+        -- box.ctl.demote() for that - it would be rejected as an interfering
+        -- promotion while the PROMOTE is in progress. The mode switch makes
+        -- the leader resign without any WAL writes.
+        --
+        box.cfg{election_mode = 'voter'}
+        local ok, res = f:join(60)
         t.assert(ok)
-        ok, err = unpack(err)
-        t.assert(err)
-        t.assert_not(ok)
+        local promote_ok, promote_err = unpack(res)
+        t.assert_not(promote_ok)
+        t.assert_equals(promote_err.code, box.error.INTERFERING_ELECTIONS)
+        --
+        -- Cleanup.
+        --
+        box.cfg{election_mode = 'manual'}
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_not(box.info.synchro.queue.busy)
+        end)
+        box.ctl.promote()
+        local info = box.info
+        t.assert_equals(info.election.leader, info.id)
+        t.assert_equals(info.synchro.queue.owner, info.id)
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+end
+
+g.test_promote_succeeds_when_read_only = function(cg)
+    cg.master:exec(function()
+        box.ctl.demote()
+        t.assert_equals(box.info.election.leader, 0)
+        --
+        -- The limbo claim doesn't depend on the instance's writability. An
+        -- explicitly read-only instance can still win the elections and
+        -- claim the queue.
+        --
+        box.cfg{read_only = true}
+        local ok, err = pcall(box.ctl.promote)
+        t.assert_equals(err, nil)
+        t.assert(ok)
+        local info = box.info
+        t.assert(info.ro)
+        t.assert_equals(info.election.leader, info.id)
+        t.assert_equals(info.election.term, info.synchro.queue.term)
+        t.assert_equals(info.synchro.queue.owner, info.id)
         --
         -- Cleanup.
         --
         box.cfg{read_only = false}
-        box.ctl.promote()
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_not(box.info.ro)
+        end)
     end)
     cg.replica:wait_for_vclock_of(cg.master)
 end

--- a/test/replication-luatest/gh_12972_election_bootstrap_leader_claims_limbo_test.lua
+++ b/test/replication-luatest/gh_12972_election_bootstrap_leader_claims_limbo_test.lua
@@ -1,0 +1,95 @@
+local server = require('luatest.server')
+local t = require('luatest')
+local g = t.group()
+
+--
+-- gh-12972: when the bootstrap leader was elected during box.cfg(), the cfg
+-- returned right after the Raft elections, without waiting for the synchro
+-- queue claim. The caller of box.cfg() could observe the instance being an
+-- election leader with the queue still unclaimed and the instance read-only,
+-- regardless of the box.cfg.read_only setting.
+--
+-- It is actually expected that the limbo is claimed by the bootstrap leader.
+-- The leader needs that, at least to grant privileges, create spaces, etc. It
+-- was eventually promoted, but there is no sense in having a read-only time
+-- gap after box.cfg().
+--
+local function before_box_cfg()
+    local fiber = require('fiber')
+    box.error.injection.set('ERRINJ_TXN_LIMBO_BEGIN_DELAY_COUNTDOWN', 0)
+    local watcher = fiber.new(function()
+        -- Wait until the instance wins Raft elections, but block its attempt to
+        -- claim the limbo.
+        while true do
+            while not box.error.injection.get(
+                    'ERRINJ_TXN_LIMBO_BEGIN_DELAY') do
+                fiber.sleep(0.001)
+            end
+            local ok, info = pcall(function()
+                return box.info.election
+            end)
+            if ok and info.state == 'leader' then
+                break
+            end
+            box.error.injection.set('ERRINJ_TXN_LIMBO_BEGIN_DELAY_COUNTDOWN', 0)
+            box.error.injection.set('ERRINJ_TXN_LIMBO_BEGIN_DELAY', false)
+        end
+        -- Give it time to return from box.cfg{} in the potential
+        -- limbo-unclaimed bad state.
+        --
+        -- A hardcoded 'best effort' timeout is the only way to test this here.
+        --
+        -- In the broken code box.cfg{} would indeed return regardless of this
+        -- fiber, since it wouldn't wait for the limbo claim.
+        --
+        -- In the fixed code box.cfg{} simply won't return until the injection
+        -- is removed. And its immediate removal would make the broken code also
+        -- pass.
+        --
+        -- This timeout is big enough so that the broken code has time to leave
+        -- box.cfg() too early, and is small enough not to block box.cfg() for
+        -- too long when the bug is fixed.
+        --
+        fiber.sleep(0.1)
+        box.error.injection.set('ERRINJ_TXN_LIMBO_BEGIN_DELAY', false)
+    end)
+    watcher:set_joinable(true)
+    local orig_cfg = box.cfg
+    box.cfg = function(cfg)
+        local res = orig_cfg(cfg)
+        rawset(_G, 'at_cfg_return', {
+            election_state = box.info.election.state,
+            queue_owner = box.info.synchro.queue.owner,
+        })
+        watcher:join()
+        return res
+    end
+end
+
+g.before_all(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.master = server:new{
+        alias = 'master',
+        box_cfg = {
+            election_mode = 'candidate',
+        },
+        env = {
+            TARANTOOL_RUN_BEFORE_BOX_CFG =
+                ('loadstring(%q)()'):format(string.dump(before_box_cfg)),
+        },
+    }
+    cg.master:start()
+end)
+
+g.after_all(function(cg)
+    cg.master:drop()
+end)
+
+g.test_case = function(cg)
+    cg.master:exec(function()
+        local state = rawget(_G, 'at_cfg_return')
+        t.assert_not_equals(state, nil)
+        t.assert_equals(state.election_state, 'leader')
+        t.assert_equals(state.queue_owner, box.info.id)
+    end)
+end

--- a/test/replication-luatest/gh_13066_params_change_during_synchro_write_test.lua
+++ b/test/replication-luatest/gh_13066_params_change_during_synchro_write_test.lua
@@ -1,0 +1,187 @@
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+--
+-- gh-13066: there was the following bug.
+--
+-- A limbo request (PROMOTE/DEMOTE) is prepared under the limbo latch, and the
+-- latch is held across its WAL write, which yields.
+--
+-- The PROMOTE/DEMOTE was speculatively bumping the volatile confirmed LSN
+-- during prepare. This temporarily violated the invariant, that the volatile
+-- confirmed lsn is always less than the LSN of the next entry to confirm.
+--
+-- It was assumed the violation wasn't observable, but it actually was. ACK
+-- processing code works with the volatile confirmed LSN without a latch, and it
+-- does actually check this invariant.
+--
+-- This led to a crash and was fixed earlier. But the state could still be in
+-- theory observed from the code handling `box.cfg` parameters change affecting
+-- the limbo. That path wasn't covered with tests, and the test below fixes
+-- that.
+--
+g.before_each(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri('master', cg.replica_set.id),
+            server.build_listen_uri('victim', cg.replica_set.id),
+            server.build_listen_uri('laggard', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+        replication_synchro_timeout = 60,
+        election_mode = 'off',
+    }
+    -- Master - owns the limbo and writes the synchronous transactions.
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = box_cfg,
+    }
+    -- Victim - applies master txns and later applies the DEMOTE - it is the
+    -- node which gets the parameters change in the middle of the DEMOTE WAL
+    -- write.
+    cg.victim = cg.replica_set:build_and_add_server{
+        alias = 'victim',
+        box_cfg = box_cfg,
+    }
+    -- Laggard - ACKs the first transaction and gets stuck, so that the ACKs
+    -- collected by the victim stay behind the DEMOTE's confirm boundary.
+    cg.laggard = cg.replica_set:build_and_add_server{
+        alias = 'laggard',
+        box_cfg = box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.master:exec(function()
+        rawset(_G, 'fiber', require('fiber'))
+        box.ctl.promote()
+        box.schema.space.create('s', {is_sync = true}):create_index('p')
+    end)
+    cg.victim:wait_for_vclock_of(cg.master)
+    cg.laggard:wait_for_vclock_of(cg.master)
+    cg.master_id = cg.master:exec(function() return box.info.id end)
+    cg.laggard_id = cg.laggard:exec(function() return box.info.id end)
+end)
+
+g.after_each(function(cg)
+    for _, instance in pairs({cg.master, cg.victim, cg.laggard}) do
+        pcall(instance.exec, instance, function()
+            box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', false)
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', -1)
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        end)
+    end
+    cg.replica_set:drop()
+end)
+
+--
+-- Write one synchronous transaction and return its LSN. Assuming it is not
+-- confirmed, because the server's limbo worker is frozen.
+--
+local function make_txn(server_, value)
+    return server_:exec(function(value)
+        local lsn = box.info.lsn
+        local f = _G.fiber.create(function() box.space.s:replace{value} end)
+        f:set_joinable(true)
+        local fibers = rawget(_G, 'fibers') or {}
+        table.insert(fibers, f)
+        rawset(_G, 'fibers', fibers)
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_gt(box.info.lsn, lsn)
+        end)
+        return box.info.lsn
+    end, {value})
+end
+
+g.test_params_change_during_synchro_request_write = function(cg)
+    cg.master:exec(function()
+        -- No CONFIRM must ever be written: the transactions have to stay in the
+        -- limbo of all the nodes until the DEMOTE.
+        box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', true)
+        -- The master must be able to write the DEMOTE without waiting for
+        -- anybody - the laggard is stuck by then.
+        box.cfg{replication_synchro_quorum = 1}
+    end)
+    cg.victim:exec(function()
+        --
+        -- The victim can collect at most 3 ACKs: its own, the master's, and
+        -- the laggard's. The quorum is unreachable until the parameters change
+        -- lowers it.
+        --
+        box.cfg{replication_synchro_quorum = 4}
+    end)
+
+    -- Transaction 1 - everybody has it, and the victim knows the laggard's
+    -- ACK for it.
+    local lsn1 = make_txn(cg.master, 1)
+    cg.laggard:wait_for_vclock_of(cg.master)
+    cg.victim:exec(function(laggard_id, master_id, lsn1)
+        t.helpers.retrying({timeout = 60}, function()
+            local down = box.info.replication[laggard_id].downstream
+            t.assert_not_equals(down, nil)
+            t.assert_equals(down.vclock[master_id], lsn1)
+        end)
+    end, {cg.laggard_id, cg.master_id, lsn1})
+
+    -- Transaction 2 - the laggard never gets it, so the ACKs known to the
+    -- victim keep covering only transaction 1.
+    cg.laggard:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+    end)
+    make_txn(cg.master, 2)
+    cg.victim:wait_for_vclock_of(cg.master)
+
+    -- The DEMOTE confirms both transactions, i.e. its confirm boundary is
+    -- ahead of what the ACKs known to the victim cover.
+    cg.victim:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+    end)
+    cg.master:exec(function() box.ctl.demote() end)
+
+    cg.victim:exec(function()
+        --
+        -- Let the WAL writes through one by one until the one made under the
+        -- limbo latch is reached - that is the DEMOTE.
+        --
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+            if box.info.synchro.queue.busy then
+                return
+            end
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+            t.fail('Not the synchro request write yet')
+        end)
+        --
+        -- The parameters change lands right in the middle of the DEMOTE WAL
+        -- write. The bump it makes can only be based on the collected ACKs -
+        -- the boundary is the laggard's ACK, behind the DEMOTE's one.
+        --
+        box.cfg{replication_synchro_quorum = 3}
+        -- Release the DEMOTE.
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', -1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end)
+
+    -- The victim must survive and apply the DEMOTE as usual.
+    cg.laggard:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end)
+    cg.master:exec(function()
+        box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', false)
+        for _, f in pairs(rawget(_G, 'fibers')) do
+            f:join()
+        end
+    end)
+    cg.victim:exec(function()
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_equals(box.info.synchro.queue.len, 0)
+        end)
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        t.assert_equals(box.space.s:select(), {{1}, {2}})
+    end)
+end

--- a/test/replication-luatest/gh_13066_quorum_ack_during_synchro_write_test.lua
+++ b/test/replication-luatest/gh_13066_quorum_ack_during_synchro_write_test.lua
@@ -1,0 +1,212 @@
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+--
+-- gh-13066: there was the following bug.
+--
+-- A limbo request (PROMOTE/DEMOTE) is prepared under the limbo latch, and the
+-- latch is held across its WAL write, which yields.
+--
+-- The PROMOTE/DEMOTE was speculatively bumping the volatile confirmed LSN
+-- during prepare. This temporarily violated the invariant, that the volatile
+-- confirmed lsn is always less than the LSN of the next entry to confirm.
+--
+-- It was assumed the violation wasn't observable, but it actually was. ACK
+-- processing code works with the volatile confirmed LSN without a latch, and it
+-- does actually check this invariant.
+--
+-- This led to an assertion failure on ACK:
+--     assert(max_assigned_lsn >= queue->volatile_confirmed_lsn)
+--
+-- The fix was to simply stop violating the invariant and bump the LSNs when
+-- PROMOTE/DEMOTE get committed, not when prepared.
+--
+g.before_each(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri('master', cg.replica_set.id),
+            server.build_listen_uri('victim', cg.replica_set.id),
+            server.build_listen_uri('laggard', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+        replication_synchro_timeout = 120,
+        election_mode = 'off',
+    }
+    -- Master - owns the limbo and writes the synchronous transactions.
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = box_cfg,
+    }
+    -- Victim - applies master txns and later applies the DEMOTE - it is the
+    -- node whose queue must survive the late ACK.
+    cg.victim = cg.replica_set:build_and_add_server{
+        alias = 'victim',
+        box_cfg = box_cfg,
+    }
+    -- Laggard - is stuck from the very beginning, so that the victim stays one
+    -- ACK short of the quorum. Its single ACK is released right into the middle
+    -- of the victim's DEMOTE WAL write.
+    cg.laggard = cg.replica_set:build_and_add_server{
+        alias = 'laggard',
+        box_cfg = box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.master:exec(function()
+        rawset(_G, 'fiber', require('fiber'))
+        box.ctl.promote()
+        box.schema.space.create('s', {is_sync = true}):create_index('p')
+    end)
+    cg.victim:wait_for_vclock_of(cg.master)
+    cg.laggard:wait_for_vclock_of(cg.master)
+    cg.master_id = cg.master:exec(function() return box.info.id end)
+    cg.laggard_id = cg.laggard:exec(function() return box.info.id end)
+end)
+
+g.after_each(function(cg)
+    --
+    -- The injections must be dropped explicitly. A frozen limbo worker doesn't
+    -- react to the fiber cancellation, so an instance left with the injection
+    -- on would hang on shutdown. Servers which died in the middle of the test
+    -- are simply not reachable - hence pcall().
+    --
+    for _, instance in pairs({cg.master, cg.victim, cg.laggard}) do
+        pcall(instance.exec, instance, function()
+            box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', false)
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', -1)
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        end)
+    end
+    cg.replica_set:drop()
+end)
+
+--
+-- Write one synchronous transaction and return its LSN. Assuming it is not
+-- confirmed, because the server's limbo worker is frozen.
+--
+local function make_txn(server_, value)
+    return server_:exec(function(value)
+        local lsn = box.info.lsn
+        local f = _G.fiber.create(function() box.space.s:replace{value} end)
+        f:set_joinable(true)
+        local fibers = rawget(_G, 'fibers') or {}
+        table.insert(fibers, f)
+        rawset(_G, 'fibers', fibers)
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_gt(box.info.lsn, lsn)
+        end)
+        return box.info.lsn
+    end, {value})
+end
+
+g.test_quorum_ack_during_synchro_request_write = function(cg)
+    cg.master:exec(function()
+        -- No CONFIRM must ever be written: the transactions have to stay in the
+        -- limbo of all the nodes until the DEMOTE.
+        box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', true)
+        -- The master must be able to write the DEMOTE without waiting for
+        -- anybody - the laggard is stuck the whole time.
+        box.cfg{replication_synchro_quorum = 1}
+    end)
+    cg.victim:exec(function()
+        --
+        -- The victim collects at most 3 ACKs: its own applied LSN, the
+        -- master's, and the laggard's. The laggard is stuck from the start,
+        -- so the quorum stays incomplete until its single ACK is released.
+        --
+        box.cfg{replication_synchro_quorum = 3}
+    end)
+    cg.laggard:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+    end)
+
+    -- Transaction 1 - the victim and the master have it. The laggard receives
+    -- it, but can't write it, so its ACK is missing everywhere.
+    local lsn1 = make_txn(cg.master, 1)
+    cg.victim:wait_for_vclock_of(cg.master)
+
+    -- Transaction 2 - makes the DEMOTE's confirm boundary run ahead of the
+    -- laggard's future ACK.
+    local lsn2 = make_txn(cg.master, 2)
+    cg.victim:wait_for_vclock_of(cg.master)
+    cg.victim:exec(function(laggard_id, master_id, lsn2)
+        local down = box.info.replication[laggard_id].downstream
+        t.assert_not_equals(down, nil)
+        t.assert_not_equals(down.vclock[master_id], lsn2)
+        t.assert_equals(box.info.vclock[master_id], lsn2)
+        t.assert_equals(box.info.synchro.queue.len, 2)
+    end, {cg.laggard_id, cg.master_id, lsn2})
+
+    -- The DEMOTE confirms both transactions, i.e. carries lsn2, which is
+    -- ahead of what the laggard's ACK is going to cover (lsn1).
+    cg.victim:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+    end)
+    cg.master:exec(function() box.ctl.demote() end)
+
+    cg.victim:exec(function()
+        --
+        -- Let the WAL writes through one by one until the one made under the
+        -- limbo latch is reached - that is the DEMOTE.
+        --
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+            if box.info.synchro.queue.busy then
+                return
+            end
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+            t.fail('Not the synchro request write yet')
+        end)
+    end)
+    --
+    -- Here the victim's volatile confirmed LSN is lsn2 while the next entry to
+    -- confirm is still lsn1, and the collected ACKs are one short of the
+    -- quorum.
+    --
+    -- Let exactly one row - txn 1 - through the laggard's WAL. Its ACK
+    -- completes the quorum right in the middle of the victim's DEMOTE WAL
+    -- write, and the confirmation border it brings is lsn1 - behind the
+    -- volatile confirmed LSN.
+    --
+    cg.laggard:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+        end)
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end)
+    cg.victim:exec(function(laggard_id, master_id, lsn1)
+        t.helpers.retrying({timeout = 120}, function()
+            local down = box.info.replication[laggard_id].downstream
+            t.assert_not_equals(down, nil)
+            t.assert_equals(down.vclock[master_id], lsn1)
+        end)
+        -- The ACK is processed, the victim is alive. Release the DEMOTE.
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', -1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end, {cg.laggard_id, cg.master_id, lsn1})
+
+    -- The victim must have survived and applied the DEMOTE as usual.
+    cg.laggard:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end)
+    cg.master:exec(function()
+        box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', false)
+        for _, f in pairs(rawget(_G, 'fibers')) do
+            f:join()
+        end
+    end)
+    cg.victim:exec(function()
+        t.helpers.retrying({timeout = 120}, function()
+            t.assert_equals(box.info.synchro.queue.len, 0)
+        end)
+        t.assert_equals(box.info.synchro.queue.owner, 0)
+        t.assert_equals(box.space.s:select(), {{1}, {2}})
+    end)
+end

--- a/test/replication-luatest/gh_13066_txn_timeout_during_synchro_write_test.lua
+++ b/test/replication-luatest/gh_13066_txn_timeout_during_synchro_write_test.lua
@@ -1,0 +1,154 @@
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+--
+-- gh-13066: there was the following bug, which indirectly has motivated this
+-- test.
+--
+-- A limbo request (PROMOTE/DEMOTE) is prepared under the limbo latch, and the
+-- latch is held across its WAL write, which yields.
+--
+-- The PROMOTE/DEMOTE was speculatively bumping the volatile confirmed LSN
+-- during prepare.
+--
+-- This was used by the synchronous transaction local rollback
+-- (IPROTO_RAFT_ROLLBACK) on timeout. If a fiber sees the synchro transaction
+-- has timed out, but its LSN is < the volatile confirmed LSN, then it wouldn't
+-- write a rollback as it is too late for that.
+--
+-- This speculative bump was removed, and so the rollback-on-timeout code had to
+-- be updated.
+--
+-- The behaviour above was working before the speculation removal, but it wasn't
+-- tested anywhere. So this test is added in scope of the bigger rework to just
+-- cover a related and previously untested path.
+--
+
+g.before_each(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri('master', cg.replica_set.id),
+            server.build_listen_uri('replica', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+        replication_synchro_timeout = 60,
+        election_mode = 'off',
+    }
+    -- Master - owns the limbo, writes the transaction and can't gather the
+    -- quorum for it.
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = box_cfg,
+    }
+    -- Replica - promotes itself with a confirm boundary covering the
+    -- transaction, right when the master's waiter times out.
+    cg.replica = cg.replica_set:build_and_add_server{
+        alias = 'replica',
+        box_cfg = box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.master:exec(function()
+        rawset(_G, 'fiber', require('fiber'))
+        box.ctl.promote()
+        box.schema.space.create('s', {is_sync = true}):create_index('p')
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+    cg.replica_id = cg.replica:exec(function() return box.info.id end)
+end)
+
+g.after_each(function(cg)
+    for _, instance in pairs({cg.master, cg.replica}) do
+        pcall(instance.exec, instance, function()
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', -1)
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        end)
+    end
+    cg.replica_set:drop()
+end)
+
+g.test_txn_timeout_during_synchro_request_write = function(cg)
+    cg.master:exec(function()
+        -- Unreachable quorum - the transaction can only be confirmed by a
+        -- PROMOTE.
+        box.cfg{replication_synchro_quorum = 3}
+    end)
+    cg.replica:exec(function()
+        -- The replica's own view of the transaction is enough for its
+        -- promotion to cover it.
+        box.cfg{replication_synchro_quorum = 1}
+    end)
+
+    -- The transaction whose waiter is going to time out.
+    cg.master:exec(function()
+        local lsn = box.info.lsn
+        local f = _G.fiber.create(function() box.space.s:replace{1} end)
+        f:set_joinable(true)
+        rawset(_G, 'txn_fiber', f)
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_gt(box.info.lsn, lsn)
+        end)
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+
+    -- The promotion covering the transaction, parked in its WAL write on the
+    -- master.
+    cg.master:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+    end)
+    cg.replica:exec(function() box.ctl.promote() end)
+    cg.master:exec(function()
+        --
+        -- Let the WAL writes through one by one until the one made under the
+        -- limbo latch is reached - that is the PROMOTE.
+        --
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+            if box.info.synchro.queue.busy then
+                return
+            end
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+            t.fail('Not the synchro request write yet')
+        end)
+        --
+        -- Time the waiter out right in the middle of the PROMOTE WAL write. The
+        -- waiter decides to start a rollback-by-timeout and blocks on the limbo
+        -- latch held by the PROMOTE.
+        --
+        box.cfg{replication_synchro_timeout = 0.001}
+        --
+        -- The decision to roll back is only made by the waiter fiber itself.
+        -- Give it time to actually reach the latch before letting the PROMOTE
+        -- finish.
+        --
+        require('fiber').sleep(0.1)
+        --
+        -- Release the PROMOTE. It confirms the transaction and transfers the
+        -- queue ownership while the timed out waiter is on the latch.
+        --
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', -1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end)
+    -- The waiter must wake up and find its transaction committed. No
+    -- rollback, no hang.
+    cg.master:exec(function(replica_id)
+        local joined, err = _G.txn_fiber:join(60)
+        t.assert(joined)
+        t.assert_equals(err, nil)
+        t.assert_equals(box.space.s:select(), {{1}})
+        t.assert_equals(box.info.synchro.queue.owner, replica_id)
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_equals(box.info.synchro.queue.len, 0)
+        end)
+    end, {cg.replica_id})
+    cg.replica:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, box.info.id)
+        t.assert_equals(box.space.s:select(), {{1}})
+    end)
+end

--- a/test/replication-luatest/gh_13085_qsync_ack_during_rollback_write_test.lua
+++ b/test/replication-luatest/gh_13085_qsync_ack_during_rollback_write_test.lua
@@ -1,0 +1,183 @@
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+--
+-- gh-13085: there was the following bug.
+--
+-- When a synchronous transaction's waiter times out, it writes a ROLLBACK into
+-- the WAL. The write yields, and the doomed entry is still in the limbo,
+-- visible to the rest of the system.
+--
+-- The ACK processing doesn't take the limbo latch and doesn't check for an
+-- ongoing rollback. An ACK completing a quorum during the ROLLBACK WAL write
+-- would bump the volatile confirmed LSN up to the entry being rolled back and
+-- wake the limbo worker up.
+--
+-- The rollback, when applied after its WAL write, didn't revert the volatile
+-- confirmed LSN. The worker then found it ahead of the persistent one and wrote
+-- a CONFIRM for the very LSN just covered by the ROLLBACK, even though the
+-- limbo was empty by then.
+--
+-- Locally the CONFIRM was a nop - the transaction was already gone. But it
+-- bumped the persistent confirmed LSN, which made the split-brain detection
+-- blind. A replica which ACKed the transaction and got promoted before
+-- receiving the ROLLBACK would confirm the transaction via its PROMOTE. The
+-- PROMOTE's LSN would exactly match the old master's bogus confirmed LSN, and
+-- the old master would silently follow the new one, with the instances having
+-- diverged: the transaction is committed on the new master and rolled back on
+-- the old one.
+--
+g.before_each(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri('master', cg.replica_set.id),
+            server.build_listen_uri('replica', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+        replication_synchro_timeout = 60,
+        replication_synchro_quorum = 2,
+        election_mode = 'off',
+    }
+    -- Master - owns the limbo, writes the transaction, times it out and
+    -- rolls it back while the quorum arrives.
+    cg.master = cg.replica_set:build_and_add_server{
+        alias = 'master',
+        box_cfg = box_cfg,
+    }
+    -- Replica - completes the quorum right in the middle of the master's
+    -- ROLLBACK WAL write, and later confirms the transaction via its own
+    -- PROMOTE.
+    cg.replica = cg.replica_set:build_and_add_server{
+        alias = 'replica',
+        box_cfg = box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.master:exec(function()
+        rawset(_G, 'fiber', require('fiber'))
+        box.ctl.promote()
+        box.schema.space.create('s', {is_sync = true}):create_index('p')
+    end)
+    cg.replica:wait_for_vclock_of(cg.master)
+end)
+
+g.after_each(function(cg)
+    for _, instance in pairs({cg.master, cg.replica}) do
+        pcall(instance.exec, instance, function()
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', -1)
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        end)
+    end
+    cg.replica_set:drop()
+end)
+
+g.test_ack_during_rollback_write = function(cg)
+    local master_id = cg.master:get_instance_id()
+    local replica_id = cg.replica:get_instance_id()
+    -- Block the replica's WAL, so the transaction can't be written there and
+    -- hence can't be ACKed until allowed explicitly.
+    cg.replica:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+    end)
+    -- The transaction is written on the master and is waiting for the quorum,
+    -- which can't be reached while the replica's WAL is blocked.
+    local lsn = cg.master:exec(function()
+        local lsn = box.info.lsn
+        local f = _G.fiber.create(function() box.space.s:replace{1} end)
+        f:set_joinable(true)
+        rawset(_G, 'txn_fiber', f)
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_gt(box.info.lsn, lsn)
+        end)
+        return box.info.lsn
+    end)
+    -- Time the waiter out and park its ROLLBACK right in the WAL write.
+    cg.master:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        box.cfg{replication_synchro_timeout = 0.001}
+        --
+        -- Let the WAL writes through one by one until the one made under the
+        -- limbo latch is reached - that is the ROLLBACK.
+        --
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+            if box.info.synchro.queue.busy then
+                return
+            end
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+            t.fail('Not the synchro request write yet')
+        end)
+    end)
+    -- Release the replica's WAL. Its ACK completes the quorum while the
+    -- master's ROLLBACK for the same transaction is still being written.
+    cg.replica:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end)
+    cg.master:exec(function(replica_id, master_id, lsn)
+        t.helpers.retrying({timeout = 60}, function()
+            local down = box.info.replication[replica_id].downstream
+            t.assert_not_equals(down, nil)
+            t.assert_equals(down.vclock[master_id], lsn)
+        end)
+        -- The ACK is processed while the ROLLBACK is still parked.
+        t.assert(box.info.synchro.queue.busy)
+        t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+    end, {replica_id, master_id, lsn})
+    -- Detach the replica, so it never learns about the rollback and keeps the
+    -- transaction pending in its limbo.
+    cg.replica:exec(function()
+        box.cfg{replication = {}}
+        t.assert_equals(box.info.synchro.queue.len, 1)
+    end)
+    -- Let the ROLLBACK finish. The transaction is rolled back on the master.
+    cg.master:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', -1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        local ok, err = rawget(_G, 'txn_fiber'):join(60)
+        t.assert_not(ok)
+        t.assert_equals(err.code, box.error.SYNC_QUORUM_TIMEOUT)
+        t.assert_equals(box.space.s:select(), {})
+        t.assert_equals(box.info.synchro.queue.len, 0)
+    end)
+    -- The replica confirms the transaction via its own PROMOTE - a perfectly
+    -- legal thing to do. It has the quorum of one, and no idea about the
+    -- rollback. The instances have diverged now.
+    cg.replica:exec(function()
+        box.cfg{replication_synchro_quorum = 1}
+        box.ctl.promote()
+        t.assert_equals(box.info.synchro.queue.len, 0)
+        t.assert_equals(box.info.synchro.queue.owner, box.info.id)
+        t.assert_equals(box.space.s:select(), {{1}})
+    end)
+    --
+    -- The master must notice the split-brain: the PROMOTE confirms an LSN which
+    -- the master has rolled back. With the bug the bogus CONFIRM would bump the
+    -- master's confirmed LSN to exactly the PROMOTE's LSN, and the PROMOTE
+    -- would be silently applied.
+    --
+    local outcome = cg.master:exec(function(replica_id)
+        local result
+        t.helpers.retrying({timeout = 60}, function()
+            if box.info.synchro.queue.owner == replica_id then
+                result = 'accepted'
+                return
+            end
+            result = box.info.replication[replica_id].upstream.status
+            t.assert_equals(result, 'stopped')
+        end)
+        return result
+    end, {replica_id})
+    t.assert_equals(outcome, 'stopped')
+    cg.master:exec(function(master_id, lsn)
+        -- Nothing but the ROLLBACK went into the WAL after the transaction.
+        t.assert_equals(box.info.lsn, lsn + 1)
+        t.assert_equals(box.info.synchro.queue.owner, master_id)
+        t.assert_equals(box.space.s:select(), {})
+    end, {master_id, lsn})
+end

--- a/test/replication-luatest/gh_13095_qsync_txn_during_promote_write_test.lua
+++ b/test/replication-luatest/gh_13095_qsync_txn_during_promote_write_test.lua
@@ -1,0 +1,174 @@
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+--
+-- gh-13095: there was the following bug.
+--
+-- A synchronous transaction, whose submission into the limbo got blocked on
+-- the queue being full, was parked inside the submission code waiting for free
+-- space, not yet sent to the journal.
+--
+-- The protection against new transactions joining the queue during an ongoing
+-- synchro request was only applied at the submission start.
+--
+-- It could happen that a transaction started the submission while there was no
+-- fencing yet, then it got blocked on the synchro queue being full, and then
+-- the fencing was activated.
+--
+-- The parked transaction then could be woken up in the middle of, for example,
+-- a PROMOTE WAL write, not notice the fencing, but notice free space in the
+-- synchro queue. Then it would happily become 'submitted' and get sent to WAL
+-- right after the PROMOTE.
+--
+-- After the PROMOTE was written, the transaction itself would be rolled back in
+-- memory as a part of the leadership change process.
+--
+-- Local recovery would resurrect it as a pending synchronous transaction again.
+-- Also replicas would apply it even without any restarts.
+--
+g.before_each(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri('node1', cg.replica_set.id),
+            server.build_listen_uri('node2', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+        replication_synchro_quorum = 2,
+        replication_synchro_timeout = 60,
+        election_mode = 'manual',
+    }
+    -- Node 1 - the first leader. Owns the limbo, writes the transactions, and
+    -- applies the new leader's PROMOTE in the end.
+    cg.node1 = cg.replica_set:build_and_add_server{
+        alias = 'node1',
+        box_cfg = box_cfg,
+    }
+    -- Node 2 - the second leader. Gets elected while node 1 has a parked
+    -- transaction, and its PROMOTE covers the first transaction.
+    cg.node2 = cg.replica_set:build_and_add_server{
+        alias = 'node2',
+        box_cfg = box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.node1:exec(function()
+        rawset(_G, 'fiber', require('fiber'))
+        box.ctl.promote()
+        box.schema.space.create('s', {is_sync = true}):create_index('p')
+        -- One synchronous transaction already overflows the queue.
+        box.cfg{replication_synchro_queue_max_size = 1}
+    end)
+    cg.node2:wait_for_vclock_of(cg.node1)
+end)
+
+g.after_each(function(cg)
+    -- The injections must be dropped explicitly. A frozen limbo worker doesn't
+    -- react to the fiber cancellation, so an instance left with the injection
+    -- on would hang on shutdown.
+    for _, instance in pairs({cg.node1, cg.node2}) do
+        pcall(instance.exec, instance, function()
+            box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', false)
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', -1)
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        end)
+    end
+    cg.replica_set:drop()
+end)
+
+g.test_txn_during_promote_write = function(cg)
+    -- Freeze the CONFIRM writing on node 1, so the first transaction stays in
+    -- the queue even after gathering the quorum.
+    cg.node1:exec(function()
+        box.error.injection.set('ERRINJ_TXN_LIMBO_WORKER_DELAY', true)
+    end)
+    -- Transaction 1 - is written to the WAL of both nodes and fills the queue
+    -- up to its max size.
+    local lsn = cg.node1:exec(function()
+        local lsn = box.info.lsn
+        local f = _G.fiber.create(function() box.space.s:replace{1} end)
+        f:set_joinable(true)
+        rawset(_G, 'txn1_fiber', f)
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_gt(box.info.lsn, lsn)
+        end)
+        return box.info.lsn
+    end)
+    cg.node2:wait_for_vclock_of(cg.node1)
+    -- Transaction 2 - the queue is full, so it parks inside the submission
+    -- waiting for free space. It has no WAL row yet and is not accounted in
+    -- the queue.
+    cg.node1:exec(function(lsn)
+        local f = _G.fiber.create(function() box.space.s:replace{2} end)
+        f:set_joinable(true)
+        rawset(_G, 'txn2_fiber', f)
+        t.assert_equals(box.info.lsn, lsn)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        -- Catch the coming WAL writes.
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+    end, {lsn})
+    -- Elect node 2. Its promotion is blocked on node 1's vote, whose WAL
+    -- write is caught above, so it can't be waited on synchronously here.
+    cg.node2:exec(function()
+        local f = require('fiber').create(function() box.ctl.promote() end)
+        f:set_joinable(true)
+        rawset(_G, 'promote_fiber', f)
+    end)
+    cg.node1:exec(function(lsn)
+        --
+        -- Let the WAL writes (the election term and vote bumps) through one
+        -- by one until the one made under the limbo latch is reached - that
+        -- is the PROMOTE of the new leader.
+        --
+        -- Note that the CONFIRM from the beginning of this test is still
+        -- blocked. The limbo worker isn't processing anything right now.
+        --
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+            if box.info.synchro.queue.busy then
+                return
+            end
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+            t.fail('Not the synchro request write yet')
+        end)
+        -- Give the parked transaction 2 a reason to wake up in the middle of
+        -- the PROMOTE write: raise the max size, which on its own doesn't
+        -- wake anybody up, and then poke the queue with a synchro parameter
+        -- change, which does.
+        box.cfg{replication_synchro_queue_max_size = 1024 * 1024}
+        box.cfg{replication_synchro_timeout = 59}
+        _G.fiber.sleep(0.1)
+        -- The transaction must not have gone to the journal while the
+        -- PROMOTE is in progress.
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        t.assert_equals(box.info.lsn, lsn)
+        -- Release the PROMOTE.
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', -1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end, {lsn})
+    cg.node2:exec(function()
+        local ok, err = rawget(_G, 'promote_fiber'):join(60)
+        t.assert_equals(err, nil)
+        t.assert(ok)
+    end)
+    -- The PROMOTE commits the first transaction and rolls the second one
+    -- back, without it ever getting into the journal.
+    cg.node1:exec(function(lsn, node2_id)
+        local ok, err = rawget(_G, 'txn1_fiber'):join(60)
+        t.assert_equals(err, nil)
+        t.assert(ok)
+        ok, err = rawget(_G, 'txn2_fiber'):join(60)
+        t.assert_not(ok)
+        t.assert_equals(err.code, box.error.SYNC_ROLLBACK)
+        -- Nothing went into node 1's own WAL after the first transaction.
+        t.assert_equals(box.info.lsn, lsn)
+        t.assert_equals(box.info.synchro.queue.len, 0)
+        t.assert_equals(box.info.synchro.queue.owner, node2_id)
+        t.assert_equals(box.space.s:select(), {{1}})
+    end, {lsn, cg.node2:get_instance_id()})
+end

--- a/test/replication-luatest/gh_13095_qsync_txn_during_rollback_write_test.lua
+++ b/test/replication-luatest/gh_13095_qsync_txn_during_rollback_write_test.lua
@@ -1,0 +1,127 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+--
+-- gh-13095: there was the following bug.
+--
+-- A synchronous transaction, whose submission into the limbo got blocked on
+-- the queue being full, was parked inside the submission code waiting for free
+-- space, not yet sent to the journal.
+--
+-- The protection against new transactions joining the queue during an ongoing
+-- synchro request was only applied at the submission start.
+--
+-- It could happen that a transaction started the submission while there was no
+-- fencing yet, then it got blocked on the synchro queue being full, and then
+-- the fencing was activated.
+--
+-- The parked transaction then could be woken up in the middle of, for example,
+-- a ROLLBACK WAL write, not notice the fencing, but notice free space in the
+-- synchro queue. Then it would happily become 'submitted' and get sent to WAL
+-- right after the ROLLBACK.
+--
+-- After the ROLLBACK was written, the transaction itself would be rolled back
+-- in memory as a part of the same rollback process.
+--
+-- Local recovery would resurrect it as a pending synchronous transaction again.
+-- Also replicas would apply it even without any restarts.
+--
+-- This test covers entirely the ROLLBACK request, which is expected to be
+-- deprecated eventually. Same situation happened with PROMOTE/DEMOTE requests,
+-- which are tested separately using only the APIs, which aren't scheduled for
+-- deprecation.
+--
+g.before_each(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.server = server:new{
+        alias = 'master',
+        box_cfg = {
+            replication_synchro_quorum = 2,
+            replication_synchro_timeout = 60,
+            election_mode = 'off',
+        },
+    }
+    cg.server:start()
+    cg.server:exec(function()
+        box.ctl.promote()
+        box.schema.space.create('s', {is_sync = true}):create_index('p')
+        -- One synchronous transaction already overflows the queue.
+        box.cfg{replication_synchro_queue_max_size = 1}
+    end)
+end)
+
+g.after_each(function(cg)
+    pcall(cg.server.exec, cg.server, function()
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', -1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+    end)
+    cg.server:drop()
+end)
+
+g.test_txn_during_rollback_write = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        -- Transaction 1 - is written to the WAL and fills the queue up to its
+        -- max size. The quorum of 2 is unreachable on a single instance, so
+        -- the transaction can only end by the timeout.
+        local lsn = box.info.lsn
+        local f1 = fiber.create(function() box.space.s:replace{1} end)
+        f1:set_joinable(true)
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_gt(box.info.lsn, lsn)
+        end)
+        lsn = box.info.lsn
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        -- Transaction 2 - the queue is full, so it parks inside the submission
+        -- waiting for free space. It has no WAL row yet and is not accounted
+        -- in the queue.
+        local f2 = fiber.create(function() box.space.s:replace{2} end)
+        f2:set_joinable(true)
+        t.assert_equals(box.info.lsn, lsn)
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        -- Time the first transaction out and park its ROLLBACK right in the
+        -- WAL write.
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+        box.cfg{replication_synchro_timeout = 0.001}
+        --
+        -- Let the WAL writes through one by one until the one made under the
+        -- limbo latch is reached - that is the ROLLBACK.
+        --
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert(box.error.injection.get('ERRINJ_WAL_DELAY'))
+            if box.info.synchro.queue.busy then
+                return
+            end
+            box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', 0)
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+            t.fail('Not the synchro request write yet')
+        end)
+        -- Give the parked transaction 2 a reason to wake up in the middle of
+        -- the ROLLBACK write: raise the max size, which on its own doesn't
+        -- wake anybody up, and then poke the queue with a synchro parameter
+        -- change, which does.
+        box.cfg{replication_synchro_queue_max_size = 1024 * 1024}
+        box.cfg{replication_synchro_timeout = 60}
+        fiber.sleep(0.1)
+        -- The transaction must not have gone to the journal while the
+        -- rollback is in progress.
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        t.assert_equals(box.info.lsn, lsn)
+        -- Let the ROLLBACK finish. Both transactions are rolled back, the
+        -- second one - without ever getting into the journal.
+        box.error.injection.set('ERRINJ_WAL_DELAY_COUNTDOWN', -1)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        local ok, err = f1:join(60)
+        t.assert_not(ok)
+        t.assert_equals(err.code, box.error.SYNC_QUORUM_TIMEOUT)
+        ok, err = f2:join(60)
+        t.assert_not(ok)
+        t.assert_equals(err.code, box.error.SYNC_ROLLBACK)
+        -- Only the ROLLBACK went into the WAL after the transactions.
+        t.assert_equals(box.info.lsn, lsn + 1)
+        t.assert_equals(box.info.synchro.queue.len, 0)
+        t.assert_equals(box.space.s:select(), {})
+    end)
+end

--- a/test/replication-luatest/gh_7486_replication_synchro_queue_max_size_test.lua
+++ b/test/replication-luatest/gh_7486_replication_synchro_queue_max_size_test.lua
@@ -133,9 +133,9 @@ g.test_recovery_with_small_max_size = function(cg)
     server_wait_synchro_queue_len_is_equal(cg.master, 1000)
     cg.master:exec(function()
         box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        box.cfg{replication_synchro_timeout = 100000}
         box.ctl.promote()
         t.assert_equals(box.space.test:len(), 1000)
-        box.cfg{replication_synchro_timeout = 100000}
         -- wait = 'complete' by default, so after truncate completes,
         -- the synchronous queue is guaranteed to be empty
         box.space.test:truncate()

--- a/test/replication-luatest/qsync_txn_during_promote_filter_test.lua
+++ b/test/replication-luatest/qsync_txn_during_promote_filter_test.lua
@@ -1,0 +1,133 @@
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+--
+-- An incoming synchro request has to be filtered before being applied. Some of
+-- the validation checks compare the request against the LSNs of the queued
+-- transactions, so the filtering sometimes is supposed to start by waiting
+-- until all the pending WAL writes of the queue are finished.
+--
+-- The queue needs to be protected from new writes during that. Otherwise the
+-- waiting in the filter would never end until the writes stop coming for some
+-- other reason, thus also not allowing the synchro request to proceed.
+--
+g.before_each(function(cg)
+    t.tarantool.skip_if_not_debug()
+    cg.replica_set = replica_set:new{}
+    local box_cfg = {
+        replication = {
+            server.build_listen_uri('node1', cg.replica_set.id),
+            server.build_listen_uri('node2', cg.replica_set.id),
+        },
+        replication_timeout = 0.1,
+        replication_synchro_quorum = 2,
+        replication_synchro_timeout = 60,
+        election_mode = 'manual',
+    }
+    -- Node 1 - the first leader. Owns the limbo, writes the transactions, and
+    -- receives the new leader's PROMOTE in the end.
+    cg.node1 = cg.replica_set:build_and_add_server{
+        alias = 'node1',
+        box_cfg = box_cfg,
+    }
+    -- Node 2 - the second leader. Takes the limbo over while node 1 has a
+    -- transaction with an unfinished WAL write.
+    box_cfg.read_only = true
+    cg.node2 = cg.replica_set:build_and_add_server{
+        alias = 'node2',
+        box_cfg = box_cfg,
+    }
+    cg.replica_set:start()
+    cg.replica_set:wait_for_fullmesh()
+    cg.node1:exec(function()
+        rawset(_G, 'fiber', require('fiber'))
+        box.schema.space.create('s', {is_sync = true}):create_index('p')
+        box.schema.space.create('l', {is_local = true}):create_index('p')
+        -- A fully confirmed transaction, so both nodes agree on the confirmed
+        -- LSN and the coming PROMOTE passes the filter cleanly.
+        box.space.s:replace{1}
+    end)
+    cg.node2:wait_for_vclock_of(cg.node1)
+end)
+
+g.after_each(function(cg)
+    -- The injections must be dropped explicitly. An instance left with the
+    -- injection on would hang on shutdown.
+    for _, instance in pairs({cg.node1, cg.node2}) do
+        pcall(instance.exec, instance, function()
+            box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        end)
+    end
+    cg.replica_set:drop()
+end)
+
+g.test_txn_during_promote_filter = function(cg)
+    -- Transaction 1 - enters the queue, but its WAL write is blocked. The queue
+    -- now has an entry with an unknown LSN.
+    cg.node1:exec(function()
+        box.error.injection.set('ERRINJ_WAL_DELAY', true)
+        local lsn = box.info.lsn
+        local f = _G.fiber.new(function() box.space.s:replace{2} end)
+        f:set_joinable(true)
+        rawset(_G, 'txn1_fiber', f)
+        _G.fiber.yield()
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        t.assert_equals(box.info.lsn, lsn)
+    end)
+    -- The takeover happens entirely on node 2 - it doesn't need anything from
+    -- node 1 whose WAL is blocked (assume it got votes from some other nodes).
+    cg.node2:exec(function()
+        box.cfg{read_only = false, replication_synchro_quorum = 1}
+        box.ctl.promote()
+    end)
+    -- The PROMOTE arrives at node 1 and gets stuck in the filtering, waiting
+    -- for the WAL write of transaction 1 to finish. The wait happens under
+    -- the limbo latch.
+    cg.node1:exec(function()
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert(box.info.synchro.queue.busy)
+        end)
+    end)
+    -- Transaction 2 - tries to enter the queue while the PROMOTE is being
+    -- filtered. It must be rejected right away. Otherwise a stream of such txns
+    -- would indefinitely restart the filter's waiting, thus starving the
+    -- PROMOTE.
+    --
+    -- Node 1 is already read-only here - it has learned the new raft term
+    -- before receiving the PROMOTE row and stepped down from the leadership.
+    -- Hence the transaction goes into a replica-local space, which is writable
+    -- regardless.
+    cg.node1:exec(function()
+        t.assert(box.info.ro)
+        local f = _G.fiber.new(function() box.space.l:replace{3} end)
+        f:set_joinable(true)
+        _G.fiber.yield()
+        t.assert_equals(box.info.synchro.queue.len, 1)
+        local ok, err = f:join(60)
+        t.assert_not(ok)
+        t.assert_equals(err.code, box.error.SYNC_ROLLBACK)
+    end)
+    -- Let the WAL write of transaction 1 finish. The filter wait ends, and
+    -- the PROMOTE gets applied, rolling transaction 1 back.
+    cg.node1:exec(function(node2_id)
+        box.error.injection.set('ERRINJ_WAL_DELAY', false)
+        local ok, err = rawget(_G, 'txn1_fiber'):join(60)
+        t.assert_not(ok)
+        t.assert_equals(err.code, box.error.SYNC_ROLLBACK)
+        t.helpers.retrying({timeout = 60}, function()
+            t.assert_equals(box.info.synchro.queue.owner, node2_id)
+        end)
+        t.assert_equals(box.info.synchro.queue.len, 0)
+        t.assert_equals(box.space.s:select(), {{1}})
+        t.assert_equals(box.space.l:select(), {})
+    end, {cg.node2:get_instance_id()})
+    -- The old leader's transaction 1 is nopified on the new leader.
+    cg.node2:wait_for_vclock_of(cg.node1)
+    cg.node2:exec(function()
+        t.assert_equals(box.info.synchro.queue.owner, box.info.id)
+        t.assert_equals(box.space.s:select(), {{1}})
+    end)
+end


### PR DESCRIPTION
The patchset brings fixes for several bugs in various places related to the limbo, which were discovered during development of #8095 and were blocking it.

The remaining part of #8095 at the moment of writing is still in work. This PR is sent early to reduce the cognitive load of the next parts (hopefully only one remaining after this).