### PR TITLE
config: allow to redefine the alerts logger

### DIFF
--- a/src/box/lua/config/utils/aboard.lua
+++ b/src/box/lua/config/utils/aboard.lua
@@ -3,6 +3,26 @@
 local datetime = require('datetime')
 local log = require('internal.config.utils.log')
 
+-- Report the given alert to the log.
+--
+-- The `log_f` function given to the aboard.new() call is used if it
+-- is provided, otherwise the alert is written using the logger of
+-- this module.
+--
+-- The alert has no timestamp at this point: it is set by the
+-- caller after the logging.
+local function aboard_log(self, alert)
+    if self._log_f ~= nil then
+        return self._log_f(alert)
+    end
+
+    if alert.type == 'error' then
+        log.error(alert.message)
+    else
+        log.warn(alert.message)
+    end
+end
+
 -- Set an alert.
 --
 -- Optional `opts.key` declares an unique identifier of the alert.
@@ -47,11 +67,7 @@ local function aboard_set(self, alert, opts)
         end
     end
 
-    if alert.type == 'error' then
-        log.error(alert.message)
-    else
-        log.warn(alert.message)
-    end
+    aboard_log(self, alert)
     alert.timestamp = datetime.now()
 
     self._alerts[key] = alert
@@ -298,10 +314,25 @@ local mt = {
 -- | local function on_drop_cb(aboard, key)
 -- |     <...>
 -- | end
+--
+-- The `log_f` option redefines how an alert is reported to the log.
+-- It is called instead of the logger of this module on the :set()
+-- method call and it has the following prototype.
+--
+-- | local function log_f(alert)
+-- |     <...>
+-- | end
+--
+-- It is needed for the users that have their own logging format,
+-- for example, the failover coordinator writes JSON lines. It is a
+-- temporary solution: the option should be dropped in favor of a
+-- logger configured per module (ghe-924).
 local function new(opts)
     local on_drop
+    local log_f
     if opts ~= nil then
         on_drop = opts.on_drop
+        log_f = opts.log_f
     end
 
     return setmetatable({
@@ -324,6 +355,7 @@ local function new(opts)
         _alerts = {},
         _next_key = 1,
         _on_drop = on_drop,
+        _log_f = log_f,
     }, mt)
 end
 

--- a/test/config-luatest/alerts_test.lua
+++ b/test/config-luatest/alerts_test.lua
@@ -294,6 +294,45 @@ g.test_aboard_set_get_drop_if_clean_return_values = function(g)
     })
 end
 
+-- Ensure that the `log_f` option of aboard.new() redefines how the
+-- alerts are reported to the log.
+g.test_aboard_log_f = function(g)
+    local verify = function()
+        local aboard = require('internal.config.utils.aboard')
+
+        local logged = {}
+        local board = aboard.new({
+            log_f = function(alert)
+                table.insert(logged, {
+                    type = alert.type,
+                    message = alert.message,
+                })
+            end,
+        })
+
+        board:set({type = 'warn', message = 'msg1'}, {key = 'key1'})
+        board:set({type = 'error', message = 'msg2'})
+        t.assert_equals(logged, {
+            {type = 'warn', message = 'msg1'},
+            {type = 'error', message = 'msg2'},
+        })
+
+        -- A repeated alert is not set and, so, is not logged.
+        board:set({type = 'warn', message = 'msg1'}, {key = 'key1'})
+        t.assert_equals(#logged, 2)
+
+        -- Without the option the built-in logger is used: verify
+        -- that :set() still works.
+        local default_board = aboard.new()
+        t.assert_is(default_board:set({type = 'warn', message = 'msg'}), true)
+        t.assert_equals(#default_board:alerts(), 1)
+    end
+
+    helpers.success_case(g, {
+        verify = verify,
+    })
+end
+
 -- Ensure that namespace:get() returns a copy.
 g.test_alert_get_returns_copy = function(g)
     local verify = function()


### PR DESCRIPTION
The alert board reports every alert to the log using the logger of the configuration module. However, a user of the board may have its own logging format. For example, the failover coordinator from Tarantool Enterprise Edition writes JSON lines and the alerts break the format of its log.

Add an optional `log_f` option to aboard.new(). It is called instead of the module's own logger, so a caller decides how to report an alert.

It is a temporary solution until a logger can be configured per module (see tarantool/tarantool-ee#924).