### PR TITLE
test: set search root in read_view.threads test

### DIFF
--- a/test/box-luatest/read_view_test.lua
+++ b/test/box-luatest/read_view_test.lua
@@ -2670,6 +2670,20 @@ g_threads.before_all(function(cg)
         net_box_credentials = {user = 'admin'}
     })
     cg.server:start()
+    --
+    -- FIXME(gh-12546): For server.exec to be able to find the luatest module,
+    -- searchroot must be set in the test server. For the main thread, this is
+    -- done automatically by luatest itself, but due to the bug in Tarantool,
+    -- searchroot isn't propagated to application threads so we have to set it
+    -- manually. Remove this when the bug is fixed.
+    --
+    local searchroot = cg.server:exec(function()
+        return package.searchroot()
+    end)
+    for i = 1, cg.server.box_cfg.app_threads do
+        cg.server:eval('package.setsearchroot(...)', {searchroot},
+                       {_thread_id = i})
+    end
 end)
 
 g_threads.after_all(function(cg)


### PR DESCRIPTION
The value of `package.searchroot` isn't propagated to application threads, see #12546, so we need to propagate it in tests that use the luatest module in threads, like we already do in `app_threads_test` and `app_threads_module_test`.

Although tests pass without this hack, we do need it for Tarantool EE GitLab workflow, which does some weird things to prepare the test environment.