### PR TITLE
Adding a meta-field to a iproto message in call

### DIFF
--- a/changelogs/unreleased/gh-12998-adding-metadata-field-in-fiber.md
+++ b/changelogs/unreleased/gh-12998-adding-metadata-field-in-fiber.md
@@ -1,0 +1,4 @@
+* Now struct fiber includes a map-type field
+  for context that is inherited when a new fiber is created.
+  The command get_cnt() is used to retrieve the metadata,
+  set_cnt() is used to modify it.

--- a/src/box/call.c
+++ b/src/box/call.c
@@ -32,6 +32,7 @@
 #include "box/call.h"
 #include "lua/call.h"
 #include "../lua/init.h" /* tarantool_lua_is_builtin_global */
+#include "lua/fiber.h"
 #include "schema.h"
 #include "session.h"
 #include "fiber.h"
@@ -225,6 +226,11 @@ access_check_lua_eval(void)
 int
 box_process_call(struct call_request *request, struct port *port)
 {
+	fiber()->cnt_ref = request->request_cnt;
+	fiber()->cnt_len = request->request_cnt_len;
+	struct trigger *on_stop = xmalloc(sizeof(*on_stop));
+	trigger_create(on_stop, lbox_fiber_on_stop, NULL, (trigger_f0)free);
+	trigger_add(&fiber()->on_stop, on_stop);
 	rmean_collect(rmean_box, IPROTO_CALL, 1);
 	/**
 	 * Find the function definition and check access.

--- a/src/box/iproto_constants.h
+++ b/src/box/iproto_constants.h
@@ -243,6 +243,8 @@ extern const char *iproto_flag_bit_strs[];
 	  * true and CHECKPOINT_VCLOCK to be set.
 	  */								\
 	 _(CHECKPOINT_LSN, 0x64, MP_UINT)				\
+	 _(REQUEST_CNT, 0x65, MP_INT)					\
+	 _(REQUEST_CNT_LEN, 0x66, MP_UINT)				\
 
 #define IPROTO_KEY_MEMBER(s, v, ...) IPROTO_ ## s = v,
 

--- a/src/box/lua/net_box.c
+++ b/src/box/lua/net_box.c
@@ -838,7 +838,7 @@ netbox_encode_call(lua_State *L, int idx, struct netbox_method_encode_ctx *ctx)
 	size_t svp = netbox_begin_encode(ctx->stream, ctx->sync, IPROTO_CALL,
 					 ctx->thread_id, ctx->stream_id);
 
-	mpstream_encode_map(ctx->stream, 3);
+	mpstream_encode_map(ctx->stream, 5);
 
 	/* encode proc name */
 	size_t name_len;
@@ -846,9 +846,20 @@ netbox_encode_call(lua_State *L, int idx, struct netbox_method_encode_ctx *ctx)
 	mpstream_encode_uint(ctx->stream, IPROTO_FUNCTION_NAME);
 	mpstream_encode_strn(ctx->stream, name, name_len);
 
+	int cnt_ref = fiber()->cnt_ref;
+	if (cnt_ref != FIBER_LUA_NOREF) {
+		lua_rawgeti(L, LUA_REGISTRYINDEX, fiber()->cnt_ref);
+		cnt_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+	}
+	mpstream_encode_uint(ctx->stream, IPROTO_REQUEST_CNT);
+	mpstream_encode_int64(ctx->stream, cnt_ref);
+	mpstream_encode_uint(ctx->stream, IPROTO_REQUEST_CNT_LEN);
+	mpstream_encode_uint(ctx->stream, fiber()->cnt_len);
 	if (netbox_encode_call_or_eval_args(L, idx + 1, ctx->stream,
-					    ctx->box_tuple_arg_as_ext) != 0)
+					    ctx->box_tuple_arg_as_ext) != 0) {
+		luaL_unref(tarantool_L, LUA_REGISTRYINDEX, cnt_ref);
 		return -1;
+	}
 
 	netbox_end_encode(ctx->stream, svp);
 	return 0;

--- a/src/box/xrow.c
+++ b/src/box/xrow.c
@@ -1733,6 +1733,24 @@ error:
 			request->tuple_formats = value;
 			request->tuple_formats_end = data;
 			break;
+		case IPROTO_REQUEST_CNT:
+			uint32_t typ = mp_typeof(*value);
+			if (typ == MP_INT) {
+				request->request_cnt = mp_decode_int(&value);
+			}
+			else if (typ == MP_UINT) {
+				request->request_cnt = mp_decode_uint(&value);
+			}
+			else
+				goto error;
+			break;
+		case IPROTO_REQUEST_CNT_LEN:
+			if (mp_typeof(*value) == MP_UINT) {
+				request->request_cnt_len = mp_decode_uint(&value);
+			}
+			else
+				goto error;
+			break;
 		default:
 			continue; /* unknown key */
 		}

--- a/src/box/xrow.h
+++ b/src/box/xrow.h
@@ -275,6 +275,8 @@ struct request {
 	const char *end_key;
 	/** End of @end_key. */
 	const char *end_key_end;
+	int request_cnt;
+	uint32_t request_cnt_len;
 };
 
 /**
@@ -489,6 +491,8 @@ struct call_request {
 	const char *tuple_formats;
 	/** End of tuple formats of CALL/EVAL parameters. */
 	const char *tuple_formats_end;
+	int request_cnt;
+	uint32_t request_cnt_len;
 };
 
 /**

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1060,6 +1060,7 @@ fiber_recycle(struct fiber *fiber)
 	memset(&fiber->storage, 0, sizeof(fiber->storage));
 	fiber->storage.lua.storage_ref = FIBER_LUA_NOREF;
 	fiber->storage.lua.fid_ref = FIBER_LUA_NOREF;
+	fiber->cnt_ref = FIBER_LUA_NOREF;
 	unregister_fid(fiber);
 	fiber->fid = 0;
 	fiber->gc_initial_size = 0;
@@ -1556,6 +1557,7 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 		memset(fiber, 0, sizeof(struct fiber));
 		fiber->storage.lua.storage_ref = FIBER_LUA_NOREF;
 		fiber->storage.lua.fid_ref = FIBER_LUA_NOREF;
+		fiber->cnt_ref = FIBER_LUA_NOREF;
 
 		fiber_stack_create(fiber, fiber_attr, &cord()->slabc);
 		coro_create(&fiber->ctx, fiber_loop, NULL,
@@ -1574,6 +1576,7 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 	fiber->f = f;
 	fiber->fid = cord->next_fid;
 	fiber_set_name(fiber, name);
+	fiber->cnt_ref = FIBER_LUA_NOREF;
 	register_fid(fiber);
 	fiber->max_slice = zero_slice;
 	fiber->csw = 0;

--- a/src/lib/core/fiber.c
+++ b/src/lib/core/fiber.c
@@ -1061,6 +1061,7 @@ fiber_recycle(struct fiber *fiber)
 	fiber->storage.lua.storage_ref = FIBER_LUA_NOREF;
 	fiber->storage.lua.fid_ref = FIBER_LUA_NOREF;
 	fiber->cnt_ref = FIBER_LUA_NOREF;
+	fiber->cnt_len = 0;
 	unregister_fid(fiber);
 	fiber->fid = 0;
 	fiber->gc_initial_size = 0;
@@ -1558,6 +1559,7 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 		fiber->storage.lua.storage_ref = FIBER_LUA_NOREF;
 		fiber->storage.lua.fid_ref = FIBER_LUA_NOREF;
 		fiber->cnt_ref = FIBER_LUA_NOREF;
+		fiber->cnt_len = 0;
 
 		fiber_stack_create(fiber, fiber_attr, &cord()->slabc);
 		coro_create(&fiber->ctx, fiber_loop, NULL,
@@ -1577,6 +1579,7 @@ fiber_new_ex(const char *name, const struct fiber_attr *fiber_attr,
 	fiber->fid = cord->next_fid;
 	fiber_set_name(fiber, name);
 	fiber->cnt_ref = FIBER_LUA_NOREF;
+	fiber->cnt_len = 0;
 	register_fid(fiber);
 	fiber->max_slice = zero_slice;
 	fiber->csw = 0;

--- a/src/lib/core/fiber.h
+++ b/src/lib/core/fiber.h
@@ -677,6 +677,10 @@ struct fiber {
 	int csw;
 	/** Fiber id. */
 	uint64_t fid;
+	/** Reference on fiber metadata. */
+	int cnt_ref;
+	/** Len on fiber metadata. */
+	size_t cnt_len;
 	/** Fiber flags */
 	uint32_t flags;
 	struct clock_stat clock_stat;

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -39,6 +39,10 @@
 
 #include <lua.h>
 #include <lauxlib.h>
+#include "lua/msgpack.h" /* luaL_msgpack_default */
+#include "mpstream/mpstream.h"
+#include "cord_buf.h"
+#include <small/ibuf.h>
 
 static_assert(FIBER_LUA_NOREF == LUA_NOREF, "FIBER_LUA_NOREF is ok");
 
@@ -100,8 +104,15 @@ static int
 lbox_fiber_on_stop(struct trigger *trigger, void *event)
 {
 	struct fiber *f = event;
-	luaL_unref(tarantool_L, LUA_REGISTRYINDEX, f->storage.lua.storage_ref);
-	f->storage.lua.storage_ref = FIBER_LUA_NOREF;
+	if (f->storage.lua.storage_ref != FIBER_LUA_NOREF) {
+		luaL_unref(tarantool_L, LUA_REGISTRYINDEX,
+			   f->storage.lua.storage_ref);
+		f->storage.lua.storage_ref = FIBER_LUA_NOREF;
+	}
+	if (f->cnt_ref != FIBER_LUA_NOREF) {
+		luaL_unref(tarantool_L, LUA_REGISTRYINDEX, f->cnt_ref);
+		f->cnt_ref = FIBER_LUA_NOREF;
+	}
 	trigger_clear(trigger);
 	free(trigger);
 	return 0;
@@ -169,6 +180,27 @@ lbox_checkfiber(struct lua_State *L, int index)
 		luaT_error(L);
 	}
 	return f;
+}
+
+/**
+ * Puts fiber metadata in Lua stack.
+ */
+static int
+lbox_fiber_get_cnt(struct lua_State *L)
+{
+	struct fiber *f;
+	if (lua_gettop(L) == 0)
+		f = fiber();
+	else
+		f = lbox_checkfiber(L, 1);
+	if (f->cnt_ref == FIBER_LUA_NOREF) {
+		lua_pushnil(L);
+	} else {
+		lua_rawgeti(L, LUA_REGISTRYINDEX, f->cnt_ref);
+		const char *cnt = lua_tolstring(L, -1, &f->cnt_len);
+		luamp_decode(L, luaL_msgpack_default, &cnt);
+	}
+	return 1;
 }
 
 static int
@@ -475,6 +507,19 @@ fiber_create(struct lua_State *L)
 	int coro_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
 	struct fiber *f = fiber_new("lua", lua_fiber_run_f);
+
+	if (f == NULL) {
+		luaL_unref(L, LUA_REGISTRYINDEX, coro_ref);
+		luaT_error(L);
+	}
+	struct fiber *fib = fiber();
+	if (fib->cnt_ref != FIBER_LUA_NOREF) {
+		f->cnt_len = fib->cnt_len;
+		lua_rawgeti(L, LUA_REGISTRYINDEX, fib->cnt_ref);
+		f->cnt_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+	} else {
+		f->cnt_ref = FIBER_LUA_NOREF;
+	}
 #ifdef ENABLE_BACKTRACE
 	if (fiber_parent_backtrace_is_enabled()) {
 		struct fiber *parent = fiber();
@@ -663,6 +708,49 @@ lbox_fiber_name(struct lua_State *L)
 		lua_pushstring(L, fiber_name(f));
 		return 1;
 	}
+}
+
+/*
+ * This function encodes context of type map from lua stack,
+ * puts it in lua storage and save in fiber ref on cnt and its len.
+ */
+static int
+lbox_fiber_set_cnt(struct lua_State *L)
+{
+	struct fiber *f = fiber();
+	if (lua_type(L, 1) == LUA_TUSERDATA) {
+		f = lbox_checkfiber(L, 1);
+	}
+	if (f->flags & FIBER_IS_DEAD) {
+		diag_set(IllegalParams, "the fiber is dead");
+		luaT_error(L);
+	}
+	int index = lua_gettop(L);
+	if (index < 1)
+		return luaL_error(L, "msgpack.encode: a Lua object expected");
+
+	struct ibuf *buf = cord_ibuf_take();
+	struct mpstream stream;
+	mpstream_init(&stream, buf, ibuf_reserve_cb, ibuf_alloc_cb,
+		      luamp_error, L);
+	luamp_encode(L, luaL_msgpack_default, &stream, index);
+	mpstream_flush(&stream);
+
+	if (f->cnt_ref != FIBER_LUA_NOREF) {
+		luaL_unref(tarantool_L, LUA_REGISTRYINDEX, f->cnt_ref);
+	} else {
+		struct trigger *on_stop = xmalloc(sizeof(*on_stop));
+		trigger_create(on_stop, lbox_fiber_on_stop, NULL,
+			       (trigger_f0)free);
+		trigger_add(&f->on_stop, on_stop);
+	}
+	size_t cnt_len = ibuf_used(buf);
+	lua_pushlstring(L, buf->buf, cnt_len);
+	f->cnt_len = cnt_len;
+	int cnt_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+	f->cnt_ref = cnt_ref;
+	cord_ibuf_drop(buf);
+	return 0;
 }
 
 static int
@@ -1063,6 +1151,8 @@ lbox_fiber_set_max_slice(struct lua_State *L)
 }
 
 static const struct luaL_Reg lbox_fiber_meta [] = {
+	{"get_cnt", lbox_fiber_get_cnt},
+	{"set_cnt", lbox_fiber_set_cnt},
 	{"id", lbox_fiber_id},
 	{"name", lbox_fiber_name},
 	{"cancel", lbox_fiber_cancel},
@@ -1095,6 +1185,8 @@ static const struct luaL_Reg fiberlib[] = {
 	{"sleep", lbox_fiber_sleep},
 	{"yield", lbox_fiber_yield},
 	{"self", lbox_fiber_self},
+	{"get_cnt", lbox_fiber_get_cnt},
+	{"set_cnt", lbox_fiber_set_cnt},
 	{"id", lbox_fiber_id},
 	{"find", lbox_fiber_find},
 	{"kill", lbox_fiber_cancel},

--- a/src/lua/fiber.c
+++ b/src/lua/fiber.c
@@ -100,7 +100,7 @@ static const char *fiberlib_name = "fiber";
  * which can create the storage. Trigger guarantees, that even for non-Lua
  * fibers the Lua storage is destroyed.
  */
-static int
+int
 lbox_fiber_on_stop(struct trigger *trigger, void *event)
 {
 	struct fiber *f = event;
@@ -112,6 +112,7 @@ lbox_fiber_on_stop(struct trigger *trigger, void *event)
 	if (f->cnt_ref != FIBER_LUA_NOREF) {
 		luaL_unref(tarantool_L, LUA_REGISTRYINDEX, f->cnt_ref);
 		f->cnt_ref = FIBER_LUA_NOREF;
+		f->cnt_len = 0;
 	}
 	trigger_clear(trigger);
 	free(trigger);
@@ -519,6 +520,7 @@ fiber_create(struct lua_State *L)
 		f->cnt_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 	} else {
 		f->cnt_ref = FIBER_LUA_NOREF;
+		f->cnt_len = 0;
 	}
 #ifdef ENABLE_BACKTRACE
 	if (fiber_parent_backtrace_is_enabled()) {

--- a/src/lua/fiber.h
+++ b/src/lua/fiber.h
@@ -35,6 +35,7 @@ extern "C" {
 #endif /* defined(__cplusplus) */
 
 struct lua_State;
+struct trigger;
 
 /**
 * Initialize box.fiber system
@@ -44,6 +45,10 @@ tarantool_lua_fiber_init(struct lua_State *L);
 
 void
 luaL_testcancel(struct lua_State *L);
+
+int
+lbox_fiber_on_stop(struct trigger *trigger, void *event);
+
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/lua/log.lua
+++ b/src/lua/log.lua
@@ -96,6 +96,8 @@ local special_fields = {
     "line",
     "cord_name",
     "fiber_name",
+    "fiber_get_cnt",
+    "fiber_set_cnt",
     "fiber_id",
     "error_msg"
 }

--- a/test/app-luatest/fiber_test.lua
+++ b/test/app-luatest/fiber_test.lua
@@ -96,3 +96,58 @@ g.test_gh_10196_no_hang_on_self_join = function()
         message = 'cannot join itself',
     })
 end
+
+g.test_check_distribution_meta_data_in_fiber = function()
+    local f = fiber.self()
+
+    local res, err = f:get_cnt()
+    t.assert_equals(res, nil)
+    t.assert_equals(err, nil)
+
+    local sleep = function() require('fiber').sleep(500) end
+    local f_new = fiber.new(sleep)
+    res, err = f_new:get_cnt()
+    t.assert_equals(res, nil)
+    t.assert_equals(err, nil)
+    f_new:cancel()
+
+    local f_create = fiber.create(sleep)
+    res, err = f_create:get_cnt()
+    t.assert_equals(res, nil)
+    t.assert_equals(err, nil)
+    f_create:cancel()
+
+    local exp = {id = 0, a = 1, b = '2'}
+    f:set_cnt(exp)
+    res = f:get_cnt()
+    t.assert_equals(res, exp)
+
+    f_new = fiber.new(sleep)
+    res = f_new:get_cnt()
+    t.assert_equals(res, exp)
+
+    f_create = fiber.create(sleep)
+    res = f_create:get_cnt()
+    t.assert_equals(res, exp)
+
+    local exp_new = {c = 'llll'}
+    f_new:set_cnt(exp_new)
+    res = f_new:get_cnt()
+    t.assert_equals(res, exp_new)
+    res = f:get_cnt()
+    t.assert_equals(res, exp)
+    res = f_create:get_cnt()
+    t.assert_equals(res, exp)
+
+    local exp_create = {p = 0}
+    f_create:set_cnt(exp_create)
+    res = f_create:get_cnt()
+    t.assert_equals(res, exp_create)
+    res = f:get_cnt()
+    t.assert_equals(res, exp)
+    res = f_new:get_cnt()
+    t.assert_equals(res, exp_new)
+
+    f_new:cancel()
+    f_create:cancel()
+end

--- a/test/app-luatest/fiber_test.lua
+++ b/test/app-luatest/fiber_test.lua
@@ -151,3 +151,65 @@ g.test_check_distribution_meta_data_in_fiber = function()
     f_new:cancel()
     f_create:cancel()
 end
+
+g = t.group("fiber2")
+local server = require('luatest.server')
+
+g.before_all(function()
+    g.server = server:new({alias = 'master'})
+    g.server:start()
+end)
+
+g.after_all(function()
+    g.server:drop()
+end)
+
+g.test_check_distribution_meta_data_in_fiber_call = function()
+    g.server:exec(function()
+        local netbox = require('net.box')
+        local fiber = require('fiber')
+        box.schema.user.create('test_user', {password = 'test'})
+        box.schema.user.grant('test_user', 'read, write, execute', 'universe')
+        box.schema.user.grant('test_user', 'create', 'space')
+        local cn = netbox.connect(box.cfg.listen,{user = 'test_user', password = 'test'})
+
+        box.schema.func.create('f_nil', {
+            body = [[
+                function()
+                    return require('fiber').self():get_cnt()
+                end
+            ]],
+            language = 'Lua'
+        })
+
+        box.schema.func.create('f_set', {
+            body = [[
+                function()
+                    require('fiber').self():set_cnt({a = 0, b = 1})
+                    return require('fiber').self():get_cnt()
+                end
+            ]],
+            language = 'Lua'
+        })
+
+        local f = fiber.self()
+        local res = cn:call('f_nil', {})
+        t.assert_equals(res, nil)
+
+        res = cn:call('f_set', {})
+        t.assert_equals(res, {a = 0, b = 1})
+        t.assert_equals(f:get_cnt(), nil)
+
+        f:set_cnt({c = 'abd'})
+
+        res = cn:call('f_nil', {})
+        t.assert_equals(res, {c = 'abd'})
+
+        res = cn:call('f_set', {})
+        t.assert_equals(res, {a = 0, b = 1})
+        t.assert_equals(f:get_cnt(), {c = 'abd'})
+
+        cn:close()
+        box.schema.user.drop('test_user')
+    end)
+end


### PR DESCRIPTION
After this patch struct map-type field for metadata in fiber
is transmitted in call requests.

Part of #12998
