### PR TITLE
box: introduce `index:info()` method

### DIFF
--- a/src/box/index.cc
+++ b/src/box/index.cc
@@ -757,6 +757,17 @@ box_iterator_free(box_iterator_t *it)
 /* {{{ Other index functions */
 
 int
+box_index_info(uint32_t space_id, uint32_t index_id, struct info_handler *info)
+{
+	struct space *space;
+	struct index *index;
+	if (check_index(space_id, index_id, &space, &index) != 0)
+		return -1;
+	index_info(index, info);
+	return 0;
+}
+
+int
 box_index_stat(uint32_t space_id, uint32_t index_id,
 	       struct info_handler *info)
 {
@@ -1303,6 +1314,14 @@ generic_index_create_read_view(struct index *index)
 {
 	diag_set(UnsupportedIndexFeature, index->def, "consistent read view");
 	return NULL;
+}
+
+void
+generic_index_info(struct index *index, struct info_handler *handler)
+{
+	(void)index;
+	info_begin(handler);
+	info_end(handler);
 }
 
 void

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -685,8 +685,8 @@ struct index_vtab {
 				   struct ArrowArrayStream *stream);
 	/** Create an index read view. */
 	struct index_read_view *(*create_read_view)(struct index *index);
-	/** Introspection (index:stat()) */
-	void (*stat)(struct index *, struct info_handler *);
+	/** Index statistics (`index:stat()`). */
+	void (*stat)(struct index *index, struct info_handler *handler);
 	/**
 	 * Trigger asynchronous index compaction. What exactly
 	 * is implied under 'compaction' depends on the engine.

--- a/src/box/index.h
+++ b/src/box/index.h
@@ -322,6 +322,18 @@ box_index_tuple_position(uint32_t space_id, uint32_t index_id,
 			 const char **packed_pos, const char **packed_pos_end);
 
 /**
+ * Index information (`index:info()`).
+ *
+ * \param space_id space identifier
+ * \param index_id index identifier
+ * \param info info handler
+ * \retval -1 on error (check `box_error_last()`)
+ * \retval 0 on success
+ */
+int
+box_index_info(uint32_t space_id, uint32_t index_id, struct info_handler *info);
+
+/**
  * Index statistics (index:stat())
  *
  * \param space_id space identifier
@@ -685,6 +697,8 @@ struct index_vtab {
 				   struct ArrowArrayStream *stream);
 	/** Create an index read view. */
 	struct index_read_view *(*create_read_view)(struct index *index);
+	/** Index information (`index:info()`). */
+	void (*info)(struct index *index, struct info_handler *handler);
 	/** Index statistics (`index:stat()`). */
 	void (*stat)(struct index *index, struct info_handler *handler);
 	/**
@@ -1075,6 +1089,12 @@ index_create_read_view(struct index *index)
 }
 
 static inline void
+index_info(struct index *index, struct info_handler *handler)
+{
+	index->vtab->info(index, handler);
+}
+
+static inline void
 index_stat(struct index *index, struct info_handler *handler)
 {
 	index->vtab->stat(index, handler);
@@ -1248,6 +1268,7 @@ generic_index_read_view_count(struct index_read_view *rv,
 int generic_index_get(struct index *, const char *, uint32_t, struct tuple **);
 struct index_read_view *
 generic_index_create_read_view(struct index *index);
+void generic_index_info(struct index *, struct info_handler *);
 void generic_index_stat(struct index *, struct info_handler *);
 void generic_index_compact(struct index *);
 void generic_index_reset_stat(struct index *);

--- a/src/box/lua/index.c
+++ b/src/box/lua/index.c
@@ -408,15 +408,15 @@ lbox_truncate(struct lua_State *L)
 
 /* {{{ Introspection */
 
+/** Index statistics (`index:stat()`). */
 static int
 lbox_index_stat(lua_State *L)
 {
 	if (lua_gettop(L) != 2 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
 		diag_set(IllegalParams,
-			 "Usage: index.info(space_id, index_id)");
+			 "Usage: box.internal.stat(space_id, index_id)");
 		return luaT_error(L);
 	}
-
 	uint32_t space_id = lua_tonumber(L, 1);
 	uint32_t index_id = lua_tonumber(L, 2);
 
@@ -426,6 +426,8 @@ lbox_index_stat(lua_State *L)
 		return luaT_error(L);
 	return 1;
 }
+
+/* }}} */
 
 static int
 lbox_index_compact(lua_State *L)
@@ -465,8 +467,6 @@ lbox_insert_arrow(lua_State *L)
 		return luaT_error(L);
 	return 0;
 }
-
-/* }}} */
 
 void
 box_lua_index_init(struct lua_State *L)

--- a/src/box/lua/index.c
+++ b/src/box/lua/index.c
@@ -408,6 +408,25 @@ lbox_truncate(struct lua_State *L)
 
 /* {{{ Introspection */
 
+/** Index information (`index:info()`). */
+static int
+lbox_index_info(lua_State *L)
+{
+	if (lua_gettop(L) != 2 || !lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
+		diag_set(IllegalParams,
+			 "Usage: box.internal.info(space_id, index_id)");
+		return luaT_error(L);
+	}
+	uint32_t space_id = lua_tonumber(L, 1);
+	uint32_t index_id = lua_tonumber(L, 2);
+
+	struct info_handler info;
+	luaT_info_handler_create(&info, L);
+	if (box_index_info(space_id, index_id, &info) != 0)
+		return luaT_error(L);
+	return 1;
+}
+
 /** Index statistics (`index:stat()`). */
 static int
 lbox_index_stat(lua_State *L)
@@ -493,6 +512,7 @@ box_lua_index_init(struct lua_State *L)
 		{"iterator", lbox_index_iterator},
 		{"iterator_next", lbox_iterator_next},
 		{"truncate", lbox_truncate},
+		{"info", lbox_index_info},
 		{"stat", lbox_index_stat},
 		{"compact", lbox_index_compact},
 		{"insert_arrow", lbox_insert_arrow},

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -2260,6 +2260,7 @@ base_index_mt.delete_range = function(index, begin_key, end_key)
 end
 
 base_index_mt.stat = function(index)
+    check_index_arg(index, 'stat', 2)
     return internal.stat(index.space_id, index.id);
 end
 

--- a/src/box/lua/schema.lua
+++ b/src/box/lua/schema.lua
@@ -2259,6 +2259,11 @@ base_index_mt.delete_range = function(index, begin_key, end_key)
                                  keify(begin_key), keify(end_key))
 end
 
+base_index_mt.info = function(index)
+    check_index_arg(index, 'info', 2)
+    return internal.info(index.space_id, index.id);
+end
+
 base_index_mt.stat = function(index)
     check_index_arg(index, 'stat', 2)
     return internal.stat(index.space_id, index.id);

--- a/src/box/memtx_bitset.cc
+++ b/src/box/memtx_bitset.cc
@@ -522,6 +522,7 @@ static const struct index_vtab memtx_bitset_index_vtab_base = {
 	generic_index_create_iterator_with_offset,
 	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ generic_index_create_read_view,
+	/* .info = */ generic_index_info,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,
 	/* .reset_stat = */ generic_index_reset_stat,

--- a/src/box/memtx_hash.cc
+++ b/src/box/memtx_hash.cc
@@ -790,6 +790,7 @@ static const struct index_vtab memtx_hash_index_vtab_base = {
 	generic_index_create_iterator_with_offset,
 	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ memtx_hash_index_create_read_view,
+	/* .info = */ generic_index_info,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,
 	/* .reset_stat = */ generic_index_reset_stat,

--- a/src/box/memtx_rtree.cc
+++ b/src/box/memtx_rtree.cc
@@ -420,6 +420,7 @@ static const struct index_vtab memtx_rtree_index_vtab_base = {
 	generic_index_create_iterator_with_offset,
 	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ generic_index_create_read_view,
+	/* .info = */ generic_index_info,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,
 	/* .reset_stat = */ generic_index_reset_stat,

--- a/src/box/memtx_tree.cc
+++ b/src/box/memtx_tree.cc
@@ -3082,6 +3082,7 @@ static const struct index_vtab memtx_tree_disabled_index_vtab_base = {
 	generic_index_create_iterator_with_offset,
 	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ generic_index_create_read_view,
+	/* .info = */ generic_index_info,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,
 	/* .reset_stat = */ generic_index_reset_stat,
@@ -3152,6 +3153,7 @@ get_memtx_tree_index_vtab(void)
 		/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 		/* .create_read_view = */
 			memtx_tree_index_create_read_view<USE_HINT>,
+		/* .info = */ generic_index_info,
 		/* .stat = */ generic_index_stat,
 		/* .compact = */ generic_index_compact,
 		/* .reset_stat = */ generic_index_reset_stat,

--- a/src/box/session_settings.c
+++ b/src/box/session_settings.c
@@ -285,6 +285,7 @@ static const struct index_vtab session_settings_index_vtab = {
 	generic_index_create_iterator_with_offset,
 	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ generic_index_create_read_view,
+	/* .info = */ generic_index_info,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,
 	/* .reset_stat = */ generic_index_reset_stat,

--- a/src/box/sysview.c
+++ b/src/box/sysview.c
@@ -210,6 +210,7 @@ static const struct index_vtab sysview_index_vtab = {
 	generic_index_create_iterator_with_offset,
 	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ generic_index_create_read_view,
+	/* .info = */ generic_index_info,
 	/* .stat = */ generic_index_stat,
 	/* .compact = */ generic_index_compact,
 	/* .reset_stat = */ generic_index_reset_stat,

--- a/src/box/vinyl.c
+++ b/src/box/vinyl.c
@@ -4830,6 +4830,7 @@ static const struct index_vtab vinyl_index_vtab = {
 	generic_index_create_iterator_with_offset,
 	/* .create_arrow_stream = */ generic_index_create_arrow_stream,
 	/* .create_read_view = */ generic_index_create_read_view,
+	/* .info = */ generic_index_info,
 	/* .stat = */ vinyl_index_stat,
 	/* .compact = */ vinyl_index_compact,
 	/* .reset_stat = */ vinyl_index_reset_stat,

--- a/test/box-luatest/index_info_test.lua
+++ b/test/box-luatest/index_info_test.lua
@@ -1,0 +1,75 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+-- Check the info() method error messages.
+g.test_index_info_errors = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        local pk = s:create_index('pk')
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "Use index:info(...) instead of index.info(...)",
+        }, pk.info)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "Usage: box.internal.info(space_id, index_id)",
+        }, box.internal.info, 'abc', pk.id)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "Usage: box.internal.info(space_id, index_id)",
+        }, box.internal.info, s.id, 'abc')
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'NO_SUCH_SPACE',
+            message = "Space '100500' does not exist",
+        }, box.internal.info, 100500, pk.id)
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'NO_SUCH_INDEX_ID',
+            message = "No index #100500 is defined in space 'test'",
+        }, box.internal.info, s.id, 100500)
+    end)
+end
+
+-- Test the info() method of memtx indexes.
+g.test_index_info_memtx = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('i1', {type = 'tree'})
+        s:create_index('i2', {type = 'hash'})
+        s:create_index('i3', {type = 'bitset', parts = {3, 'unsigned'}})
+        s:create_index('i4', {type = 'rtree', parts = {4, 'array'}})
+        t.assert_equals(s.index.i1:info(), {})
+        t.assert_equals(s.index.i2:info(), {})
+        t.assert_equals(s.index.i3:info(), {})
+        t.assert_equals(s.index.i4:info(), {})
+    end)
+end
+
+-- Test the info() method of a vinyl index.
+g.test_index_info_vinyl = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test', {engine = 'vinyl'})
+        s:create_index('pk')
+        t.assert_equals(s.index.pk:info(), {})
+    end)
+end

--- a/test/box-luatest/index_stat_test.lua
+++ b/test/box-luatest/index_stat_test.lua
@@ -1,0 +1,66 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new()
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        if box.space.test then
+            box.space.test:drop()
+        end
+    end)
+end)
+
+-- Check the stat() method error messages.
+g.test_index_stat_errors = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        local pk = s:create_index('pk')
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "Use index:stat(...) instead of index.stat(...)",
+        }, pk.stat)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "Usage: box.internal.stat(space_id, index_id)",
+        }, box.internal.stat, 'abc', pk.id)
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = "Usage: box.internal.stat(space_id, index_id)",
+        }, box.internal.stat, s.id, 'abc')
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'NO_SUCH_SPACE',
+            message = "Space '100500' does not exist",
+        }, box.internal.stat, 100500, pk.id)
+        t.assert_error_covers({
+            type = 'ClientError',
+            name = 'NO_SUCH_INDEX_ID',
+            message = "No index #100500 is defined in space 'test'",
+        }, box.internal.stat, s.id, 100500)
+    end)
+end
+
+-- Test the stat() method of memtx indexes.
+g.test_index_stat_memtx = function(cg)
+    cg.server:exec(function()
+        local s = box.schema.space.create('test')
+        s:create_index('i1', {type = 'tree'})
+        s:create_index('i2', {type = 'hash'})
+        s:create_index('i3', {type = 'bitset', parts = {3, 'unsigned'}})
+        s:create_index('i4', {type = 'rtree', parts = {4, 'array'}})
+        t.assert_equals(s.index.i1:stat(), {})
+        t.assert_equals(s.index.i2:stat(), {})
+        t.assert_equals(s.index.i3:stat(), {})
+        t.assert_equals(s.index.i4:stat(), {})
+    end)
+end


### PR DESCRIPTION
It exposes detailed engine-specific information about an index. Adding such details directly to the serialized index object would clutter it, so a dedicated method was introduced. Note that the information like runtime counters belongs to the existing `index:stat()` method.

At the moment no engine in CE implements it.

EE part:
- https://github.com/tarantool/tarantool-ee/pull/1921