### PR TITLE
doc: add agent review guidance and gh-review tool

### DIFF
--- a/.claude/skills/tnt-review-gh/SKILL.md
+++ b/.claude/skills/tnt-review-gh/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: tnt-review-gh
+description: >-
+  Enables code reviewing on GitHub. This extends the regular review skill. MUST
+  use when the user asks for a review to be posted on GitHub.
+---
+
+Read `doc/agents/review-gh.md` (relative to the repo root) for the full
+guidance.

--- a/.claude/skills/tnt-review/SKILL.md
+++ b/.claude/skills/tnt-review/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: tnt-review
+description: >-
+  Enables code reviewing: validation of commits and code for correctness and
+  against the project standards. MUST use when the user asks to review a patch,
+  a branch, a pull request.
+---
+
+Read `doc/agents/review.md` (relative to the repo root) for the full
+guidance.

--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,7 @@ states/
 
 # Per-developer local setup notes (agent-generated, machine-specific)
 doc/agents/local_setup.md
+
+# Local findings files of the agent-driven reviews (see
+# doc/agents/review.md)
+/reviews/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,14 @@ descriptions here.
   replication-specific code. MUST use when editing/adding tests under
   `test/replication/` or `test/replication-luatest/`.
 
+- `doc/agents/review.md` - Enables code reviewing: validation of commits and
+  code for correctness and against the project standards. MUST use when the user
+  asks to review a patch, a branch, a pull request.
+
+- `doc/agents/review-gh.md` - Enables code reviewing on GitHub. This extends the
+  regular review skill. MUST use when the user asks for a review to be posted on
+  GitHub.
+
 - `doc/agents/setup-dev.md` - Enables access to user-specific development setup:
   sources fetch, configure, build, tests, static analysis. MUST use when
   `doc/agents/local_setup.md` is missing or seems outdated, and you need to do

--- a/doc/agents/review-gh.md
+++ b/doc/agents/review-gh.md
@@ -1,0 +1,240 @@
+# Posting reviews to GitHub
+
+This document explains how to publish a patch review to a GitHub pull request.
+
+## Required knowledge
+
+Posting a review to GitHub means a review has to be performed first. You MUST
+load `doc/agents/review.md` and follow it for the review itself. This document
+only adds the publishing mechanics on top of it.
+
+## Permissions
+
+The only allowed actions are the following:
+- Checking out the PR branch locally.
+- Reading the PR details, its commit list, the diffs.
+- Reading existing reviews and comments.
+- Posting new review comments attached to the diffs.
+- Posting PR-global comments.
+- Replying to existing review comment threads.
+- Reacting to existing comments of other people.
+- Dropping your own not yet submitted pending review, with the comments
+  collected in it (the `abort` command below).
+
+Forbidden - anything else that writes. In particular it is not allowed to
+close, reopen, approve, edit, delete PRs and comments.
+
+By default `gh` will use the profile that the user had authenticated with. But
+it can be changed using the env variable `GH_TOKEN`. It can be handy if the user
+wants to post comments using a non-default profile.
+
+Before starting to work on a review, sort out the identities, to understand
+when to pass what:
+
+- The default `gh` profile: `gh api user --jq .login`.
+- The token from the local setup: the same command with `GH_TOKEN` set.
+- The cookie's account: the `<login>` prefix of the `GH_COOKIE` value. The
+  cookie itself cannot be checked programmatically, which is exactly why the
+  login is stored inside the same value.
+
+All the posting must run under the token of the same account the cookie
+belongs to. Otherwise the private API sends the comments into an invisible
+pending review of the cookie's account, while the token's own review gets
+submitted empty.
+
+## Reading commits
+
+The diffs and the commit data is best to take from the local git repo instead of
+accessing them via the web APIs. Because the web APIs often have limitations
+like max number of commits listed, max number of files changed, and so on. PRs
+with their base branches can be fetched like this:
+
+```Bash
+git fetch origin pull/<num>/head <base-branch>
+```
+
+A plain fetch is enough, no need to create branches and/or switch them unless
+this is necessary for the review. After the fetch everything about the commits
+is available locally: `git log <base-branch>..FETCH_HEAD` for the commit list
+with SHAs and messages, `git show <sha>` for the diff of a single commit.
+
+The PR metadata and the review state exist only on GitHub. `gh api` substitutes
+the `{owner}` and `{repo}` placeholders from the git remote of the current
+repository, so the commands below can be used literally.
+
+- PR details:
+  `gh pr view <num> --json number,title,body,state,headRefOid,url`
+- Existing reviews:
+  `gh api 'repos/{owner}/{repo}/pulls/<num>/reviews?per_page=100' --paginate`
+- Existing review comments (the ones attached to diffs):
+  `gh api 'repos/{owner}/{repo}/pulls/<num>/comments?per_page=100' --paginate`
+- Existing PR-global conversation comments:
+  `gh api 'repos/{owner}/{repo}/issues/<num>/comments?per_page=100' --paginate`
+
+The list endpoints return at most one page - 30 items by default - and nothing
+in the output hints that more exist, hence the `--paginate`. Mind that it
+prints one JSON array per page: iterating with `--jq '.[]'` works as is, while
+feeding the output to a JSON parser needs the extra `--slurp` flag.
+
+Read the existing comments before posting anything: do not duplicate remarks
+which were already made by anyone, and find the threads which expect an answer
+from you. When somebody wrote a comment which you agree with, you can react to
+it with a reaction or by replying there that you agree and why.
+
+## Posting review
+
+The review is published as one single review: each comment is attached to
+the diff of a specific commit, and the review's main message carries the
+PR-global comments. Plain `gh` commands cannot do this cleanly - use the
+`tools/gh-review.py` wrapper (run it with `--help` for details when this
+document isn't enough).
+
+If the tool lacks something you need - a missing feature, a bug, an
+inconvenience - you must suggest the user to make a patch which extends or
+fixes `tools/gh-review.py`, instead of silently working around the tool
+with raw API calls.
+
+The tool works via the public GitHub API by default.
+
+### Comment post
+
+```Bash
+tools/gh-review.py comment \
+  --pr <num> \
+  -c <commit sha> \
+  -p <file path> \
+  -l <line> \
+  -m <comment text>
+```
+
+Add the comments one by one. The first invocation creates a pending review.
+
+The lines are numbered against the diff between the PR base and the commit, not
+the commit's own diff: `-l` takes the file line as of the commit, and for a
+deleted line `--left` takes the line number in the PR base version of the file,
+which differs from what `git show` prints.
+
+A line which was both added and deleted between the PR base and the given commit
+cannot carry a comment - anchor it at that line in the diff of the earlier
+commit which added it, or at a nearby surviving line, and explain that in the
+text.
+
+A comment addresses exactly one line - for a range, anchor at its most relevant
+line and describe the range in the text.
+
+A remark about a commit message or title attaches to any line of that
+commit's diff, and its text must explicitly say that it concerns the commit
+message or title, not the code at that line. Same goes for commit-wide comments
+about its layout, architecture, ordering.
+
+**Experimental mode**
+
+The `comment` command also has an experimental mode - the `--experimental`
+flag - which works via the private API of the GitHub web UI and lifts some
+public API limitations.
+
+It needs a special setup which user must opt-in for in their local dev setup
+(see `doc/agents/setup-dev.md`) in order for this mode to be enabled. This mode
+requires a cookie which must be passed in the `GH_COOKIE` environment variable,
+in the `<login>:<cookie>` format, where the login names the GitHub account the
+cookie belongs to. The location of the cookie is a part of the local setup.
+
+Unless enabled in the local setup, this mode can't be used. If the local setup
+says nothing about this, then prompt the user to decide, and persist the
+decision in the local setup.
+
+In this mode the lines are numbered by the commit's own diff, exactly as
+`git show` prints it: the file as of the commit, or its parent's version with
+`--left`. Lines added and deleted within one patchset become commentable. A
+range of lines can be commented too: `--start-line <first>` makes the comment
+cover the lines from there to `-l`.
+
+### Review status
+
+```Bash
+tools/gh-review.py status --pr <num>
+```
+
+`status` lists every collected comment with its real file line numbers,
+including the ranges of the private-API comments. Mind that a `--left` anchor is
+listed by its old-file line number and is not visually distinguished from a
+right-side anchor at the same line.
+
+To check the collected review before publishing.
+
+### Review submit
+
+```Bash
+tools/gh-review.py submit --pr <num> -m <review summary text>
+```
+
+When all is ready, publish everything as one review, whose main message carries
+a very short PR-global summary and comments on patchset-wide things.
+
+### Review abort
+
+```Bash
+tools/gh-review.py abort --pr <num>
+```
+
+Drops the unsubmitted review with all its comments.
+
+## Replying to comments
+
+While a pending review exists, do not reply to any comments. They will be
+rejected or will become a part of that pending review, which is usually
+undesirable. Reply only when no pending review exists.
+
+For threaded replies to other review comments:
+```Bash
+gh api repos/{owner}/{repo}/pulls/<num>/comments/<comment id>/replies \
+  -f body=<reply text>
+```
+
+PR-global comments have no threads. To respond to one, post a new global
+comment:
+```Bash
+gh pr comment <num> --body <text>
+```
+quoting the relevant part of the answered text with Markdown `>` quotes.
+
+A reaction to an existing review comment (allowed values of `content` are
+`+1`, `-1`, `laugh`, `confused`, `heart`, `hooray`, `rocket`, `eyes`):
+```Bash
+gh api repos/{owner}/{repo}/pulls/comments/<comment id>/reactions \
+  -f content=+1
+```
+
+## Formatting specifics
+
+On top of the regular review comment formatting rules, the ones below apply
+specifically to GitHub.
+
+Never use a bare `@` outside of backtick code spans: `@param`, `@TarantoolBot`
+and alike trigger GitHub mentions of the users having the matching names. Wrap
+such tokens in backticks. Mentioning a real user on purpose is fine.
+
+Never write "this commit", "the previous/next commit" and alike: the GitHub web
+UI does not show which commit a review comment is attached to, so such
+references are unresolvable for the reader. In a PR with more than one commit,
+every comment must state which commit it talks about, in a standard trailer on
+the comment's last line:
+
+    (for commit <short-hash> `<title>`)
+
+Backtick quotes used inside the title itself are dropped, since they cannot nest
+inside the backtick-quoted title.
+
+Other commits mentioned in the comment body are named inline the same way - by
+the short hash and/or the backtick-quoted title.
+
+Never hard-wrap the prose of the comments posted to GitHub: the markdown is
+reflowed by the browser, and manual line breaks render as a ragged mess. The
+line length limits apply to the local files only - when the comments are
+drafted in a local text/md file, wrap them there for readability, and unwrap
+when posting. Code blocks keep their line structure in both places.
+
+---
+
+If anything in this document seems outdated from how the code actually works,
+then it must be immediately flagged to the user.

--- a/doc/agents/review.md
+++ b/doc/agents/review.md
@@ -1,0 +1,109 @@
+# Reviewing patches in Tarantool
+
+This document explains how to review a Tarantool patch: which standards to
+validate it against, which additional knowledge to load, and how to report
+the findings.
+
+## Required knowledge
+
+The review standards are exactly the development standards. You MUST load
+`doc/agents/general-dev.md` and validate the patch against everything stated
+there: commit organization and message format, modularity, performance,
+comments, code style, test coverage.
+
+Additionally, look at the other documents in `doc/agents/` and load the ones
+whose subject matches what the patch touches. For example, a patch changing
+replication logic requires `replication-dev.md`, and its tests require
+`replication-test.md`. Do not load documents unrelated to the patch. New
+documents can appear there over time, so always check the actual directory
+listing, not just the examples above.
+
+## Reporting
+
+Each finding in a specific commit must reference that commit and, when it is
+about code, the file and the line. State the reasoning behind each comment, not
+just 'do this' or 'do that'.
+
+Split the findings into separate comments instead of presenting them as a flat
+list of squashed remarks.
+
+A review only reports findings. Do not edit the patch and do not fix the
+findings, unless the user explicitly asks for that afterwards. But you can
+suggest direction of the fix in the comment itself when it is clear.
+
+Be picky and dig deep, but stay polite. Never phrase findings as commands
+("Test this", "Fix this", "Restore the guard"). Phrase them as questions
+or suggestions: "Is that right? Would be worth fixing then", "Would you
+test this please?", "Perhaps X would work here?". Be confident about the
+facts and humble about the ask.
+
+The review summary must be short and encouraging - the inline comments carry all
+the details. Acknowledge the work, optionally point at the one or two comment
+types worth reading first, and stop. Do not catalog everything that is wrong
+with the patch: a wall of negatives destroys the reader, and duplicates what the
+comments already say.
+
+## Review file
+
+When a review is just getting started, suggest the user to keep the findings in
+a local review file. Suggest it before every new review. The user might later
+use the file as a source for posting the comments somewhere, or might prefer to
+work with the findings directly from the chat.
+
+The file is stored as `reviews/<target>.md`, where the target names the
+reviewed thing: a PR number like `pr12989`, a branch name, a commit range.
+
+The structure of the file:
+
+- A header: what is reviewed (the PR, the branch, the commit range), its base,
+  the date of starting the review.
+- When the findings are being delivered somewhere (for example, posted to
+  GitHub), a note explaining the progress marks: delivered findings get `DONE`
+  appended to their headings, consciously dropped ones - `SKIPPED`. This way it
+  is always visible where the work stopped.
+- The patchset-wide findings, each as its own section.
+- A section per commit, `### <short-hash> <title>`, holding that commit's
+  findings. Each finding is written exactly like a ready comment (the label, the
+  type, the text), and references its file and line.
+
+## Formatting
+
+The first line of every comment must be literally these six characters:
+
+    `[AI]`
+
+The backquotes are part of the comment text - they make the label render as
+inline code, so it is clearly visible, and the readers know the comment is
+automatically generated.
+
+When the comment belongs to one of the types below, the label line also carries
+the type's emoji and the type name in backquote quotes (lowercase, one short
+word), and the comment body starts on the next line. The emoji are given here
+by their name and Unicode code instead of literally, to keep this file
+ASCII-only as the general guidelines demand - in the posted comments use the
+actual emoji characters:
+
+- `typo`, pencil emoji (U+270F U+FE0F) - typos.
+- `nit`, light bulb emoji (U+1F4A1) - recommendations which are not
+  obligatory to address.
+- `crash`, collision emoji (U+1F4A5) - crashes.
+- `bug`, lady beetle emoji (U+1F41E) - behavior bugs.
+- `optimization`, high voltage emoji (U+26A1) - removal of unused struct
+  members, performance issues anywhere, code simplification.
+
+All other comments carry no emoji and no type word - just the label.
+
+Split the comment body into short paragraphs when it has more than one
+thought in it, instead of posting a single wall of text. The rule applies
+everywhere a ready comment lives: posted to GitHub or stored in the local
+review file.
+
+An example of a full comment:
+
+    `[AI]` <emoji> `bug`
+    The check compares the wrong counter: ... <the comment body>.
+
+---
+
+If anything in this document seems outdated from how the code actually works,
+then it must be immediately flagged to the user.

--- a/doc/agents/setup-dev.md
+++ b/doc/agents/setup-dev.md
@@ -87,6 +87,67 @@ provided config will automatically decide which Lua files can be ignored, and
 which will be validated. That includes all Lua files, including Luatest
 `..._test.lua` files.
 
+## GitHub API for reviews
+
+Publishing reviews on GitHub (`doc/agents/review-gh.md`) has an experimental
+mode which works via the private API of the GitHub web UI. Enabling it requires
+a browser cookie.
+
+Normally one wouldn't want to extract and store a cookie of their main account
+anywhere, as it might be dangerous. The user can be suggested to create a bot
+account and use its cookie instead.
+
+The experimental mode unlocks certain features unavailable in the public API.
+See the above mentioned md file to find which features, and list them to the
+user so they can make a decision.
+
+Walk the user through this setup when they want the mode enabled:
+
+1. Optional but very desirable. Create a separate GitHub bot account (it is
+  allowed by the GitHub ToS) or use an existing one. Instead of using the main
+  account.
+
+If creating a new bot account and the user already has a gmail, there is a
+convenient way to bind the bot account to the same email as the main account.
+
+Simply use a gmail alias like `<your-original-gmail>+bot@gmail.com`. For
+example, if the original email is `claude@gmail.com`, then a new GitHub account
+for the bot can be bound to `claude+bot@gmail.com`. GitHub treats them as
+separate emails, but in gmail they are treated as one email.
+
+2. Create a personal access token for that account with only the `public_repo`
+  scope. It covers all the public-API work of `tools/gh-review.py`, which must
+  then always run with the token in the `GH_TOKEN` environment variable when the
+  bot account should be used.
+
+3. Create a bot's browser session cookie for the private API: the `user_session`
+  and `__Host-user_session_same_site` values from a logged-in browser profile,
+  formatted as one `Cookie` header value. It is passed to `tools/gh-review.py`
+  in the `GH_COOKIE` environment variable as a `<login>:<cookie>` pair, where
+  the login is the GitHub account the cookie belongs to - store it in exactly
+  this form. If the session expires, just generate a new one.
+
+The private API routes the posted comments by the cookie's session, and there
+is no reliable way to check programmatically which account a cookie belongs to.
+That is why the account login is kept inside the `GH_COOKIE` value itself. On a
+cookie refresh, remind the user to extract it from the same account's browser
+profile and to keep the login prefix correct. When the token and the cookie
+resolve to different accounts, the review falls apart in a confusing way: the
+comments land into an invisible pending review of the cookie's account, while
+the token's review has nothing to submit.
+
+Strongly suggest to the user to keep the token and the cookie in a secrets
+storage, for example the macOS keychain, with a plain text file only as a
+fallback.
+
+Enrich the steps with details how to do them exactly. For example,
+- How exactly to create a token in GitHub.
+- On Mac - how exactly to paste the cookies into the secrets storage.
+
+Record in `doc/agents/local_setup.md`: the bot account name and the commands
+fetching the token and the cookie (or their plain text in case the user asked
+for this). How to use them, is described in the relevant skills.
+
 ## Local setup file
 
 The results of your survey must be persisted in the `doc/agents/local_setup.md`

--- a/test/tool-luatest/gh_review_test.lua
+++ b/test/tool-luatest/gh_review_test.lua
@@ -1,0 +1,648 @@
+local fio = require('fio')
+local json = require('json')
+local popen = require('popen')
+local socket = require('socket')
+local t = require('luatest')
+
+local SRC_DIR = fio.abspath(os.getenv('TARANTOOL_SRC_DIR') or '../..')
+local TOOL = fio.pathjoin(SRC_DIR, 'tools/gh-review.py')
+local PYTHON = os.getenv('PYTHON_EXECUTABLE') or 'python3'
+local PR = 77
+-- Environment for the fixture commands: the inherited one, but with
+-- the global git config cut off, so that the developer's settings
+-- (commit.gpgsign, diff.*) cannot break or reshape the scratch repo.
+local SHELL_ENV = os.environ()
+SHELL_ENV.GIT_CONFIG_GLOBAL = '/dev/null'
+SHELL_ENV.GIT_CONFIG_NOSYSTEM = '1'
+--
+-- gh-review.py tool tests.
+--
+local g = t.group('gh_review_tool')
+
+local function read_all(ph, opts)
+    local res = ''
+    while true do
+        local chunk = ph:read(opts)
+        if chunk == nil or chunk == '' then
+            return res
+        end
+        res = res .. chunk
+    end
+end
+
+-- Run a shell command in the given directory, return its output, fail the test
+-- if the command fails.
+local function shell(dir, cmd)
+    cmd = ('cd %q && %s'):format(dir, cmd)
+    local ph = popen.new({'/bin/sh', '-c', cmd},
+                         {env = SHELL_ENV, stdout = popen.opts.PIPE})
+    t.assert(ph)
+    local out = read_all(ph)
+    local st = ph:wait()
+    ph:close()
+    t.assert_equals(st.exit_code, 0, ('%s:\n%s'):format(cmd, out))
+    return out
+end
+
+--
+-- The fake GitHub server. Serves the routes installed by each test case and
+-- records every received request for the assertions.
+--
+local function gh_handle_client(gh, fd)
+    local head = fd:read({delimiter = '\r\n\r\n'})
+    if head == nil or head == '' then
+        return
+    end
+    local method, path = head:match('^(%u+) (%S+) HTTP')
+    local clen = tonumber(head:match('[Cc]ontent%-[Ll]ength: (%d+)')) or 0
+    local body = ''
+    if clen > 0 then
+        body = fd:read(clen)
+    end
+    local req = {method = method, path = path, body = body, head = head}
+    table.insert(gh.requests, req)
+    local reply = nil
+    for _, r in ipairs(gh.routes) do
+        if method == r.method and path:match(r.pattern) then
+            reply = r.reply
+            break
+        end
+    end
+    if reply == nil then
+        reply = {status = 404, body = {message = 'no such route'}}
+    elseif type(reply) == 'function' then
+        reply = reply(req)
+    end
+    local status = reply.status or 200
+    local rbody = reply.body or ''
+    if type(rbody) == 'table' then
+        rbody = json.encode(rbody)
+    end
+    local ctype = reply.content_type or 'application/json'
+    local headers = {
+        ['Content-Type'] = ctype .. '; charset=utf-8',
+        ['Content-Length'] = #rbody,
+        ['Connection'] = 'close',
+    }
+    if reply.link ~= nil then
+        headers['Link'] = reply.link
+    end
+    local lines = {('HTTP/1.1 %d X'):format(status)}
+    for k, v in pairs(headers) do
+        table.insert(lines, ('%s: %s'):format(k, v))
+    end
+    fd:write(table.concat(lines, '\r\n') .. '\r\n\r\n' .. rbody)
+end
+
+-- Requests matching the pattern, as 'METHOD path' strings.
+local function gh_log(cg, pattern)
+    local res = {}
+    for _, req in ipairs(cg.gh.requests) do
+        local line = req.method .. ' ' .. req.path
+        if pattern == nil or line:match(pattern) then
+            table.insert(res, line)
+        end
+    end
+    return res
+end
+
+-- The only request matching the pattern, with the parsed JSON body.
+local function gh_request(cg, pattern)
+    local found = nil
+    for _, req in ipairs(cg.gh.requests) do
+        if (req.method .. ' ' .. req.path):match(pattern) then
+            t.assert_equals(found, nil, 'one request expected: ' .. pattern)
+            found = req
+        end
+    end
+    t.assert_not_equals(found, nil, 'no request matching: ' .. pattern)
+    if found.body ~= '' then
+        found.json = json.decode(found.body)
+    end
+    return found
+end
+
+local function run_tool(cg, argline, env_extra)
+    local env = {
+        PATH = os.getenv('PATH'),
+        HOME = os.getenv('HOME'),
+        -- HOME is needed, but brings the developer's ~/.gitconfig
+        -- within the reach of the tool's git calls - keep those
+        -- hermetic.
+        GIT_CONFIG_GLOBAL = SHELL_ENV.GIT_CONFIG_GLOBAL,
+        GIT_CONFIG_NOSYSTEM = SHELL_ENV.GIT_CONFIG_NOSYSTEM,
+        GH_TOKEN = 'test-token',
+        GH_COOKIE = 'Test-Bot:test-session-cookie',
+        GH_API_URL = cg.url,
+        GH_WEB_URL = cg.url,
+    }
+    for k, v in pairs(env_extra or {}) do
+        env[k] = v ~= '' and v or nil
+    end
+    local cmd = ('cd %q && %q %q %s'):format(cg.repo, PYTHON, TOOL,
+                                             argline)
+    local ph = popen.new({'/bin/sh', '-c', cmd},
+                         {env = env, stdout = popen.opts.PIPE,
+                          stderr = popen.opts.PIPE})
+    t.assert(ph)
+    -- Read before waiting - a child blocked on a full pipe would
+    -- never exit.
+    local res = {
+        stdout = read_all(ph),
+        stderr = read_all(ph, {stderr = true}),
+    }
+    res.code = ph:wait().exit_code
+    ph:close()
+    return res
+end
+
+local function run_tool_ok(cg, argline, env_extra)
+    local res = run_tool(cg, argline, env_extra)
+    t.assert_equals(res.code, 0, res.stderr)
+    return res
+end
+
+local function run_tool_err(cg, argline, env_extra)
+    local res = run_tool(cg, argline, env_extra)
+    t.assert_equals(res.code, 1, res.stdout)
+    return res
+end
+
+--
+-- The Python unit-call bridge: import the tool, evaluate one
+-- expression, return it as decoded JSON.
+--
+local function py_call(expr)
+    local script = ([[
+import importlib.util, json
+spec = importlib.util.spec_from_file_location('ghr', %s)
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+print(json.dumps(%s))
+]]):format(json.encode(TOOL), expr)
+    local ph = popen.new({PYTHON, '-c', script},
+                         {env = {PATH = os.getenv('PATH')},
+                          stdout = popen.opts.PIPE,
+                          stderr = popen.opts.PIPE})
+    t.assert(ph)
+    local out = read_all(ph)
+    local err = read_all(ph, {stderr = true})
+    local st = ph:wait()
+    ph:close()
+    t.assert_equals(st.exit_code, 0, err)
+    return json.decode(out)
+end
+
+--
+-- The scratch git repository:
+--
+--   main:  base -> C (modifies 'line 20', adds other.txt)
+--   pr:    base -> A (inserts A-one, A-two after line 5)
+--               -> B (deletes A-two and the original line 10)
+--
+-- The main branch advancing after the fork makes the base...commit three-dot
+-- diff differ from the plain two-dot one, so the position computation is
+-- checked against the semantics GitHub actually uses.
+--
+
+local function write_file(dir, name, lines)
+    local fh = fio.open(fio.pathjoin(dir, name),
+                        {'O_WRONLY', 'O_CREAT', 'O_TRUNC'}, tonumber(644, 8))
+    t.assert(fh)
+    fh:write(table.concat(lines, '\n') .. '\n')
+    fh:close()
+end
+
+g.before_all(function(cg)
+    -- popen.new() does not resolve the program name via PATH - find
+    -- the interpreter's absolute path. Also skip when there is none.
+    local ph = popen.shell('command -v ' .. PYTHON, 'r')
+    local out = read_all(ph)
+    local st = ph:wait()
+    ph:close()
+    t.skip_if(st.exit_code ~= 0, 'no python interpreter')
+    PYTHON = out:strip()
+
+    local base_lines = {}
+    for i = 1, 20 do
+        table.insert(base_lines, 'line ' .. i)
+    end
+
+    local vardir = fio.abspath(os.getenv('VARDIR') or 'test/var')
+    cg.repo = fio.pathjoin(vardir, 'scratch-repo')
+    fio.rmtree(cg.repo)
+    t.assert(fio.mktree(cg.repo))
+    local r = cg.repo
+    -- 'git init -b <name>' needs git >= 2.28 and 'git switch' needs
+    -- >= 2.23, while some CI machines have an older git - stick to the
+    -- ancient equivalents: a post-commit branch rename and 'checkout'.
+    shell(r, 'git init -q . && git config user.email t@t.t && ' ..
+             'git config user.name t && ' ..
+             'git remote add origin git@github.com:test/repo.git')
+    write_file(r, 'f.txt', base_lines)
+    shell(r, 'git add . && git commit -qm base && git branch -m main')
+
+    shell(r, 'git checkout -qb pr')
+    local lines = table.copy(base_lines)
+    table.insert(lines, 6, 'A-two')
+    table.insert(lines, 6, 'A-one')
+    write_file(r, 'f.txt', lines)
+    shell(r, 'git commit -aqm commit-A')
+    cg.sha_a = shell(r, 'git rev-parse HEAD'):strip()
+
+    -- Delete 'A-two' (line 7) and the original 'line 10' (line 12).
+    table.remove(lines, 12)
+    table.remove(lines, 7)
+    write_file(r, 'f.txt', lines)
+    shell(r, 'git commit -aqm commit-B')
+    cg.sha_b = shell(r, 'git rev-parse HEAD'):strip()
+
+    shell(r, 'git checkout -q main')
+    lines = table.copy(base_lines)
+    lines[20] = 'line 20 main'
+    write_file(r, 'f.txt', lines)
+    write_file(r, 'other.txt', {'other'})
+    shell(r, 'git add . && git commit -aqm commit-C')
+    cg.sha_main = shell(r, 'git rev-parse HEAD'):strip()
+end)
+
+g.before_each(function(cg)
+    cg.gh = {requests = {}, routes = {}}
+    cg.server = socket.tcp_server('localhost', 0, {handler = function(fd)
+        local ok, err = pcall(gh_handle_client, cg.gh, fd)
+        if not ok then
+            cg.gh.error = err
+        end
+    end})
+    t.assert(cg.server)
+    cg.url = 'http://localhost:' .. cg.server:name().port
+end)
+
+g.after_each(function(cg)
+    if cg.server ~= nil then
+        cg.server:close()
+        cg.server = nil
+    end
+    t.assert_equals(cg.gh.error, nil)
+end)
+
+-- The routes common for the public path: the PR metadata and the
+-- pending review listing with the given contents.
+local function install_public_routes(cg, reviews)
+    local prefix = '/repos/test/repo/pulls/' .. PR
+    table.insert(cg.gh.routes, {
+        method = 'GET', pattern = '^' .. prefix .. '$',
+        reply = {body = {base = {sha = cg.sha_main, ref = 'main'}}},
+    })
+    table.insert(cg.gh.routes, {
+        method = 'GET', pattern = '^' .. prefix .. '/reviews',
+        reply = {body = reviews or {}},
+    })
+end
+
+g.test_unit_patch_position = function()
+    local patch = table.concat({
+        '@@ -3,6 +3,8 @@',
+        ' line 3',
+        ' line 4',
+        ' line 5',
+        '+A-one',
+        '+A-two',
+        ' line 6',
+        '-line 7',
+        ' line 8',
+    }, '\n')
+    local cases = {
+        -- {line, is_left, expected position}.
+        -- Context lines are addressable from both sides.
+        {3, false, 1},
+        {3, true, 1},
+        -- Added lines - only on the right.
+        {6, false, 4},
+        {7, false, 5},
+        -- The right line 6 is the added one, the old line 6 is a context line
+        -- further below.
+        {6, true, 6},
+        -- Deleted lines - only on the left.
+        {7, true, 7},
+        -- Not in the patch at all.
+        {100, false, json.NULL},
+        {1, false, json.NULL},
+    }
+    -- One Python invocation for all the cases - the interpreter startup is much
+    -- more expensive than the calls themselves.
+    local calls = {}
+    for _, c in ipairs(cases) do
+        table.insert(calls, ('m.patch_position(%s, %d, %s)'):format(
+                     json.encode(patch), c[1], c[2] and 'True' or 'False'))
+    end
+    local res = py_call('[' .. table.concat(calls, ', ') .. ']')
+    for i, c in ipairs(cases) do
+        t.assert_equals(res[i], c[3],
+                        ('case %d: line %d, is_left=%s'):format(
+                        i, c[1], tostring(c[2])))
+    end
+end
+
+-- A child producing more than the pipe buffer (~64KB) deadlocks
+-- against a wait-before-read runner: the reading-first order in
+-- py_call()/run_tool() is what keeps this test from hanging.
+g.test_unit_large_child_output = function()
+    t.assert_equals(#py_call('"x" * (1024 * 1024)'), 1024 * 1024)
+end
+
+g.test_public_api_comment = function(cg)
+    install_public_routes(cg)
+    table.insert(cg.gh.routes, {
+        method = 'POST', pattern = '/pulls/' .. PR .. '/reviews$',
+        reply = {body = {id = 1, node_id = 'R_test'}},
+    })
+    table.insert(cg.gh.routes, {
+        method = 'POST', pattern = '/graphql$',
+        reply = {body = {data = {addPullRequestReviewComment =
+                                 {comment = {databaseId = 42}}}}},
+    })
+    local res = run_tool_ok(cg, ('comment --pr %d -c %s -p f.txt -l 6 ' ..
+                                 '-m test-body'):format(PR, cg.sha_a))
+    t.assert_str_contains(res.stdout, 'Added pending comment 42')
+    -- The review is created only after the anchor is validated, and the
+    -- position is computed against the three-dot diff: the base branch changes
+    -- after the fork must not shift it.
+    t.assert_equals(gh_log(cg), {
+        'GET /repos/test/repo/pulls/' .. PR,
+        'GET /repos/test/repo/pulls/' .. PR .. '/reviews?per_page=100',
+        'POST /repos/test/repo/pulls/' .. PR .. '/reviews',
+        'POST /graphql',
+    })
+    local gql = gh_request(cg, 'POST /graphql').json
+    t.assert_equals(gql.variables.pos, 4)
+    t.assert_equals(gql.variables.sha, cg.sha_a)
+    t.assert_equals(gql.variables.body, 'test-body')
+    t.assert_equals(gql.variables.rid, 'R_test')
+end
+
+-- The position is an offset into the diff as GitHub renders it, while
+-- 'git diff' obeys the local config knobs reshaping the patch: the context
+-- width, the hunk-boundary algorithm, the colors. The tool must pin the diff
+-- format, or the same line would silently yield a different position - and a
+-- misplaced comment on GitHub.
+g.test_public_api_comment_hostile_diff_config = function(cg)
+    shell(cg.repo, 'git config diff.context 5 && ' ..
+                   'git config diff.algorithm patience && ' ..
+                   'git config color.diff always')
+    install_public_routes(cg)
+    table.insert(cg.gh.routes, {
+        method = 'POST', pattern = '/pulls/' .. PR .. '/reviews$',
+        reply = {body = {id = 1, node_id = 'R_test'}},
+    })
+    table.insert(cg.gh.routes, {
+        method = 'POST', pattern = '/graphql$',
+        reply = {body = {data = {addPullRequestReviewComment =
+                                 {comment = {databaseId = 42}}}}},
+    })
+    run_tool_ok(cg, ('comment --pr %d -c %s -p f.txt -l 6 ' ..
+                     '-m test-body'):format(PR, cg.sha_a))
+    local gql = gh_request(cg, 'POST /graphql').json
+    t.assert_equals(gql.variables.pos, 4)
+end
+
+g.after_test('test_public_api_comment_hostile_diff_config', function(cg)
+    shell(cg.repo, 'git config --remove-section diff && ' ..
+                   'git config --remove-section color')
+end)
+
+g.test_public_api_bad_anchor_creates_nothing = function(cg)
+    install_public_routes(cg)
+    local res = run_tool_err(cg, ('comment --pr %d -c %s -p f.txt ' ..
+                                  '-l 99 -m x'):format(PR, cg.sha_a))
+    t.assert_str_contains(res.stderr, 'is not in the PR diff')
+    t.assert_equals(gh_log(cg, 'POST'), {})
+end
+
+g.test_public_api_unknown_commit = function(cg)
+    install_public_routes(cg)
+    local res = run_tool_err(cg, ('comment --pr %d -c deadbeef12 ' ..
+                                  '-p f.txt -l 6 -m x'):format(PR))
+    t.assert_str_contains(res.stderr,
+                          'not in the local repo - fetch the PR')
+end
+
+g.test_public_api_unknown_base = function(cg)
+    local prefix = '/repos/test/repo/pulls/' .. PR
+    table.insert(cg.gh.routes, {
+        method = 'GET', pattern = '^' .. prefix .. '$',
+        reply = {body = {base = {sha = ('e'):rep(40), ref = 'main'}}},
+    })
+    local res = run_tool_err(cg, ('comment --pr %d -c %s -p f.txt ' ..
+                                  '-l 6 -m x'):format(PR, cg.sha_a))
+    t.assert_str_contains(res.stderr, 'git fetch origin main')
+end
+
+local PRIVATE_API_PATTERN =
+    '/test/repo/pull/' .. PR .. '/page_data/create_review_comment$'
+
+g.test_private_api_comment = function(cg)
+    table.insert(cg.gh.routes, {
+        method = 'POST', pattern = PRIVATE_API_PATTERN,
+        reply = {body = {}},
+    })
+    local res = run_tool_ok(cg, ('comment --pr %d --experimental ' ..
+                                 '-c %s -p f.txt -l 6 -m exp-body')
+                                :format(PR, cg.sha_b))
+    t.assert_str_contains(res.stdout, 'via the private API')
+    -- The private API is the only request: no REST at all, no pending review
+    -- pre-creation.
+    t.assert_equals(#cg.gh.requests, 1)
+    local req = gh_request(cg, PRIVATE_API_PATTERN).json
+    t.assert_equals(req.text, 'exp-body')
+    t.assert_equals(req.line, 6)
+    t.assert_equals(req.comparisonStartOid, cg.sha_a)
+    t.assert_equals(req.comparisonEndOid, cg.sha_b)
+    t.assert_equals(req.positioning.commitOid, cg.sha_b)
+    t.assert_equals(req.side, 'right')
+end
+
+-- The experimental path authenticates with the cookie alone, so the
+-- token must not even be resolved for it: with no GH_TOKEN in the
+-- environment and no `gh` binary in PATH an eager resolution would
+-- crash before the single private-API request is made.
+g.test_private_api_comment_no_token = function(cg)
+    local bindir = fio.pathjoin(fio.dirname(cg.repo), 'bin-no-gh')
+    fio.rmtree(bindir)
+    t.assert(fio.mktree(bindir))
+    local git = shell(cg.repo, 'command -v git'):strip()
+    t.assert(fio.symlink(git, fio.pathjoin(bindir, 'git')))
+    table.insert(cg.gh.routes, {
+        method = 'POST', pattern = PRIVATE_API_PATTERN,
+        reply = {body = {}},
+    })
+    local res = run_tool_ok(cg, ('comment --pr %d --experimental ' ..
+                                 '-c %s -p f.txt -l 6 -m exp-body')
+                                :format(PR, cg.sha_b),
+                            {GH_TOKEN = '', PATH = bindir})
+    t.assert_str_contains(res.stdout, 'via the private API')
+    t.assert_equals(#cg.gh.requests, 1)
+end
+
+g.test_private_api_left_and_range = function(cg)
+    table.insert(cg.gh.routes, {
+        method = 'POST', pattern = PRIVATE_API_PATTERN,
+        reply = {body = {}},
+    })
+    -- A deleted line: 'A-two' exists only in the parent of B.
+    local res = run_tool_ok(cg, ('comment --pr %d --experimental ' ..
+                                 '-c %s -p f.txt -l 7 --left -m x')
+                                :format(PR, cg.sha_b))
+    t.assert_str_contains(res.stdout, 'f.txt:7')
+    local req = gh_request(cg, PRIVATE_API_PATTERN).json
+    t.assert_equals(req.side, 'left')
+    t.assert_equals(req.positioning.commitOid, cg.sha_a)
+    -- A range.
+    cg.gh.requests = {}
+    run_tool_ok(cg, ('comment --pr %d --experimental -c %s -p f.txt ' ..
+                     '--start-line 6 -l 7 -m x'):format(PR, cg.sha_a))
+    req = gh_request(cg, PRIVATE_API_PATTERN).json
+    t.assert_equals(req.subjectType, 'multiline')
+    t.assert_equals(req.positioning.startLine, 6)
+    t.assert_equals(req.positioning.endLine, 7)
+end
+
+g.test_private_api_api_errors = function(cg)
+    table.insert(cg.gh.routes, {
+        method = 'POST', pattern = PRIVATE_API_PATTERN,
+        reply = {status = 422, body = {error = 'Line could not be ' ..
+                                               'resolved.'}},
+    })
+    local args = ('comment --pr %d --experimental -c %s -p f.txt ' ..
+                  '-l 6 -m x'):format(PR, cg.sha_b)
+    local res = run_tool_err(cg, args)
+    t.assert_str_contains(res.stderr,
+                          'the private API returned HTTP 422')
+    t.assert_str_contains(res.stderr, 'Line could not be resolved')
+    -- Non-JSON response - the expired cookie symptom.
+    cg.gh.routes = {{
+        method = 'POST', pattern = PRIVATE_API_PATTERN,
+        reply = {body = 'sign in', content_type = 'text/html'},
+    }}
+    res = run_tool_err(cg, args)
+    t.assert_str_contains(res.stderr, 'did not return JSON')
+end
+
+g.test_cookie_validation = function(cg)
+    local args = ('comment --pr %d --experimental -c %s -p f.txt ' ..
+                  '-l 6 -m x'):format(PR, cg.sha_b)
+    local res = run_tool_err(cg, args, {GH_COOKIE = ''})
+    t.assert_str_contains(res.stderr, 'requires the session cookie')
+    res = run_tool_err(cg, args, {GH_COOKIE = 'no-login-prefix'})
+    t.assert_str_contains(res.stderr, '<login>:<cookie> format')
+    -- The cookie is validated before anything is sent.
+    t.assert_equals(#cg.gh.requests, 0)
+end
+
+g.test_status = function(cg)
+    install_public_routes(cg, {{id = 7, node_id = 'R_st',
+                                state = 'PENDING'}})
+    table.insert(cg.gh.routes, {
+        method = 'POST', pattern = '/graphql$',
+        reply = function(req)
+            local page
+            if req.body:match('"cursor": null') then
+                page = {
+                    pageInfo = {hasNextPage = true, endCursor = 'C1'},
+                    nodes = {{databaseId = 1, body = 'one\nmore',
+                              path = 'f.txt', originalLine = 6,
+                              originalStartLine = json.NULL,
+                              originalCommit =
+                                  {abbreviatedOid = 'abc1234'}}},
+                }
+            else
+                page = {
+                    pageInfo = {hasNextPage = false,
+                                endCursor = json.NULL},
+                    nodes = {{databaseId = 2, body = 'two',
+                              path = 'f.txt', originalLine = 7,
+                              originalStartLine = 6,
+                              originalCommit =
+                                  {abbreviatedOid = 'abc1234'}}},
+                }
+            end
+            return {body = {data = {node = {comments = page}}}}
+        end,
+    })
+    local res = run_tool_ok(cg, 'status --pr ' .. PR)
+    t.assert_str_contains(res.stdout, '2 comment(s)')
+    t.assert_str_contains(res.stdout, '1 abc1234 f.txt:6 | one')
+    t.assert_str_contains(res.stdout, '2 abc1234 f.txt:6-7 | two')
+end
+
+g.test_status_no_pending = function(cg)
+    install_public_routes(cg)
+    local res = run_tool_ok(cg, 'status --pr ' .. PR)
+    t.assert_str_contains(res.stdout, 'No pending review')
+end
+
+g.test_list_pagination = function(cg)
+    -- The pending review is on the second page: without following the
+    -- Link headers it is invisible.
+    local prefix = '/repos/test/repo/pulls/' .. PR
+    table.insert(cg.gh.routes, {
+        method = 'GET', pattern = '^' .. prefix .. '/reviews%?per_page',
+        reply = {
+            body = {{id = 1, state = 'COMMENTED'}},
+            link = ('<%s%s/reviews?page=2>; rel="next"'):format(
+                   cg.url, prefix),
+        },
+    })
+    table.insert(cg.gh.routes, {
+        method = 'GET', pattern = '^' .. prefix .. '/reviews%?page=2',
+        reply = {body = {{id = 2, node_id = 'R_p2',
+                          state = 'PENDING'}}},
+    })
+    table.insert(cg.gh.routes, {
+        method = 'DELETE', pattern = prefix .. '/reviews/2$',
+        reply = {body = {}},
+    })
+    local res = run_tool_ok(cg, 'abort --pr ' .. PR)
+    t.assert_str_contains(res.stdout, 'Dropped pending review 2')
+end
+
+g.test_submit_abort = function(cg)
+    install_public_routes(cg, {{id = 7, node_id = 'R_su',
+                                state = 'PENDING'}})
+    local prefix = '/repos/test/repo/pulls/' .. PR
+    table.insert(cg.gh.routes, {
+        method = 'POST', pattern = prefix .. '/reviews/7/events$',
+        reply = {body = {}},
+    })
+    table.insert(cg.gh.routes, {
+        method = 'DELETE', pattern = prefix .. '/reviews/7$',
+        reply = {body = {}},
+    })
+    local res = run_tool_ok(cg, 'submit --pr ' .. PR .. ' -m summary')
+    t.assert_str_contains(res.stdout, 'Submitted review 7')
+    local req = gh_request(cg, 'POST .*/events').json
+    t.assert_equals(req.event, 'COMMENT')
+    t.assert_equals(req.body, 'summary')
+    res = run_tool_ok(cg, 'abort --pr ' .. PR)
+    t.assert_str_contains(res.stdout, 'Dropped pending review 7')
+    t.assert_equals(#gh_log(cg, 'DELETE'), 1)
+end
+
+g.test_submit_no_pending = function(cg)
+    install_public_routes(cg)
+    local res = run_tool_err(cg, 'submit --pr ' .. PR .. ' -m x')
+    t.assert_str_contains(res.stderr, 'no pending review')
+end
+
+g.test_graphql_errors_are_fatal = function(cg)
+    install_public_routes(cg, {{id = 7, node_id = 'R_ge',
+                                state = 'PENDING'}})
+    table.insert(cg.gh.routes, {
+        method = 'POST', pattern = '/graphql$',
+        reply = {body = {data = json.NULL,
+                         errors = {{message = 'boom'}}}},
+    })
+    local res = run_tool_err(cg, 'status --pr ' .. PR)
+    t.assert_str_contains(res.stderr, 'GraphQL failed')
+    t.assert_str_contains(res.stderr, 'boom')
+end

--- a/test/tool-luatest/suite.ini
+++ b/test/tool-luatest/suite.ini
@@ -1,0 +1,4 @@
+[default]
+core = luatest
+description = tests for the developer tools from tools/
+is_parallel = True

--- a/tools/gh-review.py
+++ b/tools/gh-review.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""
+Publish a patch review on a GitHub pull request as one single review whose
+comments are attached to the diffs of specific commits, like the GitHub web UI
+does when reviewing a PR commit by commit.
+
+The public REST API cannot do this: it either binds all comments of a review to
+one commit, or publishes each per-commit comment as its own one-comment review.
+This tool hides the required internal plumbing.
+
+The plumbing uses quite complicated GraphQL requests because the official REST
+API lacks the needed feature:
+https://github.com/orgs/community/discussions/168380.
+
+The flow:
+
+    tools/gh-review.py comment --pr <num> ... <params>
+    ... more 'comment' invocations ...
+    tools/gh-review.py status --pr <num>
+    tools/gh-review.py submit --pr <num> -m <review summary>
+
+The first 'comment' invocation creates a pending review, invisible to everyone
+else. Each next one appends to it. 'submit' publishes it all as one review.
+
+The 'comment' subcommand also has an opt-in --experimental mode which posts
+through the private API of the GitHub web UI. It is more powerful, but requires
+cookies for auth.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import traceback
+import urllib.error
+import urllib.request
+
+API_URL = 'https://api.github.com'
+WEB_URL = 'https://github.com'
+
+MUTATION = '''
+mutation($rid: ID!, $sha: GitObjectID!, $path: String!, $pos: Int!,
+         $body: String!) {
+    addPullRequestReviewComment(input: {pullRequestReviewId: $rid,
+            commitOID: $sha, path: $path, position: $pos, body: $body}) {
+        comment { databaseId }
+    }
+}
+'''
+
+STATUS_QUERY = '''
+query($rid: ID!, $cursor: String) {
+    node(id: $rid) {
+        ... on PullRequestReview {
+            comments(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                    databaseId
+                    body
+                    path
+                    originalLine
+                    originalStartLine
+                    originalCommit { abbreviatedOid }
+                }
+            }
+        }
+    }
+}
+'''
+
+
+def fail(msg):
+    print(f'gh-review: {msg}', file=sys.stderr)
+    sys.exit(1)
+
+
+def git(args):
+    """Run git and return the exit code, stdout, and stderr. Whether a
+    failure is fatal is up to the caller."""
+    res = subprocess.run(['git'] + args, capture_output=True,
+                         encoding='utf-8')
+    return res.returncode, res.stdout, res.stderr
+
+
+def repo_full_name():
+    """The 'owner/repo' pair, parsed from the origin remote URL."""
+    code, out, err = git(['remote', 'get-url', 'origin'])
+    if code != 0:
+        fail(f'cannot read the origin remote URL:\n{err.strip()}')
+    url = out.strip()
+    m = re.search(r'github\.com[:/](.+?)(?:\.git)?/?$', url)
+    if m is None:
+        fail(f'cannot parse owner/repo from the origin remote: {url}')
+    return m.group(1)
+
+
+class Api:
+    """All the GitHub network access: the public REST and GraphQL APIs and
+    the private API of the web UI. Every parameter comes through the
+    constructor and nothing is read from the environment here, so the
+    tests can aim an instance at a local server."""
+
+    def __init__(self, repo, token, cookie_pair=None, api_url=API_URL,
+                 web_url=WEB_URL, timeout=30):
+        """The cookie pair is the raw '<login>:<cookie>' value. It is
+        stored as is and parsed only when the private API gets used.
+        A None token is resolved from the `gh` login on the first
+        authenticated request - the private API path works without a
+        token at all."""
+        self.repo = repo
+        self.token = token
+        self.cookie_pair = cookie_pair
+        self.api_url = api_url
+        self.web_url = web_url
+        self.timeout = timeout
+
+    def send(self, url, method='GET', headers=None, payload=None):
+        """One HTTP request. Returns (status, headers, body): the HTTP
+        error statuses are returned, not raised - deciding is up to the
+        caller. The network failures are fatal."""
+        data = None if payload is None else json.dumps(payload).encode()
+        hdrs = dict(headers or {})
+        if data is not None:
+            hdrs['Content-Type'] = 'application/json'
+        req = urllib.request.Request(url, data=data, method=method,
+                                     headers=hdrs)
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as r:
+                return r.status, r.headers, r.read().decode('utf-8',
+                                                            'replace')
+        except urllib.error.HTTPError as e:
+            return e.code, e.headers, e.read().decode('utf-8', 'replace')
+        except OSError as e:
+            fail(f'{method} {url} failed: {e}')
+
+    def auth_headers(self):
+        if self.token is None:
+            self.token = find_gh_token()
+        return {'Accept': 'application/vnd.github+json',
+                'Authorization': f'Bearer {self.token}'}
+
+    def rest(self, path, method='GET', payload=None):
+        """A public REST API request. Any error status is fatal. Returns
+        the parsed JSON body, or None when the body is empty."""
+        status, _, body = self.send(f'{self.api_url}/{path}', method,
+                                    self.auth_headers(), payload)
+        if status >= 400:
+            fail(f'{method} /{path} returned HTTP {status}: {body[:200]}')
+        return json.loads(body) if body.strip() else None
+
+    def rest_list(self, path):
+        """A GET of a whole list. The list endpoints return at most one
+        page - 30 items by default, silently - so every page is fetched
+        by following the Link response headers."""
+        sep = '&' if '?' in path else '?'
+        url = f'{self.api_url}/{path}{sep}per_page=100'
+        items = []
+        while url is not None:
+            status, headers, body = self.send(url, 'GET',
+                                              self.auth_headers())
+            if status >= 400:
+                fail(f'GET {url} returned HTTP {status}: {body[:200]}')
+            items += json.loads(body)
+            m = re.search(r'<([^>]+)>; rel="next"',
+                          headers.get('Link') or '')
+            url = m.group(1) if m else None
+        return items
+
+    def graphql(self, query, variables):
+        """A public GraphQL API request. GraphQL reports its errors with
+        HTTP 200 and an 'errors' array in the body - both are checked."""
+        status, _, body = self.send(f'{self.api_url}/graphql', 'POST',
+                                    self.auth_headers(),
+                                    {'query': query,
+                                     'variables': variables})
+        if status >= 400:
+            fail(f'GraphQL returned HTTP {status}: {body[:200]}')
+        res = json.loads(body)
+        if res.get('errors'):
+            fail(f'GraphQL failed: {json.dumps(res["errors"])[:300]}')
+        return res['data']
+
+    def cookie(self):
+        """The session cookie for the private API, extracted from the
+        '<login>:<cookie>' pair. The account name is kept inside the
+        value itself, because there is no way to find out
+        programmatically which account a cookie belongs to, and posting
+        with a cookie of one account and a token of another silently
+        splits the review in two."""
+        if not self.cookie_pair:
+            fail('--experimental requires the session cookie in the '
+                 'GH_COOKIE environment variable, see '
+                 'doc/agents/setup-dev.md')
+        login, sep, cookie = self.cookie_pair.partition(':')
+        if not sep or not login or not cookie:
+            fail('GH_COOKIE must have the <login>:<cookie> format, where '
+                 '<login> is the GitHub account name the cookie belongs '
+                 'to')
+        return cookie
+
+
+def find_pending_review(api, pr):
+    """Pending reviews are visible only to their author, so a PENDING entry in
+    the list can only be ours."""
+    for review in api.rest_list(f'repos/{api.repo}/pulls/{pr}/reviews'):
+        if review['state'] == 'PENDING':
+            return review
+    return None
+
+
+def require_pending_review(api, pr):
+    review = find_pending_review(api, pr)
+    if review is None:
+        fail(f'no pending review on PR #{pr}')
+    return review
+
+
+def patch_position(patch, line, is_left):
+    """Find the diff position of a file line in one file's patch. The line is
+    numbered by the new file version, or by the old one when is_left is set.
+    Returns None when the line is not in the patch."""
+    pos = None
+    old_ln = new_ln = 0
+    for text in patch.splitlines():
+        header = re.match(r'@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@', text)
+        if header:
+            pos = 0 if pos is None else pos + 1
+            old_ln = int(header.group(1))
+            new_ln = int(header.group(2))
+            continue
+        pos += 1
+        tag = text[:1]
+        if tag == '+':
+            if not is_left and new_ln == line:
+                return pos
+            new_ln += 1
+        elif tag == '-':
+            if is_left and old_ln == line:
+                return pos
+            old_ln += 1
+        elif tag != '\\':
+            if (old_ln if is_left else new_ln) == line:
+                return pos
+            old_ln += 1
+            new_ln += 1
+    return None
+
+
+def commit_position(base, commit, path, line, is_left):
+    """Turn a file line number into a legacy diff 'position'.
+
+    The GraphQL mutation used to attach per-commit comments to a pending review
+    predates the modern line+side comment addressing and only accepts the
+    archaic 'position': an offset inside the unified diff text of one file. The
+    line right below the file's first @@ hunk header is position 1, and the
+    offset keeps growing through every following patch line - context lines,
+    +/- lines, and further @@ headers alike.
+
+    Moreover, GitHub does not anchor a per-commit comment to the diff of the
+    commit against its parent, the way 'git show' and the PR "Commits" tab
+    present it.
+
+    The anchor diff is taken between the PR base and the commit, i.e. it
+    includes all the PR commits up to this one, which changes the hunks, the
+    positions, and the old-side line numbers.
+
+    Hence the file line number taken by this function means the file as of the
+    commit for the right side, or as of the PR base for the left side. The
+    mapping walks that base-to-commit diff, advancing the position together with
+    both file line counters until the requested line is met on the requested
+    side.
+
+    The API is most likely so complicated, because GitHub PRs usually are
+    reviewed by their whole diff, not commit-per-commit, and the usage here is
+    actually quite unnatural to most."""
+    sha = resolve_commit(commit)
+    base_sha = resolve_commit(base['sha'],
+                              f'fetch the base branch first: '
+                              f'git fetch origin {base["ref"]}')
+    patch = file_patch([f'{base_sha}...{sha}'], path,
+                       f'as of commit {commit}')
+    pos = patch_position(patch, line, is_left)
+    if pos is None:
+        side = 'base' if is_left else 'new'
+        fail(f'{side}-file line {line} of {path} is not in the PR diff as '
+             f'of commit {commit}. Lines both added and deleted between '
+             f'the PR base and this commit are not in this diff - anchor '
+             f'the comment at a nearby surviving line instead, or use '
+             f'--experimental')
+    return sha, pos
+
+
+def resolve_commit(commit, hint='fetch the PR first: '
+                                'git fetch origin pull/<pr>/head'):
+    """The full SHA of the given commit-ish, from the local repo."""
+    code, out, _ = git(['rev-parse', '--verify', '--quiet',
+                        commit + '^{commit}'])
+    if code != 0:
+        fail(f'commit {commit} is not in the local repo - {hint}')
+    return out.strip()
+
+
+def file_patch(refs, path, where):
+    """The diff of one file between the given revisions, taken from the local
+    git repo and cut down to the first hunk header - the format
+    patch_position() expects, and the one the GitHub API serves.
+
+    The GitHub-like settings are enforced so local git setup doesn't mess with
+    the results."""
+    code, diff, err = git(['diff', '-U3', '--no-color', '--no-ext-diff',
+                           '--no-textconv', '--diff-algorithm=myers'] +
+                          refs + ['--', path])
+    if code != 0:
+        fail(f"'git diff' failed:\n{err.strip()}")
+    if not diff:
+        code, names, err = git(['diff', '--name-only'] + refs)
+        if code != 0:
+            fail(f"'git diff --name-only' failed:\n{err.strip()}")
+        fail(f'file {path} is not changed {where}. Changed files:\n  '
+             + '\n  '.join(names.splitlines()))
+    idx = diff.find('\n@@')
+    if idx < 0:
+        fail(f'file {path} has no textual diff {where}')
+    return diff[idx + 1:]
+
+
+def commit_info(commit, path):
+    """The commit's own diff against its parent: the full commit SHA, the
+    parent SHA, and the patch of the given file. Everything comes from the
+    local git repo - the PR must be fetched beforehand (a plain fetch, no
+    checkout is needed)."""
+    sha = resolve_commit(commit)
+    code, out, err = git(['rev-list', '--parents', '-n', '1', sha])
+    if code != 0:
+        fail(f"'git rev-list' failed:\n{err.strip()}")
+    parents = out.split()[1:]
+    if len(parents) != 1:
+        fail(f'commit {commit} has {len(parents)} parents, need exactly 1')
+    return sha, parents[0], file_patch([parents[0], sha], path,
+                                       f'in commit {commit}')
+
+
+def private_comment(api, pr, commit, parent, path, line, start_line,
+                    is_left, body):
+    """Post a pending review comment via the private endpoint of the GitHub web
+    UI. Unlike the public API, it takes an explicit comparison range, so the
+    comment is anchored to the commit's own diff against its parent, and can
+    address any line of it, or a range of lines ending at `line` when
+    `start_line` is given.
+
+    The format of the request is deducted from a real one scrapped from a
+    browser."""
+    cookie = api.cookie()
+    url = (f'{api.web_url}/{api.repo}/pull/{pr}'
+           '/page_data/create_review_comment')
+    side = 'left' if is_left else 'right'
+    anchor = parent if is_left else commit
+    positioning = {
+        'baseCommitOid': parent,
+        'headCommitOid': commit,
+    }
+    if start_line is None:
+        subject = {'subjectType': 'line'}
+        positioning.update({
+            'type': 'line',
+            'path': path,
+            'line': line,
+            'commitOid': anchor,
+        })
+    else:
+        subject = {
+            'subjectType': 'multiline',
+            'startLine': start_line,
+            'startSide': side,
+        }
+        positioning.update({
+            'type': 'multiline',
+            'startPath': path,
+            'startLine': start_line,
+            'startCommitOid': anchor,
+            'endPath': path,
+            'endLine': line,
+            'endCommitOid': anchor,
+        })
+    payload = {
+        'comparisonStartOid': parent,
+        'comparisonEndOid': commit,
+        'text': body,
+        'submitBatch': False,
+        'line': line,
+        'path': path,
+        'positioning': positioning,
+        'side': side,
+        **subject,
+    }
+    status, headers, resp_body = api.send(url, 'POST', {
+        'Accept': 'application/json',
+        'Origin': api.web_url,
+        'Referer': f'{api.web_url}/{api.repo}/pull/{pr}',
+        'X-Requested-With': 'XMLHttpRequest',
+        'GitHub-Verified-Fetch': 'true',
+        'Cookie': cookie,
+    }, payload)
+    if status >= 400:
+        fail(f'the private API returned HTTP {status}: {resp_body[:200]}')
+    if 'json' not in headers.get('Content-Type', ''):
+        fail('the private API did not return JSON - most likely the '
+             'session cookie has expired and needs a refresh, see '
+             'doc/agents/local_setup.md')
+
+
+def read_message(args):
+    if args.message is not None:
+        return args.message
+    try:
+        with open(args.message_file, encoding='utf-8') as f:
+            return f.read()
+    except OSError as e:
+        fail(f'cannot read the message file: {e}')
+
+
+def ensure_pending_review(api, pr):
+    review = find_pending_review(api, pr)
+    if review is None:
+        review = api.rest(f'repos/{api.repo}/pulls/{pr}/reviews', 'POST',
+                          {})
+        print(f'Started pending review {review["id"]} on PR #{pr}')
+    return review
+
+
+def comment_public(api, args):
+    pr = args.pr
+    if args.start_line is not None:
+        fail('range comments are only possible with --experimental; in '
+             'the public mode anchor at one line and describe the range '
+             'in the text')
+    base = api.rest(f'repos/{api.repo}/pulls/{pr}')['base']
+    sha, pos = commit_position(base, args.commit, args.path, args.line,
+                               args.left)
+    body = read_message(args)
+    review = ensure_pending_review(api, pr)
+    out = api.graphql(MUTATION, {'rid': review['node_id'], 'sha': sha,
+                                 'path': args.path, 'pos': pos,
+                                 'body': body})
+    cid = out['addPullRequestReviewComment']['comment']['databaseId']
+    print(f'Added pending comment {cid} on {sha[:12]} '
+          f'{args.path}:{args.line}')
+
+
+def comment_experimental(api, args):
+    pr = args.pr
+    sha, parent, patch = commit_info(args.commit, args.path)
+    side = 'old' if args.left else 'new'
+    if patch_position(patch, args.line, args.left) is None:
+        fail(f'{side}-file line {args.line} of {args.path} is not in '
+             f'the diff of commit {args.commit}')
+    if args.start_line is not None:
+        if args.start_line >= args.line:
+            fail('--start-line must be less than --line')
+        if patch_position(patch, args.start_line, args.left) is None:
+            fail(f'{side}-file line {args.start_line} of {args.path} is '
+                 f'not in the diff of commit {args.commit}')
+    body = read_message(args)
+    # No ensure_pending_review() here: the private API attaches the
+    # comment to the session's pending review, auto-creating it when
+    # there is none - the same way the first comment in the web UI
+    # works. It also makes an identity mismatch between the cookie and
+    # the token fail loudly later: submit finds no pending review at
+    # all, instead of publishing an empty one.
+    private_comment(api, pr, sha, parent, args.path, args.line,
+                    args.start_line, args.left, body)
+    span = (f'{args.line}' if args.start_line is None else
+            f'{args.start_line}-{args.line}')
+    print(f'Added pending comment on {sha[:12]} '
+          f'{args.path}:{span} via the private API')
+
+
+def cmd_comment(api, args):
+    if args.experimental:
+        comment_experimental(api, args)
+    else:
+        comment_public(api, args)
+
+
+def pending_review_comments(api, review):
+    """All comments of the pending review, via GraphQL - the only API
+    which exposes the real file line numbers before the review is
+    submitted. The REST view of a pending review carries only the legacy
+    diff positions."""
+    comments = []
+    cursor = None
+    while True:
+        data = api.graphql(STATUS_QUERY, {'rid': review['node_id'],
+                                          'cursor': cursor})
+        page = data['node']['comments']
+        comments += page['nodes']
+        if not page['pageInfo']['hasNextPage']:
+            return comments
+        cursor = page['pageInfo']['endCursor']
+
+
+def cmd_status(api, args):
+    pr = args.pr
+    review = find_pending_review(api, pr)
+    if review is None:
+        print(f'No pending review on PR #{pr}')
+        return
+    comments = pending_review_comments(api, review)
+    print(f'Pending review {review["id"]} on PR #{pr}, '
+          f'{len(comments)} comment(s):')
+    for c in comments:
+        first_line = c['body'].splitlines()[0] if c['body'] else ''
+        span = (f'{c["originalLine"]}' if c['originalStartLine'] is None
+                else f'{c["originalStartLine"]}-{c["originalLine"]}')
+        print(f'  {c["databaseId"]} '
+              f'{c["originalCommit"]["abbreviatedOid"]} '
+              f'{c["path"]}:{span} | {first_line}')
+
+
+def cmd_submit(api, args):
+    pr = args.pr
+    review = require_pending_review(api, pr)
+    api.rest(f'repos/{api.repo}/pulls/{pr}/reviews/{review["id"]}/events',
+             'POST', {'event': 'COMMENT', 'body': read_message(args)})
+    print(f'Submitted review {review["id"]} on PR #{pr}')
+
+
+def cmd_abort(api, args):
+    pr = args.pr
+    review = require_pending_review(api, pr)
+    api.rest(f'repos/{api.repo}/pulls/{pr}/reviews/{review["id"]}',
+             'DELETE')
+    print(f'Dropped pending review {review["id"]} on PR #{pr}')
+
+
+def add_message_args(parser, subject):
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-m', '--message', help=f'{subject} text')
+    group.add_argument('-F', '--message-file',
+                       help=f'read the {subject} text from a file')
+
+
+def find_gh_token():
+    """The token of the user's `gh` login - the fallback for when there
+    is no GH_TOKEN in the environment, so the tool keeps working
+    without any setup for the default profile."""
+    res = subprocess.run(['gh', 'auth', 'token'], capture_output=True,
+                         encoding='utf-8')
+    if res.returncode != 0:
+        fail('no GH_TOKEN in the environment and no `gh` login to take '
+             'the token from')
+    return res.stdout.strip()
+
+
+def main():
+    # The comments and the GitHub data are UTF-8 regardless of the local
+    # environment, so make the output independent from the locale too.
+    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+    sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    subs = parser.add_subparsers(dest='command', required=True)
+
+    sub = subs.add_parser(
+        'comment', help='add a comment to the pending review, creating '
+                        'the review if needed')
+    sub.add_argument('-c', '--commit', required=True,
+                     help='SHA of the commit whose diff the comment is '
+                          'attached to')
+    sub.add_argument('-p', '--path', required=True,
+                     help='path of the commented file')
+    sub.add_argument('-l', '--line', required=True, type=int,
+                     help='line number in the file as of the commit; '
+                          'with --left - in the PR base file, or in the '
+                          'parent commit file with --experimental')
+    sub.add_argument('--left', action='store_true',
+                     help='the line is in the old file version (use for '
+                          'deleted lines)')
+    sub.add_argument('--start-line', type=int,
+                     help='first line of a multi-line comment ending at '
+                          '--line; only with --experimental')
+    sub.add_argument('--experimental', action='store_true',
+                     help='post via the private web UI API: the lines '
+                          'are then numbered by the commit own diff, '
+                          'and lines added+deleted within the PR become '
+                          'reachable; requires GH_COOKIE')
+    add_message_args(sub, 'comment')
+    sub.set_defaults(func=cmd_comment)
+
+    sub = subs.add_parser('status', help='show the pending review')
+    sub.set_defaults(func=cmd_status)
+
+    sub = subs.add_parser(
+        'submit', help='publish the pending review with a summary message')
+    add_message_args(sub, 'review summary')
+    sub.set_defaults(func=cmd_submit)
+
+    sub = subs.add_parser(
+        'abort', help='drop the pending review and all its comments')
+    sub.set_defaults(func=cmd_abort)
+
+    for sub in subs.choices.values():
+        sub.add_argument('--pr', type=int, required=True,
+                         help='PR number')
+
+    args = parser.parse_args()
+    # The environment is read only here: everything below takes the
+    # values as parameters, so the tests can inject their own.
+    api = Api(repo=repo_full_name(),
+              token=os.environ.get('GH_TOKEN'),
+              cookie_pair=os.environ.get('GH_COOKIE'),
+              api_url=os.environ.get('GH_API_URL', API_URL),
+              web_url=os.environ.get('GH_WEB_URL', WEB_URL))
+    args.func(api, args)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception:
+        fail(f'internal error:\n{traceback.format_exc()}')


### PR DESCRIPTION
See an example review here:
https://github.com/tarantool/tarantool/pull/12989#pullrequestreview-4905572161

First comments in this review are raw, I was polishing the rules as I was going through the review. After a few first comments the style was stabilized. For the final version of the output look at the last comments and the summary comment.

---

New skills to enable review via LLMs:

- doc/agents/review.md - general description how to
  review a patch.

- doc/agents/review-gh.md - how to publish a review
  on a GitHub pull request.

The skills by default will use 'gh' CLI, officially
maintained by GitHub.

The 'gh' comment posting usage is wrapped into a Python
CLI script, because it has to use quite complicated
requests most parts of which are the same anyway in
all usages.

Besides, the public API available via 'gh' and bare
REST has certain critical limitations:

- Comments can't address more than one line in the diff.

- Per-commit comments use git-diff of the commit against
  PR's base commit. Which basically makes them pointless
  in long PRs.

To bypass these limitations the newly introduced
Python script is able to use the private API of GitHub
same as browsers do.

The caveat is that this usage requires a cookie instead
of an OAuth token. The updated local-setup document
elaborates on that and guides how to set things up when
users wants to use the private API.

NO_DOC=internal
NO_CHANGELOG=internal
NO_TEST=not-worth-it