### PR TITLE
config: add reload jitter option

### DIFF
--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -682,6 +682,17 @@ I['config.reload'] = format_text([[
       reload the configuration in the application code using `config:reload()`.
 ]])
 
+I['config.reload_jitter'] = format_text([[
+    Add jitter to automatic configuration reloads caused by remote configuration
+    storage events. A positive value, specified in seconds, spreads reloads over
+    this interval and reduces the burst in simultaneous fetches from the remote
+    storage. This is especially useful for large clusters. A value of `0`
+    (the default) reloads the configuration immediately.
+
+    This option affects only automatic reloads from the remote configuration
+    storage events. Manual reloads using `config:reload()` are not delayed.
+]])
+
 -- {{{ config.storage configuration
 
 I['config.storage'] = format_text([[

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -367,6 +367,11 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'auto',
         }),
+        reload_jitter = enterprise_edition(duration(schema.scalar({
+            type = 'integer',
+            default = 0,
+            validate = validators['config.reload_jitter'],
+        }))),
         -- Defaults can't be set there, because the `validate`
         -- annotation expects either no data or data with existing
         -- prefix field. The prefix field has no default. So,

--- a/src/box/lua/config/validators.lua
+++ b/src/box/lua/config/validators.lua
@@ -130,6 +130,12 @@ M['config.context.*'] = function(var, w)
     end
 end
 
+M['config.reload_jitter'] = function(data, w)
+    if data < 0 then
+        w.error('The reload jitter must be a non-negative integer')
+    end
+end
+
 M['config.etcd'] = function(data, w)
     -- No config.etcd section at all -- OK.
     if data == nil or next(data) == nil then

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -360,6 +360,7 @@ g.test_defaults = function()
         },
         config = {
             reload = 'auto',
+            reload_jitter = is_enterprise and 0 or nil,
             storage = {
                 timeout = 3,
                 reconnect_after = 3,

--- a/test/config-luatest/instance_config_schema_test.lua
+++ b/test/config-luatest/instance_config_schema_test.lua
@@ -149,6 +149,7 @@ g.test_config_enterprise = function()
     local iconfig = {
         config = {
             reload = 'auto',
+            reload_jitter = 0,
             context = {},
             etcd = {
                 prefix = '/one',
@@ -202,6 +203,7 @@ g.test_config_enterprise = function()
 
     local exp = {
         reload = 'auto',
+        reload_jitter = 0,
         storage = {
             timeout = 3,
             reconnect_after = 3,


### PR DESCRIPTION
When an etcd configuration update is published, every cluster instance reloads it at once. In large clusters, this can create a burst of simultaneous requests to etcd.

Add the `config.reload_jitter` option to the configuration schema. The option accepts a non-negative integer number of seconds and defaults to zero. In Enterprise Edition, the etcd configuration source uses it to spread automatic reloads over the configured interval.

Required by tarantool/tarantool-ee#1920.