### PR TITLE
decimal: reject a scale that does not fit int32

### DIFF
--- a/changelogs/unreleased/gh-noticket-decimal-unpack-scale.md
+++ b/changelogs/unreleased/gh-noticket-decimal-unpack-scale.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* Fixed decoding of a MsgPack decimal whose scale does not fit in `int32_t`.
+  The scale was truncated instead of rejected, so such a value was accepted
+  as a different number.

--- a/src/lib/core/decimal.c
+++ b/src/lib/core/decimal.c
@@ -812,14 +812,19 @@ decimal_unpack(const char **data, uint32_t len, decimal_t *dec)
 	if (type == MP_UINT) {
 		if (mp_check_uint(p, end) > 0)
 			return NULL;
-		scale = mp_decode_uint(&p);
 	} else if (type == MP_INT) {
 		if (mp_check_int(p, end) > 0)
 			return NULL;
-		scale = mp_decode_int(&p);
 	} else {
 		return NULL;
 	}
+	/*
+	 * The scale is negated to get the exponent, by decPackedToNumber()
+	 * below and back by decimal_pack(), so it must fit in int32_t and
+	 * must not be INT32_MIN.
+	 */
+	if (mp_read_int32(&p, &scale) != 0 || scale == INT32_MIN)
+		return NULL;
 	len -= p - *data;
 	/* First check that there is enough space to store the digits. */
 	if (len > (DECIMAL_DIGIT_CAPACITY + 1) / 2)

--- a/test/unit/decimal.c
+++ b/test/unit/decimal.c
@@ -483,10 +483,37 @@ test_mp_print(void)
 static void
 test_mp_validate(void)
 {
-	plan(1);
+	plan(6);
 	header();
 
 	ok(mp_validate_decimal("", 0) != 0, "reading scale type is checked");
+
+	/*
+	 * A scale that does not fit in int32_t must be rejected rather than
+	 * truncated: otherwise "1E-77" and a scale of 2^32 + 77 decode to the
+	 * same number.
+	 */
+	char b[16];
+	char *e = mp_encode_uint(b, (uint64_t)UINT32_MAX + 1 + 77);
+	*e++ = 0x1c;
+	ok(mp_validate_decimal(b, e - b) != 0, "scale 2^32 + 77 is rejected");
+
+	e = mp_encode_uint(b, (uint64_t)INT32_MAX + 1);
+	*e++ = 0x1c;
+	ok(mp_validate_decimal(b, e - b) != 0, "scale 2^31 is rejected");
+
+	e = mp_encode_int(b, INT32_MIN);
+	*e++ = 0x1c;
+	ok(mp_validate_decimal(b, e - b) != 0, "scale INT32_MIN is rejected");
+
+	/* A representable scale is still accepted. */
+	e = mp_encode_uint(b, 77);
+	*e++ = 0x1c;
+	ok(mp_validate_decimal(b, e - b) == 0, "scale 77 is accepted");
+
+	e = mp_encode_int(b, -1);
+	*e++ = 0x1c;
+	ok(mp_validate_decimal(b, e - b) == 0, "scale -1 is accepted");
 
 	footer();
 	check_plan();


### PR DESCRIPTION
Repro: insert a tuple whose decimal field is an MP_DECIMAL with scale `2^32 + 77` (`c7 0a 01 cf 000000010000004d 1c`). It passes field validation and reads back as `1E-77`, the same value as the well-formed 5-byte encoding, and both land in a decimal index as equal keys.
Cause: `decimal_unpack()` assigns the 64-bit decoded scale to an `int32_t`, so anything outside int32 is truncated rather than rejected. It is the MP_EXT validator for MP_DECIMAL, so this is the gate for every decimal arriving over IPROTO or replication.
Fix: read the scale with `mp_read_int32()` after the existing bounds check, the way `interval_unpack()` already does for the same kind of field, and drop `INT32_MIN`, which `decPackedToNumber()` negates before it range-checks it.

Representable scales decode exactly as before. The new checks in `test_mp_validate()` fail on master and pass with the patch.