### PR TITLE
config: move vshard check back to apply stage

### DIFF
--- a/changelogs/unreleased/config-searchroot-work-dir.md
+++ b/changelogs/unreleased/config-searchroot-work-dir.md
@@ -1,0 +1,9 @@
+## bugfix/config
+
+* Modules installed into the configured `process.work_dir` (for example,
+  into its `.rocks` directory) are now resolvable, and a relative `app.file`
+  path is interpreted against the working directory even before the first
+  `box.cfg()` call. In particular, roles and an application marked with
+  the `early_load` tag can now be loaded from the working directory, and
+  the configuration defaults that depend on the installed vshard version
+  are applied at first startup.

--- a/changelogs/unreleased/config-searchroot-work-dir.md
+++ b/changelogs/unreleased/config-searchroot-work-dir.md
@@ -1,0 +1,6 @@
+## bugfix/config
+
+* Modules installed into the configured `process.work_dir` (for example,
+  into its `.rocks` directory) are now resolvable before the first
+  `box.cfg()` call. In particular, roles and an application marked with
+  the `early_load` tag can now be loaded from the working directory.

--- a/changelogs/unreleased/config-vshard-check-before-box-cfg.md
+++ b/changelogs/unreleased/config-vshard-check-before-box-cfg.md
@@ -1,0 +1,6 @@
+## bugfix/config
+
+* An unavailable or outdated vshard module for a configured sharding role,
+  as well as a configured sharding option that requires a newer vshard, is
+  now reported before the first `box.cfg()` call, so a misconfigured instance
+  fails fast instead of failing after a potentially long database recovery.

--- a/changelogs/unreleased/config-vshard-check-before-box-cfg.md
+++ b/changelogs/unreleased/config-vshard-check-before-box-cfg.md
@@ -1,0 +1,5 @@
+## bugfix/config
+
+* An unavailable or too old vshard module for a configured sharding role is
+  now reported before `box.cfg()`, so a misconfigured instance fails fast
+  instead of failing after a potentially long database recovery.

--- a/changelogs/unreleased/config-vshard-in-work-dir.md
+++ b/changelogs/unreleased/config-vshard-in-work-dir.md
@@ -1,0 +1,10 @@
+## bugfix/config
+
+* Fixed a spurious `The vshard-ee/vshard module is not available`
+  configuration validation error on startup when the vshard module is
+  installed into the configured `process.work_dir` and the process is started
+  from a different directory, or when an instance without a sharding role
+  inherits a global sharding option, such as `sharding.bucket_count`
+  (gh-12928). The availability of vshard and its minimum version are checked
+  when the sharding configuration is applied, after `box.cfg()`, when the
+  configured working directory is already entered.

--- a/changelogs/unreleased/config-vshard-in-work-dir.md
+++ b/changelogs/unreleased/config-vshard-in-work-dir.md
@@ -5,6 +5,5 @@
   installed into the configured `process.work_dir` and the process is started
   from a different directory, or when an instance without a sharding role
   inherits a global sharding option, such as `sharding.bucket_count`
-  (gh-12928). The availability of vshard and its minimum version are checked
-  when the sharding configuration is applied, after `box.cfg()`, when the
-  configured working directory is already entered.
+  (gh-12928). The availability of vshard and its minimum version are now
+  checked only on instances with a configured sharding role.

--- a/changelogs/unreleased/config-vshard-in-work-dir.md
+++ b/changelogs/unreleased/config-vshard-in-work-dir.md
@@ -4,5 +4,4 @@
   configuration validation error on startup when the vshard module is
   installed into the configured `process.work_dir` and the process is started
   from a different directory. The vshard availability and its minimum version
-  are checked when the sharding configuration is applied, after `box.cfg()`,
-  when the configured working directory is already entered.
+  are now checked only on instances with a configured sharding role.

--- a/changelogs/unreleased/config-vshard-in-work-dir.md
+++ b/changelogs/unreleased/config-vshard-in-work-dir.md
@@ -1,0 +1,8 @@
+## bugfix/config
+
+* Fixed a spurious `The vshard-ee/vshard module is not available`
+  configuration validation error on startup when the vshard module is
+  installed into the configured `process.work_dir` and the process is started
+  from a different directory. The vshard availability and its minimum version
+  are checked when the sharding configuration is applied, after `box.cfg()`,
+  when the configured working directory is already entered.

--- a/src/box/lua/config/applier/app.lua
+++ b/src/box/lua/config/applier/app.lua
@@ -26,8 +26,19 @@ local function run(config, opts)
     if file ~= nil then
         assert(module == nil)
 
+        -- A relative path is interpreted against process.work_dir.
+        -- The first box.cfg() call changes the current working
+        -- directory to it, but before that the path has to be
+        -- rebased manually.
+        local path = file
+        if type(box.cfg) == 'function' then
+            local work_dir = configdata:get('process.work_dir',
+                                            {use_default = true})
+            path = utils_file.rebase_file_abspath(work_dir, file)
+        end
+
         local metadata = {}
-        local ok, res = pcall(utils_file.get_file_metadata, file)
+        local ok, res = pcall(utils_file.get_file_metadata, path)
         if not ok then
             log.error(('Unable to get metadata for file %q: %s'):format(
                 file, res))
@@ -62,7 +73,7 @@ local function run(config, opts)
             return
         end
 
-        local fn = assert(loadfile(file))
+        local fn = assert(loadfile(path))
         log.verbose('app.run: loading '..file)
         fn(file)
 

--- a/src/box/lua/config/applier/credentials.lua
+++ b/src/box/lua/config/applier/credentials.lua
@@ -329,8 +329,8 @@ local function sharding_role(configdata)
     -- VShard availability and its minimum version are ensured by the
     -- sharding.stage_1 applier, which runs before this one.
     local funcs = {}
-    local vexports = loaders.require_first('vshard-ee.storage.exports',
-        'vshard.storage.exports')
+    local vexports = loaders.require_first('vshard.storage.exports',
+        'vshard-ee.storage.exports')
     local exports = vexports.compile(vexports.log[#vexports.log])
     for name in pairs(exports.funcs) do
         table.insert(funcs, name)

--- a/src/box/lua/config/applier/credentials.lua
+++ b/src/box/lua/config/applier/credentials.lua
@@ -1,4 +1,3 @@
-local expression = require('internal.config.utils.expression')
 local log = require('internal.config.utils.log')
 local textutils = require('internal.config.utils.textutils')
 local loaders = require('internal.loaders')
@@ -327,19 +326,14 @@ local function sharding_role(configdata)
         return {}
     end
 
+    -- VShard availability and its minimum version are ensured by the
+    -- sharding.stage_1 applier, which runs before this one.
     local funcs = {}
-    --
-    -- The error will be thrown later, in sharding.lua. Here we are simply
-    -- trying to avoid the "module not found" error.
-    --
-    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
-    if ok and expression.eval('v >= 0.1.25', {v = vshard.consts.VERSION}) then
-        local vexports = loaders.require_first('vshard-ee.storage.exports',
-            'vshard.storage.exports')
-        local exports = vexports.compile(vexports.log[#vexports.log])
-        for name in pairs(exports.funcs) do
-            table.insert(funcs, name)
-        end
+    local vexports = loaders.require_first('vshard-ee.storage.exports',
+        'vshard.storage.exports')
+    local exports = vexports.compile(vexports.log[#vexports.log])
+    for name in pairs(exports.funcs) do
+        table.insert(funcs, name)
     end
     return {
         privileges = {{

--- a/src/box/lua/config/applier/credentials.lua
+++ b/src/box/lua/config/applier/credentials.lua
@@ -1,3 +1,4 @@
+local expression = require('internal.config.utils.expression')
 local log = require('internal.config.utils.log')
 local textutils = require('internal.config.utils.textutils')
 local loaders = require('internal.loaders')
@@ -326,15 +327,19 @@ local function sharding_role(configdata)
         return {}
     end
 
-    -- VShard availability and its minimum version are ensured by the sharding
-    -- configuration validation (the `vshard_since` schema annotation).
     local funcs = {}
-    local vexports = loaders.require_first('vshard-ee.storage.exports',
-        'vshard.storage.exports')
-    assert(vexports)
-    local exports = vexports.compile(vexports.log[#vexports.log])
-    for name in pairs(exports.funcs) do
-        table.insert(funcs, name)
+    --
+    -- The error will be thrown later, in sharding.lua. Here we are simply
+    -- trying to avoid the "module not found" error.
+    --
+    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
+    if ok and expression.eval('v >= 0.1.25', {v = vshard.consts.VERSION}) then
+        local vexports = loaders.require_first('vshard-ee.storage.exports',
+            'vshard.storage.exports')
+        local exports = vexports.compile(vexports.log[#vexports.log])
+        for name in pairs(exports.funcs) do
+            table.insert(funcs, name)
+        end
     end
     return {
         privileges = {{

--- a/src/box/lua/config/applier/lua.lua
+++ b/src/box/lua/config/applier/lua.lua
@@ -1,4 +1,5 @@
 local alloc = require('internal.alloc')
+local fio = require('fio')
 local log = require('internal.config.utils.log')
 
 -- After limiting the memory to some value we want to be sure
@@ -12,7 +13,37 @@ local log = require('internal.config.utils.log')
 -- as 1/16 of the minimum Lua memory limit.
 local REQUIRED_UNUSED_MEMORY_AFTER_APPLICATION = 16 * 1024 * 1024
 
-local function apply(config)
+-- Point the module search root to process.work_dir.
+--
+-- The first box.cfg() call changes the current working directory
+-- to process.work_dir and modules installed into it (for
+-- example, into the .rocks subdirectory) become resolvable,
+-- because the module search is relative to the current directory
+-- by default.
+--
+-- However, some code runs before box.cfg(): roles and an
+-- application marked with the early_load tag and their metadata
+-- scan. Set the search root to make modules installed into the
+-- working directory resolvable before the chdir occurs.
+local function set_searchroot(config)
+    if type(box.cfg) ~= 'function' then
+        -- box.cfg() is already called, the current working
+        -- directory is process.work_dir. Nothing to do.
+        return
+    end
+    local configdata = config._configdata
+    local work_dir = configdata:get('process.work_dir', {use_default = true})
+    if work_dir == nil then
+        return
+    end
+    -- A relative process.work_dir is interpreted against the
+    -- startup working directory, which is not changed yet.
+    work_dir = fio.abspath(work_dir)
+    package.setsearchroot(work_dir)
+    log.verbose('lua.apply: set the module search root to %q', work_dir)
+end
+
+local function set_memory_limit(config)
     local configdata = config._configdata
     local memory_limit = configdata:get('lua.memory', {use_default = true})
     local old_memory_limit = alloc.getlimit()
@@ -43,6 +74,11 @@ local function apply(config)
     alloc.setlimit(memory_limit)
 
     log.verbose(('lua.apply: set memory limit to %d'):format(memory_limit))
+end
+
+local function apply(config)
+    set_searchroot(config)
+    set_memory_limit(config)
 end
 
 return {

--- a/src/box/lua/config/applier/sharding.lua
+++ b/src/box/lua/config/applier/sharding.lua
@@ -1,3 +1,4 @@
+local expression = require('internal.config.utils.expression')
 local health = require('internal.healthcheck')
 local log = require('internal.config.utils.log')
 local loaders = require('internal.loaders')
@@ -36,10 +37,22 @@ local function apply(config)
         unregister_vshard_health_checks()
         return
     end
-    -- VShard availability and its minimum version are ensured by the sharding
-    -- configuration validation (the `vshard_since` schema annotation).
-    _G.vshard = loaders.require_first('vshard-ee', 'vshard')
-    assert(_G.vshard)
+    -- Make sure vshard is available and its version is not too old.
+    --
+    -- It can't be done earlier, on the configuration validation stage: it
+    -- occurs before box.cfg() and if the module is installed into the
+    -- configured process.work_dir, it can be resolved only after box.cfg()
+    -- chdir()s there.
+    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
+    if not ok then
+        error('The vshard-ee/vshard module is not available', 0)
+    end
+    if expression.eval('v < 0.1.25', {v = vshard.consts.VERSION}) then
+        error('The vshard module is too old: the minimum supported version ' ..
+              'is 0.1.25.', 0)
+    end
+
+    _G.vshard = vshard
     local is_storage = false
     local is_router = false
     for _, role in pairs(roles) do

--- a/src/box/lua/config/applier/sharding.lua
+++ b/src/box/lua/config/applier/sharding.lua
@@ -30,19 +30,25 @@ local function register_vshard_router_health_check()
     end
 end
 
-local function apply(config)
+-- Make sure vshard is available and its version is not too old.
+--
+-- The check is performed before box.cfg() and so before a
+-- potentially long database recovery: a misconfiguration is
+-- reported as fast as possible.
+--
+-- It can't be done even earlier, on the configuration validation
+-- stage, for two reasons. First, the validation is performed
+-- before the module search root is pointed to process.work_dir
+-- (the work_dir is not known yet), so a module installed into the
+-- working directory is not resolvable at that point. Second, the
+-- same schema validates cluster configurations as a whole, while
+-- the module is only needed on instances that have a sharding
+-- role.
+local function check_vshard(config)
     local configdata = config._configdata
-    local roles = configdata:get('sharding.roles')
-    if roles == nil then
-        unregister_vshard_health_checks()
+    if configdata:get('sharding.roles') == nil then
         return
     end
-    -- Make sure vshard is available and its version is not too old.
-    --
-    -- It can't be done earlier, on the configuration validation stage: it
-    -- occurs before box.cfg() and if the module is installed into the
-    -- configured process.work_dir, it can be resolved only after box.cfg()
-    -- chdir()s there.
     local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
     if not ok then
         error('The vshard-ee/vshard module is not available', 0)
@@ -51,8 +57,18 @@ local function apply(config)
         error('The vshard module is too old: the minimum supported version ' ..
               'is 0.1.25.', 0)
     end
+end
 
-    _G.vshard = vshard
+local function apply(config)
+    local configdata = config._configdata
+    local roles = configdata:get('sharding.roles')
+    if roles == nil then
+        unregister_vshard_health_checks()
+        return
+    end
+    -- The availability and the minimum version are verified by
+    -- the sharding.stage_1 applier.
+    _G.vshard = loaders.require_first('vshard-ee', 'vshard')
     local is_storage = false
     local is_router = false
     for _, role in pairs(roles) do
@@ -97,6 +113,12 @@ local function apply(config)
 end
 
 return {
-    name = 'sharding',
-    apply = apply,
+    stage_1 = {
+        name = 'sharding.stage_1',
+        apply = check_vshard,
+    },
+    stage_2 = {
+        name = 'sharding.stage_2',
+        apply = apply,
+    },
 }

--- a/src/box/lua/config/applier/sharding.lua
+++ b/src/box/lua/config/applier/sharding.lua
@@ -65,7 +65,7 @@ local function check_vshard(config)
     if not is_storage and not is_router then
         return
     end
-    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
+    local ok, vshard = pcall(loaders.require_first, 'vshard', 'vshard-ee')
     if not ok then
         error('The vshard-ee/vshard module is not available', 0)
     end
@@ -97,14 +97,14 @@ local function apply(config)
     end
     -- The availability and the minimum version are verified by
     -- the sharding.stage_1 applier.
-    _G.vshard = loaders.require_first('vshard-ee', 'vshard')
+    _G.vshard = loaders.require_first('vshard', 'vshard-ee')
     local cfg = configdata:sharding()
     if is_storage then
         -- Start a watcher which will create all the necessary functions.
         if watcher == nil then
             local function deploy_funcs()
                 local vexports = loaders.require_first(
-                    'vshard-ee.storage.exports', 'vshard.storage.exports')
+                    'vshard.storage.exports', 'vshard-ee.storage.exports')
                 local exports = vexports.compile(vexports.log[#vexports.log])
                 vexports.deploy_funcs(exports)
             end

--- a/src/box/lua/config/applier/sharding.lua
+++ b/src/box/lua/config/applier/sharding.lua
@@ -30,38 +30,74 @@ local function register_vshard_router_health_check()
     end
 end
 
-local function apply(config)
-    local configdata = config._configdata
-    local roles = configdata:get('sharding.roles')
-    if roles == nil then
-        unregister_vshard_health_checks()
-        return
-    end
-    -- Make sure vshard is available and its version is not too old.
-    --
-    -- It can't be done earlier, on the configuration validation stage: it
-    -- occurs before box.cfg() and if the module is installed into the
-    -- configured process.work_dir, it can be resolved only after box.cfg()
-    -- chdir()s there.
-    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
-    if not ok then
-        error('The vshard-ee/vshard module is not available', 0)
-    end
-    if expression.eval('v < 0.1.25', {v = vshard.consts.VERSION}) then
-        error('The vshard module is too old: the minimum supported version ' ..
-              'is 0.1.25.', 0)
-    end
-
-    _G.vshard = vshard
+-- Whether the storage and the router vshard roles are configured
+-- on the instance.
+local function get_vshard_roles(configdata)
     local is_storage = false
     local is_router = false
-    for _, role in pairs(roles) do
+    for _, role in pairs(configdata:get('sharding.roles') or {}) do
         if role == 'storage' then
             is_storage = true
         elseif role == 'router' then
             is_router = true
         end
     end
+    return is_storage, is_router
+end
+
+-- Make sure vshard is available and its version is not too old.
+--
+-- The check is performed before box.cfg() and so before a
+-- potentially long database recovery: a misconfiguration is
+-- reported as fast as possible.
+--
+-- It can't be done even earlier, on the configuration validation
+-- stage, for two reasons. First, the validation is performed
+-- before the module search root is pointed to process.work_dir
+-- (the work_dir is not known yet), so a module installed into the
+-- working directory is not resolvable at that point. Second, the
+-- same schema validates cluster configurations as a whole, while
+-- the module is only needed on instances that have a sharding
+-- role.
+local function check_vshard(config)
+    local configdata = config._configdata
+    local is_storage, is_router = get_vshard_roles(configdata)
+    if not is_storage and not is_router then
+        return
+    end
+    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
+    if not ok then
+        error('The vshard-ee/vshard module is not available', 0)
+    end
+    local version = vshard.consts.VERSION
+    -- The minimum vshard version accepted by the sharding section
+    -- and by particular sharding options is declared in the schema,
+    -- see the vshard_since annotation. Verify the configured ones.
+    configdata:filter(function(w)
+        return w.schema.vshard_since ~= nil
+    end):each(function(w)
+        if w.data == nil then
+            return
+        end
+        local since = w.schema.vshard_since
+        if expression.eval('v < ' .. since, {v = version}) then
+            error(('%s: The vshard module is too old: the minimum ' ..
+                   'supported version is %s'):format(
+                   table.concat(w.path, '.'), since), 0)
+        end
+    end)
+end
+
+local function apply(config)
+    local configdata = config._configdata
+    local is_storage, is_router = get_vshard_roles(configdata)
+    if not is_storage and not is_router then
+        unregister_vshard_health_checks()
+        return
+    end
+    -- The availability and the minimum version are verified by
+    -- the sharding.stage_1 applier.
+    _G.vshard = loaders.require_first('vshard-ee', 'vshard')
     local cfg = configdata:sharding()
     if is_storage then
         -- Start a watcher which will create all the necessary functions.
@@ -97,6 +133,12 @@ local function apply(config)
 end
 
 return {
-    name = 'sharding',
-    apply = apply,
+    stage_1 = {
+        name = 'sharding.stage_1',
+        apply = check_vshard,
+    },
+    stage_2 = {
+        name = 'sharding.stage_2',
+        apply = apply,
+    },
 }

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -341,13 +341,14 @@ function methods._initialize(self)
     self:_register_applier(require('internal.config.applier.console'))
     self:_register_applier(require('internal.config.applier.runtime_priv'))
     self:_register_applier(require('internal.config.applier.session_settings'))
+    self:_register_applier(require('internal.config.applier.sharding').stage_1)
     self:_register_applier(require('internal.config.applier.roles').stage_1)
     self:_register_applier(require('internal.config.applier.app').stage_1)
     self:_register_applier(require('internal.config.applier.box_cfg'))
     self:_register_applier(require('internal.config.applier.box_status'))
     self:_register_applier(require('internal.config.applier.credentials'))
     self:_register_applier(require('internal.config.applier.fiber'))
-    self:_register_applier(require('internal.config.applier.sharding'))
+    self:_register_applier(require('internal.config.applier.sharding').stage_2)
     self:_register_applier(require('internal.config.applier.autoexpel'))
     self:_register_applier(require('internal.config.applier.connpool'))
     self:_register_applier(require('internal.config.applier.roles').stage_2)
@@ -548,6 +549,7 @@ function methods._apply_on_startup(self, opts)
         mkdir = true,
         console = true,
         runtime_priv = true,
+        ['sharding.stage_1'] = true,
         ['roles.stage_1'] = true,
         ['app.stage_1'] = true,
         box_cfg = true,

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -56,6 +56,57 @@ local function filter_out_private_fields(t)
     return res
 end
 
+-- Point the module search root to process.work_dir.
+--
+-- The first box.cfg() call changes the current working directory
+-- to process.work_dir and modules installed into it (for
+-- example, into the .rocks subdirectory) become resolvable,
+-- because the module search is relative to the current directory
+-- by default.
+--
+-- However, modules are needed before box.cfg(): roles and an
+-- application marked with the early_load tag and their metadata
+-- scan, and the schema defaults that depend on an installed
+-- module version (see the vshard_since annotation), which are
+-- evaluated when the configdata object is constructed. Set the
+-- search root as soon as the working directory is known to make
+-- modules installed into it resolvable before the chdir occurs.
+--
+-- This is a stopgap that covers the module search only. It is
+-- planned to enter process.work_dir right at this point instead,
+-- so that everything before box.cfg() works as if the process was
+-- started in the working directory, see gh-13086.
+local function set_searchroot(iconfig, vars)
+    if type(box.cfg) ~= 'function' then
+        -- box.cfg() is already called, the current working
+        -- directory is process.work_dir. Nothing to do.
+        return
+    end
+    local work_dir = instance_config:get(iconfig, 'process.work_dir')
+    if work_dir == nil then
+        return
+    end
+    -- The variables are substituted later, when the configdata
+    -- object is constructed. Substitute the name variables here
+    -- in the same way. The other ones (config.context.*) can't be
+    -- resolved at this point: the context files are relative to
+    -- the working directory itself. Leave the module search as is
+    -- in this case.
+    work_dir = work_dir:gsub('{{ *(.-) *}}', function(var_name)
+        return vars[var_name]
+    end)
+    if work_dir:find('{{', 1, true) then
+        log.verbose('the module search root is not set: unable to ' ..
+                    'resolve process.work_dir %q', work_dir)
+        return
+    end
+    -- A relative process.work_dir is interpreted against the
+    -- startup working directory, which is not changed yet.
+    work_dir = fio.abspath(work_dir)
+    package.setsearchroot(work_dir)
+    log.verbose('set the module search root to %q', work_dir)
+end
+
 -- }}} Helpers
 
 local methods = {}
@@ -453,7 +504,8 @@ function methods._store(self, iconfig, cconfig, source_info)
         ]]):format(action, source_info_str, self._instance_name), 0)
     end
 
-    if cluster_config:find_instance(cconfig, self._instance_name) == nil then
+    local found = cluster_config:find_instance(cconfig, self._instance_name)
+    if found == nil then
         local is_reload = self._status == 'reload_in_progress'
         local action = is_reload and 'Reload' or 'Startup'
         local source_info_str = table.concat(source_info, '\n')
@@ -479,6 +531,11 @@ function methods._store(self, iconfig, cconfig, source_info)
         ]]):format(action, self._instance_name, source_info_str), 0)
     end
 
+    set_searchroot(iconfig, {
+        instance_name = self._instance_name,
+        replicaset_name = found.replicaset_name,
+        group_name = found.group_name,
+    })
     self._configdata = configdata.new(iconfig, cconfig, self._instance_name)
 end
 

--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -290,13 +290,14 @@ function methods._initialize(self)
     self:_register_applier(require('internal.config.applier.console'))
     self:_register_applier(require('internal.config.applier.runtime_priv'))
     self:_register_applier(require('internal.config.applier.session_settings'))
+    self:_register_applier(require('internal.config.applier.sharding').stage_1)
     self:_register_applier(require('internal.config.applier.roles').stage_1)
     self:_register_applier(require('internal.config.applier.app').stage_1)
     self:_register_applier(require('internal.config.applier.box_cfg'))
     self:_register_applier(require('internal.config.applier.box_status'))
     self:_register_applier(require('internal.config.applier.credentials'))
     self:_register_applier(require('internal.config.applier.fiber'))
-    self:_register_applier(require('internal.config.applier.sharding'))
+    self:_register_applier(require('internal.config.applier.sharding').stage_2)
     self:_register_applier(require('internal.config.applier.autoexpel'))
     self:_register_applier(require('internal.config.applier.connpool'))
     self:_register_applier(require('internal.config.applier.roles').stage_2)
@@ -491,6 +492,7 @@ function methods._apply_on_startup(self, opts)
         mkdir = true,
         console = true,
         runtime_priv = true,
+        ['sharding.stage_1'] = true,
         ['roles.stage_1'] = true,
         ['app.stage_1'] = true,
         box_cfg = true,

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -20,7 +20,8 @@ local enterprise_edition = schema._enterprise_edition
 -- * vshard_since (string)
 --
 --   The minimum vshard version that accepts this sharding option.
---   Enforced in configdata's sharding() method.
+--   The option's default value is applied only when the installed
+--   vshard accepts the option.
 --
 -- * default (any)
 --
@@ -65,26 +66,14 @@ local function sensitive_ee(schema_node)
     return sensitive(enterprise_edition(schema_node))
 end
 
-local function vshard_since_validate(data, w)
-    -- OK if the option is not set.
-    if data == nil then
-        return
-    end
-
-    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
-    if not ok then
-        w.error('The vshard-ee/vshard module is not available')
-    end
-
-    if expression.eval('v < '..w.schema.vshard_since,
-                       {v = vshard.consts.VERSION}) then
-        w.error('The vshard module is too old: the minimum supported ' ..
-                'version is %s', w.schema.vshard_since)
-    end
-end
-
 local function vshard_since_apply_default_if(_data, w)
     -- Apply the default only when the installed vshard accepts the option.
+    --
+    -- Note: the vshard module availability must not be checked here or on
+    -- the validation stage. Both happen before box.cfg(), while the module
+    -- may become available only later: for example, when it is installed
+    -- into process.work_dir, the module can be resolved only after box.cfg()
+    -- chdir()s there. The availability is verified by the sharding applier.
     local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
     if not ok then
         return false
@@ -93,17 +82,12 @@ local function vshard_since_apply_default_if(_data, w)
                                {v = vshard.consts.VERSION})
 end
 
--- Accepted by vshard only since the given version. Configuring the annotated
--- node (an option or the whole sharding section) with an older vshard is a
--- configuration error.
+-- Accepted by vshard only since the given version (an option or the whole
+-- sharding section). A default value of the annotated node is not applied
+-- when the installed vshard is older.
 local function vshard_since(version, schema_node)
     schema_node.vshard_since = version
 
-    -- Perform a domain specific validation first and only then check the
-    -- vshard version, consistent with the data type validation order.
-    schema_node.validate = funcutils.chain2(
-        schema_node.validate,
-        vshard_since_validate)
     schema_node.apply_default_if = funcutils.chain2(
         schema_node.apply_default_if,
         vshard_since_apply_default_if)

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -75,7 +75,7 @@ local function vshard_since_apply_default_if(_data, w)
     -- defaults are evaluated on every instance, while the module is needed
     -- only on instances with a sharding role. The availability is verified
     -- by the sharding applier.
-    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
+    local ok, vshard = pcall(loaders.require_first, 'vshard', 'vshard-ee')
     if not ok then
         return false
     end

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -69,11 +69,10 @@ end
 local function vshard_since_apply_default_if(_data, w)
     -- Apply the default only when the installed vshard accepts the option.
     --
-    -- Note: the vshard module availability must not be checked here or on
-    -- the validation stage. Both happen before box.cfg(), while the module
-    -- may become available only later: for example, when it is installed
-    -- into process.work_dir, the module can be resolved only after box.cfg()
-    -- chdir()s there. The availability is verified by the sharding applier.
+    -- Note: it is not the place to verify the module availability: the
+    -- defaults are evaluated on every instance, while the module is needed
+    -- only on instances with a sharding role. The availability is verified
+    -- by the sharding applier.
     local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
     if not ok then
         return false

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -21,7 +21,9 @@ local enterprise_edition = schema._enterprise_edition
 --
 --   The minimum vshard version that accepts this sharding option.
 --   The option's default value is applied only when the installed
---   vshard accepts the option.
+--   vshard accepts the option. An explicitly set option (or the
+--   sharding section as a whole) is verified against the installed
+--   vshard version by the sharding applier before box.cfg().
 --
 -- * default (any)
 --

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -20,7 +20,8 @@ local enterprise_edition = schema._enterprise_edition
 -- * vshard_since (string)
 --
 --   The minimum vshard version that accepts this sharding option.
---   Enforced in configdata's sharding() method.
+--   The option's default value is applied only when the installed
+--   vshard accepts the option.
 --
 -- * default (any)
 --
@@ -65,26 +66,14 @@ local function sensitive_ee(schema_node)
     return sensitive(enterprise_edition(schema_node))
 end
 
-local function vshard_since_validate(data, w)
-    -- OK if the option is not set.
-    if data == nil then
-        return
-    end
-
-    local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
-    if not ok then
-        w.error('The vshard-ee/vshard module is not available')
-    end
-
-    if expression.eval('v < '..w.schema.vshard_since,
-                       {v = vshard.consts.VERSION}) then
-        w.error('The vshard module is too old: the minimum supported ' ..
-                'version is %s', w.schema.vshard_since)
-    end
-end
-
 local function vshard_since_apply_default_if(_data, w)
     -- Apply the default only when the installed vshard accepts the option.
+    --
+    -- Note: the vshard module availability must not be checked here or on
+    -- the validation stage. Both happen before box.cfg(), while the module
+    -- may become available only later: for example, when it is installed
+    -- into process.work_dir, the module can be resolved only after box.cfg()
+    -- chdir()s there. The availability is verified by the sharding applier.
     local ok, vshard = pcall(loaders.require_first, 'vshard-ee', 'vshard')
     if not ok then
         return false
@@ -93,17 +82,11 @@ local function vshard_since_apply_default_if(_data, w)
                                {v = vshard.consts.VERSION})
 end
 
--- Accepted by vshard only since the given version. Configuring the annotated
--- node (an option or the whole sharding section) with an older vshard is a
--- configuration error.
+-- Accepted by vshard only since the given version. A default value of the
+-- annotated option is not applied when the installed vshard is older.
 local function vshard_since(version, schema_node)
     schema_node.vshard_since = version
 
-    -- Perform a domain specific validation first and only then check the
-    -- vshard version, consistent with the data type validation order.
-    schema_node.validate = funcutils.chain2(
-        schema_node.validate,
-        vshard_since_validate)
     schema_node.apply_default_if = funcutils.chain2(
         schema_node.apply_default_if,
         vshard_since_apply_default_if)
@@ -1883,7 +1866,7 @@ return schema.new('instance_config', schema.record({
             value = schema.scalar({type = 'string'}),
         }),
     }),
-    sharding = vshard_since('0.1.25', schema.record({
+    sharding = schema.record({
         -- Instance vshard options.
         zone = schema.scalar({type = 'integer'}),
         -- Replicaset vshard options.
@@ -1974,7 +1957,7 @@ return schema.new('instance_config', schema.record({
             default = TIMEOUT_INFINITY,
             validate = validators['sharding.rebalancer_bucket_send_timeout'],
         })),
-    })),
+    }),
     audit_log = enterprise_edition(schema.record({
         -- The same as the destination for the logger, audit logger destination
         -- is handled separately in the box_cfg applier, so there are no

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -535,23 +535,18 @@ g.test_defaults = function()
 end
 
 local examples = {
-    single = {path = 'single.yaml'},
-    upgrade = {path = 'upgrade.yaml'},
-    sharding = {path = 'sharding.yaml', vshard_since = '0.1.25'},
-    replicaset = {path = 'replicaset.yaml'},
-    replicaset_manual_failover = {path = 'replicaset_manual_failover.yaml'},
-    replicaset_election_failover = {path = 'replicaset_election_failover.yaml'},
+    single = 'single.yaml',
+    upgrade = 'upgrade.yaml',
+    sharding = 'sharding.yaml',
+    replicaset = 'replicaset.yaml',
+    replicaset_manual_failover = 'replicaset_manual_failover.yaml',
+    replicaset_election_failover = 'replicaset_election_failover.yaml',
 }
 
-for case, example in pairs(examples) do
+for case, path in pairs(examples) do
     local test_name = ('test_example_%s'):format(case)
-    local config_path = ('test/config-luatest/examples/config/%s'):format(
-        example.path)
+    local config_path = ('test/config-luatest/examples/config/%s'):format(path)
     g[test_name] = function()
-        if example.vshard_since ~= nil then
-            t.skip_if(not helpers.has_vshard_since(example.vshard_since),
-                      'Module "vshard-ee/vshard" is not available')
-        end
         local config_file = fio.abspath(config_path)
         local fh = fio.open(config_file, {'O_RDONLY'})
         local config = yaml.decode(fh:read())
@@ -866,7 +861,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.bucket_count',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     bucket_count = 30000,
@@ -879,7 +873,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.connection_outdate_delay',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     connection_outdate_delay = 10,
@@ -892,7 +885,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.discovery_mode',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     discovery_mode = 'off',
@@ -905,7 +897,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.failover_ping_timeout',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     failover_ping_timeout = 10,
@@ -918,7 +909,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.lock',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     lock = true,
@@ -931,7 +921,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.rebalancer_bucket_send_timeout',
-            vshard_since = '0.1.41',
             data = {
                 sharding = {
                     rebalancer_bucket_send_timeout = 42,
@@ -944,7 +933,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.rebalancer_disbalance_threshold',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     rebalancer_disbalance_threshold = 7,
@@ -957,7 +945,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.rebalancer_max_receiving',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     rebalancer_max_receiving = 1000,
@@ -970,7 +957,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.rebalancer_max_sending',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     rebalancer_max_sending = 10,
@@ -983,7 +969,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.rebalancer_mode',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     rebalancer_mode = 'off',
@@ -996,7 +981,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.sched_move_quota',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     sched_move_quota = 10,
@@ -1009,7 +993,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.sched_ref_quota',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     sched_ref_quota = 1000,
@@ -1022,7 +1005,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.shard_index',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     shard_index = 'my_bucket_id',
@@ -1035,7 +1017,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.sync_timeout',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     sync_timeout = 10,
@@ -1048,7 +1029,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.weight',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     weight = 10,
@@ -1061,7 +1041,6 @@ g.test_scope = function()
         },
         {
             name = 'sharding.roles',
-            vshard_since = '0.1.25',
             data = {
                 sharding = {
                     roles = {'storage'},
@@ -1075,13 +1054,6 @@ g.test_scope = function()
     }
 
     for _, case in ipairs(cases) do
-        -- The sharding section is validated only with a vshard module that
-        -- accepts the option, so its scope cannot be checked otherwise.
-        if case.vshard_since ~= nil and
-           not helpers.has_vshard_since(case.vshard_since) then
-            goto continue
-        end
-
         -- Global level.
         local global_data = case.data
         if case.global then
@@ -1154,7 +1126,6 @@ g.test_scope = function()
         -- Validation against the instance config: accepted for
         -- all the options.
         instance_config:validate(case.data)
-    ::continue::
     end
 end
 

--- a/test/config-luatest/gh_10182_roles_before_box_cfg_test.lua
+++ b/test/config-luatest/gh_10182_roles_before_box_cfg_test.lua
@@ -1,5 +1,7 @@
 local t = require('luatest')
 local fio = require('fio')
+local treegen = require('luatest.treegen')
+local justrun = require('luatest.justrun')
 local helpers = require('test.config-luatest.helpers')
 
 ---@class luatest.group
@@ -286,4 +288,49 @@ tg.test_app_with_early_load_tag_added = function(g)
         'App "main" with the "early_load" tag was added to the config, ' ..
         'it cannot be loaded before the first box.cfg call',
         1024, {filename = g.server.chdir .. '/tarantool.log'}))
+end
+
+--
+-- A role installed into the configured process.work_dir becomes
+-- resolvable before box.cfg(): the config module points the
+-- module search root to the working directory before the early
+-- load occurs. Verify that a role with the early_load tag is
+-- loaded before box.cfg() in this scenario.
+--
+tg.test_role_with_early_load_tag_in_work_dir = function()
+    local dir = treegen.prepare_directory({}, {})
+    treegen.write_file(dir, 'wd/.rocks/share/tarantool/myrole.lua',
+                       early_load_role)
+    treegen.write_file(dir, 'wd/main.lua', [[
+        print(('on_load_status: %s'):format(_G.on_load_status))
+        print(('on_apply_status: %s'):format(_G.on_apply_status))
+        os.exit(0)
+    ]])
+    local config = ([[
+    process:
+      work_dir: wd
+
+    app:
+      file: %s/wd/main.lua
+
+    roles: [myrole]
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            instances:
+              instance-001: {}
+    ]]):format(dir)
+    treegen.write_file(dir, 'config.yaml', config)
+
+    -- Start tarantool in a directory from which the role module
+    -- is not resolvable. LUA_PATH is emptied to not resolve
+    -- anything from the testing environment.
+    local res = justrun.tarantool(dir, {LUA_PATH = ''},
+        {'--name', 'instance-001', '--config', 'config.yaml'},
+        {nojson = true, stderr = true, setsearchroot = false})
+    t.assert_equals(res.exit_code, 0, res.stderr)
+    t.assert_str_contains(res.stdout, 'on_load_status: unconfigured')
+    t.assert_str_contains(res.stdout, 'on_apply_status: running')
 end

--- a/test/config-luatest/gh_10182_roles_before_box_cfg_test.lua
+++ b/test/config-luatest/gh_10182_roles_before_box_cfg_test.lua
@@ -1,5 +1,7 @@
 local t = require('luatest')
 local fio = require('fio')
+local treegen = require('luatest.treegen')
+local justrun = require('luatest.justrun')
 local helpers = require('test.config-luatest.helpers')
 
 ---@class luatest.group
@@ -286,4 +288,87 @@ tg.test_app_with_early_load_tag_added = function(g)
         'App "main" with the "early_load" tag was added to the config, ' ..
         'it cannot be loaded before the first box.cfg call',
         1024, {filename = g.server.chdir .. '/tarantool.log'}))
+end
+
+-- A role installed into the configured process.work_dir becomes
+-- resolvable before box.cfg(): the config module points the
+-- module search root to the working directory before the early
+-- load occurs. Verify that a role with the early_load tag is
+-- loaded before box.cfg() in this scenario.
+tg.test_role_with_early_load_tag_in_work_dir = function()
+    local dir = treegen.prepare_directory({}, {})
+    treegen.write_file(dir, 'wd/.rocks/share/tarantool/myrole.lua',
+                       early_load_role)
+    treegen.write_file(dir, 'wd/main.lua', [[
+        print(('on_load_status: %s'):format(_G.on_load_status))
+        print(('on_apply_status: %s'):format(_G.on_apply_status))
+        os.exit(0)
+    ]])
+    local config = ([[
+    process:
+      work_dir: wd
+
+    app:
+      file: %s/wd/main.lua
+
+    roles: [myrole]
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            instances:
+              instance-001: {}
+    ]]):format(dir)
+    treegen.write_file(dir, 'config.yaml', config)
+
+    -- Start tarantool in a directory from which the role module
+    -- is not resolvable. LUA_PATH is emptied to not resolve
+    -- anything from the testing environment.
+    local res = justrun.tarantool(dir, {LUA_PATH = ''},
+        {'--name', 'instance-001', '--config', 'config.yaml'},
+        {nojson = true, stderr = true, setsearchroot = false})
+    t.assert_equals(res.exit_code, 0, res.stderr)
+    t.assert_str_contains(res.stdout, 'on_load_status: unconfigured')
+    t.assert_str_contains(res.stdout, 'on_apply_status: running')
+end
+
+-- The same for an application: a relative app.file path is
+-- interpreted against process.work_dir and an app.module is
+-- searched there. Verify that an application is loaded with
+-- respect to the configured working directory.
+tg.test_app_with_early_load_tag_in_work_dir = function()
+    local script = early_load_script .. [[
+        print(('on_load_status: %s'):format(_G.on_load_status))
+        os.exit(0)
+    ]]
+    local config = [[
+    process:
+      work_dir: wd
+
+    app:
+      %s
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            instances:
+              instance-001: {}
+    ]]
+
+    for _, app in ipairs({'file: main.lua', 'module: main'}) do
+        local dir = treegen.prepare_directory({}, {})
+        treegen.write_file(dir, 'wd/main.lua', script)
+        treegen.write_file(dir, 'config.yaml', config:format(app))
+
+        -- Start tarantool in a directory from which the script
+        -- is not resolvable. LUA_PATH is emptied to not resolve
+        -- anything from the testing environment.
+        local res = justrun.tarantool(dir, {LUA_PATH = ''},
+            {'--name', 'instance-001', '--config', 'config.yaml'},
+            {nojson = true, stderr = true, setsearchroot = false})
+        t.assert_equals(res.exit_code, 0, res.stderr)
+        t.assert_str_contains(res.stdout, 'on_load_status: unconfigured')
+    end
 end

--- a/test/config-luatest/helpers.lua
+++ b/test/config-luatest/helpers.lua
@@ -13,9 +13,9 @@ local server = require('luatest.server')
 -- sharding options annotated with the vshard_since version, nil otherwise.
 --
 local function has_vshard_since(version)
-    local ok, vshard = pcall(require, 'vshard-ee')
+    local ok, vshard = pcall(require, 'vshard')
     if not ok then
-        ok, vshard = pcall(require, 'vshard')
+        ok, vshard = pcall(require, 'vshard-ee')
     end
     if not ok then
         return nil

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -1804,9 +1804,6 @@ g.test_metrics = function()
 end
 
 g.test_sharding = function()
-    -- The sharding section is validated only with the vshard module available.
-    t.skip_if(not helpers.has_vshard(),
-              'vshard module is required to validate sharding')
     local iconfig = {
         sharding = {
             roles = {'router', 'storage'},

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -919,15 +919,12 @@ g.test_has_sharding_role = function()
 end
 
 --
--- The whole sharding section is annotated with vshard_since('0.1.25'), so
--- configuring sharding with an older vshard must be rejected at the
--- configuration validation stage.
+-- The vshard availability and its minimum version are verified when the
+-- sharding configuration is applied.
 --
 g.test_vshard_too_old = function(g)
     skip_if_no_vshard()
     local dir = treegen.prepare_directory({}, {})
-    -- Note, that none of the nodes has `sharding.roles` set, the error will
-    -- still be thrown, since it's now checked on config validation stage.
     local config = [[
     credentials:
       users:
@@ -951,6 +948,8 @@ g.test_vshard_too_old = function(g)
       group-001:
         replicasets:
           replicaset-001:
+            sharding:
+              roles: [storage]
             instances:
               instance-001: {}
     ]]
@@ -975,13 +974,64 @@ g.test_vshard_too_old = function(g)
         vshard.consts.VERSION = saved
 
         t.assert_not(ok)
-        -- The error must come from the configuration validation stage: it
-        -- carries the schema path prefix ("...sharding:"). This distinguishes
-        -- it from any apply-stage check producing a bare message.
         t.assert_str_contains(tostring(err),
-            'sharding: The vshard module is too old: the minimum supported ' ..
-            'version is 0.1.25')
+            'The vshard module is too old: the minimum supported ' ..
+            'version is 0.1.25.')
     end)
+end
+
+--
+-- The vshard module installed into the configured process.work_dir can be
+-- resolved only after box.cfg() chdir()s there. Make sure the configuration
+-- is not rejected due to the unavailable vshard before that.
+--
+g.test_vshard_in_work_dir = function()
+    local dir = treegen.prepare_directory({}, {})
+    -- A fake vshard module: the test verifies where the module is searched
+    -- for, not how it is configured.
+    treegen.write_file(dir, 'wd/.rocks/share/tarantool/vshard/init.lua', [[
+        return {
+            consts = {VERSION = '0.1.25'},
+            storage = {cfg = function() end, internal = {}},
+            router = {
+                cfg = function() end,
+                info = function() return {bucket = {unknown = 0}} end,
+            },
+        }
+    ]])
+    treegen.write_file(dir, 'wd/main.lua', [[
+        print(('vshard version: %s'):format(_G.vshard.consts.VERSION))
+        os.exit(0)
+    ]])
+    local config = ([[
+    process:
+      work_dir: wd
+
+    app:
+      file: %s/wd/main.lua
+
+    sharding:
+      roles: [router]
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            instances:
+              instance-001: {}
+    ]]):format(dir)
+    treegen.write_file(dir, 'config.yaml', config)
+
+    -- Start tarantool in a directory from which the module is not
+    -- resolvable. LUA_PATH is emptied to not resolve the real vshard from
+    -- the testing environment. justrun by default pins package.searchroot()
+    -- to the testing source tree, which would disable the cwd-relative
+    -- module search this test verifies, so it is turned off.
+    local res = justrun.tarantool(dir, {LUA_PATH = ''},
+        {'--name', 'instance-001', '--config', 'config.yaml'},
+        {nojson = true, stderr = true, setsearchroot = false})
+    t.assert_equals(res.exit_code, 0, res.stderr)
+    t.assert_str_contains(res.stdout, 'vshard version: 0.1.25')
 end
 
 --
@@ -1033,70 +1083,4 @@ g.test_rebalancer_bucket_send_timeout = function(g)
 
     local res = g.server:eval('return vshard.storage.internal.current_cfg')
     t.assert_equals(res.rebalancer_bucket_send_timeout, 42)
-end
-
---
--- sharding.rebalancer_bucket_send_timeout requires vshard 0.1.41. A vshard
--- that is new enough for sharding in general (>= 0.1.25) but older than
--- 0.1.41 must reject the option at the configuration validation stage.
---
-g.test_rebalancer_bucket_send_timeout_vshard_too_old = function(g)
-    t.skip_if(not helpers.has_vshard_since('0.1.41'),
-              'vshard module accepting rebalancer_bucket_send_timeout ' ..
-              'is required')
-    local dir = treegen.prepare_directory({}, {})
-    local config = [[
-    credentials:
-      users:
-        guest:
-          roles: [super]
-        storage:
-          roles: [sharding]
-          password: "storage"
-
-    iproto:
-      listen:
-        - uri: 'unix/:./{{ instance_name }}.iproto'
-      advertise:
-        sharding:
-          login: 'storage'
-
-    sharding:
-      rebalancer_bucket_send_timeout: 42
-
-    groups:
-      group-001:
-        replicasets:
-          replicaset-001:
-            sharding:
-              roles: [storage, rebalancer, router]
-            instances:
-              instance-001: {}
-    ]]
-    local config_file = treegen.write_file(dir, 'config.yaml', config)
-    local opts = {
-        env = {LUA_PATH = os.environ()['LUA_PATH']},
-        config_file = config_file,
-        chdir = dir,
-        alias = 'instance-001',
-    }
-    g.server = server:new(opts)
-    g.server:start()
-
-    g.server:exec(function()
-        local loaders = require('internal.loaders')
-        local config = require('config')
-        local vshard = loaders.require_first('vshard-ee', 'vshard')
-
-        -- New enough for sharding (0.1.25), too old for the option (0.1.41).
-        local saved = vshard.consts.VERSION
-        vshard.consts.VERSION = '0.1.30'
-        local ok, err = pcall(config.reload, config)
-        vshard.consts.VERSION = saved
-
-        t.assert_not(ok)
-        t.assert_str_contains(tostring(err),
-            'rebalancer_bucket_send_timeout: The vshard module is too old: ' ..
-            'the minimum supported version is 0.1.41')
-    end)
 end

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -615,9 +615,9 @@ g.test_sharding_credentials_role = function(g)
         local role = box.space._user.index.name:get('sharding')
         local repl_id = box.space._user.index.name:get('replication').id
         t.assert(role ~= nil)
-        local ok, vexports = pcall(require, 'vshard-ee.storage.exports')
+        local ok, vexports = pcall(require, 'vshard.storage.exports')
         if not ok then
-            vexports = require('vshard.storage.exports')
+            vexports = require('vshard-ee.storage.exports')
         end
         local exports = vexports.compile(vexports.log[#vexports.log])
 
@@ -967,7 +967,7 @@ g.test_vshard_too_old = function(g)
     g.server:exec(function()
         local loaders = require('internal.loaders')
         local config = require('config')
-        local vshard = loaders.require_first('vshard-ee', 'vshard')
+        local vshard = loaders.require_first('vshard', 'vshard-ee')
 
         local saved = vshard.consts.VERSION
         vshard.consts.VERSION = '0.1.20'

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -919,15 +919,12 @@ g.test_has_sharding_role = function()
 end
 
 --
--- The whole sharding section is annotated with vshard_since('0.1.25'), so
--- configuring sharding with an older vshard must be rejected at the
--- configuration validation stage.
+-- The vshard availability and its minimum version are verified when the
+-- sharding configuration is applied.
 --
 g.test_vshard_too_old = function(g)
     skip_if_no_vshard()
     local dir = treegen.prepare_directory({}, {})
-    -- Note, that none of the nodes has `sharding.roles` set, the error will
-    -- still be thrown, since it's now checked on config validation stage.
     local config = [[
     credentials:
       users:
@@ -951,6 +948,8 @@ g.test_vshard_too_old = function(g)
       group-001:
         replicasets:
           replicaset-001:
+            sharding:
+              roles: [storage]
             instances:
               instance-001: {}
     ]]
@@ -975,13 +974,101 @@ g.test_vshard_too_old = function(g)
         vshard.consts.VERSION = saved
 
         t.assert_not(ok)
-        -- The error must come from the configuration validation stage: it
-        -- carries the schema path prefix ("...sharding:"). This distinguishes
-        -- it from any apply-stage check producing a bare message.
         t.assert_str_contains(tostring(err),
-            'sharding: The vshard module is too old: the minimum supported ' ..
-            'version is 0.1.25')
+            'The vshard module is too old: the minimum supported ' ..
+            'version is 0.1.25.')
     end)
+end
+
+--
+-- The vshard module installed into the configured process.work_dir can be
+-- resolved only after box.cfg() chdir()s there. Make sure the configuration
+-- is not rejected due to the unavailable vshard before that.
+--
+g.test_vshard_in_work_dir = function()
+    local dir = treegen.prepare_directory({}, {})
+    -- A fake vshard module: the test verifies where the module is searched
+    -- for, not how it is configured.
+    treegen.write_file(dir, 'wd/.rocks/share/tarantool/vshard/init.lua', [[
+        return {
+            consts = {VERSION = '0.1.25'},
+            storage = {cfg = function() end, internal = {}},
+            router = {
+                cfg = function() end,
+                info = function() return {bucket = {unknown = 0}} end,
+            },
+        }
+    ]])
+    treegen.write_file(dir, 'wd/main.lua', [[
+        print(('vshard version: %s'):format(_G.vshard.consts.VERSION))
+        os.exit(0)
+    ]])
+    local config = ([[
+    process:
+      work_dir: wd
+
+    app:
+      file: %s/wd/main.lua
+
+    sharding:
+      roles: [router]
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            instances:
+              instance-001: {}
+    ]]):format(dir)
+    treegen.write_file(dir, 'config.yaml', config)
+
+    -- Start tarantool in a directory from which the module is not
+    -- resolvable. LUA_PATH is emptied to not resolve the real vshard from
+    -- the testing environment. justrun by default pins package.searchroot()
+    -- to the testing source tree, which would disable the cwd-relative
+    -- module search this test verifies, so it is turned off.
+    local res = justrun.tarantool(dir, {LUA_PATH = ''},
+        {'--name', 'instance-001', '--config', 'config.yaml'},
+        {nojson = true, stderr = true, setsearchroot = false})
+    t.assert_equals(res.exit_code, 0, res.stderr)
+    t.assert_str_contains(res.stdout, 'vshard version: 0.1.25')
+end
+
+-- gh-12928: sharding options set on the global level (like
+-- sharding.bucket_count) are inherited by all the instances of
+-- the cluster.
+--
+-- Make sure an instance without a sharding role starts even
+-- when the vshard module is not available.
+g.test_no_sharding_role_without_vshard = function()
+    local dir = treegen.prepare_directory({}, {})
+    treegen.write_file(dir, 'main.lua', [[
+        print('started')
+        os.exit(0)
+    ]])
+    local config = [[
+    app:
+      file: main.lua
+
+    sharding:
+      bucket_count: 1000
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            instances:
+              instance-001: {}
+    ]]
+    treegen.write_file(dir, 'config.yaml', config)
+
+    -- LUA_PATH is emptied to not resolve the real vshard from the testing
+    -- environment.
+    local res = justrun.tarantool(dir, {LUA_PATH = ''},
+        {'--name', 'instance-001', '--config', 'config.yaml'},
+        {nojson = true, stderr = true})
+    t.assert_equals(res.exit_code, 0, res.stderr)
+    t.assert_str_contains(res.stdout, 'started')
 end
 
 --
@@ -1033,70 +1120,4 @@ g.test_rebalancer_bucket_send_timeout = function(g)
 
     local res = g.server:eval('return vshard.storage.internal.current_cfg')
     t.assert_equals(res.rebalancer_bucket_send_timeout, 42)
-end
-
---
--- sharding.rebalancer_bucket_send_timeout requires vshard 0.1.41. A vshard
--- that is new enough for sharding in general (>= 0.1.25) but older than
--- 0.1.41 must reject the option at the configuration validation stage.
---
-g.test_rebalancer_bucket_send_timeout_vshard_too_old = function(g)
-    t.skip_if(not helpers.has_vshard_since('0.1.41'),
-              'vshard module accepting rebalancer_bucket_send_timeout ' ..
-              'is required')
-    local dir = treegen.prepare_directory({}, {})
-    local config = [[
-    credentials:
-      users:
-        guest:
-          roles: [super]
-        storage:
-          roles: [sharding]
-          password: "storage"
-
-    iproto:
-      listen:
-        - uri: 'unix/:./{{ instance_name }}.iproto'
-      advertise:
-        sharding:
-          login: 'storage'
-
-    sharding:
-      rebalancer_bucket_send_timeout: 42
-
-    groups:
-      group-001:
-        replicasets:
-          replicaset-001:
-            sharding:
-              roles: [storage, rebalancer, router]
-            instances:
-              instance-001: {}
-    ]]
-    local config_file = treegen.write_file(dir, 'config.yaml', config)
-    local opts = {
-        env = {LUA_PATH = os.environ()['LUA_PATH']},
-        config_file = config_file,
-        chdir = dir,
-        alias = 'instance-001',
-    }
-    g.server = server:new(opts)
-    g.server:start()
-
-    g.server:exec(function()
-        local loaders = require('internal.loaders')
-        local config = require('config')
-        local vshard = loaders.require_first('vshard-ee', 'vshard')
-
-        -- New enough for sharding (0.1.25), too old for the option (0.1.41).
-        local saved = vshard.consts.VERSION
-        vshard.consts.VERSION = '0.1.30'
-        local ok, err = pcall(config.reload, config)
-        vshard.consts.VERSION = saved
-
-        t.assert_not(ok)
-        t.assert_str_contains(tostring(err),
-            'rebalancer_bucket_send_timeout: The vshard module is too old: ' ..
-            'the minimum supported version is 0.1.41')
-    end)
 end

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -1,4 +1,5 @@
 local fun = require('fun')
+local fio = require('fio')
 local t = require('luatest')
 local treegen = require('luatest.treegen')
 local justrun = require('luatest.justrun')
@@ -981,9 +982,11 @@ g.test_vshard_too_old = function(g)
 end
 
 --
--- The vshard module installed into the configured process.work_dir can be
--- resolved only after box.cfg() chdir()s there. Make sure the configuration
--- is not rejected due to the unavailable vshard before that.
+-- The vshard module installed into the configured process.work_dir is
+-- resolvable even before box.cfg() chdir()s there: the module search root
+-- is pointed to the working directory. Make sure the configuration is not
+-- rejected due to the unavailable vshard when tarantool is started from a
+-- different directory.
 --
 g.test_vshard_in_work_dir = function()
     local dir = treegen.prepare_directory({}, {})
@@ -1032,6 +1035,40 @@ g.test_vshard_in_work_dir = function()
         {nojson = true, stderr = true, setsearchroot = false})
     t.assert_equals(res.exit_code, 0, res.stderr)
     t.assert_str_contains(res.stdout, 'vshard version: 0.1.25')
+end
+
+--
+-- A configured sharding role without an available vshard module is an
+-- error. Make sure it is raised before box.cfg(), so a misconfigured
+-- instance fails fast, without a potentially long database recovery.
+--
+g.test_vshard_missing_error_before_box_cfg = function()
+    local dir = treegen.prepare_directory({}, {})
+    local config = [[
+    sharding:
+      roles: [router]
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            instances:
+              instance-001: {}
+    ]]
+    treegen.write_file(dir, 'config.yaml', config)
+
+    -- LUA_PATH is emptied to not resolve the real vshard from the testing
+    -- environment.
+    local res = justrun.tarantool(dir, {LUA_PATH = ''},
+        {'--name', 'instance-001', '--config', 'config.yaml'},
+        {nojson = true, stderr = true, setsearchroot = false})
+    t.assert_equals(res.exit_code, 1)
+    t.assert_str_contains(res.stderr,
+                          'The vshard-ee/vshard module is not available')
+    -- The error is raised before box.cfg(): the database is not
+    -- initialized.
+    local snaps = fio.glob(fio.pathjoin(dir, 'var/lib/instance-001/*.snap'))
+    t.assert_equals(snaps, {})
 end
 
 --

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -1,4 +1,5 @@
 local fun = require('fun')
+local fio = require('fio')
 local t = require('luatest')
 local treegen = require('luatest.treegen')
 local justrun = require('luatest.justrun')
@@ -975,15 +976,17 @@ g.test_vshard_too_old = function(g)
 
         t.assert_not(ok)
         t.assert_str_contains(tostring(err),
-            'The vshard module is too old: the minimum supported ' ..
-            'version is 0.1.25.')
+            'sharding: The vshard module is too old: the minimum supported ' ..
+            'version is 0.1.25')
     end)
 end
 
 --
--- The vshard module installed into the configured process.work_dir can be
--- resolved only after box.cfg() chdir()s there. Make sure the configuration
--- is not rejected due to the unavailable vshard before that.
+-- The vshard module installed into the configured process.work_dir is
+-- resolvable even before box.cfg() chdir()s there: the module search root
+-- is pointed to the working directory. Make sure the configuration is not
+-- rejected due to the unavailable vshard when tarantool is started from a
+-- different directory.
 --
 g.test_vshard_in_work_dir = function()
     local dir = treegen.prepare_directory({}, {})
@@ -1122,6 +1125,111 @@ g.test_no_sharding_role_without_vshard = function()
         {nojson = true, stderr = true})
     t.assert_equals(res.exit_code, 0, res.stderr)
     t.assert_str_contains(res.stdout, 'started')
+end
+
+--
+-- The vshard module is required only for the storage and the router roles.
+-- Make sure an instance with an empty list of sharding roles starts even
+-- when the vshard module is not available.
+--
+g.test_no_vshard_roles_without_vshard = function()
+    local dir = treegen.prepare_directory({}, {})
+    treegen.write_file(dir, 'main.lua', [[
+        print('started')
+        os.exit(0)
+    ]])
+    local config = [[
+    app:
+      file: main.lua
+
+    sharding:
+      roles: []
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            instances:
+              instance-001: {}
+    ]]
+    treegen.write_file(dir, 'config.yaml', config)
+
+    local res = justrun.tarantool(dir, {LUA_PATH = ''},
+        {'--name', 'instance-001', '--config', 'config.yaml'},
+        {nojson = true, stderr = true})
+    t.assert_equals(res.exit_code, 0, res.stderr)
+    t.assert_str_contains(res.stdout, 'started')
+end
+
+--
+-- A configured sharding role without an available vshard module is an
+-- error. Make sure it is raised before box.cfg(), so a misconfigured
+-- instance fails fast, without a potentially long database recovery.
+--
+g.test_vshard_missing_error_before_box_cfg = function()
+    local dir = treegen.prepare_directory({}, {})
+    local config = [[
+    sharding:
+      roles: [router]
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            instances:
+              instance-001: {}
+    ]]
+    treegen.write_file(dir, 'config.yaml', config)
+
+    -- LUA_PATH is emptied to not resolve the real vshard from the testing
+    -- environment.
+    local res = justrun.tarantool(dir, {LUA_PATH = ''},
+        {'--name', 'instance-001', '--config', 'config.yaml'},
+        {nojson = true, stderr = true, setsearchroot = false})
+    t.assert_equals(res.exit_code, 1)
+    t.assert_str_contains(res.stderr,
+                          'The vshard-ee/vshard module is not available')
+    -- The error is raised before box.cfg(): the database is not
+    -- initialized.
+    local snaps = fio.glob(fio.pathjoin(dir, 'var/lib/instance-001/*.snap'))
+    t.assert_equals(snaps, {})
+end
+
+--
+-- Some sharding options are accepted by vshard only since a particular
+-- version (see the vshard_since schema annotation). Make sure such an
+-- option configured with an older vshard is rejected before box.cfg().
+--
+g.test_vshard_too_old_for_option_error_before_box_cfg = function()
+    local dir = treegen.prepare_directory({}, {})
+    -- A fake vshard module: new enough for sharding (0.1.25), too old for
+    -- the rebalancer_bucket_send_timeout option (0.1.41).
+    treegen.write_file(dir, '.rocks/share/tarantool/vshard/init.lua', [[
+        return {consts = {VERSION = '0.1.30'}}
+    ]])
+    local config = [[
+    sharding:
+      roles: [router]
+      rebalancer_bucket_send_timeout: 42
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            instances:
+              instance-001: {}
+    ]]
+    treegen.write_file(dir, 'config.yaml', config)
+
+    local res = justrun.tarantool(dir, {LUA_PATH = ''},
+        {'--name', 'instance-001', '--config', 'config.yaml'},
+        {nojson = true, stderr = true, setsearchroot = false})
+    t.assert_equals(res.exit_code, 1)
+    t.assert_str_contains(res.stderr,
+        'sharding.rebalancer_bucket_send_timeout: The vshard module is too ' ..
+        'old: the minimum supported version is 0.1.41')
+    local snaps = fio.glob(fio.pathjoin(dir, 'var/lib/instance-001/*.snap'))
+    t.assert_equals(snaps, {})
 end
 
 --

--- a/test/config-luatest/vshard_test.lua
+++ b/test/config-luatest/vshard_test.lua
@@ -1034,6 +1034,59 @@ g.test_vshard_in_work_dir = function()
     t.assert_str_contains(res.stdout, 'vshard version: 0.1.25')
 end
 
+-- The defaults of the options accepted only by a newer vshard (see the
+-- vshard_since schema annotation) depend on the installed vshard version.
+-- Make sure they are applied on the first startup when the module is
+-- installed into process.work_dir, the same way as on a reload.
+g.test_vshard_since_default_in_work_dir = function()
+    local dir = treegen.prepare_directory({}, {})
+    -- The working directory is set using a template to verify that the
+    -- variables are substituted before the module search root is set.
+    local wd = 'wd-instance-001'
+    treegen.write_file(dir, wd .. '/.rocks/share/tarantool/vshard/init.lua', [[
+        return {
+            consts = {VERSION = '0.1.41'},
+            storage = {cfg = function() end, internal = {}},
+            router = {
+                cfg = function() end,
+                info = function() return {bucket = {unknown = 0}} end,
+            },
+        }
+    ]])
+    treegen.write_file(dir, wd .. '/main.lua', [[
+        local config = require('config')
+        print(('rebalancer_bucket_send_timeout: %s'):format(
+            config:get('sharding.rebalancer_bucket_send_timeout')))
+        os.exit(0)
+    ]])
+    local config = ([[
+    process:
+      work_dir: wd-{{ instance_name }}
+
+    app:
+      file: %s/wd-instance-001/main.lua
+
+    sharding:
+      roles: [router]
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            instances:
+              instance-001: {}
+    ]]):format(dir)
+    treegen.write_file(dir, 'config.yaml', config)
+
+    local res = justrun.tarantool(dir, {LUA_PATH = ''},
+        {'--name', 'instance-001', '--config', 'config.yaml'},
+        {nojson = true, stderr = true, setsearchroot = false})
+    t.assert_equals(res.exit_code, 0, res.stderr)
+    -- TIMEOUT_INFINITY, the option's default.
+    t.assert_str_contains(res.stdout,
+                          'rebalancer_bucket_send_timeout: 15768000000')
+end
+
 -- gh-12928: sharding options set on the global level (like
 -- sharding.bucket_count) are inherited by all the instances of
 -- the cluster.


### PR DESCRIPTION
Commit c35e137252f8 ("config: version-gate sharding via vshard_since")
moved the vshard availability and minimum version check from the
sharding applier to the configuration validation stage.

However, the validation runs before `box.cfg()`, so before the process
`chdir()` into the configured `process.work_dir`. When the vshard rock
is installed into that working directory and tarantool is started from a
different directory, the module is not resolvable at the validation
stage yet, and a valid configuration is rejected on startup:

```
    [cluster_config] sharding: The vshard-ee/vshard module is not
    available
```

This patchset contains a few related fixes.

The first one is a partial revert of that commit: don't require the vshard
module during the configuration validation, restore the availability and
minimum version check in the sharding applier (it runs after
`box.cfg()`, when the working directory is already entered), and restore
the defensive vshard guard in the credentials applier, which defers the
missing module error to the sharding applier's user-friendly message.

The second one sets the module search root (`package.setsearchroot()`) to
the configured `process.work_dir` in the lua applier, which runs before
`box.cfg()` and the early load. This makes the module resolution
consistent during the whole instance lifetime: everything is searched
relative to the working directory, as if the process was started in it.

The third one splits vshard checks into two stages. 1) perform the vshard
check and runs before box.cfg(), so the error is reported on startup,
before the recovery; 2) apply the vshard configuration as before. This
is important to detected "bad vshard installation/configuration" scenarios
before calling relatively expensive `box.cfg()`.