### PR TITLE
[backport 3.7] sql: fix PRIMARY KEY table constraint parsing

### DIFF
--- a/changelogs/unreleased/gh-12968-primary-key-with-autoinc.md
+++ b/changelogs/unreleased/gh-12968-primary-key-with-autoinc.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed an inability to set both the sort order and the AUTOINCREMENT property
+  on columns in a PRIMARY KEY table constraint at the same time (gh-12968).

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -1103,7 +1103,7 @@ emitNewSysSequenceRecord(Parse *pParse, int reg_seq_id, const char *seq_name)
 static int
 emitNewSysSpaceSequenceRecord(Parse *pParse, int reg_space_id, int reg_seq_id)
 {
-	uint32_t fieldno = pParse->autoinc_fieldno;
+	uint32_t fieldno = *pParse->autoinc_fieldno;
 
 	Vdbe *v = sqlGetVdbe(pParse);
 	int first_col = pParse->nMem + 1;
@@ -1377,7 +1377,7 @@ vdbe_emit_create_constraints(struct Parse *parse, int reg_space_id)
 	 * Check to see if we need to create an _sequence table
 	 * for keeping track of autoincrement keys.
 	 */
-	if (parse->has_autoinc) {
+	if (parse->autoinc_fieldno != NULL) {
 		/* Do an insertion into _sequence. */
 		int reg_seq_id = ++parse->nMem;
 		struct Vdbe *v = sqlGetVdbe(parse);
@@ -2591,6 +2591,11 @@ index_fill_def(struct Parse *parse, struct index *index,
 		assert(column_expr->op == TK_COLUMN_REF);
 
 		uint32_t fieldno = column_expr->iColumn;
+		if (parse->autoinc_fieldno == &expr->iColumn) {
+			parse->autoinc_fieldno =
+				xregion_alloc_object(&parse->region, int);
+			*parse->autoinc_fieldno = fieldno;
+		}
 		uint32_t coll_id;
 		if (expr->op == TK_COLLATE) {
 			coll_id = sql_coll_id_by_expr(expr);
@@ -2971,10 +2976,26 @@ sql_create_index(struct Parse *parse) {
 		sqlVdbeAddOp0(vdbe, OP_Expire);
 	}
 
-	if (!is_create_table_or_add_col)
+	if (is_create_table_or_add_col) {
+		sql_space_add_index(parse, space, index);
+		index = NULL;
 		goto exit_create_index;
-	sql_space_add_index(parse, space, index);
-	index = NULL;
+	}
+
+	if (parse->autoinc_fieldno != NULL) {
+		struct Vdbe *v = sqlGetVdbe(parse);
+		assert(v != NULL);
+		int reg_space_id = ++parse->nMem;
+		sqlVdbeAddOp2(v, OP_Integer, def->id, reg_space_id);
+		int reg_seq_id = ++parse->nMem;
+		sqlVdbeAddOp2(v, OP_NextSequenceId, 0, reg_seq_id);
+		int reg_seq_rec = emitNewSysSequenceRecord(parse, reg_seq_id,
+							   def->name);
+		sqlVdbeAddOp2(v, OP_SInsert, BOX_SEQUENCE_ID, reg_seq_rec);
+		int reg = emitNewSysSpaceSequenceRecord(parse, reg_space_id,
+							reg_seq_id);
+		sqlVdbeAddOp2(v, OP_SInsert, BOX_SPACE_SEQUENCE_ID, reg);
+	}
 
 	/* Clean up before exiting. */
  exit_create_index:
@@ -3486,36 +3507,15 @@ vdbe_emit_halt_with_presence_test(struct Parse *parser, int space_id,
 int
 sql_add_autoincrement(struct Parse *parse_context, uint32_t fieldno)
 {
-	if (parse_context->has_autoinc) {
-		diag_set(ClientError, ER_SQL_SYNTAX_WITH_POS,
-			 parse_context->line_count, parse_context->line_pos,
-			 "table must feature at most one AUTOINCREMENT field");
+	if (parse_context->autoinc_fieldno != NULL) {
+		diag_set(ClientError, ER_SQL_PARSER_GENERIC,
+			 "Table must feature at most one AUTOINCREMENT field");
 		parse_context->is_aborted = true;
 		return -1;
 	}
-	parse_context->has_autoinc = true;
-	parse_context->autoinc_fieldno = fieldno;
-	return 0;
-}
-
-int
-sql_fieldno_by_name(struct Parse *parse_context, struct Expr *field_name,
-		    uint32_t *fieldno)
-{
-	const struct space *space = parse_context->create_table_def.new_space;
-	struct Expr *name = sqlExprSkipCollate(field_name);
-	if (name->op != TK_ID) {
-		diag_set(ClientError, ER_INDEX_DEF_UNSUPPORTED, "Expressions");
-		parse_context->is_aborted = true;
-		return -1;
-	}
-	uint32_t id = sql_fieldno_by_expr(space, name);
-	if (id == UINT32_MAX) {
-		diag_set(ClientError, ER_SQL_CANT_RESOLVE_FIELD, name->u.zToken);
-		parse_context->is_aborted = true;
-		return -1;
-	}
-	*fieldno = id;
+	parse_context->autoinc_fieldno =
+		xregion_alloc_object(&parse_context->region, int);
+	*parse_context->autoinc_fieldno = fieldno;
 	return 0;
 }
 

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -724,6 +724,28 @@ sortlist(A) ::= expr(Y) sortorder(Z). {
   sqlExprListSetSortOrder(A,Z);
 }
 
+
+%include {
+/** Set AUTOINCREMENT for a field in table PRIMARY KEY constraint. */
+static void
+set_autoinc(struct Parse *parser, struct Expr *expr)
+{
+  if (parser->autoinc_fieldno != NULL) {
+    diag_set(ClientError, ER_SQL_PARSER_GENERIC,
+             "Table must feature at most one AUTOINCREMENT field");
+    parser->is_aborted = true;
+    return;
+  }
+  if (expr != sqlExprSkipCollate(expr)) {
+    diag_set(ClientError, ER_SQL_PARSER_GENERIC,
+             "AUTOINCREMENT cannot be used with a non-integer column");
+    parser->is_aborted = true;
+    return;
+  }
+  parser->autoinc_fieldno = &expr->iColumn;
+}
+}
+
 /**
  * Non-terminal rule to store a list of columns within PRIMARY KEY
  * declaration.
@@ -731,28 +753,19 @@ sortlist(A) ::= expr(Y) sortorder(Z). {
 %type col_list_with_autoinc {ExprList*}
 %destructor col_list_with_autoinc {sql_expr_list_delete($$);}
 
-col_list_with_autoinc(A) ::= col_list_with_autoinc(A) COMMA expr(Y)
+col_list_with_autoinc(A) ::= col_list_with_autoinc(A) COMMA expr(Y) sortorder(Z)
                              autoinc(I). {
-  uint32_t fieldno;
-  if (I == 1) {
-    if (sql_fieldno_by_name(pParse, Y.pExpr, &fieldno) != 0)
-      return;
-    if (sql_add_autoincrement(pParse, fieldno) != 0)
-      return;
-  }
   A = sql_expr_list_append(A, Y.pExpr);
+  sqlExprListSetSortOrder(A, Z);
+  if (I == 1)
+    set_autoinc(pParse, Y.pExpr);
 }
 
-col_list_with_autoinc(A) ::= expr(Y) autoinc(I). {
-  if (I == 1) {
-    uint32_t fieldno = 0;
-    if (sql_fieldno_by_name(pParse, Y.pExpr, &fieldno) != 0)
-      return;
-    if (sql_add_autoincrement(pParse, fieldno) != 0)
-      return;
-  }
-  /* A-overwrites-Y. */
+col_list_with_autoinc(A) ::= expr(Y) sortorder(Z) autoinc(I). {
   A = sql_expr_list_append(NULL, Y.pExpr);
+  sqlExprListSetSortOrder(A, Z);
+  if (I == 1)
+    set_autoinc(pParse, Y.pExpr);
 }
 
 %type sortorder {int}
@@ -1711,15 +1724,17 @@ cmd ::= alter_add_constraint(N) CHECK LP expr(X) RP. {
     sql_create_check_contraint(pParse, false);
 }
 
-cmd ::= alter_add_constraint(N) unique_spec(U) LP sortlist(X) RP. {
-  create_index_def_init(&pParse->create_index_def, N.table_name, &N.name, X, U,
-                        SORT_ORDER_ASC, false);
+cmd ::= alter_add_constraint(N) UNIQUE LP sortlist(X) RP. {
+  create_index_def_init(&pParse->create_index_def, N.table_name, &N.name, X,
+                        SQL_INDEX_TYPE_CONSTRAINT_UNIQUE, SORT_ORDER_ASC,
+                        false);
   sql_create_index(pParse);
 }
-
-%type unique_spec {int}
-unique_spec(U) ::= UNIQUE.      { U = SQL_INDEX_TYPE_CONSTRAINT_UNIQUE; }
-unique_spec(U) ::= PRIMARY KEY. { U = SQL_INDEX_TYPE_CONSTRAINT_PK; }
+cmd ::= alter_add_constraint(N) PRIMARY KEY LP col_list_with_autoinc(X) RP. {
+  create_index_def_init(&pParse->create_index_def, N.table_name, &N.name, X,
+                        SQL_INDEX_TYPE_CONSTRAINT_PK, SORT_ORDER_ASC, false);
+  sql_create_index(pParse);
+}
 
 cmd ::= alter_table_start(A) RENAME TO nm(N). {
     rename_entity_def_init(&pParse->rename_entity_def, A, &N);

--- a/src/box/sql/prepare.c
+++ b/src/box/sql/prepare.c
@@ -193,7 +193,6 @@ sql_parser_create(struct Parse *parser, uint32_t sql_flags)
 	parser->sql_flags = sql_flags;
 	parser->line_count = 1;
 	parser->line_pos = 1;
-	parser->has_autoinc = false;
 	region_create(&parser->region, &cord()->slabc);
 }
 

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2078,14 +2078,8 @@ struct Parse {
 	 */
 	struct create_fk_constraint_parse_def create_fk_constraint_parse_def;
 	struct create_ck_constraint_parse_def create_ck_constraint_parse_def;
-	/*
-	 * True, if column in a <CREATE TABLE> or an
-	 * <ALTER TABLE ADD COLUMN> statement to be created has
-	 * <AUTOINCREMENT>.
-	 */
-	bool has_autoinc;
 	/* Id of field with <AUTOINCREMENT>. */
-	uint32_t autoinc_fieldno;
+	int *autoinc_fieldno;
 	bool initiateTTrans;	/* Initiate Tarantool transaction */
 	/** If set - do not emit byte code at all, just parse.  */
 	bool parse_only;
@@ -4519,24 +4513,6 @@ vdbe_emit_halt_with_presence_test(struct Parse *parser, int space_id,
  */
 int
 sql_add_autoincrement(struct Parse *parse_context, uint32_t fieldno);
-
-/**
- * Get fieldno by field name. At the moment of forming space format
- * there's no tuple dictionary, so we can't use hash, in contrast to
- * tuple_fieldno_by_name(). However, AUTOINCREMENT can occur at most
- * once in table's definition, so it's not a big deal if we use O(n)
- * search.
- *
- * @param parse_context Parsing context.
- * @param field_name Expr that contains field name.
- * @param fieldno[out] Field number in new space format.
- *
- * @retval 0 on success.
- * @retval -1 on error.
- */
-int
-sql_fieldno_by_name(struct Parse *parse_context, struct Expr *field_name,
-		    uint32_t *fieldno);
 
 /**
  * Create VDBE instructions to set the new value of the session setting.

--- a/test/sql-luatest/ddl_test.lua
+++ b/test/sql-luatest/ddl_test.lua
@@ -348,3 +348,61 @@ g.test_4086_ddl = function(cg)
         monster_ddl_clear()
     end)
 end
+
+--
+-- Check that PRIMARY KEY table constraint with both sort order and
+-- AUTOINCREMENT works as expected.
+--
+g.test_12968_primary_key_constraint_parsing = function(cg)
+    cg.server:exec(function()
+        -- Check PRIMARY KEY table constraint in CREATE TABLE.
+        local _, err = box.execute([[CREATE TABLE t (i INT, a INT, b INT, c INT,
+                                     PRIMARY KEY(a ASC, b DESC AUTOINCREMENT,
+                                     c DESC));]])
+        t.assert_equals(err, nil)
+        local seq = box.space._space_sequence:select()[1]
+        t.assert_equals(seq.id, box.space.t.id)
+        t.assert_equals(seq.field, 2)
+        box.execute([[DROP TABLE t;]])
+        t.assert_equals(box.space._space_sequence:count(), 0)
+
+        -- Check column with collate.
+        _, err = box.execute([[CREATE TABLE t (a INT, b SCALAR,
+                               PRIMARY KEY(a ASC, b COLLATE "unicode" DESC
+                               AUTOINCREMENT));]])
+        local exp_err = "AUTOINCREMENT cannot be used with a non-integer column"
+        t.assert_str_contains(err.message, exp_err)
+        t.assert_equals(box.space._space_sequence:count(), 0)
+
+        -- Check PRIMARY KEY table constraint in ALTER TABLE ADD CONSTRAINT.
+        local format = {
+            {'i', 'integer'},
+            {'a', 'integer'},
+            {'b', 'integer'},
+            {'c', 'integer'},
+        }
+        box.schema.space.create('t', {format = format})
+        _, err = box.execute([[ALTER TABLE t ADD CONSTRAINT pk
+                               PRIMARY KEY(a ASC, b DESC AUTOINCREMENT,
+                               c DESC)]])
+        t.assert_equals(err, nil)
+        seq = box.space._space_sequence:select()[1]
+        t.assert_equals(seq.id, box.space.t.id)
+        t.assert_equals(seq.field, 2)
+        box.execute([[DROP TABLE t;]])
+        t.assert_equals(box.space._space_sequence:count(), 0)
+
+        -- Check duplicate AUTOINCREMENT in ALTER TABLE ADD CONSTRAINT.
+        format = {
+            {'a', 'integer'},
+            {'b', 'integer'},
+        }
+        box.schema.space.create('t', {format = format})
+        _, err = box.execute([[ALTER TABLE t ADD CONSTRAINT pk
+                               PRIMARY KEY(a AUTOINCREMENT, b AUTOINCREMENT)]])
+        exp_err = "Table must feature at most one AUTOINCREMENT field"
+        t.assert_str_contains(err.message, exp_err)
+        t.assert_equals(box.space._space_sequence:count(), 0)
+        box.space.t:drop()
+    end)
+end

--- a/test/sql-tap/autoinc.test.lua
+++ b/test/sql-tap/autoinc.test.lua
@@ -864,7 +864,7 @@ test:do_catchsql_test(
     [[
         CREATE TABLE t11_5 (i INT, a INT, PRIMARY KEY(a, i COLLATE "unicode_ci" AUTOINCREMENT));
     ]], {
-        1, "Wrong index part 2: collation is only reasonable for 'string' and 'scalar' parts"
+        1, "AUTOINCREMENT cannot be used with a non-integer column"
     })
 
 test:do_catchsql_test(
@@ -881,7 +881,7 @@ test:do_catchsql_test(
     [[
         CREATE TABLE t11_7 (i INT AUTOINCREMENT, a INT AUTOINCREMENT, PRIMARY KEY(a, i));
     ]], {
-        1, "Syntax error at line 1 at or near position 69: table must feature at most one AUTOINCREMENT field"
+        1, "Table must feature at most one AUTOINCREMENT field"
     })
 
 test:do_catchsql_test(
@@ -889,7 +889,7 @@ test:do_catchsql_test(
     [[
         CREATE TABLE t11_8 (i INT, a INT, PRIMARY KEY(a AUTOINCREMENT, i AUTOINCREMENT));
     ]], {
-        1, "Syntax error at line 1 at or near position 87: table must feature at most one AUTOINCREMENT field"
+        1, "Table must feature at most one AUTOINCREMENT field"
     })
 
 test:do_catchsql_test(


### PR DESCRIPTION
This patch fixes the problem with inability to set the sort order and the AUTOINCREMENT property on columns in a PRIMARY KEY table constraint at the same time.

Closes #12968

NO_DOC=bugfix

(cherry picked from commit 44267034f8c130740d39887f634dbab65b7800b6)