### PR TITLE
sql: fixed loss of foreign field ID

### DIFF
--- a/changelogs/unreleased/gh-13010-fix-trigerring-assertion-at-repeat-adding-column-with-constraint.md
+++ b/changelogs/unreleased/gh-13010-fix-trigerring-assertion-at-repeat-adding-column-with-constraint.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed a bug where the foreign field ID for a field foreign key
+  was lost after executing an `ALTER TABLE ADD COLUMN` statement (gh-13010).

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -972,8 +972,10 @@ sql_mpstream_encode_constraints(struct mpstream *stream,
 				mpstream_encode_map(stream, 1);
 			}
 			mpstream_encode_str(stream, "field");
-			assert(fkey->field.name_len != 0);
-			mpstream_encode_str(stream, fkey->field.name);
+			if (fkey->field.name_len > 0)
+				mpstream_encode_str(stream, fkey->field.name);
+			else
+				mpstream_encode_uint(stream, fkey->field.id);
 		}
 	}
 	if (ck_count > 0) {

--- a/test/sql-luatest/alter_table_test.lua
+++ b/test/sql-luatest/alter_table_test.lua
@@ -73,3 +73,17 @@ g.test_3613_idx_alter_update_2 = function(cg)
         box.execute('DROP TABLE j3;')
     end)
 end
+
+--
+-- Check the foreign field ID for a field foreign key
+-- not lost after executing an `ALTER TABLE ADD COLUMN` statement.
+--
+g.test_13010_repeat_adding_constraint_column = function(cg)
+    cg.server:exec(function()
+        box.execute("CREATE TABLE t(i INT PRIMARY KEY, a INT REFERENCES t(i));")
+        local exp = {fk_unnamed_t_a_1 = {space = box.space.t.id, field = 1}}
+        t.assert_equals(box.space.t:format()[2]['foreign_key'], exp)
+        box.execute("ALTER TABLE t ADD COLUMN b;")
+        t.assert_equals(box.space.t:format()[2]['foreign_key'], exp)
+    end)
+end


### PR DESCRIPTION
Fixed a bug where the foreign field ID for a field foreign key
was lost after executing an `ALTER TABLE ADD COLUMN` statement.

Closes #13010

NO_DOC=bugfix
