### PR TITLE
sql: fix work of numeric variables

### DIFF
--- a/changelogs/unreleased/gh-12733-fix-work-of-numeric-and-anonymous-bind-variables.md
+++ b/changelogs/unreleased/gh-12733-fix-work-of-numeric-and-anonymous-bind-variables.md
@@ -1,0 +1,5 @@
+## bugfix/sql
+
+* Now, a numeric variable ($number) always refers to the bind variable
+  at position number, a anonumous variables (?) always means the next
+  bind variable (gh-12733).

--- a/src/box/bind.c
+++ b/src/box/bind.c
@@ -177,8 +177,8 @@ int
 sql_bind_column(struct Vdbe *stmt, const struct sql_bind *p, uint32_t pos)
 {
 	if (p->name != NULL) {
-		pos = sql_bind_parameter_lindex(stmt, p->name, p->name_len);
-		if (pos == 0) {
+		if (sql_bind_parameter_lindex(stmt, p->name,
+					      p->name_len) == 0) {
 			diag_set(ClientError, ER_SQL_BIND_NOT_FOUND,
 				 sql_bind_name(p));
 			return -1;
@@ -186,14 +186,14 @@ sql_bind_column(struct Vdbe *stmt, const struct sql_bind *p, uint32_t pos)
 	}
 	switch (p->type) {
 	case MP_INT:
-		return sql_bind_int64(stmt, pos, p->i64);
+		return sql_bind_int64(stmt, pos, p->i64, p->name, p->name_len);
 	case MP_UINT:
-		return sql_bind_uint64(stmt, pos, p->u64);
+		return sql_bind_uint64(stmt, pos, p->u64, p->name, p->name_len);
 	case MP_BOOL:
-		return sql_bind_boolean(stmt, pos, p->b);
+		return sql_bind_boolean(stmt, pos, p->b, p->name, p->name_len);
 	case MP_DOUBLE:
 	case MP_FLOAT:
-		return sql_bind_double(stmt, pos, p->d);
+		return sql_bind_double(stmt, pos, p->d, p->name, p->name_len);
 	case MP_STR:
 		/*
 		 * Parameters are allocated within message pack,
@@ -203,25 +203,33 @@ sql_bind_column(struct Vdbe *stmt, const struct sql_bind *p, uint32_t pos)
 		 * there is no need to copy the packet and we can
 		 * use SQL_STATIC.
 		 */
-		return sql_bind_str_static(stmt, pos, p->s, p->bytes);
+		return sql_bind_str_static(stmt, pos, p->s, p->bytes, p->name,
+					   p->name_len);
 	case MP_NIL:
 		return sql_bind_null(stmt, pos);
 	case MP_BIN:
-		return sql_bind_bin_static(stmt, pos, p->s, p->bytes);
+		return sql_bind_bin_static(stmt, pos, p->s, p->bytes, p->name,
+					   p->name_len);
 	case MP_ARRAY:
-		return sql_bind_array_static(stmt, pos, p->s, p->bytes);
+		return sql_bind_array_static(stmt, pos, p->s, p->bytes, p->name,
+					     p->name_len);
 	case MP_MAP:
-		return sql_bind_map_static(stmt, pos, p->s, p->bytes);
+		return sql_bind_map_static(stmt, pos, p->s, p->bytes, p->name,
+					   p->name_len);
 	case MP_EXT:
 		switch (p->ext_type) {
 		case MP_UUID:
-			return sql_bind_uuid(stmt, pos, &p->uuid);
+			return sql_bind_uuid(stmt, pos, &p->uuid, p->name,
+					     p->name_len);
 		case MP_DECIMAL:
-			return sql_bind_dec(stmt, pos, &p->dec);
+			return sql_bind_dec(stmt, pos, &p->dec, p->name,
+					    p->name_len);
 		case MP_DATETIME:
-			return sql_bind_datetime(stmt, pos, &p->dt);
+			return sql_bind_datetime(stmt, pos, &p->dt, p->name,
+						 p->name_len);
 		case MP_INTERVAL:
-			return sql_bind_interval(stmt, pos, &p->itv);
+			return sql_bind_interval(stmt, pos, &p->itv, p->name,
+						 p->name_len);
 		default:
 			unreachable();
 		}

--- a/src/box/execute.c
+++ b/src/box/execute.c
@@ -126,7 +126,7 @@ sql_reprepare(struct Vdbe **stmt)
 	const char *sql_str = sql_stmt_query_str(*stmt);
 	struct Vdbe *new_stmt;
 	if (sql_stmt_compile(sql_str, strlen(sql_str), NULL,
-			     &new_stmt, NULL) != 0)
+			     &new_stmt, NULL, 0) != 0)
 		return -1;
 	sql_stmt_set_id(new_stmt, sql_stmt_get_id(*stmt));
 	if (sql_stmt_cache_update(*stmt, new_stmt) != 0)
@@ -164,7 +164,7 @@ sql_prepare(const char *sql, size_t len, struct port *port)
 		count++;
 	}
 	if (stmt == NULL) {
-		if (sql_stmt_compile(sql, len, NULL, &stmt, NULL) != 0)
+		if (sql_stmt_compile(sql, len, NULL, &stmt, NULL, 0) != 0)
 			return -1;
 		sql_stmt_set_id(stmt, stmt_id);
 		if (sql_stmt_cache_insert(stmt) != 0) {
@@ -291,7 +291,7 @@ sql_prepare_and_execute(const char *sql, int len, const struct sql_bind *bind,
 			struct region *region)
 {
 	struct Vdbe *stmt;
-	if (sql_stmt_compile(sql, len, NULL, &stmt, NULL) != 0)
+	if (sql_stmt_compile(sql, len, NULL, &stmt, NULL, bind_count) != 0)
 		return -1;
 	assert(stmt != NULL);
 	enum sql_serialization_format format = sql_column_count(stmt) > 0 ?

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -3690,13 +3690,10 @@ sqlExprCodeTarget(Parse * pParse, Expr * pExpr, int target)
 			sqlVdbeAddOp2(v, OP_Variable, pExpr->iColumn,
 					  target);
 			if (pExpr->u.zToken[1] != 0) {
-				const char *z =
-				    sqlVListNumToName(pParse->pVList,
-							  pExpr->iColumn);
-				assert(pExpr->u.zToken[0] == '$'
-				       || strcmp(pExpr->u.zToken, z) == 0);
-				pParse->pVList[0] = 0;	/* Indicate VList may no longer be enlarged */
-				sqlVdbeAppendP4(v, (char *)z, P4_STATIC);
+				/* Indicate VList may no longer be enlarged */
+				pParse->pVList[0] = 0;
+				sqlVdbeAppendP4(v, (char *)pExpr->u.zToken,
+						P4_STATIC);
 			}
 			return target;
 		}

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -2547,7 +2547,7 @@ func_sql_expr_call(struct func *func, struct port *args, struct port *ret)
 	else
 		vdbe_field_ref_prepare_array(ref, 1, data, mp_size);
 	ref->format = format;
-	if (sql_bind_ptr(stmt, 1, ref) != 0)
+	if (sql_bind_ptr(stmt, 1, ref, NULL, 0) != 0)
 		goto error;
 
 	if (sql_step(stmt) != SQL_ROW)

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -2876,6 +2876,18 @@ sqlVdbeMemClearAndResize(struct Mem *pMem, size_t szNew)
 }
 
 void
+releaseVarArray(struct Var *p, int N)
+{
+	if (p && N) {
+		for (int i = 0; i < N; i++) {
+			assert(sqlVdbeCheckMemInvariants(p[i].value));
+			mem_destroy(p[i].value);
+			sql_xfree(p[i].value);
+		}
+	}
+}
+
+void
 releaseMemArray(Mem * p, int N)
 {
 	if (p && N) {

--- a/src/box/sql/mem.h
+++ b/src/box/sql/mem.h
@@ -36,6 +36,7 @@
 
 struct sql;
 struct Vdbe;
+struct Var;
 struct region;
 struct mpstream;
 struct VdbeFrame;
@@ -778,6 +779,12 @@ int sqlVdbeCheckMemInvariants(struct Mem *);
  */
 void
 sqlVdbeMemClearAndResize(struct Mem *pMem, size_t n);
+
+/*
+ * Release an array of N Var elements
+ */
+void
+releaseVarArray(struct Var *p, int N);
 
 /*
  * Release an array of N Mem elements

--- a/src/box/sql/prepare.c
+++ b/src/box/sql/prepare.c
@@ -41,11 +41,12 @@
 
 int
 sql_stmt_compile(const char *zSql, int nBytes, struct Vdbe *pReprepare,
-		 struct Vdbe **ppStmt, const char **pzTail)
+		 struct Vdbe **ppStmt, const char **pzTail, uint32_t bind_count)
 {
 	int rc = 0;	/* Result code */
 	Parse sParse;		/* Parsing context */
 	sql_parser_create(&sParse, current_session()->sql_flags);
+	sParse.bind_count = bind_count;
 	sParse.pReprepare = pReprepare;
 	*ppStmt = NULL;
 
@@ -174,7 +175,7 @@ sqlReprepare(Vdbe * p)
 
 	zSql = sql_sql(p);
 	assert(zSql != 0);
-	if (sql_stmt_compile(zSql, -1, p, &pNew, 0) != 0) {
+	if (sql_stmt_compile(zSql, -1, p, &pNew, 0, 0) != 0) {
 		assert(pNew == 0);
 		return -1;
 	}

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -315,7 +315,8 @@ sql_vsnprintf(int, char *, const char *, va_list);
  */
 int
 sql_stmt_compile(const char *sql, int bytes_count, struct Vdbe *re_prepared,
-		 struct Vdbe **stmt, const char **sql_tail);
+		 struct Vdbe **stmt, const char **sql_tail,
+		 uint32_t bind_count);
 
 /** This is the top-level implementation of sqlStep(). */
 int
@@ -490,7 +491,8 @@ sql_reset_autoinc_id_list(struct Vdbe *stmt);
 
 /** Perform double parameter binding for the sql statement. */
 int
-sql_bind_double(struct Vdbe *v, int i, double value);
+sql_bind_double(struct Vdbe *v, int i, double value, const char *name,
+		uint32_t name_len);
 
 /**
  * Perform boolean parameter binding for the prepared sql
@@ -501,19 +503,23 @@ sql_bind_double(struct Vdbe *v, int i, double value);
  * @retval 0 On Success, not 0 otherwise.
  */
 int
-sql_bind_boolean(struct Vdbe *v, int i, bool value);
+sql_bind_boolean(struct Vdbe *v, int i, bool value, const char *name,
+		 uint32_t name_len);
 
 /** Perform integer parameter binding for the sql statement. */
 int
-sql_bind_int(struct Vdbe *v, int i, int value);
+sql_bind_int(struct Vdbe *v, int i, int value, const char *name,
+	     uint32_t name_len);
 
 /** Perform 64-bit negative integer parameter binding for the sql statement. */
 int
-sql_bind_int64(struct Vdbe *v, int i, int64_t value);
+sql_bind_int64(struct Vdbe *v, int i, int64_t value, const char *name,
+	       uint32_t name_len);
 
 /** Perform 64-bit unsigned integer parameter binding for the sql statement. */
 int
-sql_bind_uint64(struct Vdbe *v, int i, uint64_t value);
+sql_bind_uint64(struct Vdbe *v, int i, uint64_t value, const char *name,
+		uint32_t name_len);
 
 /** Perform NULL parameter binding for the sql statement. */
 int
@@ -521,35 +527,43 @@ sql_bind_null(struct Vdbe *v, int i);
 
 /** Perform string parameter binding for the sql statement. */
 int
-sql_bind_str_static(struct Vdbe *v, int i, const char *str, uint32_t len);
+sql_bind_str_static(struct Vdbe *v, int i, const char *str, uint32_t len,
+		    const char *name, uint32_t name_len);
 
 /** Perform binary string parameter binding for the sql statement. */
 int
-sql_bind_bin_static(struct Vdbe *v, int i, const char *str, uint32_t size);
+sql_bind_bin_static(struct Vdbe *v, int i, const char *str, uint32_t size,
+		    const char *name, uint32_t name_len);
 
 /** Perform array parameter binding for the sql statement. */
 int
-sql_bind_array_static(struct Vdbe *v, int i, const char *str, uint32_t size);
+sql_bind_array_static(struct Vdbe *v, int i, const char *str, uint32_t size,
+		      const char *name, uint32_t name_len);
 
 /** Perform map parameter binding for the sql statement. */
 int
-sql_bind_map_static(struct Vdbe *v, int i, const char *str, uint32_t size);
+sql_bind_map_static(struct Vdbe *v, int i, const char *str, uint32_t size,
+		    const char *name, uint32_t name_len);
 
 /** Perform UUID parameter binding for the sql statement. */
 int
-sql_bind_uuid(struct Vdbe *v, int i, const struct tt_uuid *uuid);
+sql_bind_uuid(struct Vdbe *v, int i, const struct tt_uuid *uuid,
+	      const char *name, uint32_t name_len);
 
 /** Perform decimal parameter binding for the sql statement. */
 int
-sql_bind_dec(struct Vdbe *v, int i, const decimal_t *dec);
+sql_bind_dec(struct Vdbe *v, int i, const decimal_t *dec, const char *name,
+	     uint32_t name_len);
 
 /** Perform DATETIME parameter binding for the sql statement. */
 int
-sql_bind_datetime(struct Vdbe *v, int i, const struct datetime *dt);
+sql_bind_datetime(struct Vdbe *v, int i, const struct datetime *dt,
+		  const char *name, uint32_t name_len);
 
 /** Perform INTERVAL parameter binding for the SQL statement. */
 int
-sql_bind_interval(struct Vdbe *v, int i, const struct interval *itv);
+sql_bind_interval(struct Vdbe *v, int i, const struct interval *itv,
+		  const char *name, uint32_t name_len);
 
 /**
  * Return the number of wildcards that should be bound to.
@@ -575,7 +589,8 @@ sql_bind_parameter_name(const struct Vdbe *v, int i);
  * @retval Not 0 otherwise.
  */
 int
-sql_bind_ptr(struct Vdbe *v, int i, void *ptr);
+sql_bind_ptr(struct Vdbe *v, int i, void *ptr, const char *name,
+	     uint32_t name_len);
 
 int
 sql_init_db(sql **db);
@@ -2075,6 +2090,7 @@ struct Parse {
 		struct Select *select;
 		struct sql_trigger *trigger;
 	} parsed_ast;
+	uint32_t bind_count;	/* Count of bind variables. */
 };
 
 /*

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -358,6 +358,7 @@ vdbe_field_ref_fetch(struct vdbe_field_ref *field_ref, uint32_t fieldno,
  */
 int sqlVdbeExec(Vdbe *p)
 {
+	ynVar last = 0;
 	Op *aOp = p->aOp;          /* Copy of p->aOp */
 	Op *pOp = aOp;             /* Current operation */
 #if defined(SQL_DEBUG)
@@ -862,9 +863,25 @@ case OP_Blob: {                /* out2 */
 case OP_Variable: {            /* out2 */
 	Mem *pVar;       /* Value being transferred */
 
+	if (pOp->p4.z != NULL) {
+		if (pOp->p4.z[0] == ':' || pOp->p4.z[0] == '@' ||
+		    pOp->p4.z[0] == '#') {
+			for (uint32_t i = 0; i < (uint32_t)p->nVar; i++) {
+				if (p->aVar[i].name != NULL) {
+					if (strncmp(p->aVar[i].name, pOp->p4.z,
+						    p->aVar[i].name_len) == 0) {
+						pOp->p1 = i + 1;
+						break;
+					}
+				}
+			}
+		}
+	} else {
+		pOp->p1 = ++last;
+	}
+	last = pOp->p1;
 	assert(pOp->p1>0 && pOp->p1<=p->nVar);
-	assert(pOp->p4.z==0 || pOp->p4.z==sqlVListNumToName(p->pVList,pOp->p1));
-	pVar = &p->aVar[pOp->p1 - 1];
+	pVar = p->aVar[pOp->p1 - 1].value;
 	if (sqlVdbeMemTooBig(pVar)) {
 		goto too_big;
 	}

--- a/src/box/sql/vdbeInt.h
+++ b/src/box/sql/vdbeInt.h
@@ -216,6 +216,16 @@ struct sql_column_metadata {
 };
 
 /*
+ * A structure used to create the `aVar` array of variables
+ * within the `Vdbe` struct; it holds the variable's value and its name.
+ */
+struct Var {
+	Mem *value; /* Value of Variable. */
+	const char *name; /* Name of value. */
+	uint32_t name_len; /* Len of name of value. */
+};
+
+/*
  * An instance of the virtual machine.  This structure contains the complete
  * state of the virtual machine.
  *
@@ -265,7 +275,7 @@ struct Vdbe {
 	struct sql_column_metadata *metadata;
 	Mem *pResultSet;	/* Pointer to an array of results */
 	VdbeCursor **apCsr;	/* One element of this array for each open cursor */
-	Mem *aVar;		/* Values for the OP_Variable opcode. */
+	struct Var *aVar;		/* Values for the OP_Variable opcode. */
 	/**
 	 * Array which contains positions of variables to be
 	 * bound in resulting set of SELECT.

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -325,7 +325,7 @@ vdbeUnbind(struct Vdbe *p, int i)
 		return -1;
 	}
 	i--;
-	pVar = &p->aVar[i];
+	pVar = p->aVar[i].value;
 	mem_destroy(pVar);
 	return 0;
 }
@@ -394,49 +394,68 @@ sql_reset_autoinc_id_list(struct Vdbe *v)
 	stailq_create(&v->autoinc_id_list);
 }
 
+/*
+ * Set name and length of name in strcut `Var`.
+ */
+void
+var_set_name(struct Var *variable, const char *name, uint32_t name_len)
+{
+	variable->name = name;
+	variable->name_len = name_len;
+}
+
 int
-sql_bind_double(struct Vdbe *p, int i, double rValue)
+sql_bind_double(struct Vdbe *p, int i, double rValue,
+		const char *name, uint32_t name_len)
 {
 	if (vdbeUnbind(p, i) != 0)
 		return -1;
 	int rc = sql_bind_type(p, i, "numeric");
-	mem_set_double(&p->aVar[i - 1], rValue);
+	mem_set_double(p->aVar[i - 1].value, rValue);
+	var_set_name(&p->aVar[i - 1], name, name_len);
 	return rc;
 }
 
 int
-sql_bind_boolean(struct Vdbe *p, int i, bool value)
+sql_bind_boolean(struct Vdbe *p, int i, bool value,
+		 const char *name, uint32_t name_len)
 {
 	if (vdbeUnbind(p, i) != 0)
 		return -1;
 	int rc = sql_bind_type(p, i, "boolean");
-	mem_set_bool(&p->aVar[i - 1], value);
+	mem_set_bool(p->aVar[i - 1].value, value);
+	var_set_name(&p->aVar[i - 1], name, name_len);
 	return rc;
 }
 
 int
-sql_bind_int(struct Vdbe *p, int i, int iValue)
+sql_bind_int(struct Vdbe *p, int i, int iValue, const char *name,
+	     uint32_t name_len)
 {
-	return sql_bind_int64(p, i, (i64) iValue);
+	return sql_bind_int64(p, i, (i64) iValue, name, name_len);
 }
 
 int
-sql_bind_int64(struct Vdbe *p, int i, int64_t iValue)
+sql_bind_int64(struct Vdbe *p, int i, int64_t iValue, const char *name,
+	       uint32_t name_len)
 {
 	if (vdbeUnbind(p, i) != 0)
 		return -1;
 	int rc = sql_bind_type(p, i, "integer");
-	mem_set_int(&p->aVar[i - 1], iValue);
+	mem_set_int(p->aVar[i - 1].value, iValue);
+	var_set_name(&p->aVar[i - 1], name, name_len);
 	return rc;
 }
 
 int
-sql_bind_uint64(struct Vdbe *p, int i, uint64_t value)
+sql_bind_uint64(struct Vdbe *p, int i, uint64_t value, const char *name,
+		uint32_t name_len)
 {
 	if (vdbeUnbind(p, i) != 0)
 		return -1;
 	int rc = sql_bind_type(p, i, "integer");
-	mem_set_uint(&p->aVar[i - 1], value);
+	mem_set_uint(p->aVar[i - 1].value, value);
+	var_set_name(&p->aVar[i - 1], name, name_len);
 	return rc;
 }
 
@@ -449,77 +468,95 @@ sql_bind_null(struct Vdbe *p, int i)
 }
 
 int
-sql_bind_ptr(struct Vdbe *p, int i, void *ptr)
+sql_bind_ptr(struct Vdbe *p, int i, void *ptr, const char *name,
+	     uint32_t name_len)
 {
 	int rc = vdbeUnbind(p, i);
 	if (rc == 0) {
 		rc = sql_bind_type(p, i, "varbinary");
-		mem_set_ptr(&p->aVar[i - 1], ptr);
+		mem_set_ptr(p->aVar[i - 1].value, ptr);
+		var_set_name(&p->aVar[i - 1], name, name_len);
 	}
 	return rc;
 }
 
 int
-sql_bind_str_static(struct Vdbe *vdbe, int i, const char *str, uint32_t len)
+sql_bind_str_static(struct Vdbe *vdbe, int i, const char *str, uint32_t len,
+		    const char *name, uint32_t name_len)
 {
-	mem_set_str_static(&vdbe->aVar[i - 1], (char *)str, len);
+	mem_set_str_static(vdbe->aVar[i - 1].value, (char *)str, len);
+	var_set_name(&vdbe->aVar[i - 1], name, name_len);
 	return sql_bind_type(vdbe, i, "text");
 }
 
 int
-sql_bind_bin_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
+sql_bind_bin_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size,
+		    const char *name, uint32_t name_len)
 {
-	mem_set_bin_static(&vdbe->aVar[i - 1], (char *)str, size);
+	mem_set_bin_static(vdbe->aVar[i - 1].value, (char *)str, size);
+	var_set_name(&vdbe->aVar[i - 1], name, name_len);
 	return sql_bind_type(vdbe, i, "text");
 }
 
 int
-sql_bind_array_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
+sql_bind_array_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size,
+		      const char *name, uint32_t name_len)
 {
-	mem_set_array_static(&vdbe->aVar[i - 1], (char *)str, size);
+	mem_set_array_static(vdbe->aVar[i - 1].value, (char *)str, size);
+	var_set_name(&vdbe->aVar[i - 1], name, name_len);
 	return sql_bind_type(vdbe, i, "array");
 }
 
 int
-sql_bind_map_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
+sql_bind_map_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size,
+		    const char *name, uint32_t name_len)
 {
-	mem_set_map_static(&vdbe->aVar[i - 1], (char *)str, size);
+	mem_set_map_static(vdbe->aVar[i - 1].value, (char *)str, size);
+	var_set_name(&vdbe->aVar[i - 1], name, name_len);
 	return sql_bind_type(vdbe, i, "map");
 }
 
 int
-sql_bind_uuid(struct Vdbe *p, int i, const struct tt_uuid *uuid)
+sql_bind_uuid(struct Vdbe *p, int i, const struct tt_uuid *uuid,
+	      const char *name, uint32_t name_len)
 {
 	if (vdbeUnbind(p, i) != 0 || sql_bind_type(p, i, "uuid") != 0)
 		return -1;
-	mem_set_uuid(&p->aVar[i - 1], uuid);
+	mem_set_uuid(p->aVar[i - 1].value, uuid);
+	var_set_name(&p->aVar[i - 1], name, name_len);
 	return 0;
 }
 
 int
-sql_bind_dec(struct Vdbe *p, int i, const decimal_t *dec)
+sql_bind_dec(struct Vdbe *p, int i, const decimal_t *dec, const char *name,
+	     uint32_t name_len)
 {
 	if (vdbeUnbind(p, i) != 0 || sql_bind_type(p, i, "decimal") != 0)
 		return -1;
-	mem_set_dec(&p->aVar[i - 1], dec);
+	mem_set_dec(p->aVar[i - 1].value, dec);
+	var_set_name(&p->aVar[i - 1], name, name_len);
 	return 0;
 }
 
 int
-sql_bind_datetime(struct Vdbe *p, int i, const struct datetime *dt)
+sql_bind_datetime(struct Vdbe *p, int i, const struct datetime *dt,
+		  const char *name, uint32_t name_len)
 {
 	if (vdbeUnbind(p, i) != 0 || sql_bind_type(p, i, "datetime") != 0)
 		return -1;
-	mem_set_datetime(&p->aVar[i - 1], dt);
+	mem_set_datetime(p->aVar[i - 1].value, dt);
+	var_set_name(&p->aVar[i - 1], name, name_len);
 	return 0;
 }
 
 int
-sql_bind_interval(struct Vdbe *p, int i, const struct interval *itv)
+sql_bind_interval(struct Vdbe *p, int i, const struct interval *itv,
+		  const char *name, uint32_t name_len)
 {
 	if (vdbeUnbind(p, i) != 0 || sql_bind_type(p, i, "interval") != 0)
 		return -1;
-	mem_set_interval(&p->aVar[i - 1], itv);
+	mem_set_interval(p->aVar[i - 1].value, itv);
+	var_set_name(&p->aVar[i - 1], name, name_len);
 	return 0;
 }
 
@@ -562,7 +599,7 @@ sqlTransferBindings(struct Vdbe *pFrom, struct Vdbe *pTo)
 	int i;
 	assert(pTo->nVar == pFrom->nVar);
 	for (i = 0; i < pFrom->nVar; i++) {
-		mem_move(&pTo->aVar[i], &pFrom->aVar[i]);
+		mem_move(pTo->aVar[i].value, pFrom->aVar[i].value);
 	}
 	return 0;
 }

--- a/src/box/sql/vdbeaux.c
+++ b/src/box/sql/vdbeaux.c
@@ -1404,7 +1404,10 @@ sqlVdbeMakeReady(Vdbe * p,	/* The VDBE */
 	assert(pParse != 0);
 	assert(p->magic == VDBE_MAGIC_INIT);
 	assert(pParse == p->pParse);
-	nVar = pParse->nVar;
+	if (pParse->bind_count == 0)
+		nVar = pParse->nVar;
+	else
+		nVar = pParse->bind_count;
 	nMem = pParse->nMem;
 	nCursor = pParse->nTab;
 
@@ -1447,7 +1450,7 @@ sqlVdbeMakeReady(Vdbe * p,	/* The VDBE */
 	do {
 		x.nNeeded = 0;
 		p->aMem = allocSpace(&x, p->aMem, nMem * sizeof(Mem));
-		p->aVar = allocSpace(&x, p->aVar, nVar * sizeof(Mem));
+		p->aVar = allocSpace(&x, p->aVar, nVar * sizeof(struct Var));
 		p->apCsr =
 		    allocSpace(&x, p->apCsr, nCursor * sizeof(VdbeCursor *));
 		if (x.nNeeded == 0)
@@ -1462,8 +1465,10 @@ sqlVdbeMakeReady(Vdbe * p,	/* The VDBE */
 	p->explain = pParse->explain;
 	p->nCursor = nCursor;
 	p->nVar = nVar;
-	for (int i = 0; i < nVar; ++i)
-		mem_create(&p->aVar[i]);
+	for (int i = 0; i < nVar; ++i) {
+		p->aVar[i].value = sql_xmalloc(sizeof(Mem));
+		mem_create(p->aVar[i].value);
+	}
 	p->nMem = nMem;
 	for (int i = 0; i < nMem; ++i) {
 		mem_create(&p->aMem[i]);
@@ -1987,7 +1992,7 @@ sqlVdbeClearObject(struct Vdbe *p)
 		sql_xfree(pSub);
 	}
 	if (p->magic != VDBE_MAGIC_INIT) {
-		releaseMemArray(p->aVar, p->nVar);
+		releaseVarArray(p->aVar, p->nVar);
 		sql_xfree(p->pVList);
 		sql_xfree(p->pFree);
 	}
@@ -2073,7 +2078,7 @@ vdbe_get_bound_value(struct Vdbe *vdbe, int id)
 {
 	if (vdbe == NULL || id < 0 || id >= vdbe->nVar)
 		return NULL;
-	return &vdbe->aVar[id];
+	return vdbe->aVar[id].value;
 }
 
 void

--- a/src/box/sql/vdbetrace.c
+++ b/src/box/sql/vdbetrace.c
@@ -138,7 +138,7 @@ sqlVdbeExpandSql(Vdbe * p,	/* The prepared statement being evaluated */
 			zRawSql += nToken;
 			nextIndex = idx + 1;
 			assert(idx > 0 && idx <= p->nVar);
-			const char *value = mem_str(&p->aVar[idx - 1]);
+			const char *value = mem_str(p->aVar[idx - 1].value);
 			sqlStrAccumAppend(&out, value, strlen(value));
 		}
 	}

--- a/test/box/net.box_iproto_transactions_over_streams.result
+++ b/test/box/net.box_iproto_transactions_over_streams.result
@@ -1647,10 +1647,10 @@ conn.space.TEST:select()
 ---
 - []
 ...
-stream_pr = stream:prepare("SELECT * FROM TEST WHERE ID = ? AND A = ?;")
+stream_pr = stream:prepare("SELECT * FROM TEST WHERE ID = :id AND A = :a;")
 ---
 ...
-conn_pr = conn:prepare("SELECT * FROM TEST WHERE ID = ? AND A = ?;")
+conn_pr = conn:prepare("SELECT * FROM TEST WHERE ID = :id AND A = :a;")
 ---
 ...
 assert(stream_pr.stmt_id == conn_pr.stmt_id)
@@ -1658,7 +1658,7 @@ assert(stream_pr.stmt_id == conn_pr.stmt_id)
 - true
 ...
 -- [ 1, 2, '3' ]
-stream:execute(stream_pr.stmt_id, {1, 2})
+stream:execute(stream_pr.stmt_id, {{[':id'] = 1}, {[':a'] = 2}})
 ---
 - metadata:
   - name: ID
@@ -1671,7 +1671,7 @@ stream:execute(stream_pr.stmt_id, {1, 2})
   - [1, 2, '3']
 ...
 -- empty select, transaction was not commited
-conn:execute(conn_pr.stmt_id, {1, 2})
+conn:execute(conn_pr.stmt_id, {{[':id'] = 1}, {[':a'] = 2}})
 ---
 - metadata:
   - name: ID
@@ -1687,7 +1687,7 @@ stream:execute('COMMIT')
 - row_count: 0
 ...
 -- [ 1, 2, '3' ]
-stream:execute(stream_pr.stmt_id, {1, 2})
+stream:execute(stream_pr.stmt_id, {{[':id'] = 1}, {[':a'] = 2}})
 ---
 - metadata:
   - name: ID
@@ -1700,7 +1700,7 @@ stream:execute(stream_pr.stmt_id, {1, 2})
   - [1, 2, '3']
 ...
 -- [ 1, 2, '3' ]
-conn:execute(conn_pr.stmt_id, {1, 2})
+conn:execute(conn_pr.stmt_id, {{[':id'] = 1}, {[':a'] = 2}})
 ---
 - metadata:
   - name: ID

--- a/test/box/net.box_iproto_transactions_over_streams.test.lua
+++ b/test/box/net.box_iproto_transactions_over_streams.test.lua
@@ -798,18 +798,18 @@ space:replace{1, 2, '3'}
 space:select()
 -- select is empty, because transaction was not commited
 conn.space.TEST:select()
-stream_pr = stream:prepare("SELECT * FROM TEST WHERE ID = ? AND A = ?;")
-conn_pr = conn:prepare("SELECT * FROM TEST WHERE ID = ? AND A = ?;")
+stream_pr = stream:prepare("SELECT * FROM TEST WHERE ID = :id AND A = :a;")
+conn_pr = conn:prepare("SELECT * FROM TEST WHERE ID = :id AND A = :a;")
 assert(stream_pr.stmt_id == conn_pr.stmt_id)
 -- [ 1, 2, '3' ]
-stream:execute(stream_pr.stmt_id, {1, 2})
+stream:execute(stream_pr.stmt_id, {{[':id'] = 1}, {[':a'] = 2}})
 -- empty select, transaction was not commited
-conn:execute(conn_pr.stmt_id, {1, 2})
+conn:execute(conn_pr.stmt_id, {{[':id'] = 1}, {[':a'] = 2}})
 stream:execute('COMMIT')
 -- [ 1, 2, '3' ]
-stream:execute(stream_pr.stmt_id, {1, 2})
+stream:execute(stream_pr.stmt_id, {{[':id'] = 1}, {[':a'] = 2}})
 -- [ 1, 2, '3' ]
-conn:execute(conn_pr.stmt_id, {1, 2})
+conn:execute(conn_pr.stmt_id, {{[':id'] = 1}, {[':a'] = 2}})
 stream:unprepare(stream_pr.stmt_id)
 conn:close()
 test_run:switch('test')

--- a/test/sql-luatest/bind_test.lua
+++ b/test/sql-luatest/bind_test.lua
@@ -29,6 +29,19 @@ g.test_bind_2 = function()
     t.assert_equals(err.message, res)
 end
 
+-- Check work of numeric bind variables
+g.test_12733_numeric_bind_variables = function()
+    g.server:exec(function()
+        local sql = [[SELECT $3, $1, $2;]]
+        local res = box.execute(sql, {'a', 'b', 'c'})
+        t.assert_equals(res.rows, {{'c', 'a', 'b'}})
+
+        sql = [[select #a, ?, :a;]]
+        res = box.execute(sql, {{['#a'] = 222}, {[':a'] = 333}})
+        t.assert_equals(res.rows, {{222, 333, 333}})
+    end)
+end
+
 g = t.group("bind2", {{remote = true}, {remote = false}})
 
 g.before_all(function(cg)
@@ -108,9 +121,9 @@ g.test_3401_box_execute_parameter_binding = function(cg)
         parameters[5] = 5
         parameters[6] = {}
         parameters[6]['@value2'] = 6
-        sql = 'SELECT :value3, ?, :value1, ?, ?, @value2, ?, :value3;'
+        sql = 'SELECT :value3, ?, :value1, ?, ?, @value2, :value3;'
         res = _G.execute(sql, parameters)
-        t.assert_equals(res.rows, {{1, 2, 3, 4, 5, 6, nil, 1}})
+        t.assert_equals(res.rows, {{1, 2, 3, 4, 5, 6, 1}})
 
         -- Try not-integer types.
         local msgpack = require('msgpack')
@@ -178,13 +191,11 @@ g.test_3401_box_execute_parameter_binding = function(cg)
 
         box.execute('DROP TABLE test;')
 
-        exp_err = "Failed to execute SQL statement: "..
-                  "The number of parameters is too large"
-        local _, err = box.execute('SELECT ?;', {1, 2})
-        t.assert_equals(tostring(err), exp_err)
+        res = box.execute('SELECT ?;', {1, 2})
+        t.assert_equals(res.rows, {{1}})
 
-        _, err = box.execute('SELECT $2;', {1, 2, 3})
-        t.assert_equals(tostring(err), exp_err)
+        res = box.execute('SELECT $2;', {1, 2, 3})
+        t.assert_equals(res.rows, {{2}})
     end)
 end
 

--- a/test/sql-luatest/prepared_test.lua
+++ b/test/sql-luatest/prepared_test.lua
@@ -74,12 +74,13 @@ g.test_prepared = function(cg)
         space:replace{1, 2, '3'}
         space:replace{4, 5, '6'}
         space:replace{7, 8.5, '9'}
-        local s, err = _G.prepare("SELECT * FROM test WHERE id = ? AND a = ?;")
+        local sql = "SELECT * FROM test WHERE id = :id AND a = :a;"
+        local s, err = _G.prepare(sql)
         t.assert_equals(err, nil)
-        t.assert_equals(s.stmt_id, 3603193623)
+        t.assert_equals(s.stmt_id, 4051716978)
 
         exp = {
-            stmt_id = 3603193623,
+            stmt_id = 4051716978,
             metadata = {
                 {
                     name = "id",
@@ -96,11 +97,11 @@ g.test_prepared = function(cg)
             },
             params = {
                 {
-                    name = "?",
+                    name = ":id",
                     type = "ANY",
                 },
                 {
-                    name = "?",
+                    name = ":a",
                     type = "ANY",
                 },
             },
@@ -108,16 +109,18 @@ g.test_prepared = function(cg)
         }
         t.assert_covers(s, exp)
 
-        t.assert_equals(_G.execute(s.stmt_id, {1, 2}).rows, {{1, 2, '3'}})
-        t.assert_equals(_G.execute(s.stmt_id, {1, 3}).rows, {})
+        t.assert_equals(_G.execute(s.stmt_id, {{[':id'] = 1},
+                                   {[':a'] = 2}}).rows, {{1, 2, '3'}})
+        t.assert_equals(_G.execute(s.stmt_id, {{[':id'] = 1},
+                                   {[':a'] = 3}}).rows, {})
 
         t.assert_not_equals(box.info.sql().cache.stmt_count, 0)
         t.assert_not_equals(box.info.sql().cache.size, 0)
 
         if not remote then
-            res = s:execute({1, 2})
+            res = s:execute({{[':id'] = 1}, {[':a'] = 2}})
             t.assert_not_equals(res, nil)
-            res = s:execute({1, 3})
+            res = s:execute({{[':id'] = 1}, {[':a'] = 3}})
             t.assert_not_equals(res, nil)
         end
 
@@ -150,7 +153,7 @@ g.test_prepared = function(cg)
         check_prepared_ddl_fails("ALTER TABLE test RENAME TO test1;")
 
         box.execute("CREATE TABLE test2 (id INT PRIMARY KEY);")
-        local sql =  [[ALTER TABLE test2 ADD CONSTRAINT fk1
+        sql =  [[ALTER TABLE test2 ADD CONSTRAINT fk1
                        FOREIGN KEY (id) REFERENCES test2;]]
         check_prepared_ddl_fails(sql)
         box.space.test2:drop()

--- a/test/sql/boolean.result
+++ b/test/sql/boolean.result
@@ -389,7 +389,7 @@ SELECT GROUP_CONCAT(a, ' +++ ') FROM t0;
  | ---
  | - true
  | ...
-box.execute('SELECT ?, ?, return_type($1), TYPEOF($2);', {true, false})
+box.execute('SELECT :a, :b, return_type($1), TYPEOF($2);', {{[':a'] = true}, {[':b'] = false}})
  | ---
  | - metadata:
  |   - name: COLUMN_1

--- a/test/sql/boolean.test.sql
+++ b/test/sql/boolean.test.sql
@@ -102,7 +102,7 @@ SELECT GROUP_CONCAT(a, ' +++ ') FROM t0;
 
 -- Check BOOLEAN as binding parameter.
 \set language lua
-box.execute('SELECT ?, ?, return_type($1), TYPEOF($2);', {true, false})
+box.execute('SELECT :a, :b, return_type($1), TYPEOF($2);', {{[':a'] = true}, {[':b'] = false}})
 
 parameters = {}
 parameters[1] = {}


### PR DESCRIPTION
sql: fix work of bind variables

After this patch:
The number of a numeric bind variable always corresponds to
its position in the provided array of bind variables;
The anonymous bind variable always corresponds to the next variable
to be processed in the provided array of bind variables.
Due to the query planner, the execution order of variables may differ
from their order of appearance in the query; therefore, in some queries,
they should be replaced with numbered or named variables;
The named bind variables always corresponds to a variable
with the same name in the provided array of bind variables.

Part of #12733

@TarantoolBot document
Title: behavior of bind variables

The number of a numeric bind variable always corresponds to
its position in the provided array of bind variables;
The anonymous bind variable always corresponds to the next variable
to be processed in the provided array of bind variables.
Due to the query planner, the execution order of variables may differ
from their order of appearance in the query; therefore, in some queries,
they should be replaced with numbered or named variables;
The named bind variables always corresponds to a variable
with the same name in the provided array of bind variables.