### PR TITLE
sql: add new option in compat for sql id

### DIFF
--- a/changelogs/unreleased/gh-12732-sql-uppercase-id-option-in-compat.md
+++ b/changelogs/unreleased/gh-12732-sql-uppercase-id-option-in-compat.md
@@ -1,0 +1,7 @@
+## feature/sql
+
+* When the option is `old`, the search id first looks for an exact match;
+  if that fails, it searches using the id converted to uppercase.
+  When the option is `new`, the search looks only for an exact name match.
+  The default setting is `old`. This can be toggled using the command
+  `compat.sql_uppercase_id = option` (gh-12732).

--- a/changelogs/unreleased/gh-12732-sql-uppercase-id-option-in-compat.md
+++ b/changelogs/unreleased/gh-12732-sql-uppercase-id-option-in-compat.md
@@ -1,0 +1,9 @@
+## feature/sql
+
+* Added a new option sql_uppercased_id. When the value is `new` we do search
+  in sql looks only for an exact name match. When the value is `old` we
+  additionally do search in sql first looks for an exact match; if that fails,
+  we do searc using the name converted to uppercase. The default setting is
+  `old`. If name in request enclosed in quotation marks we use `new` behaviour.
+  This can be toggled using the command `compat.sql_legacy_name_normalization = option`
+  (gh-12732).

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -502,6 +502,14 @@ I['compat.datetime_setfn_timestamp_type_check'] = format_text([[
     - `old` (3.x default): don't check
 ]])
 
+I['compat.sql_uppercase_id'] = format_text([[
+    In SQL if the name is not found via an exact match,
+    it also searches for the uppercase version:
+
+    - `new` (3.x default): false
+    - `old` (2.x default): true
+]])
+
 -- }}} compat configuration
 
 -- {{{ config configuration

--- a/src/box/lua/config/descriptions.lua
+++ b/src/box/lua/config/descriptions.lua
@@ -502,6 +502,14 @@ I['compat.datetime_setfn_timestamp_type_check'] = format_text([[
     - `old` (3.x default): don't check
 ]])
 
+I['compat.sql_legacy_name_normalization'] = format_text([[
+    If an object is not found using an exact match against the specified name
+    in SQL, try searching by the name normalized using legacy rules:
+
+    - `new` (3.x default): false
+    - `old` (2.x default): true
+]])
+
 -- }}} compat configuration
 
 -- {{{ config configuration

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2461,6 +2461,12 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'old',
         }),
+        sql_uppercase_id = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'old',
+        }),
     }),
     -- Instance labels.
     labels = schema.map({

--- a/src/box/lua/config/instance_config.lua
+++ b/src/box/lua/config/instance_config.lua
@@ -2446,6 +2446,12 @@ return schema.new('instance_config', schema.record({
         }, {
             default = 'old',
         }),
+        sql_legacy_name_normalization = schema.enum({
+            'old',
+            'new',
+        }, {
+            default = 'old',
+        }),
     }),
     -- Instance labels.
     labels = schema.map({

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -66,6 +66,9 @@ static const char nil_key[] = { 0x90 }; /* Empty MsgPack array. */
 static bool sql_seq_scan_default = false;
 TWEAK_BOOL(sql_seq_scan_default);
 
+bool sql_uppercase_id = true;
+TWEAK_BOOL(sql_uppercase_id);
+
 uint32_t
 sql_default_session_flags(void)
 {
@@ -1618,7 +1621,8 @@ sql_space_by_token(const struct Token *name)
 	char *name_str = sql_name_from_token(name);
 	struct space *res = space_by_name0(name_str);
 	sql_xfree(name_str);
-	if (res != NULL || name->z[0] == '"')
+	if (res != NULL || name->z[0] == '"' ||
+	    !sql_uppercase_id)
 		return res;
 	char *old_name_str = sql_legacy_name_new(name->z, name->n);
 	res = space_by_name0(old_name_str);
@@ -1630,7 +1634,8 @@ const struct space *
 sql_space_by_src(const struct SrcList_item *src)
 {
 	struct space *res = space_by_name0(src->zName);
-	if (res != NULL || src->legacy_name == NULL)
+	if (res != NULL || src->legacy_name == NULL ||
+	    !sql_uppercase_id)
 		return res;
 	return space_by_name0(src->legacy_name);
 }
@@ -1655,7 +1660,8 @@ sql_index_id_by_token(const struct space *space, const struct Token *name)
 	char *name_str = sql_name_from_token(name);
 	uint32_t res = sql_space_index_id(space, name_str);
 	sql_xfree(name_str);
-	if (res != UINT32_MAX || name->z[0] == '"')
+	if (res != UINT32_MAX || name->z[0] == '"' ||
+	    !sql_uppercase_id)
 		return res;
 	char *old_name_str = sql_legacy_name_new(name->z, name->n);
 	res = sql_space_index_id(space, old_name_str);
@@ -1709,7 +1715,7 @@ sql_coll_id_by_token(const struct Token *name)
 	sql_xfree(name_str);
 	if (coll_id != NULL)
 		return coll_id->id;
-	if (name->z[0] == '"')
+	if (name->z[0] == '"' || !sql_uppercase_id)
 		return UINT32_MAX;
 
 	char *old_name_str = sql_legacy_name_new(name->z, name->n);
@@ -1740,7 +1746,7 @@ sql_constraint_by_token(const struct tuple_constraint_def *cdefs,
 		}
 	}
 	sql_xfree(name_str);
-	if (name->z[0] == '"')
+	if (name->z[0] == '"' || !sql_uppercase_id)
 		return NULL;
 	char *old_name_str = sql_legacy_name_new(name->z, name->n);
 	for (uint32_t i = 0; i < count; ++i) {

--- a/src/box/sql.c
+++ b/src/box/sql.c
@@ -66,6 +66,9 @@ static const char nil_key[] = { 0x90 }; /* Empty MsgPack array. */
 static bool sql_seq_scan_default = false;
 TWEAK_BOOL(sql_seq_scan_default);
 
+bool sql_legacy_name_normalization = true;
+TWEAK_BOOL(sql_legacy_name_normalization);
+
 uint32_t
 sql_default_session_flags(void)
 {
@@ -1620,7 +1623,8 @@ sql_space_by_token(const struct Token *name)
 	char *name_str = sql_name_from_token(name);
 	struct space *res = space_by_name0(name_str);
 	sql_xfree(name_str);
-	if (res != NULL || name->z[0] == '"')
+	if (res != NULL || name->z[0] == '"' ||
+	    !sql_legacy_name_normalization)
 		return res;
 	char *old_name_str = sql_legacy_name_new(name->z, name->n);
 	res = space_by_name0(old_name_str);
@@ -1632,7 +1636,8 @@ const struct space *
 sql_space_by_src(const struct SrcList_item *src)
 {
 	struct space *res = space_by_name0(src->zName);
-	if (res != NULL || src->legacy_name == NULL)
+	if (res != NULL || src->legacy_name == NULL ||
+	    !sql_legacy_name_normalization)
 		return res;
 	return space_by_name0(src->legacy_name);
 }
@@ -1657,7 +1662,8 @@ sql_index_id_by_token(const struct space *space, const struct Token *name)
 	char *name_str = sql_name_from_token(name);
 	uint32_t res = sql_space_index_id(space, name_str);
 	sql_xfree(name_str);
-	if (res != UINT32_MAX || name->z[0] == '"')
+	if (res != UINT32_MAX || name->z[0] == '"' ||
+	    !sql_legacy_name_normalization)
 		return res;
 	char *old_name_str = sql_legacy_name_new(name->z, name->n);
 	res = sql_space_index_id(space, old_name_str);
@@ -1711,7 +1717,7 @@ sql_coll_id_by_token(const struct Token *name)
 	sql_xfree(name_str);
 	if (coll_id != NULL)
 		return coll_id->id;
-	if (name->z[0] == '"')
+	if (name->z[0] == '"' || !sql_legacy_name_normalization)
 		return UINT32_MAX;
 
 	char *old_name_str = sql_legacy_name_new(name->z, name->n);
@@ -1742,7 +1748,7 @@ sql_constraint_by_token(const struct tuple_constraint_def *cdefs,
 		}
 	}
 	sql_xfree(name_str);
-	if (name->z[0] == '"')
+	if (name->z[0] == '"' || !sql_legacy_name_normalization)
 		return NULL;
 	char *old_name_str = sql_legacy_name_new(name->z, name->n);
 	for (uint32_t i = 0; i < count; ++i) {

--- a/src/box/sql/ast.c
+++ b/src/box/sql/ast.c
@@ -316,7 +316,7 @@ expr_id(struct ast_expr *expr)
 	t.isReserved = false;
 	struct Expr *res = sql_expr_new_dequoted(expr->op, &t);
 	res->type = FIELD_TYPE_SCALAR;
-	if (expr->str[0] != '"')
+	if (expr->str[0] != '"' && sql_uppercase_id)
 		res->flags |= EP_Lookup2;
 	return res;
 }

--- a/src/box/sql/ast.c
+++ b/src/box/sql/ast.c
@@ -351,7 +351,7 @@ expr_id(struct ast_expr *expr)
 	t.isReserved = false;
 	struct Expr *res = sql_expr_new_dequoted(expr->op, &t);
 	res->type = FIELD_TYPE_SCALAR;
-	if (expr->str[0] != '"')
+	if (expr->str[0] != '"' && sql_legacy_name_normalization)
 		res->flags |= EP_Lookup2;
 	return res;
 }

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -1937,6 +1937,19 @@ fk_constraint_def_sizeof(uint32_t link_count, uint32_t name_len,
 	return *links_offset + link_count * sizeof(struct field_link);
 }
 
+bool
+sql_find_foregin_key(const char *parent_name, const char *space_name)
+{
+	bool is_self_referenced = strcmp(parent_name, space_name) == 0;
+	if (!is_self_referenced && parent->z[0] != '"' &&
+	    sql_uppercase_id) {
+		char *old_name = sql_legacy_name_new(parent->z,
+						     parent->n);
+		is_self_referenced = strcmp(old_name, space_name) == 0;
+		sql_xfree(old_name);
+	}
+	return is_self_referenced;
+}
 void
 sql_create_foreign_key(struct Parse *parse_context)
 {
@@ -2020,13 +2033,7 @@ sql_create_foreign_key(struct Parse *parse_context)
 	 */
 	if (!is_alter_add_constr) {
 		const char *space_name = space->def->name;
-		is_self_referenced = strcmp(parent_name, space_name) == 0;
-		if (!is_self_referenced && parent->z[0] != '"') {
-			char *old_name = sql_legacy_name_new(parent->z,
-							     parent->n);
-			is_self_referenced = strcmp(old_name, space_name) == 0;
-			sql_xfree(old_name);
-		}
+		is_self_referenced = sql_find_foregin_key_name(parent_name, space_name);
 	}
 	const struct space *parent_space = sql_space_by_token(parent);
 	if (parent_space == NULL && !is_self_referenced) {
@@ -3135,7 +3142,7 @@ sql_id_list_append(struct IdList *list, struct Token *name_token)
 	list->a = sqlArrayAllocate(list->a, sizeof(list->a[0]), &list->nId, &i);
 	assert(i >= 0);
 	list->a[i].zName = sql_name_from_token(name_token);
-	if (name_token->z[0] != '"') {
+	if (name_token->z[0] != '"' && sql_uppercase_id) {
 		list->a[i].legacy_name = sql_legacy_name_new(name_token->z,
 							     name_token->n);
 	}
@@ -3231,7 +3238,7 @@ sql_src_list_append(struct SrcList *list, struct Token *name_token)
 	struct SrcList_item *item = &list->a[list->nSrc - 1];
 	if (name_token != NULL) {
 		item->zName = sql_name_from_token(name_token);
-		if (name_token->z[0] != '"') {
+		if (name_token->z[0] != '"' && sql_uppercase_id) {
 			item->legacy_name = sql_legacy_name_new(name_token->z,
 								name_token->n);
 		}
@@ -3334,7 +3341,7 @@ sqlSrcListIndexedBy(struct SrcList *p, struct Token *pIndexedBy)
 		} else if (pIndexedBy->z != NULL) {
 			pItem->u1.zIndexedBy = sql_name_from_token(pIndexedBy);
 			pItem->fg.isIndexedBy = true;
-			if (pIndexedBy->z[0] != '"') {
+			if (pIndexedBy->z[0] != '"' && sql_uppercase_id) {
 				pItem->legacy_index_name =
 					sql_legacy_name_new(pIndexedBy->z,
 							    pIndexedBy->n);
@@ -3406,7 +3413,8 @@ sqlSavepoint(Parse * pParse, int op, Token * pName)
 	 */
 	int old_name_reg = 0;
 	assert(pName->n > 0);
-	if (op != SAVEPOINT_BEGIN && pName->z[0] != '"') {
+	if (op != SAVEPOINT_BEGIN && pName->z[0] != '"' &&
+	    sql_uppercase_id) {
 		old_name_reg = ++pParse->nMem;
 		char *old_name = sql_legacy_name_new(pName->z, pName->n);
 		sqlVdbeAddOp4(v, OP_String8, 0, old_name_reg, 0, old_name,

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -1864,6 +1864,25 @@ fk_constraint_def_sizeof(uint32_t link_count, uint32_t name_len,
 	return *links_offset + link_count * sizeof(struct field_link);
 }
 
+/**
+ * The function checks whether the table reference is self-referencing.
+ * `true` returns if the link is self-referential;
+ * `false` returns otherwise.
+ */
+static bool
+sql_find_foregin_key_name(const Token *parent, const char *space_name)
+{
+	const char *parent_name = sql_name_from_token(parent);
+	bool is_self_referenced = strcmp(parent_name, space_name) == 0;
+	if (!is_self_referenced && parent->z[0] != '"' &&
+	    sql_legacy_name_normalization) {
+		char *old_name = sql_legacy_name_new(parent->z,
+						     parent->n);
+		is_self_referenced = strcmp(old_name, space_name) == 0;
+		sql_xfree(old_name);
+	}
+	return is_self_referenced;
+}
 void
 sql_create_foreign_key(struct Parse *parse_context, struct Token *table,
 		       struct Token *name, struct ExprList *child_cols,
@@ -1926,22 +1945,20 @@ sql_create_foreign_key(struct Parse *parse_context, struct Token *table,
 	}
 	assert(parent != NULL);
 	parent_name = sql_name_from_token(parent);
-	/*
-	 * Within ALTER TABLE ADD CONSTRAINT FK also can be
-	 * self-referenced, but in this case parent (which is
-	 * also child) table will definitely exist.
-	 */
-	if (!is_alter_add_constr) {
-		const char *space_name = space->def->name;
-		is_self_referenced = strcmp(parent_name, space_name) == 0;
-		if (!is_self_referenced && parent->z[0] != '"') {
-			char *old_name = sql_legacy_name_new(parent->z,
-							     parent->n);
-			is_self_referenced = strcmp(old_name, space_name) == 0;
-			sql_xfree(old_name);
+	const struct space *parent_space = sql_space_by_token(parent);
+	if (parent_space == NULL ||
+	    (space != NULL && space->def->id == parent_space->def->id)) {
+		/*
+		 * Within ALTER TABLE ADD CONSTRAINT FK also can be
+		 * self-referenced, but in this case parent (which is
+		 * also child) table will definitely exist.
+		 */
+		if (!is_alter_add_constr) {
+			const char *space_name = space->def->name;
+			is_self_referenced =
+			sql_find_foregin_key_name(parent, space_name);
 		}
 	}
-	const struct space *parent_space = sql_space_by_token(parent);
 	if (parent_space == NULL && !is_self_referenced) {
 		diag_set(ClientError, ER_NO_SUCH_SPACE, parent_name);
 		goto tnt_error;
@@ -3023,7 +3040,7 @@ sql_id_list_append(struct IdList *list, struct Token *name_token)
 	list->a = sqlArrayAllocate(list->a, sizeof(list->a[0]), &list->nId, &i);
 	assert(i >= 0);
 	list->a[i].zName = sql_name_from_token(name_token);
-	if (name_token->z[0] != '"') {
+	if (name_token->z[0] != '"' && sql_legacy_name_normalization) {
 		list->a[i].legacy_name = sql_legacy_name_new(name_token->z,
 							     name_token->n);
 	}
@@ -3119,7 +3136,7 @@ sql_src_list_append(struct SrcList *list, struct Token *name_token)
 	struct SrcList_item *item = &list->a[list->nSrc - 1];
 	if (name_token != NULL) {
 		item->zName = sql_name_from_token(name_token);
-		if (name_token->z[0] != '"') {
+		if (name_token->z[0] != '"' && sql_legacy_name_normalization) {
 			item->legacy_name = sql_legacy_name_new(name_token->z,
 								name_token->n);
 		}
@@ -3222,7 +3239,8 @@ sqlSrcListIndexedBy(struct SrcList *p, struct Token *pIndexedBy)
 		} else if (pIndexedBy->z != NULL) {
 			pItem->u1.zIndexedBy = sql_name_from_token(pIndexedBy);
 			pItem->fg.isIndexedBy = true;
-			if (pIndexedBy->z[0] != '"') {
+			if (pIndexedBy->z[0] != '"' &&
+			    sql_legacy_name_normalization) {
 				pItem->legacy_index_name =
 					sql_legacy_name_new(pIndexedBy->z,
 							    pIndexedBy->n);
@@ -3294,7 +3312,8 @@ sqlSavepoint(Parse * pParse, int op, Token * pName)
 	 */
 	int old_name_reg = 0;
 	assert(pName->n > 0);
-	if (op != SAVEPOINT_BEGIN && pName->z[0] != '"') {
+	if (op != SAVEPOINT_BEGIN && pName->z[0] != '"' &&
+	    sql_legacy_name_normalization) {
 		old_name_reg = ++pParse->nMem;
 		char *old_name = sql_legacy_name_new(pName->z, pName->n);
 		sqlVdbeAddOp4(v, OP_String8, 0, old_name_reg, 0, old_name,

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -1061,7 +1061,9 @@ sql_expr_new_dequoted(int op, const struct Token *token)
 	e->u.zToken[token->n] = '\0';
 	sqlDequote(e->u.zToken);
 	if (op == TK_ID || op == TK_COLLATE || op == TK_FUNCTION)
-		e->flags |= token->z[0] != '"' ? EP_Lookup2 : 0;
+		e->flags |= (token->z[0] != '"' &&
+			     sql_uppercase_id) ?
+			    EP_Lookup2 : 0;
 	return e;
 }
 

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -1061,7 +1061,8 @@ sql_expr_new_dequoted(int op, const struct Token *token)
 	e->u.zToken[token->n] = '\0';
 	sqlDequote(e->u.zToken);
 	if (op == TK_ID || op == TK_COLLATE || op == TK_FUNCTION)
-		e->flags |= token->z[0] != '"' ? EP_Lookup2 : 0;
+		if (token->z[0] != '"' && sql_legacy_name_normalization)
+			e->flags |= EP_Lookup2;
 	return e;
 }
 

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -3738,6 +3738,27 @@ substSelect(Parse * pParse,	/* Report errors here */
 	} while (doPrior && (p = p->pPrior) != 0);
 }
 
+/**
+ * Create zName if it absent.
+ */
+static void
+sql_generate_new_names(ExprList *pList)
+{
+	for (int i = 0; i < pList->nExpr; i++) {
+		if (pList->a[i].zName == 0) {
+			const char *str = pList->a[i].zSpan;
+			size_t len = strlen(str);
+			char *name = sql_name_new(str, len);
+			pList->a[i].zName = name;
+			if (pList->a[i].zSpan[0] != '"' &&
+			    sql_uppercase_id) {
+				pList->a[i].legacy_name =
+				sql_legacy_name_new(str, len);
+			}
+		}
+	}
+}
+
 /*
  * This routine attempts to flatten subqueries as a performance optimization.
  * This routine returns 1 if it makes changes and 0 if no flattening occurs.
@@ -4196,18 +4217,7 @@ flattenSubquery(Parse * pParse,		/* Parsing context */
 		 * "a" we substitute "x*3" and every place we see "b" we substitute "y+10".
 		 */
 		pList = pParent->pEList;
-		for (i = 0; i < pList->nExpr; i++) {
-			if (pList->a[i].zName == 0) {
-				const char *str = pList->a[i].zSpan;
-				size_t len = strlen(str);
-				char *name = sql_name_new(str, len);
-				pList->a[i].zName = name;
-				if (pList->a[i].zSpan[0] != '"') {
-					pList->a[i].legacy_name =
-						sql_legacy_name_new(str, len);
-				}
-			}
-		}
+		sql_generate_new_names(pList);
 		if (pSub->pOrderBy) {
 			/* At this point, any non-zero iOrderByCol values indicate that the
 			 * ORDER BY column expression is identical to the iOrderByCol'th

--- a/src/box/sql/select.c
+++ b/src/box/sql/select.c
@@ -4112,7 +4112,8 @@ flattenSubquery(Parse * pParse,		/* Parsing context */
 				size_t len = strlen(str);
 				char *name = sql_name_new(str, len);
 				pList->a[i].zName = name;
-				if (pList->a[i].zSpan[0] != '"') {
+				if (pList->a[i].zSpan[0] != '"' &&
+				    sql_legacy_name_normalization) {
 					pList->a[i].legacy_name =
 						sql_legacy_name_new(str, len);
 				}

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -213,6 +213,13 @@
 #include <assert.h>
 #include <stddef.h>
 
+/**
+ * Then value true: if exact match search for ID failed,
+ * the ID is searched for using its uppercase version.
+ * Then value false: ID is searched for using only exact match.
+ */
+extern bool sql_uppercase_id;
+
 typedef long long int sql_int64;
 typedef unsigned long long int sql_uint64;
 typedef sql_int64 sql_int64;

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -213,6 +213,15 @@
 #include <assert.h>
 #include <stddef.h>
 
+/**
+ * When the value is `true` we do search in sql looks only for an exact
+ * name match.
+ * When the value is `false` we additionally do search in sql first looks for
+ * an exact match; if that fails, we do searc using the name
+ * converted to uppercase.
+ */
+extern bool sql_legacy_name_normalization;
+
 typedef long long int sql_int64;
 typedef unsigned long long int sql_uint64;
 typedef sql_int64 sql_int64;

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -202,6 +202,12 @@ local BOX_BACKUP_DEFAULT_TTL_BRIEF = [[
 Default backup TTL values when it is not set explicitly in box.backup.start().
 ]]
 
+local SQL_UPPERCASE_ID_BRIEF = [[
+In the old behavior, in SQL if the name is not found via an exact match,
+it also searches for the uppercase version.
+In the new behavior, names in SQL searches onle an exact match.
+]]
+
 -- Returns an action callback that toggles a tweak.
 local function tweak_action(tweak_name, old_tweak_value, new_tweak_value)
     return function(is_new)
@@ -379,6 +385,12 @@ local options = {
         brief = BOX_BACKUP_DEFAULT_TTL_BRIEF,
         action = tweak_action(
             'box_backup_default_ttl', TIMEOUT_INFINITY, 3600),
+    },
+    sql_uppercase_id = {
+        default = 'old',
+        obsolete = nil,
+        brief = SQL_UPPERCASE_ID_BRIEF,
+        action = tweak_action('sql_uppercase_id', true, false),
     },
 }
 

--- a/src/lua/compat.lua
+++ b/src/lua/compat.lua
@@ -202,6 +202,13 @@ local BOX_BACKUP_DEFAULT_TTL_BRIEF = [[
 Default backup TTL values when it is not set explicitly in box.backup.start().
 ]]
 
+local SQL_LEGACY_NAME_NORMALIZATION_BRIEF = [[
+When the behaviour is new we do search in sql looks only for an exact
+name match. When the behaviour is old we additionally do search in sql
+first looks for an exact match; if that fails, we do searc using the name
+converted to uppercase.
+]]
+
 -- Returns an action callback that toggles a tweak.
 local function tweak_action(tweak_name, old_tweak_value, new_tweak_value)
     return function(is_new)
@@ -379,6 +386,12 @@ local options = {
         brief = BOX_BACKUP_DEFAULT_TTL_BRIEF,
         action = tweak_action(
             'box_backup_default_ttl', TIMEOUT_INFINITY, 3600),
+    },
+    sql_legacy_name_normalization = {
+        default = 'old',
+        obsolete = nil,
+        brief = SQL_LEGACY_NAME_NORMALIZATION_BRIEF,
+        action = tweak_action('sql_legacy_name_normalization', true, false),
     },
 }
 

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -459,6 +459,7 @@ g.test_defaults = function()
             box_space_max = 'new',
             box_error_unpack_type_and_code = 'old',
             console_session_scope_vars = 'old',
+            sql_uppercase_id = "old",
             wal_cleanup_delay_deprecation = 'old',
             box_recovery_triggers_deprecation = 'old',
             skip_replication_names = 'new',

--- a/test/config-luatest/cluster_config_schema_test.lua
+++ b/test/config-luatest/cluster_config_schema_test.lua
@@ -459,6 +459,7 @@ g.test_defaults = function()
             box_space_max = 'new',
             box_error_unpack_type_and_code = 'old',
             console_session_scope_vars = 'old',
+            sql_legacy_name_normalization = "old",
             wal_cleanup_delay_deprecation = 'old',
             box_recovery_triggers_deprecation = 'old',
             skip_replication_names = 'new',

--- a/test/sql-luatest/compat_test.lua
+++ b/test/sql-luatest/compat_test.lua
@@ -68,3 +68,137 @@ g.test_new_sessions = function()
         t.assert(err == nil)
     end)
 end
+
+g = t.group("compat", {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+    cg.server:exec(function(engine)
+        local sql = [[SET SESSION "sql_default_engine" = '%s';]]
+        box.execute(sql:format(engine))
+        box.execute([[SET SESSION "sql_seq_scan" = true;]])
+    end, {cg.params.engine})
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--
+-- Check old and new option with sql_uppercase_id in compat
+g.test_option_sql_uppercase_id = function(cg)
+    cg.server:exec(function()
+        box.schema.func.create('FOO', {
+            language = 'LUA',
+            body = [[
+                function(val)
+                    if val ~= nil and val > 1 then
+                        return val
+                    else
+                        return nil
+                    end
+                end
+            ]],
+            param_list = {'number'},
+            returns = 'number',
+            exports = {'LUA', 'SQL'},
+        })
+
+        box.execute([[CREATE TABLE ASD (I INT PRIMARY KEY);]])
+
+        box.space.ASD:insert{1}
+        box.space.ASD:insert{2}
+        box.space.ASD:insert{3}
+
+        box.execute([[CREATE VIEW BSD as SELECT * FROM ASD;]])
+
+        local res = box.execute([[SELECT * FROM aSd;]])
+        t.assert_equals(res.rows, {{1}, {2}, {3}})
+
+        res = box.execute([[SELECT i FROM ASD;]])
+        t.assert_equals(res.rows, {{1}, {2}, {3}})
+
+        res = box.execute([[SELECT * FROM bSd;]])
+        t.assert_equals(res.rows, {{1}, {2}, {3}})
+
+        local sql = [[CREATE TABLE T (id INT PRIMARY KEY, FOREIGN KEY(id)
+                      REFERENCES t(id));]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err, nil)
+
+        res = box.execute([[SELECT foo(I) FROM ASD;]])
+        t.assert_equals(res.rows, {{nil}, {2}, {3}})
+
+        _, err = box.execute([[INSERT INTO ASD (i) VALUES (4);]])
+        t.assert_equals(err, nil)
+
+        sql = [[CREATE TABLE test(id INT PRIMARY KEY, A INT, b text);]]
+        box.execute(sql)
+        box.execute([[CREATE INDEX IDX ON test(A);]])
+        box.space.test:insert{2, 2, 'a'}
+        box.space.test:insert{1, 1, 'b'}
+
+        res = box.execute([[SELECT * FROM test INDEXED BY idx WHERE A > 1;]])
+        t.assert_equals(res.rows, {{2, 2, 'a'}})
+
+        res = box.execute([[SELECT * FROM test ORDER BY a;]])
+        t.assert_equals(res.rows, {{1, 1, 'b'}, {2, 2, 'a'}})
+
+        box.execute([[START TRANSACTION;]])
+        box.execute([[SAVEPOINT SP;]])
+        _, err = box.execute([[ROLLBACK TO sp;]])
+        t.assert_equals(err, nil)
+
+        box.execute([[DROP TABLE T;]])
+
+        local compat = require('compat')
+        compat.sql_uppercase_id = 'new'
+
+        local exp_err = [[Space 'aSd' does not exist]]
+        _, err = box.execute([[SELECT * FROM aSd;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[Can't resolve field 'i']]
+        _, err = box.execute([[SELECT i FROM ASD;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[Space 'bSd' does not exist]]
+        local _, err = box.execute([[SELECT * FROM bSd;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[Space 't' does not exist]]
+        sql = [[CREATE TABLE T (id INT PRIMARY KEY, FOREIGN KEY(id)
+                REFERENCES t(id));]]
+        _, err = box.execute(sql)
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[Function 'foo' does not exist]]
+        _, err = box.execute([[SELECT foo(I) FROM ASD;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[Field 'i' was not found in space 'ASD' format]]
+        _, err = box.execute([[INSERT INTO ASD (i) VALUES (5);]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = "Can not rollback to savepoint: "..
+                  " the savepoint does not exist"
+        _, err = box.execute([[ROLLBACK TO sp;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[No index 'idx' is defined in space 'test']]
+        _, err = box.execute([[SELECT * FROM test INDEXED BY idx WHERE A > 1;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[Can't resolve field 'a']]
+        _, err = box.execute([[SELECT * FROM test ORDER BY a;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        box.execute("DROP INDEX idx ON test;")
+        box.execute([[DROP TABLE ASD;]])
+        box.execute([[DROP TABLE T;]])
+        box.execute([[DROP TABLE test;]])
+        box.execute([[DROP VIEW BSD;]])
+        box.execute([[COMMIT;]])
+    end)
+end

--- a/test/sql-luatest/compat_test.lua
+++ b/test/sql-luatest/compat_test.lua
@@ -68,3 +68,147 @@ g.test_new_sessions = function()
         t.assert(err == nil)
     end)
 end
+
+g = t.group("compat", {{engine = 'memtx'}, {engine = 'vinyl'}})
+
+g.before_all(function(cg)
+    cg.server = server:new({alias = 'master'})
+    cg.server:start()
+    cg.server:exec(function(engine)
+        local sql = [[SET SESSION "sql_default_engine" = '%s';]]
+        box.execute(sql:format(engine))
+        box.execute([[SET SESSION "sql_seq_scan" = true;]])
+    end, {cg.params.engine})
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+--
+-- Check `sql_legacy_name_normalization` compat option.
+--
+g.test_option_sql_legacy_name_normalization = function(cg)
+    cg.server:exec(function()
+        box.schema.func.create('FOO', {
+            language = 'LUA',
+            body = [[
+                function(val)
+                    if val ~= nil and val > 1 then
+                        return val
+                    else
+                        return nil
+                    end
+                end
+            ]],
+            param_list = {'number'},
+            returns = 'number',
+            exports = {'LUA', 'SQL'},
+        })
+
+        box.execute([[CREATE TABLE ASD (I INT PRIMARY KEY);]])
+
+        box.space.ASD:insert{1}
+        box.space.ASD:insert{2}
+        box.space.ASD:insert{3}
+
+        box.execute([[CREATE VIEW BSD as SELECT * FROM ASD;]])
+
+        local res = box.execute([[SELECT * FROM aSd;]])
+        t.assert_equals(res.rows, {{1}, {2}, {3}})
+
+        res = box.execute([[SELECT i FROM ASD;]])
+        t.assert_equals(res.rows, {{1}, {2}, {3}})
+
+        res = box.execute([[SELECT * FROM bSd;]])
+        t.assert_equals(res.rows, {{1}, {2}, {3}})
+
+        local sql = [[CREATE TABLE T (id INT PRIMARY KEY, FOREIGN KEY(id)
+                      REFERENCES t(id));]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err, nil)
+
+        res = box.execute([[SELECT foo(I) FROM ASD;]])
+        t.assert_equals(res.rows, {{nil}, {2}, {3}})
+
+        _, err = box.execute([[INSERT INTO ASD (i) VALUES (4);]])
+        t.assert_equals(err, nil)
+
+        sql = [[CREATE TABLE test(id INT PRIMARY KEY, A INT, b text);]]
+        box.execute(sql)
+        box.execute([[CREATE INDEX IDX ON test(A);]])
+        box.space.test:insert{2, 2, 'a'}
+        box.space.test:insert{1, 1, 'b'}
+
+        res = box.execute([[SELECT * FROM test INDEXED BY idx WHERE A > 1;]])
+        t.assert_equals(res.rows, {{2, 2, 'a'}})
+
+        res = box.execute([[SELECT * FROM test ORDER BY a;]])
+        t.assert_equals(res.rows, {{1, 1, 'b'}, {2, 2, 'a'}})
+
+        box.execute([[START TRANSACTION;]])
+        box.execute([[SAVEPOINT SP;]])
+        _, err = box.execute([[ROLLBACK TO sp;]])
+        t.assert_equals(err, nil)
+
+        box.execute([[DROP TABLE T;]])
+
+        local compat = require('compat')
+        compat.sql_legacy_name_normalization = 'new'
+
+        local exp_err = [[Space 'aSd' does not exist]]
+        _, err = box.execute([[SELECT * FROM aSd;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[Can't resolve field 'i']]
+        _, err = box.execute([[SELECT i FROM ASD;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[Space 'bSd' does not exist]]
+        local _, err = box.execute([[SELECT * FROM bSd;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[Space 't' does not exist]]
+        sql = [[CREATE TABLE T (id INT PRIMARY KEY, FOREIGN KEY(id)
+                REFERENCES t(id));]]
+        _, err = box.execute(sql)
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[Function 'foo' does not exist]]
+        _, err = box.execute([[SELECT foo(I) FROM ASD;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[Field 'i' was not found in space 'ASD' format]]
+        _, err = box.execute([[INSERT INTO ASD (i) VALUES (5);]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = "Can not rollback to savepoint: "..
+                  "the savepoint does not exist"
+        _, err = box.execute([[ROLLBACK TO sp;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[No index 'idx' is defined in space 'test']]
+        _, err = box.execute([[SELECT * FROM test INDEXED BY idx WHERE A > 1;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        exp_err = [[Can't resolve field 'a']]
+        _, err = box.execute([[SELECT * FROM test ORDER BY a;]])
+        t.assert_equals(tostring(err), exp_err)
+
+        box.execute([[CREATE TABLE Bst (i INT PRIMARY KEY);]])
+        box.execute([[CREATE TABLE BST (i INT PRIMARY KEY,
+                      a INT REFERENCES Bst(i));]])
+        local foreign_key = box.space.BST:format()[2]['foreign_key']
+        t.assert_equals(foreign_key['fk_unnamed_BST_a_1']['space'],
+                        box.space.Bst.id)
+
+        box.execute("DROP INDEX idx ON test;")
+        box.execute([[DROP TABLE ASD;]])
+        box.execute([[DROP TABLE T;]])
+        box.execute([[DROP TABLE test;]])
+        box.execute([[DROP VIEW BSD;]])
+        box.execute([[COMMIT;]])
+        box.execute([[DROP TABLE BSD;]])
+        box.execute([[DROP TABLE Bsd;]])
+    end)
+end


### PR DESCRIPTION
After this patch a new option `sql_legacy_name_normalization` for search
id is adding in compat.

Closes #12732

@TarantoolBot document
Title: compat supports 'sql_legacy_name_normalization'

Added a new option sql_legacy_name_normalization. When the value
is `new` we do search in sql looks only for an exact name match.
When the value is `old` we additionally do search in sql first looks for
an exact match; if that fails, we do searc using the name converted
to uppercase. The default setting is `old`. If name in request enclosed
in quotation marks we use `new` behaviour. This can be toggled using
the command `compat.sql_legacy_name_normalization = option`.