### PR TITLE
sql: fix assert at adding a column with index

### DIFF
--- a/changelogs/unreleased/gh-13009-fix-assertion-at-adding-column-with-index-in-view.md
+++ b/changelogs/unreleased/gh-13009-fix-assertion-at-adding-column-with-index-in-view.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed an assertion that occurred when adding a column with a UNIQUE or
+  PRIMARY KEY constraint to the view (gh-13009).

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -2770,10 +2770,8 @@ sql_create_index(struct Parse *parse) {
 	struct space_def *def = space->def;
 
 	if (def->opts.is_view) {
-		char *name = sql_name_from_token(&token);
-		diag_set(ClientError, ER_MODIFY_INDEX, name, def->name,
-			 "views can not be indexed");
-		sql_xfree(name);
+		diag_set(ClientError, ER_SQL_PARSER_GENERIC,
+			 "Views can not be indexed");
 		parse->is_aborted = true;
 		goto exit_create_index;
 	}

--- a/test/sql-luatest/view_test.lua
+++ b/test/sql-luatest/view_test.lua
@@ -27,8 +27,7 @@ g.test_view = function(cg)
 
         -- View can't have any indexes.
         local _, err = box.execute("CREATE INDEX i1 ON v1(a);")
-        local exp_err = "Can't create or modify index 'i1' "..
-                        "in space 'v1': views can not be indexed"
+        local exp_err = "Views can not be indexed"
         t.assert_equals(err.message, exp_err)
         local v1 = box.space.v1
         local opts = {parts = {1, 'string'}}
@@ -435,5 +434,24 @@ g.test_duplicate_column_error = function(cg)
         sql = [[CREATE VIEW v AS SELECT 1 AS a, 1 AS a;]]
         _, err = box.execute(sql)
         t.assert_equals(tostring(err), exp_err)
+    end)
+end
+
+--
+-- gh-13009: Make sure that adding a column unique to the view
+-- does not trigger an assertion.
+--
+g.test_13009_adding_column_unique = function(cg)
+    cg.server:exec(function()
+        box.execute([[CREATE VIEW v AS SELECT id FROM _space;]])
+        local exp_err = "Views can not be indexed"
+        local sql = [[ALTER TABLE v ADD COLUMN a INT UNIQUE;]]
+        local _, err = box.execute(sql)
+        t.assert_equals(tostring(err), exp_err)
+
+        sql = [[ALTER TABLE v ADD COLUMN a INT PRIMARY KEY;]]
+        _, err = box.execute(sql)
+        t.assert_equals(tostring(err), exp_err)
+        box.execute([[DROP VIEW v;]])
     end)
 end

--- a/test/sql-tap/sql-errors.test.lua
+++ b/test/sql-tap/sql-errors.test.lua
@@ -134,7 +134,7 @@ test:do_catchsql_test(
 		CREATE INDEX i12 ON v0(i);
 	]], {
 		-- <sql-errors-1.12>
-        1,"Can't create or modify index 'i12' in space 'v0': views can not be indexed"
+        1,"Views can not be indexed"
 		-- </sql-errors-1.12>
 	})
 

--- a/test/sql-tap/view.test.lua
+++ b/test/sql-tap/view.test.lua
@@ -370,7 +370,7 @@ test:do_catchsql_test(
         CREATE INDEX i1v1 ON v1(xyz);
     ]], {
         -- <view-4.5>
-        1, "Can't create or modify index 'i1v1' in space 'v1': views can not be indexed"
+        1, "Views can not be indexed"
         -- </view-4.5>
     })
 


### PR DESCRIPTION
After this patch no triggering assertion at instructions
box.execute([[ALTER TABLE v ADD COLUMN a INT UNIQUE;]])
box.execute([[ALTER TABLE v ADD COLUMN a INT PRIMARY KEY;]])

Closes #13009

NO_DOC=bugfix