### PR TITLE
sql: rework functions that are used to build VDBE from parser

### DIFF
--- a/changelogs/unreleased/gh-13106-fix-memory-leak-in-add-constraints.md
+++ b/changelogs/unreleased/gh-13106-fix-memory-leak-in-add-constraints.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Fixed a memory leak in the `ALTER TABLE ADD CONSTRAINT CHECK` and
+  `ALTER TABLE ADD CONSTRAINT FOREIGN KEY` statements (gh-13106).

--- a/changelogs/unreleased/gh-5485-introduce-ast-in-sql.md
+++ b/changelogs/unreleased/gh-5485-introduce-ast-in-sql.md
@@ -10,3 +10,5 @@
   error (gh-5485).
 * The SQL query used to create a view is now in the corresponding space
   definition in `_space` as it was provided, without any changes (gh-5485).
+* The SQL query used to create a trigger is now in the corresponding SQL trigger
+  definition in `_trigger` as it was provided, without any changes (gh-5485).

--- a/changelogs/unreleased/gh-5485-introduce-ast-in-sql.md
+++ b/changelogs/unreleased/gh-5485-introduce-ast-in-sql.md
@@ -8,3 +8,5 @@
   "JOIN cannot be both OUTER and INNER"; an unrecognized `JOIN` keyword is
   now a syntax error instead of the 'unknown or unsupported join type'
   error (gh-5485).
+* The SQL query used to create a view is now in the corresponding space
+  definition in `_space` as it was provided, without any changes (gh-5485).

--- a/src/box/sql/alter.c
+++ b/src/box/sql/alter.c
@@ -38,35 +38,29 @@
 #include "box/schema.h"
 
 void
-sql_alter_table_rename(struct Parse *parse)
+sql_alter_table_rename(struct Parse *parse, struct Token *old_name,
+		       struct Token *new_name)
 {
-	struct rename_entity_def *rename_def = &parse->rename_entity_def;
-	struct SrcList *src_tab = rename_def->base.entity_name;
-	assert(rename_def->base.entity_type == ENTITY_TYPE_TABLE);
-	assert(rename_def->base.alter_action == ALTER_ACTION_RENAME);
-	assert(src_tab->nSrc == 1);
-	char *new_name = sql_name_from_token(&rename_def->new_name);
+	char *new_name_str = sql_name_from_token(new_name);
 	/* Check that new name isn't occupied by another table. */
-	if (space_by_name0(new_name) != NULL) {
-		diag_set(ClientError, ER_SPACE_EXISTS, new_name);
+	if (space_by_name0(new_name_str) != NULL) {
+		diag_set(ClientError, ER_SPACE_EXISTS, new_name_str);
 		goto tnt_error;
 	}
-	const struct space *space = sql_space_by_src(&src_tab->a[0]);
+	const struct space *space = sql_space_by_token(old_name);
 	if (space == NULL) {
-		diag_set(ClientError, ER_NO_SUCH_SPACE, src_tab->a[0].zName);
+		diag_set(ClientError, ER_NO_SUCH_SPACE,
+			 sql_tt_name_from_token(old_name));
 		goto tnt_error;
 	}
 	/* Drop and reload the internal table schema. */
 	struct Vdbe *v = sqlGetVdbe(parse);
-	sqlVdbeAddOp4(v, OP_RenameTable, space->def->id, 0, 0, new_name,
-			  P4_DYNAMIC);
-exit_rename_table:
-	sqlSrcListDelete(src_tab);
+	sqlVdbeAddOp4(v, OP_RenameTable, space->def->id, 0, 0, new_name_str,
+		      P4_DYNAMIC);
 	return;
 tnt_error:
-	sql_xfree(new_name);
+	sql_xfree(new_name_str);
 	parse->is_aborted = true;
-	goto exit_rename_table;
 }
 
 char *

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -192,7 +192,7 @@ sql_space_primary_key(const struct space *space)
  * when the "TEMP" or "TEMPORARY" keyword occurs in between
  * CREATE and TABLE.
  *
- * The new table record is initialized and put in pParse->create_table_def.
+ * The new table record is initialized and put in pParse->new_space.
  * As more of the CREATE TABLE statement is parsed, additional action
  * routines will be called to add more information to this record.
  * At the end of the CREATE TABLE statement, the sqlEndTable() routine
@@ -301,7 +301,7 @@ void
 sql_create_column_start(struct Parse *parse, struct Token *table,
 			struct Token *name, enum field_type type)
 {
-	struct space *space = parse->create_table_def.new_space;
+	struct space *space = parse->new_space;
 	bool is_alter = space == NULL;
 	if (is_alter) {
 		const struct space *origin = sql_space_by_token(table);
@@ -648,7 +648,7 @@ void
 sqlAddPrimaryKey(struct Parse *pParse, struct Token *name,
 		 struct ExprList *col_list, enum sort_order sort_order)
 {
-	struct space *space = pParse->create_table_def.new_space;
+	struct space *space = pParse->new_space;
 	if (space == NULL)
 		space = pParse->space;
 	assert(space != NULL);
@@ -725,7 +725,7 @@ sql_ck_unique_name_new(struct Parse *parse, bool is_field_ck)
 {
 	struct space *space = parse->space;
 	if (space == NULL)
-		space = parse->create_table_def.new_space;
+		space = parse->new_space;
 	assert(space != NULL);
 	const char *space_name = space->def->name;
 	struct ck_constraint_parse *ck;
@@ -784,7 +784,7 @@ sql_create_check_constraint(struct Parse *parser, struct Token *table,
 {
 	struct space *space = parser->space;
 	if (space == NULL)
-		space = parser->create_table_def.new_space;
+		space = parser->new_space;
 	bool is_alter_add_constr = space == NULL;
 
 	/* Prepare payload for ck constraint definition. */
@@ -985,7 +985,7 @@ vdbe_emit_create_index(struct Parse *parse, struct space_def *def,
 	memcpy(raw, index_parts, index_parts_sz);
 	index_parts = raw;
 
-	if (parse->create_table_def.new_space != NULL || parse->space != NULL) {
+	if (parse->new_space != NULL || parse->space != NULL) {
 		sqlVdbeAddOp2(v, OP_SCopy, space_id_reg, entry_reg);
 		sqlVdbeAddOp2(v, OP_Integer, idx_def->iid, entry_reg + 1);
 	} else {
@@ -1318,9 +1318,8 @@ vdbe_emit_fk_constraint_create(struct Parse *parse_context,
 	 * vdbe_emit_create_constraints()), but we know register
 	 * where it will be stored.
 	 */
-	bool is_alter_add_constr =
-		parse_context->create_table_def.new_space == NULL &&
-		parse_context->space == NULL;
+	bool is_alter_add_constr = parse_context->new_space == NULL &&
+				   parse_context->space == NULL;
 	if (!is_alter_add_constr)
 		sqlVdbeAddOp2(vdbe, OP_SCopy, fk->child_id, regs);
 	else
@@ -1377,7 +1376,7 @@ vdbe_emit_create_constraints(struct Parse *parse, int reg_space_id)
 	return;
 #endif /* FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION */
 	assert(reg_space_id != 0);
-	struct space *space = parse->create_table_def.new_space;
+	struct space *space = parse->new_space;
 	bool is_alter = space == NULL;
 	uint32_t i = 0;
 	/*
@@ -1476,17 +1475,10 @@ vdbe_emit_create_constraints(struct Parse *parse, int reg_space_id)
 	}
 }
 
-/*
- * This routine is called to report the final ")" that terminates
- * a CREATE TABLE statement.
- *
- * During this routine byte code for creation of new Tarantool
- * space and all necessary Tarantool indexes is emitted.
- */
 void
-sqlEndTable(struct Parse *pParse)
+vdbe_emit_create_table(struct Parse *pParse, bool if_not_exists)
 {
-	struct space *new_space = pParse->create_table_def.new_space;
+	struct space *new_space = pParse->new_space;
 	if (new_space == NULL)
 		return;
 	assert(!new_space->def->opts.is_view);
@@ -1520,10 +1512,9 @@ sqlEndTable(struct Parse *pParse)
 	int name_reg = ++pParse->nMem;
 	sqlVdbeAddOp4(pParse->pVdbe, OP_String8, 0, name_reg, 0,
 		      sql_xstrdup(new_space->def->name), P4_DYNAMIC);
-	bool no_err = pParse->create_table_def.base.if_not_exist;
 	vdbe_emit_halt_with_presence_test(pParse, BOX_SPACE_ID, 2, name_reg, 1,
 					  ER_SPACE_EXISTS, new_space->def->name,
-					  (no_err != 0), OP_NoConflict);
+					  if_not_exists, OP_NoConflict);
 	int reg_space_id = getNewSpaceId(pParse);
 	vdbe_emit_space_create(pParse, reg_space_id, name_reg, new_space);
 	vdbe_emit_create_constraints(pParse, reg_space_id);
@@ -1849,7 +1840,7 @@ sql_fk_unique_name_new(struct Parse *parse, struct ExprList *child_cols)
 {
 	struct space *space = parse->space;
 	if (space == NULL)
-		space = parse->create_table_def.new_space;
+		space = parse->new_space;
 	assert(space != NULL);
 	const char *space_name = space->def->name;
 	struct fk_constraint_parse *fk;
@@ -1908,9 +1899,8 @@ sql_create_foreign_key(struct Parse *parse_context, struct Token *table,
 	char *constraint_name = NULL;
 	bool is_self_referenced = false;
 	struct space *space = parse_context->space;
-	struct create_table_def *table_def = &parse_context->create_table_def;
 	if (space == NULL)
-		space = table_def->new_space;
+		space = parse_context->new_space;
 	/*
 	 * Space under construction during <CREATE TABLE>
 	 * processing or shallow copy of space during <ALTER TABLE
@@ -1950,7 +1940,7 @@ sql_create_foreign_key(struct Parse *parse_context, struct Token *table,
 		 * Child space already exists if it is
 		 * <ALTER TABLE ADD COLUMN>.
 		 */
-		if (table_def->new_space == NULL)
+		if (parse_context->new_space == NULL)
 			child_space = space;
 		struct rlist *fkeys =
 			&parse_context->create_fk_constraint_parse_def.fkeys;
@@ -2681,7 +2671,7 @@ sql_create_index(struct Parse *parse, struct Token *table, struct Token *name,
 	 * Find the table that is to be indexed.
 	 * Return early if not found.
 	 */
-	struct space *space = parse->create_table_def.new_space;
+	struct space *space = parse->new_space;
 	if (space == NULL)
 		space = parse->space;
 	bool is_create_table_or_add_col = space != NULL;

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -3039,37 +3039,31 @@ sql_create_index(struct Parse *parse) {
 }
 
 void
-sql_drop_index(struct Parse *parse_context)
+sql_drop_index(struct Parse *parse_context, struct Token *name,
+	       struct Token *table, bool if_exists)
 {
-	struct drop_entity_def *drop_def = &parse_context->drop_index_def.base;
-	assert(drop_def->base.entity_type == ENTITY_TYPE_INDEX);
-	assert(drop_def->base.alter_action == ALTER_ACTION_DROP);
 	struct Vdbe *v = sqlGetVdbe(parse_context);
 	assert(v != NULL);
 	/* Never called with prior errors. */
 	assert(!parse_context->is_aborted);
-	struct SrcList *table_list = drop_def->base.entity_name;
-	assert(table_list->nSrc == 1);
 	sqlVdbeCountChanges(v);
-	const struct space *space = sql_space_by_src(&table_list->a[0]);
-	bool if_exists = drop_def->if_exist;
+	const struct space *space = sql_space_by_token(table);
 	if (space == NULL) {
 		if (!if_exists) {
 			diag_set(ClientError, ER_NO_SUCH_SPACE,
-				 table_list->a[0].zName);
+				 sql_tt_name_from_token(table));
 			parse_context->is_aborted = true;
 		}
-		goto exit_drop_index;
+		return;
 	}
-	uint32_t index_id = sql_index_id_by_token(space, &drop_def->name);
+	uint32_t index_id = sql_index_id_by_token(space, name);
 	if (index_id == UINT32_MAX) {
 		if (if_exists)
-			goto exit_drop_index;
-		const char *name_str = sql_tt_name_from_token(&drop_def->name);
-		diag_set(ClientError, ER_NO_SUCH_INDEX_NAME, name_str,
-			 space->def->name);
+			return;
+		diag_set(ClientError, ER_NO_SUCH_INDEX_NAME,
+			 sql_tt_name_from_token(name), space->def->name);
 		parse_context->is_aborted = true;
-		goto exit_drop_index;
+		return;
 	}
 
 	int regs = sqlGetTempRange(parse_context, 3);
@@ -3080,9 +3074,6 @@ sql_drop_index(struct Parse *parse_context)
 	sqlVdbeAddOp3(v, OP_SDelete, BOX_INDEX_ID, regs + 2, 0);
 	sqlVdbeChangeP5(v, OPFLAG_NCHANGE);
 	sqlReleaseTempRange(parse_context, regs, 3);
-
- exit_drop_index:
-	sqlSrcListDelete(table_list);
 }
 
 void *

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -484,14 +484,14 @@ sql_expr_uint(const struct Expr *expr, uint64_t *res)
 	return errno == 0 ? 0 : -1;
 }
 
+/** This function adds literal default value for a column. */
 static void
-sql_add_term_default(struct Parse *parser, struct ExprSpan *expr_span)
+sql_add_term_default(struct Parse *parser, struct Expr *expr)
 {
 	assert(parser->space != NULL);
 	char *buf = NULL;
 	uint32_t size = 0;
 	struct region *region = &parser->region;
-	struct Expr *expr = expr_span->pExpr;
 	switch (sql_expr_type(expr)) {
 	case FIELD_TYPE_BOOLEAN: {
 		assert(expr->op == TK_TRUE || expr->op == TK_FALSE);
@@ -593,20 +593,21 @@ sql_add_term_default(struct Parse *parser, struct ExprSpan *expr_span)
 			parser->is_aborted = true;
 			break;
 		}
+		const struct Expr *int_expr = expr;
 		if (expr->op == TK_UPLUS) {
 			assert(expr->pLeft != NULL &&
 			       expr->pLeft->op == TK_INTEGER);
-			expr = expr->pLeft;
+			int_expr = expr->pLeft;
 		}
 		uint64_t val;
-		if (sql_expr_uint(expr, &val) == 0) {
+		if (sql_expr_uint(int_expr, &val) == 0) {
 			size = mp_sizeof_uint(val);
 			buf = xregion_alloc(region, size);
 			mp_encode_uint(buf, val);
 			break;
 		}
 		int errcode = ER_INT_LITERAL_MAX;
-		const char *str = expr->u.zToken;
+		const char *str = int_expr->u.zToken;
 		if (str[0] == '0' && (str[1] == 'x' || str[1] == 'X'))
 			errcode = ER_HEX_LITERAL_MAX;
 		diag_set(ClientError, errcode, str);
@@ -619,7 +620,7 @@ sql_add_term_default(struct Parse *parser, struct ExprSpan *expr_span)
 		assert(buf == NULL);
 		assert(size == 0);
 	}
-	sql_expr_delete(expr_span->pExpr);
+	sql_expr_delete(expr);
 	if (parser->is_aborted)
 		return;
 	struct space_def *def = parser->space->def;
@@ -1233,26 +1234,28 @@ vdbe_emit_ck_constraint_create(struct Parse *parser,
 	sqlVdbeCountChanges(v);
 }
 
+/** This function adds function to calculate default value for a column. */
 static void
-sql_add_func_default(struct Parse *parser, struct ExprSpan *span)
+sql_add_func_default(struct Parse *parser, struct Expr *expr, const char *str,
+		     uint32_t len)
 {
 	assert(parser->space != NULL);
 	struct space_def *def = parser->space->def;
 	uint32_t fieldno = def->field_count - 1;
 	const char *field_name = def->fields[fieldno].name;
 
-	if (!sqlExprIsConstantOrFunction(span->pExpr)) {
+	if (!sqlExprIsConstantOrFunction(expr)) {
 		diag_set(ClientError, ER_CREATE_SPACE, def->name,
 			 tt_sprintf("default value of column '%s' is not "
 				    "constant", field_name));
 		parser->is_aborted = true;
-		sql_expr_delete(span->pExpr);
+		sql_expr_delete(expr);
 		return;
 	}
-	sql_expr_delete(span->pExpr);
+	sql_expr_delete(expr);
 
 	char *name = sqlMPrintf("default_%s_%s", def->name, field_name);
-	char *body = sql_xstrndup(span->zStart, span->zEnd - span->zStart);
+	char *body = sql_xstrndup(str, len);
 	int reg_id = ++parser->nMem;
 	vdbe_emit_create_function(parser, reg_id, name, body);
 	sql_xfree(name);
@@ -1273,17 +1276,17 @@ sql_expr_is_number_term(const struct Expr *expr)
 }
 
 void
-sql_column_add_default(struct Parse *parser, struct ExprSpan *expr_span)
+sql_column_add_default(struct Parse *parser, struct Expr *expr, const char *str,
+		       uint32_t len)
 {
-	struct Expr *expr = expr_span->pExpr;
 	if (sql_expr_is_term(expr))
-		sql_add_term_default(parser, expr_span);
+		sql_add_term_default(parser, expr);
 	else if (expr->op == TK_UPLUS && sql_expr_is_number_term(expr->pLeft))
-		sql_add_term_default(parser, expr_span);
+		sql_add_term_default(parser, expr);
 	else if (expr->op == TK_UMINUS && sql_expr_is_number_term(expr->pLeft))
-		sql_add_term_default(parser, expr_span);
+		sql_add_term_default(parser, expr);
 	else
-		sql_add_func_default(parser, expr_span);
+		sql_add_func_default(parser, expr, str, len);
 }
 
 /**

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -1813,53 +1813,39 @@ sql_code_drop_table(struct Parse *parse_context, const struct space *space,
 	VdbeComment((v, "Delete entry from _space"));
 }
 
-/**
- * This routine is called to do the work of a DROP TABLE and
- * DROP VIEW statements.
- *
- * @param parse_context Current parsing context.
- */
 void
-sql_drop_table(struct Parse *parse_context)
+sql_drop_table(struct Parse *parse_context, struct Token *table, bool if_exists,
+	       bool is_view)
 {
-	struct drop_entity_def drop_def = parse_context->drop_table_def.base;
-	assert(drop_def.base.alter_action == ALTER_ACTION_DROP);
-	struct SrcList *table_name_list = drop_def.base.entity_name;
 	struct Vdbe *v = sqlGetVdbe(parse_context);
-	bool is_view = drop_def.base.entity_type == ENTITY_TYPE_VIEW;
-	assert(is_view || drop_def.base.entity_type == ENTITY_TYPE_TABLE);
 	sqlVdbeCountChanges(v);
 	assert(!parse_context->is_aborted);
-	assert(table_name_list->nSrc == 1);
-	const char *space_name = table_name_list->a[0].zName;
-	const struct space *space = sql_space_by_src(&table_name_list->a[0]);
+	const struct space *space = sql_space_by_token(table);
 	if (space == NULL) {
-		if (!drop_def.if_exist) {
-			diag_set(ClientError, ER_NO_SUCH_SPACE, space_name);
+		if (!if_exists) {
+			diag_set(ClientError, ER_NO_SUCH_SPACE,
+				 sql_tt_name_from_token(table));
 			parse_context->is_aborted = true;
 		}
-		goto exit_drop_table;
+		return;
 	}
 	/*
 	 * Ensure DROP TABLE is not used on a view,
 	 * and DROP VIEW is not used on a table.
 	 */
 	if (is_view && !space->def->opts.is_view) {
-		diag_set(ClientError, ER_DROP_SPACE, space_name,
-			 "use DROP TABLE");
+		diag_set(ClientError, ER_DROP_SPACE,
+			 sql_tt_name_from_token(table), "use DROP TABLE");
 		parse_context->is_aborted = true;
-		goto exit_drop_table;
+		return;
 	}
 	if (!is_view && space->def->opts.is_view) {
-		diag_set(ClientError, ER_DROP_SPACE, space_name,
-			 "use DROP VIEW");
+		diag_set(ClientError, ER_DROP_SPACE,
+			 sql_tt_name_from_token(table), "use DROP VIEW");
 		parse_context->is_aborted = true;
-		goto exit_drop_table;
+		return;
 	}
 	sql_code_drop_table(parse_context, space, is_view);
-
- exit_drop_table:
-	sqlSrcListDelete(table_name_list);
 }
 
 /**

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -1522,29 +1522,23 @@ vdbe_emit_create_table(struct Parse *pParse, bool if_not_exists)
 }
 
 void
-sql_create_view(struct Parse *parse_context)
+sql_create_view(struct Parse *parse_context, const char *sql,
+		struct Token *name, struct ExprList *aliases,
+		struct Select *view_select, bool if_not_exists)
 {
-	struct create_view_def *view_def = &parse_context->create_view_def;
-	struct create_entity_def *create_entity_def = &view_def->base;
-	struct alter_entity_def *alter_entity_def = &create_entity_def->base;
-	assert(alter_entity_def->entity_type == ENTITY_TYPE_VIEW);
-	assert(alter_entity_def->alter_action == ALTER_ACTION_CREATE);
-	(void) alter_entity_def;
 	if (parse_context->nVar > 0) {
-		char *name = sql_name_from_token(&create_entity_def->name);
-		diag_set(ClientError, ER_CREATE_SPACE, name,
+		diag_set(ClientError, ER_CREATE_SPACE,
+			 sql_tt_name_from_token(name),
 			 "parameters are not allowed in views");
-		sql_xfree(name);
 		parse_context->is_aborted = true;
 		goto create_view_fail;
 	}
-	struct space *space = sqlStartTable(parse_context,
-					    &create_entity_def->name);
+	struct space *space = sqlStartTable(parse_context, name);
 	if (space == NULL || parse_context->is_aborted)
 		goto create_view_fail;
 
 	/* Find result of SELECT. */
-	struct Select *select = view_def->select;
+	struct Select *select = view_select;
 	uint32_t saved_flags = parse_context->sql_flags;
 	parse_context->sql_flags = 0;
 	sqlSelectPrep(parse_context, select, 0);
@@ -1554,7 +1548,7 @@ sql_create_view(struct Parse *parse_context)
 		select = select->pPrior;
 	parse_context->sql_flags = saved_flags;
 
-	struct ExprList *columns = view_def->aliases;
+	struct ExprList *columns = aliases;
 	if (columns != NULL) {
 		if (select->pEList->nExpr != columns->nExpr) {
 			diag_set(ClientError, ER_CREATE_SPACE, space->def->name,
@@ -1563,7 +1557,7 @@ sql_create_view(struct Parse *parse_context)
 			parse_context->is_aborted = true;
 			goto create_view_fail;
 		}
-		select = view_def->select;
+		select = view_select;
 	} else {
 		columns = select->pEList;
 	}
@@ -1571,40 +1565,22 @@ sql_create_view(struct Parse *parse_context)
 	sqlSelectAddColumnTypeAndCollation(parse_context, space->def, select);
 
 	space->def->opts.is_view = true;
-	/*
-	 * Locate the end of the CREATE VIEW statement.
-	 * Make sEnd point to the end.
-	 */
-	struct Token end = parse_context->sLastToken;
-	assert(end.z[0] != 0);
-	if (end.z[0] != ';')
-		end.z += end.n;
-	end.n = 0;
-	struct Token *begin = view_def->create_start;
-	int n = end.z - begin->z;
-	assert(n > 0);
-	const char *z = begin->z;
-	while (sqlIsspace(z[n - 1]))
-		n--;
-	end.z = &z[n - 1];
-	end.n = 1;
-	space->def->opts.sql = xstrndup(begin->z, n);
-	const char *space_name = sql_name_from_token(&create_entity_def->name);
+	space->def->opts.sql = xstrdup(sql);
+	const char *space_name = sql_name_from_token(name);
 	int name_reg = ++parse_context->nMem;
 	sqlVdbeAddOp4(parse_context->pVdbe, OP_String8, 0, name_reg, 0,
 		      space_name, P4_DYNAMIC);
-	bool no_err = create_entity_def->if_not_exist;
 	vdbe_emit_halt_with_presence_test(parse_context, BOX_SPACE_ID, 2,
 					  name_reg, 1, ER_SPACE_EXISTS,
-					  space_name, (no_err != 0),
+					  space_name, if_not_exists,
 					  OP_NoConflict);
 	vdbe_emit_space_create(parse_context, getNewSpaceId(parse_context),
 			       name_reg, space);
 	free(space->def->opts.sql);
 
  create_view_fail:
-	sql_expr_list_delete(view_def->aliases);
-	sql_select_delete(view_def->select);
+	sql_expr_list_delete(aliases);
+	sql_select_delete(view_select);
 	return;
 }
 

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -788,22 +788,16 @@ ck_constraint_def_sizeof(uint32_t name_len, uint32_t expr_str_len,
 }
 
 void
-sql_create_check_contraint(struct Parse *parser, bool is_field_ck)
+sql_create_check_constraint(struct Parse *parser, struct Token *table,
+			    struct Token *name_token, const char *expr_str,
+			    uint32_t expr_str_len, bool is_field_ck)
 {
-	struct create_ck_def *create_ck_def = &parser->create_ck_def;
-	struct ExprSpan *expr_span = create_ck_def->expr;
-	sql_expr_delete(expr_span->pExpr);
-
-	struct alter_entity_def *alter_def =
-		(struct alter_entity_def *) create_ck_def;
-	assert(alter_def->entity_type == ENTITY_TYPE_CK);
 	struct space *space = parser->create_column_def.space;
 	if (space == NULL)
 		space = parser->create_table_def.new_space;
 	bool is_alter_add_constr = space == NULL;
 
 	/* Prepare payload for ck constraint definition. */
-	struct Token *name_token = &create_ck_def->base.base.name;
 	char *name;
 	if (name_token->n != 0)
 		name = sql_name_from_token(name_token);
@@ -811,9 +805,6 @@ sql_create_check_contraint(struct Parse *parser, bool is_field_ck)
 		name = sql_ck_unique_name_new(parser, is_field_ck);
 	assert(name != NULL);
 	size_t name_len = strlen(name);
-
-	uint32_t expr_str_len = (uint32_t)(expr_span->zEnd - expr_span->zStart);
-	const char *expr_str = expr_span->zStart;
 
 	/*
 	 * Allocate memory for ck constraint parse structure and
@@ -854,11 +845,11 @@ sql_create_check_contraint(struct Parse *parser, bool is_field_ck)
 	sql_xfree(name);
 	ck_def->name[name_len] = '\0';
 	if (is_alter_add_constr) {
-		const struct space *space =
-			sql_space_by_src(&alter_def->entity_name->a[0]);
+		assert(table != NULL);
+		const struct space *space = sql_space_by_token(table);
 		if (space == NULL) {
 			diag_set(ClientError, ER_NO_SUCH_SPACE,
-				 alter_def->entity_name->a[0].zName);
+				 sql_tt_name_from_token(table));
 			parser->is_aborted = true;
 			return;
 		}

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -654,17 +654,9 @@ field_def_create_for_pk(struct Parse *parser, struct field_def *field,
 	return 0;
 }
 
-/*
- * Designate the PRIMARY KEY for the table.  pList is a list of names
- * of columns that form the primary key.  If pList is NULL, then the
- * most recently added column of the table is the primary key.
- *
- * A table can have at most one primary key.  If the table already has
- * a primary key (and this is the second primary key) then create an
- * error.
- */
 void
-sqlAddPrimaryKey(struct Parse *pParse)
+sqlAddPrimaryKey(struct Parse *pParse, struct Token *name,
+		 struct ExprList *col_list, enum sort_order sort_order)
 {
 	struct space *space = pParse->create_table_def.new_space;
 	if (space == NULL)
@@ -674,10 +666,11 @@ sqlAddPrimaryKey(struct Parse *pParse)
 		diag_set(ClientError, ER_CREATE_SPACE, space->def->name,
 			 "primary key has been already declared");
 		pParse->is_aborted = true;
-		sql_expr_list_delete(pParse->create_index_def.cols);
+		sql_expr_list_delete(col_list);
 		return;
 	}
-	sql_create_index(pParse);
+	sql_create_index(pParse, &Token_nil, name, col_list,
+			 SQL_INDEX_TYPE_CONSTRAINT_PK, sort_order, false);
 	if (pParse->is_aborted)
 		return;
 
@@ -2693,27 +2686,17 @@ constraint_is_named(const char *name)
 }
 
 void
-sql_create_index(struct Parse *parse) {
+sql_create_index(struct Parse *parse, struct Token *table, struct Token *name,
+		 struct ExprList *col_list, enum sql_index_type idx_type,
+		 enum sort_order sort_order, bool if_not_exists)
+{
 	/* The index to be created. */
 	struct index *index = NULL;
 	/* Name of the index. */
-	char *name = NULL;
-	struct create_index_def *create_idx_def = &parse->create_index_def;
-	struct create_entity_def *create_entity_def = &create_idx_def->base.base;
-	struct alter_entity_def *alter_entity_def = &create_entity_def->base;
-	assert(alter_entity_def->entity_type == ENTITY_TYPE_INDEX);
-	assert(alter_entity_def->alter_action == ALTER_ACTION_CREATE);
-	/*
-	 * Get list of columns to be indexed. It will be NULL if
-	 * this is a primary key or unique-constraint on the most
-	 * recent column added to the table under construction.
-	 */
-	struct ExprList *col_list = create_idx_def->cols;
-	struct SrcList *tbl_name = alter_entity_def->entity_name;
+	char *index_name = NULL;
 
 	if (parse->is_aborted)
 		goto exit_create_index;
-	enum sql_index_type idx_type = create_idx_def->idx_type;
 	if (idx_type == SQL_INDEX_TYPE_UNIQUE ||
 	    idx_type == SQL_INDEX_TYPE_NON_UNIQUE) {
 		Vdbe *v = sqlGetVdbe(parse);
@@ -2728,21 +2711,18 @@ sql_create_index(struct Parse *parse) {
 	if (space == NULL)
 		space = parse->create_column_def.space;
 	bool is_create_table_or_add_col = space != NULL;
-	struct Token token = create_entity_def->name;
-	if (tbl_name != NULL) {
-		assert(token.n > 0 && token.z != NULL);
-		const struct space *origin = sql_space_by_src(&tbl_name->a[0]);
+	if (!is_create_table_or_add_col) {
+		assert(table != NULL && table->n > 0);
+		const struct space *origin = sql_space_by_token(table);
 		if (origin == NULL) {
-			if (! create_entity_def->if_not_exist) {
+			if (!if_not_exists) {
 				diag_set(ClientError, ER_NO_SUCH_SPACE,
-					 tbl_name->a[0].zName);
+					 sql_tt_name_from_token(table));
 				parse->is_aborted = true;
 			}
 			goto exit_create_index;
 		}
 		space = space_by_id(origin->def->id);
-	} else if (!is_create_table_or_add_col) {
-		goto exit_create_index;
 	}
 	struct space_def *def = space->def;
 
@@ -2777,22 +2757,20 @@ sql_create_index(struct Parse *parse) {
 	 *    auto-index name will be generated.
 	 */
 	if (!is_create_table_or_add_col) {
-		assert(token.z != NULL);
-		name = sql_name_from_token(&token);
-		if (space_index_by_name0(space, name) != NULL) {
-			if (! create_entity_def->if_not_exist) {
+		assert(name->z != NULL);
+		index_name = sql_name_from_token(name);
+		if (space_index_by_name0(space, index_name) != NULL) {
+			if (!if_not_exists) {
 				diag_set(ClientError, ER_INDEX_EXISTS_IN_SPACE,
-					 name, def->name);
+					 index_name, def->name);
 				parse->is_aborted = true;
 			}
 			goto exit_create_index;
 		}
 	} else {
 		char *constraint_name = NULL;
-		if (create_entity_def->name.n > 0) {
-			constraint_name =
-				sql_name_from_token(&create_entity_def->name);
-		}
+		if (name->n > 0)
+			constraint_name = sql_name_from_token(name);
 
 	       /*
 		* This naming is temporary. Now it's not
@@ -2807,24 +2785,26 @@ sql_create_index(struct Parse *parse) {
 		uint32_t idx_count = space->index_count;
 		if (constraint_name == NULL) {
 			if (idx_type == SQL_INDEX_TYPE_CONSTRAINT_UNIQUE) {
-				name = sqlMPrintf("unique_unnamed_%s_%d",
-						  def->name, idx_count + 1);
+				index_name = sqlMPrintf("unique_unnamed_%s_%d",
+							def->name,
+							idx_count + 1);
 			} else {
-				name = sqlMPrintf("pk_unnamed_%s_%d",
-						  def->name, idx_count + 1);
+				index_name = sqlMPrintf("pk_unnamed_%s_%d",
+							def->name,
+							idx_count + 1);
 			}
 		} else {
-			name = sql_xstrdup(constraint_name);
+			index_name = sql_xstrdup(constraint_name);
 		}
 		sql_xfree(constraint_name);
 	}
 
-	assert(name != NULL);
-	if (sqlCheckIdentifierName(parse, name) != 0)
+	assert(index_name != NULL);
+	if (sqlCheckIdentifierName(parse, index_name) != 0)
 		goto exit_create_index;
 
-	if (tbl_name != NULL && space_is_system(space)) {
-		diag_set(ClientError, ER_MODIFY_INDEX, name, def->name,
+	if (table->n > 0 && space_is_system(space)) {
+		diag_set(ClientError, ER_MODIFY_INDEX, index_name, def->name,
 			 "can't create index on system space");
 		parse->is_aborted = true;
 		goto exit_create_index;
@@ -2843,7 +2823,7 @@ sql_create_index(struct Parse *parse) {
 		struct Expr *expr = sql_expr_new(TK_ID, &prev_col);
 		col_list = sql_expr_list_append(NULL, expr);
 		assert(col_list->nExpr == 1);
-		sqlExprListSetSortOrder(col_list, create_idx_def->sort_order);
+		sqlExprListSetSortOrder(col_list, sort_order);
 	} else {
 		if (col_list->nExpr > SQL_MAX_COLUMN) {
 			diag_set(ClientError, ER_SQL_PARSER_LIMIT,
@@ -2866,8 +2846,8 @@ sql_create_index(struct Parse *parse) {
 		iid = space->index_id_max + 1;
 	else
 		iid = 0;
-	if (index_fill_def(parse, index, def, iid, name, strlen(name),
-			   col_list, idx_type) != 0)
+	if (index_fill_def(parse, index, def, iid, index_name,
+			   strlen(index_name), col_list, idx_type) != 0)
 		goto exit_create_index;
 	/*
 	 * Remove all redundant columns from the PRIMARY KEY.
@@ -2962,7 +2942,6 @@ sql_create_index(struct Parse *parse) {
 			    !constraint_is_named(index->def->name))
 				goto exit_create_index;
 		}
-	}
 
 	/*
 	 * If this is the initial CREATE INDEX statement (or
@@ -2972,13 +2951,13 @@ sql_create_index(struct Parse *parse) {
 	 * we are simply parsing the schema, or if this index is
 	 * the PRIMARY KEY index.
 	 *
-	 * If tbl_name == NULL it means this index is generated as
+	 * If table == Token_nil it means this index is generated as
 	 * an implied PRIMARY KEY or UNIQUE index in a CREATE
 	 * TABLE statement.  Since the table has just been
 	 * created, it contains no data and the index
 	 * initialization step can be skipped.
 	 */
-	else if (tbl_name != NULL) {
+	} else {
 		Vdbe *vdbe;
 		int cursor = parse->nTab++;
 
@@ -3034,8 +3013,7 @@ sql_create_index(struct Parse *parse) {
 	if (index != NULL && index->def != NULL)
 		index_def_delete(index->def);
 	sql_expr_list_delete(col_list);
-	sqlSrcListDelete(tbl_name);
-	sql_xfree(name);
+	sql_xfree(index_name);
 }
 
 void

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -298,26 +298,22 @@ sql_shallow_space_copy(struct Parse *parse, const struct space *space)
 }
 
 void
-sql_create_column_start(struct Parse *parse)
+sql_create_column_start(struct Parse *parse, struct Token *table,
+			struct Token *name, enum field_type type)
 {
-	struct create_column_def *create_column_def = &parse->create_column_def;
-	struct alter_entity_def *alter_entity_def =
-		&create_column_def->base.base;
-	assert(alter_entity_def->entity_type == ENTITY_TYPE_COLUMN);
-	assert(alter_entity_def->alter_action == ALTER_ACTION_CREATE);
 	struct space *space = parse->create_table_def.new_space;
 	bool is_alter = space == NULL;
 	if (is_alter) {
-		const struct space *origin =
-			sql_space_by_src(&alter_entity_def->entity_name->a[0]);
+		const struct space *origin = sql_space_by_token(table);
 		if (origin == NULL) {
 			diag_set(ClientError, ER_NO_SUCH_SPACE,
-				 alter_entity_def->entity_name->a[0].zName);
-			goto tnt_error;
+				 sql_tt_name_from_token(table));
+			parse->is_aborted = true;
+			return;
 		}
 		space = sql_shallow_space_copy(parse, origin);
 	}
-	create_column_def->space = space;
+	parse->space = space;
 	struct space_def *def = space->def;
 	assert(def->opts.is_ephemeral);
 
@@ -325,11 +321,11 @@ sql_create_column_start(struct Parse *parse)
 	if ((int)def->field_count + 1 > SQL_MAX_COLUMN) {
 		diag_set(ClientError, ER_SQL_COLUMN_COUNT_MAX, def->name,
 			 def->field_count + 1, SQL_MAX_COLUMN);
-		goto tnt_error;
+		parse->is_aborted = true;
+		return;
 	}
 #endif
 
-	struct Token *name = &create_column_def->base.name;
 	char *column_name = sql_name_temp(parse, name->z, name->n);
 
 	/*
@@ -350,14 +346,8 @@ sql_create_column_start(struct Parse *parse)
 	 */
 	column_def->nullable_action = ON_CONFLICT_ACTION_DEFAULT;
 	column_def->is_nullable = true;
-	column_def->type = create_column_def->type;
+	column_def->type = type;
 	def->field_count++;
-
-	sqlSrcListDelete(alter_entity_def->entity_name);
-	return;
-tnt_error:
-	parse->is_aborted = true;
-	sqlSrcListDelete(alter_entity_def->entity_name);
 }
 
 static void
@@ -378,7 +368,7 @@ vdbe_emit_create_defaults(struct Parse *parser, int reg_space_id)
 void
 sql_create_column_end(struct Parse *parse)
 {
-	struct space *space = parse->create_column_def.space;
+	struct space *space = parse->space;
 	assert(space != NULL);
 	struct space_def *def = space->def;
 	struct field_def *field = &def->fields[def->field_count - 1];
@@ -440,8 +430,8 @@ void
 sql_column_add_nullable_action(struct Parse *parser,
 			       enum on_conflict_action nullable_action)
 {
-	assert(parser->create_column_def.space != NULL);
-	struct space_def *def = parser->create_column_def.space->def;
+	assert(parser->space != NULL);
+	struct space_def *def = parser->space->def;
 	assert(def->field_count > 0);
 	struct field_def *field = &def->fields[def->field_count - 1];
 	if (field->nullable_action != ON_CONFLICT_ACTION_DEFAULT &&
@@ -497,7 +487,7 @@ sql_expr_uint(const struct Expr *expr, uint64_t *res)
 static void
 sql_add_term_default(struct Parse *parser, struct ExprSpan *expr_span)
 {
-	assert(parser->create_column_def.space != NULL);
+	assert(parser->space != NULL);
 	char *buf = NULL;
 	uint32_t size = 0;
 	struct region *region = &parser->region;
@@ -632,7 +622,7 @@ sql_add_term_default(struct Parse *parser, struct ExprSpan *expr_span)
 	sql_expr_delete(expr_span->pExpr);
 	if (parser->is_aborted)
 		return;
-	struct space_def *def = parser->create_column_def.space->def;
+	struct space_def *def = parser->space->def;
 	struct field_def *field = &def->fields[def->field_count - 1];
 	field->default_value = buf;
 	field->default_value_size = size;
@@ -660,7 +650,7 @@ sqlAddPrimaryKey(struct Parse *pParse, struct Token *name,
 {
 	struct space *space = pParse->create_table_def.new_space;
 	if (space == NULL)
-		space = pParse->create_column_def.space;
+		space = pParse->space;
 	assert(space != NULL);
 	if (sql_space_primary_key(space) != NULL) {
 		diag_set(ClientError, ER_CREATE_SPACE, space->def->name,
@@ -733,7 +723,7 @@ vdbe_emit_ck_constraint_create(struct Parse *parser,
 static char *
 sql_ck_unique_name_new(struct Parse *parse, bool is_field_ck)
 {
-	struct space *space = parse->create_column_def.space;
+	struct space *space = parse->space;
 	if (space == NULL)
 		space = parse->create_table_def.new_space;
 	assert(space != NULL);
@@ -792,7 +782,7 @@ sql_create_check_constraint(struct Parse *parser, struct Token *table,
 			    struct Token *name_token, const char *expr_str,
 			    uint32_t expr_str_len, bool is_field_ck)
 {
-	struct space *space = parser->create_column_def.space;
+	struct space *space = parser->space;
 	if (space == NULL)
 		space = parser->create_table_def.new_space;
 	bool is_alter_add_constr = space == NULL;
@@ -880,7 +870,7 @@ sqlAddCollateType(Parse * pParse, Token * pToken)
 		return;
 	}
 
-	struct space *space = pParse->create_column_def.space;
+	struct space *space = pParse->space;
 	assert(space != NULL);
 	uint32_t fieldno = space->def->field_count - 1;
 	space->def->fields[fieldno].coll_id = coll_id;
@@ -995,8 +985,7 @@ vdbe_emit_create_index(struct Parse *parse, struct space_def *def,
 	memcpy(raw, index_parts, index_parts_sz);
 	index_parts = raw;
 
-	if (parse->create_table_def.new_space != NULL ||
-	    parse->create_column_def.space != NULL) {
+	if (parse->create_table_def.new_space != NULL || parse->space != NULL) {
 		sqlVdbeAddOp2(v, OP_SCopy, space_id_reg, entry_reg);
 		sqlVdbeAddOp2(v, OP_Integer, idx_def->iid, entry_reg + 1);
 	} else {
@@ -1247,8 +1236,8 @@ vdbe_emit_ck_constraint_create(struct Parse *parser,
 static void
 sql_add_func_default(struct Parse *parser, struct ExprSpan *span)
 {
-	assert(parser->create_column_def.space != NULL);
-	struct space_def *def = parser->create_column_def.space->def;
+	assert(parser->space != NULL);
+	struct space_def *def = parser->space->def;
 	uint32_t fieldno = def->field_count - 1;
 	const char *field_name = def->fields[fieldno].name;
 
@@ -1331,7 +1320,7 @@ vdbe_emit_fk_constraint_create(struct Parse *parse_context,
 	 */
 	bool is_alter_add_constr =
 		parse_context->create_table_def.new_space == NULL &&
-		parse_context->create_column_def.space == NULL;
+		parse_context->space == NULL;
 	if (!is_alter_add_constr)
 		sqlVdbeAddOp2(vdbe, OP_SCopy, fk->child_id, regs);
 	else
@@ -1399,7 +1388,7 @@ vdbe_emit_create_constraints(struct Parse *parse, int reg_space_id)
 	 * (inside ephemeral space).
 	 */
 	if (is_alter) {
-		space = parse->create_column_def.space;
+		space = parse->space;
 		assert(space->def->id != 0);
 		i = space_by_id(space->def->id)->index_count;
 	}
@@ -1858,7 +1847,7 @@ columnno_by_name(struct Parse *parse_context, const struct space *space,
 static char *
 sql_fk_unique_name_new(struct Parse *parse, struct ExprList *child_cols)
 {
-	struct space *space = parse->create_column_def.space;
+	struct space *space = parse->space;
 	if (space == NULL)
 		space = parse->create_table_def.new_space;
 	assert(space != NULL);
@@ -1918,7 +1907,7 @@ sql_create_foreign_key(struct Parse *parse_context, struct Token *table,
 	char *parent_name = NULL;
 	char *constraint_name = NULL;
 	bool is_self_referenced = false;
-	struct space *space = parse_context->create_column_def.space;
+	struct space *space = parse_context->space;
 	struct create_table_def *table_def = &parse_context->create_table_def;
 	if (space == NULL)
 		space = table_def->new_space;
@@ -2694,7 +2683,7 @@ sql_create_index(struct Parse *parse, struct Token *table, struct Token *name,
 	 */
 	struct space *space = parse->create_table_def.new_space;
 	if (space == NULL)
-		space = parse->create_column_def.space;
+		space = parse->space;
 	bool is_create_table_or_add_col = space != NULL;
 	if (!is_create_table_or_add_col) {
 		assert(table != NULL && table->n > 0);

--- a/src/box/sql/build.c
+++ b/src/box/sql/build.c
@@ -1856,7 +1856,7 @@ columnno_by_name(struct Parse *parse_context, const struct space *space,
 
 /** Generate unique name for foreign key constraint. */
 static char *
-sql_fk_unique_name_new(struct Parse *parse)
+sql_fk_unique_name_new(struct Parse *parse, struct ExprList *child_cols)
 {
 	struct space *space = parse->create_column_def.space;
 	if (space == NULL)
@@ -1866,7 +1866,7 @@ sql_fk_unique_name_new(struct Parse *parse)
 	struct fk_constraint_parse *fk;
 	struct rlist *fkeys = &parse->create_fk_constraint_parse_def.fkeys;
 	uint32_t n = 1;
-	if (parse->create_fk_def.child_cols != NULL) {
+	if (child_cols != NULL) {
 		rlist_foreach_entry(fk, fkeys, link) {
 			if (!fk->fk_def->is_field_fk)
 				++n;
@@ -1907,14 +1907,10 @@ fk_constraint_def_sizeof(uint32_t link_count, uint32_t name_len,
 }
 
 void
-sql_create_foreign_key(struct Parse *parse_context)
+sql_create_foreign_key(struct Parse *parse_context, struct Token *table,
+		       struct Token *name, struct ExprList *child_cols,
+		       struct Token *parent, struct ExprList *parent_cols)
 {
-	struct create_fk_def *create_fk_def = &parse_context->create_fk_def;
-	struct create_constraint_def *create_constr_def = &create_fk_def->base;
-	struct create_entity_def *create_def = &create_constr_def->base;
-	struct alter_entity_def *alter_def = &create_def->base;
-	assert(alter_def->entity_type == ENTITY_TYPE_FK);
-	assert(alter_def->alter_action == ALTER_ACTION_CREATE);
 	/*
 	 * Beforehand initialization for correct clean-up
 	 * while emergency exiting in case of error.
@@ -1934,26 +1930,25 @@ sql_create_foreign_key(struct Parse *parse_context)
 	 */
 	bool is_alter_add_constr = space == NULL;
 	uint32_t child_cols_count;
-	struct ExprList *child_cols = create_fk_def->child_cols;
 	if (child_cols == NULL) {
 		assert(!is_alter_add_constr);
 		child_cols_count = 1;
 	} else {
 		child_cols_count = child_cols->nExpr;
 	}
-	struct ExprList *parent_cols = create_fk_def->parent_cols;
 	struct space *child_space = NULL;
-	if (create_def->name.n != 0)
-		constraint_name = sql_name_from_token(&create_def->name);
-	else
-		constraint_name = sql_fk_unique_name_new(parse_context);
+	if (name->n != 0) {
+		constraint_name = sql_name_from_token(name);
+	} else {
+		constraint_name = sql_fk_unique_name_new(parse_context,
+							 child_cols);
+	}
 	assert(constraint_name != NULL);
 	if (is_alter_add_constr) {
-		const struct space *origin =
-			sql_space_by_src(&alter_def->entity_name->a[0]);
+		const struct space *origin = sql_space_by_token(table);
 		if (origin == NULL) {
 			diag_set(ClientError, ER_NO_SUCH_SPACE,
-				 alter_def->entity_name->a[0].zName);
+				 sql_tt_name_from_token(table));
 			goto tnt_error;
 		}
 		child_space = space_by_id(origin->def->id);
@@ -1972,7 +1967,6 @@ sql_create_foreign_key(struct Parse *parse_context)
 			&parse_context->create_fk_constraint_parse_def.fkeys;
 		rlist_add_entry(fkeys, fk_parse, link);
 	}
-	struct Token *parent = create_fk_def->parent_name;
 	assert(parent != NULL);
 	parent_name = sql_name_from_token(parent);
 	/*

--- a/src/box/sql/delete.c
+++ b/src/box/sql/delete.c
@@ -82,31 +82,25 @@ sql_materialize_view(struct Parse *parse, const char *name, struct Expr *where,
 }
 
 void
-sql_table_truncate(struct Parse *parse, struct SrcList *tab_list)
+sql_table_truncate(struct Parse *parse, struct Token *table)
 {
-	assert(tab_list->nSrc == 1);
-
 	struct Vdbe *v = sqlGetVdbe(parse);
-	const struct space *space = sql_space_by_src(&tab_list->a[0]);
+	const struct space *space = sql_space_by_token(table);
 	if (space == NULL) {
-		diag_set(ClientError, ER_NO_SUCH_SPACE, tab_list->a[0].zName);
-		goto tarantool_error;
+		diag_set(ClientError, ER_NO_SUCH_SPACE,
+			 sql_tt_name_from_token(table));
+		parse->is_aborted = true;
+		return;
 	}
 	if (space->def->opts.is_view) {
 		const char *err_msg =
 			tt_sprintf("can not truncate space '%s' because space "\
 				   "is a view", space->def->name);
 		diag_set(ClientError, ER_SQL_EXECUTE, err_msg);
-		goto tarantool_error;
+		parse->is_aborted = true;
+		return;
 	}
 	sqlVdbeAddOp2(v, OP_Clear, space->def->id, true);
-	sqlSrcListDelete(tab_list);
-	return;
-
-tarantool_error:
-	parse->is_aborted = true;
-	sqlSrcListDelete(tab_list);
-	return;
 }
 
 void

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -176,12 +176,14 @@ cmd ::= ROLLBACK TO savepoint_opt nm(X). {
 
 ///////////////////// The CREATE TABLE statement ////////////////////////////
 //
-cmd ::= create_table create_table_args with_opts create_table_end.
-create_table ::= createkw TABLE ifnotexists(E) nm(Y). {
-  create_table_def_init(&pParse->create_table_def, &Y, E);
+cmd ::= createkw TABLE ifnotexists(E) create_table create_table_args
+        with_opts. {
+  vdbe_emit_create_table(pParse, E);
+}
+create_table ::= nm(Y). {
   create_ck_constraint_parse_def_init(&pParse->create_ck_constraint_parse_def);
   create_fk_constraint_parse_def_init(&pParse->create_fk_constraint_parse_def);
-  pParse->create_table_def.new_space = sqlStartTable(pParse, &Y);
+  pParse->new_space = sqlStartTable(pParse, &Y);
   pParse->initiateTTrans = true;
 }
 createkw(A) ::= CREATE(A).  {disableLookaside(pParse);}
@@ -198,30 +200,17 @@ with_opts ::= .
 engine_opts ::= ENGINE EQ STRING(A). {
   /* Note that specifying engine clause overwrites default engine. */
   if (A.n > ENGINE_NAME_MAX) {
-    diag_set(ClientError, ER_CREATE_SPACE,
-             pParse->create_table_def.new_space->def->name,
+    diag_set(ClientError, ER_CREATE_SPACE, pParse->new_space->def->name,
              "space engine name is too long");
     pParse->is_aborted = true;
     return;
   }
   /* Need to dequote name. */
   char *normalized_name = sql_name_from_token(&A);
-  memcpy(pParse->create_table_def.new_space->def->engine_name, normalized_name,
+  memcpy(pParse->new_space->def->engine_name, normalized_name,
          strlen(normalized_name) + 1);
   sql_xfree(normalized_name);
 }
-
-create_table_end ::= . { sqlEndTable(pParse); }
-
-/*
- * CREATE TABLE AS SELECT is broken. To be re-implemented
- * in gh-3223.
- *
- * create_table_args ::= AS select(S). {
- *   sqlEndTable(pParse);
- *   sql_select_delete(S);
- * }
- */
 
 columnlist ::= columnlist COMMA tcons.
 columnlist ::= columnlist COMMA column_def create_column_end.
@@ -237,7 +226,7 @@ create_column_end ::= autoinc(I). {
   uint32_t fieldno = pParse->space->def->field_count - 1;
   if (I == 1 && sql_add_autoincrement(pParse, fieldno) != 0)
     return;
-  if (pParse->create_table_def.new_space == NULL)
+  if (pParse->new_space == NULL)
     sql_create_column_end(pParse);
 }
 columnlist ::= tcons.

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -230,12 +230,11 @@ columnlist ::= column_def create_column_end.
 column_def ::= column_name_and_type carglist.
 
 column_name_and_type ::= nm(A) typedef(Y). {
-  create_column_def_init(&pParse->create_column_def, NULL, &A, Y);
-  sql_create_column_start(pParse);
+  sql_create_column_start(pParse, NULL, &A, Y);
 }
 
 create_column_end ::= autoinc(I). {
-  uint32_t fieldno = pParse->create_column_def.space->def->field_count - 1;
+  uint32_t fieldno = pParse->space->def->field_count - 1;
   if (I == 1 && sql_add_autoincrement(pParse, fieldno) != 0)
     return;
   if (pParse->create_table_def.new_space == NULL)
@@ -1499,11 +1498,9 @@ cmd ::= alter_column_def carglist create_column_end.
 
 alter_column_def ::= ALTER TABLE nm(T) ADD column_name(N) typedef(Y). {
   pParse->initiateTTrans = true;
-  struct SrcList *table = sql_src_list_append(NULL, &T);
-  create_column_def_init(&pParse->create_column_def, table, &N, Y);
   create_ck_constraint_parse_def_init(&pParse->create_ck_constraint_parse_def);
   create_fk_constraint_parse_def_init(&pParse->create_fk_constraint_parse_def);
-  sql_create_column_start(pParse);
+  sql_create_column_start(pParse, &T, &N, Y);
 }
 
 cmd ::= ALTER TABLE nm(X) ADD CONSTRAINT nm(N) FOREIGN KEY

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -389,18 +389,14 @@ resolvetype(A) ::= REPLACE.                  {A = ON_CONFLICT_ACTION_REPLACE;}
 ////////////////////////// The DROP TABLE /////////////////////////////////////
 //
 
-cmd ::= DROP TABLE ifexists(E) fullname(X) . {
-  struct Token t = Token_nil;
-  drop_table_def_init(&pParse->drop_table_def, X, &t, E);
+cmd ::= DROP TABLE ifexists(E) nm(X) . {
   pParse->initiateTTrans = true;
-  sql_drop_table(pParse);
+  sql_drop_table(pParse, &X, E, false);
 }
 
-cmd ::= DROP VIEW ifexists(E) fullname(X) . {
-  struct Token t = Token_nil;
-  drop_view_def_init(&pParse->drop_view_def, X, &t, E);
+cmd ::= DROP VIEW ifexists(E) nm(X) . {
   pParse->initiateTTrans = true;
-  sql_drop_table(pParse);
+  sql_drop_table(pParse, &X, E, true);
 }
 
 %type ifexists {int}

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -386,12 +386,10 @@ ifexists(A) ::= .            {A = 0;}
 
 ///////////////////// The CREATE VIEW statement /////////////////////////////
 //
-cmd ::= createkw(X) VIEW ifnotexists(E) nm(Y) eidlist_opt(C)
-          AS select_old(S). {
+cmd ::= createkw VIEW ifnotexists(E) nm(Y) eidlist_opt(C) AS select_old(S). {
   if (!pParse->parse_only) {
-    create_view_def_init(&pParse->create_view_def, &Y, &X, C, S, E);
     pParse->initiateTTrans = true;
-    sql_create_view(pParse);
+    sql_create_view(pParse, pParse->zTail, &Y, C, S, E);
   } else {
     sql_expr_list_delete(C);
     pParse->parsed_ast_type = AST_TYPE_SELECT;

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -335,8 +335,7 @@ ccons ::= cconsname(N) CHECK LP expr_old(X) RP. {
 }
 
 ccons ::= cconsname(N) REFERENCES nm(T) eidlist_opt(TA). {
-  create_fk_def_init(&pParse->create_fk_def, NULL, &N, NULL, &T, TA);
-  sql_create_foreign_key(pParse);
+  sql_create_foreign_key(pParse, NULL, &N, NULL, &T, TA);
 }
 ccons ::= COLLATE id(C).        {sqlAddCollateType(pParse, &C);}
 
@@ -362,8 +361,7 @@ tcons ::= cconsname(N) CHECK LP expr_old(X) RP. {
 }
 tcons ::= cconsname(N) FOREIGN KEY LP eidlist(FA) RP
           REFERENCES nm(T) eidlist_opt(TA). {
-  create_fk_def_init(&pParse->create_fk_def, NULL, &N, FA, &T, TA);
-  sql_create_foreign_key(pParse);
+  sql_create_foreign_key(pParse, NULL, &N, FA, &T, TA);
 }
 
 // The following is a non-standard extension that allows us to declare the
@@ -1511,9 +1509,7 @@ alter_column_def ::= ALTER TABLE nm(T) ADD column_name(N) typedef(Y). {
 cmd ::= ALTER TABLE nm(X) ADD CONSTRAINT nm(N) FOREIGN KEY
         LP eidlist(FA) RP REFERENCES nm(T) eidlist_opt(TA). {
   pParse->initiateTTrans = true;
-  struct SrcList *table = sql_src_list_append(NULL, &X);
-  create_fk_def_init(&pParse->create_fk_def, table, &N, FA, &T, TA);
-  sql_create_foreign_key(pParse);
+  sql_create_foreign_key(pParse, &X, &N, FA, &T, TA);
 }
 
 cmd ::= ALTER TABLE nm(T) ADD CONSTRAINT nm(N) CHECK LP expr_old(X) RP. {

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1326,10 +1326,9 @@ eidlist(A) ::= nm(Y). {
 
 ///////////////////////////// The DROP INDEX command /////////////////////////
 //
-cmd ::= DROP INDEX ifexists(E) nm(X) ON fullname(Y).   {
-  drop_index_def_init(&pParse->drop_index_def, Y, &X, E);
+cmd ::= DROP INDEX ifexists(E) nm(X) ON nm(Y). {
   pParse->initiateTTrans = true;
-  sql_drop_index(pParse);
+  sql_drop_index(pParse, &X, &Y, E);
 }
 
 ///////////////////////////// The SET SESSION command ////////////////////////

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -329,8 +329,9 @@ ccons ::= cconsname(N) UNIQUE. {
 }
 
 ccons ::= cconsname(N) CHECK LP expr_old(X) RP. {
-  create_ck_def_init(&pParse->create_ck_def, NULL, &N, &X);
-  sql_create_check_contraint(pParse, true);
+  sql_expr_delete(X.pExpr);
+  sql_create_check_constraint(pParse, NULL, &N, X.zStart, X.zEnd - X.zStart,
+                              true);
 }
 
 ccons ::= cconsname(N) REFERENCES nm(T) eidlist_opt(TA). {
@@ -355,8 +356,9 @@ tcons ::= cconsname(N) UNIQUE LP sortlist_old(X) RP. {
                    SORT_ORDER_ASC, false);
 }
 tcons ::= cconsname(N) CHECK LP expr_old(X) RP. {
-  create_ck_def_init(&pParse->create_ck_def, NULL, &N, &X);
-  sql_create_check_contraint(pParse, false);
+  sql_expr_delete(X.pExpr);
+  sql_create_check_constraint(pParse, NULL, &N, X.zStart, X.zEnd - X.zStart,
+                              false);
 }
 tcons ::= cconsname(N) FOREIGN KEY LP eidlist(FA) RP
           REFERENCES nm(T) eidlist_opt(TA). {
@@ -1515,10 +1517,10 @@ cmd ::= ALTER TABLE nm(X) ADD CONSTRAINT nm(N) FOREIGN KEY
 }
 
 cmd ::= ALTER TABLE nm(T) ADD CONSTRAINT nm(N) CHECK LP expr_old(X) RP. {
+  sql_expr_delete(X.pExpr);
   pParse->initiateTTrans = true;
-  struct SrcList *table = sql_src_list_append(NULL, &T);
-  create_ck_def_init(&pParse->create_ck_def, table, &N, &X);
-    sql_create_check_contraint(pParse, false);
+  sql_create_check_constraint(pParse, &T, &N, X.zStart, X.zEnd - X.zStart,
+                              false);
 }
 
 cmd ::= ALTER TABLE nm(T) ADD CONSTRAINT nm(N) UNIQUE LP sortlist_old(X) RP. {

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1346,21 +1346,18 @@ cmd ::= SHOW CREATE TABLE. {
 
 //////////////////////////// The CREATE TRIGGER command /////////////////////
 
-cmd ::= createkw trigger_decl(A) BEGIN trigger_cmd_list(S) END(Z). {
-  Token all;
-  all.z = A.z;
-  all.n = (int)(Z.z - A.z) + Z.n;
-  pParse->initiateTTrans = true;
-  sql_trigger_finish(pParse, S, &all);
-}
-
-trigger_decl(A) ::= TRIGGER ifnotexists(NOERR) nm(B)
-                    trigger_time(C) trigger_event(D)
-                    ON fullname(E) foreach_clause when_clause(G). {
-  create_trigger_def_init(&pParse->create_trigger_def, E, &B, C, D.a,
-                          id_list_from_ast(D.b), G, NOERR);
-  sql_trigger_begin(pParse);
-  A = B; /*A-overwrites-T*/
+cmd ::= createkw TRIGGER ifnotexists(E) nm(N) trigger_time(C) trigger_event(D)
+        ON nm(T) foreach_clause when_clause(G) BEGIN trigger_cmd_list(S) END. {
+  if (pParse->parse_only) {
+    pParse->parsed_ast_type = AST_TYPE_TRIGGER;
+    pParse->parsed_ast.trigger = sql_trigger_new(pParse, &N, &T, C, D.a,
+                                                 id_list_from_ast(D.b), G, S);
+  } else {
+    sql_expr_delete(G);
+    sqlDeleteTriggerStep(S);
+    pParse->initiateTTrans = true;
+    vdbe_emit_create_trigger(pParse, pParse->zTail, &N, &T, E);
+  }
 }
 
 %type trigger_time {int}

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -293,12 +293,7 @@ cconsname(N) ::= . { N = Token_nil; }
  * tokens go to the next ccons instead.
  */
 ccons ::= DEFAULT expr(X). [COLLATE] {
-  struct ExprSpan res;
-  struct Expr *e = expr_from_ast(pParse, X);
-  res.pExpr = e;
-  res.zStart = X->str;
-  res.zEnd = &X->str[X->len];
-  sql_column_add_default(pParse, &res);
+  sql_column_add_default(pParse, expr_from_ast(pParse, X), X->str, X->len);
 }
 
 // In addition to the type name, we also care about the primary key and

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -321,15 +321,11 @@ ccons ::= NULL.        {
 }
 ccons ::= NOT NULL onconf(R).    {sql_column_add_nullable_action(pParse, R);}
 ccons ::= cconsname(N) PRIMARY KEY sortorder(Z). {
-  create_index_def_init(&pParse->create_index_def, NULL, &N, NULL,
-                        SQL_INDEX_TYPE_CONSTRAINT_PK, Z, false);
-  sqlAddPrimaryKey(pParse);
+  sqlAddPrimaryKey(pParse, &N, NULL, Z);
 }
 ccons ::= cconsname(N) UNIQUE. {
-  create_index_def_init(&pParse->create_index_def, NULL, &N, NULL,
-                        SQL_INDEX_TYPE_CONSTRAINT_UNIQUE, SORT_ORDER_ASC,
-                        false);
-  sql_create_index(pParse);
+  sql_create_index(pParse, &Token_nil, &N, NULL,
+                   SQL_INDEX_TYPE_CONSTRAINT_UNIQUE, SORT_ORDER_ASC, false);
 }
 
 ccons ::= cconsname(N) CHECK LP expr_old(X) RP. {
@@ -351,15 +347,12 @@ autoinc(X) ::= AUTOINCR.  {X = 1;}
 // The next group of rules parses the arguments to a REFERENCES clause.
 tcons ::= cconsname(N) PRIMARY KEY LP sortlist_autoinc(X) RP. {
   struct ExprList *columns = expr_list_from_ast(pParse, X);
-  create_index_def_init(&pParse->create_index_def, NULL, &N, columns,
-                        SQL_INDEX_TYPE_CONSTRAINT_PK, SORT_ORDER_ASC, false);
-  sqlAddPrimaryKey(pParse);
+  if (!pParse->is_aborted)
+    sqlAddPrimaryKey(pParse, &N, columns, SORT_ORDER_ASC);
 }
 tcons ::= cconsname(N) UNIQUE LP sortlist_old(X) RP. {
-  create_index_def_init(&pParse->create_index_def, NULL, &N, X,
-                        SQL_INDEX_TYPE_CONSTRAINT_UNIQUE, SORT_ORDER_ASC,
-                        false);
-  sql_create_index(pParse);
+  sql_create_index(pParse, &Token_nil, &N, X, SQL_INDEX_TYPE_CONSTRAINT_UNIQUE,
+                   SORT_ORDER_ASC, false);
 }
 tcons ::= cconsname(N) CHECK LP expr_old(X) RP. {
   create_ck_def_init(&pParse->create_ck_def, NULL, &N, &X);
@@ -1272,11 +1265,8 @@ nexprlist(A) ::= expr(Y). {
 //
 cmd ::= createkw uniqueflag(U) INDEX ifnotexists(NE) nm(X)
         ON nm(Y) LP sortlist_old(Z) RP. {
-  struct SrcList *src_list = sql_src_list_append(NULL ,&Y);
-  create_index_def_init(&pParse->create_index_def, src_list, &X, Z, U,
-                        SORT_ORDER_ASC, NE);
   pParse->initiateTTrans = true;
-  sql_create_index(pParse);
+  sql_create_index(pParse, &Y, &X, Z, U, SORT_ORDER_ASC, NE);
 }
 
 %type uniqueflag {int}
@@ -1533,21 +1523,16 @@ cmd ::= ALTER TABLE nm(T) ADD CONSTRAINT nm(N) CHECK LP expr_old(X) RP. {
 
 cmd ::= ALTER TABLE nm(T) ADD CONSTRAINT nm(N) UNIQUE LP sortlist_old(X) RP. {
   pParse->initiateTTrans = true;
-  struct SrcList *table = sql_src_list_append(NULL, &T);
-  create_index_def_init(&pParse->create_index_def, table, &N, X,
-                        SQL_INDEX_TYPE_CONSTRAINT_UNIQUE, SORT_ORDER_ASC,
-                        false);
-  sql_create_index(pParse);
+  sql_create_index(pParse, &T, &N, X, SQL_INDEX_TYPE_CONSTRAINT_UNIQUE,
+                   SORT_ORDER_ASC, false);
 }
 
 cmd ::= ALTER TABLE nm(T) ADD CONSTRAINT nm(N) PRIMARY KEY
         LP sortlist_autoinc(X) RP. {
   pParse->initiateTTrans = true;
   struct ExprList *columns = expr_list_from_ast(pParse, X);
-  struct SrcList *table = sql_src_list_append(NULL, &T);
-  create_index_def_init(&pParse->create_index_def, table, &N, columns,
-                        SQL_INDEX_TYPE_CONSTRAINT_PK, SORT_ORDER_ASC, false);
-  sql_create_index(pParse);
+  sql_create_index(pParse, &T, &N, columns, SQL_INDEX_TYPE_CONSTRAINT_PK,
+                   SORT_ORDER_ASC, false);
 }
 
 cmd ::= ALTER TABLE nm(T) RENAME TO nm(N). {

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1550,10 +1550,9 @@ cmd ::= ALTER TABLE nm(T) ADD CONSTRAINT nm(N) PRIMARY KEY
   sql_create_index(pParse);
 }
 
-cmd ::= ALTER TABLE fullname(A) RENAME TO nm(N). {
-    rename_entity_def_init(&pParse->rename_entity_def, A, &N);
+cmd ::= ALTER TABLE nm(T) RENAME TO nm(N). {
     pParse->initiateTTrans = true;
-    sql_alter_table_rename(pParse);
+    sql_alter_table_rename(pParse, &T, &N);
 }
 
 cmd ::= ALTER TABLE nm(X) DROP CONSTRAINT nm(Z). {

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -782,9 +782,9 @@ cmd ::= with_old(C) DELETE FROM fullname(X) indexed_opt(I) where_opt_old(W). {
 
 /////////////////////////// The TRUNCATE statement /////////////////////////////
 //
-cmd ::= TRUNCATE TABLE fullname(X). {
+cmd ::= TRUNCATE TABLE nm(X). {
   pParse->initiateTTrans = true;
-  sql_table_truncate(pParse, X);
+  sql_table_truncate(pParse, &X);
 }
 
 %type where_opt_old {Expr*}

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -1497,11 +1497,9 @@ raisetype(A) ::= FAIL.      {A = ON_CONFLICT_ACTION_FAIL;}
 
 
 ////////////////////////  DROP TRIGGER statement //////////////////////////////
-cmd ::= DROP TRIGGER ifexists(NOERR) fullname(X). {
-  struct Token t = Token_nil;
-  drop_trigger_def_init(&pParse->drop_trigger_def, X, &t, NOERR);
+cmd ::= DROP TRIGGER ifexists(E) nm(X). {
   pParse->initiateTTrans = true;
-  sql_drop_trigger(pParse);
+  sql_drop_trigger(pParse, &X, E);
 }
 
 //////////////////////// ALTER TABLE table ... ////////////////////////////////

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -226,14 +226,6 @@ struct create_table_def {
 	struct space *new_space;
 };
 
-struct create_column_def {
-	struct create_entity_def base;
-	/** Shallow space copy. */
-	struct space *space;
-	/** Column type. */
-	enum field_type type;
-};
-
 struct create_ck_constraint_parse_def {
 	/** List of ck_constraint_parse_def objects. */
 	struct rlist checks;
@@ -316,16 +308,6 @@ create_table_def_init(struct create_table_def *table_def, struct Token *name,
 {
 	create_entity_def_init(&table_def->base, ENTITY_TYPE_TABLE, NULL, name,
 			       if_not_exists);
-}
-
-static inline void
-create_column_def_init(struct create_column_def *column_def,
-		       struct SrcList *table_name, struct Token *name,
-		       enum field_type type)
-{
-	create_entity_def_init(&column_def->base, ENTITY_TYPE_COLUMN,
-			       table_name, name, false);
-	column_def->type = type;
 }
 
 static inline void

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -267,23 +267,6 @@ struct create_view_def {
 	struct Select *select;
 };
 
-struct drop_entity_def {
-	struct alter_entity_def base;
-	/** Name of index/trigger/constraint to be dropped. */
-	struct Token name;
-	/** Statement comes with IF EXISTS clause. */
-	bool if_exist;
-};
-
-/**
- * Identical wrappers around drop_entity_def to make hierarchy of
- * structures be consistent. Arguments for drop procedures are
- * the same.
- */
-struct drop_index_def {
-	struct drop_entity_def base;
-};
-
 struct create_trigger_def {
 	struct create_entity_def base;
 	/** One of TK_BEFORE, TK_AFTER, TK_INSTEAD. */
@@ -360,26 +343,6 @@ create_constraint_def_init(struct create_constraint_def *constr_def,
 {
 	create_entity_def_init(&constr_def->base, entity_type,
 			       parent_name, name, if_not_exists);
-}
-
-static inline void
-drop_entity_def_init(struct drop_entity_def *drop_def,
-		     struct SrcList *parent_name, struct Token *name,
-		     bool if_exist, enum entity_type entity_type)
-{
-	alter_entity_def_init(&drop_def->base, parent_name, entity_type,
-			      ALTER_ACTION_DROP);
-	drop_def->name = *name;
-	drop_def->if_exist = if_exist;
-}
-
-static inline void
-drop_index_def_init(struct drop_index_def *drop_index_def,
-		    struct SrcList *parent_name, struct Token *name,
-		    bool if_exist)
-{
-	drop_entity_def_init(&drop_index_def->base, parent_name, name, if_exist,
-			     ENTITY_TYPE_INDEX);
 }
 
 static inline void

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -184,43 +184,6 @@ enum sql_index_type {
 	sql_index_type_MAX
 };
 
-enum entity_type {
-	ENTITY_TYPE_TABLE = 0,
-	ENTITY_TYPE_COLUMN,
-	ENTITY_TYPE_VIEW,
-	ENTITY_TYPE_INDEX,
-	ENTITY_TYPE_TRIGGER,
-	ENTITY_TYPE_CK,
-	ENTITY_TYPE_FK,
-	/**
-	 * For assertion checks that constraint definition is
-	 * created before initialization of a term constraint.
-	 */
-	ENTITY_TYPE_CONSTRAINT,
-};
-
-enum alter_action {
-	ALTER_ACTION_CREATE = 0,
-	ALTER_ACTION_DROP,
-	ALTER_ACTION_RENAME,
-};
-
-struct alter_entity_def {
-	/** Type of topmost entity. */
-	enum entity_type entity_type;
-	/** Action to be performed using current entity. */
-	enum alter_action alter_action;
-	/** As a rule it is a name of table to be altered. */
-	struct SrcList *entity_name;
-};
-
-struct create_entity_def {
-	struct alter_entity_def base;
-	struct Token name;
-	/** Statement comes with IF NOT EXISTS clause. */
-	bool if_not_exist;
-};
-
 struct create_ck_constraint_parse_def {
 	/** List of ck_constraint_parse_def objects. */
 	struct rlist checks;
@@ -235,54 +198,6 @@ struct create_fk_constraint_parse_def {
 	 */
 	bool is_used;
 };
-
-struct create_trigger_def {
-	struct create_entity_def base;
-	/** One of TK_BEFORE, TK_AFTER, TK_INSTEAD. */
-	int tr_tm;
-	/** One of TK_INSERT, TK_UPDATE, TK_DELETE. */
-	int op;
-	/** Column list if this is an UPDATE trigger. */
-	struct IdList *cols;
-	/** When clause. */
-	struct Expr *when;
-};
-
-/** Basic initialisers of parse structures.*/
-static inline void
-alter_entity_def_init(struct alter_entity_def *alter_def,
-		      struct SrcList *entity_name, enum entity_type type,
-		      enum alter_action action)
-{
-	alter_def->entity_name = entity_name;
-	alter_def->entity_type = type;
-	alter_def->alter_action = action;
-}
-
-static inline void
-create_entity_def_init(struct create_entity_def *create_def,
-		       enum entity_type type, struct SrcList *parent_name,
-		       struct Token *name, bool if_not_exist)
-{
-	alter_entity_def_init(&create_def->base, parent_name, type,
-			      ALTER_ACTION_CREATE);
-	create_def->name = *name;
-	create_def->if_not_exist = if_not_exist;
-}
-
-static inline void
-create_trigger_def_init(struct create_trigger_def *trigger_def,
-			struct SrcList *table_name, struct Token *name,
-			int tr_tm, int op, struct IdList *cols,
-			struct Expr *when, bool if_not_exists)
-{
-	create_entity_def_init(&trigger_def->base, ENTITY_TYPE_TRIGGER,
-			       table_name, name, if_not_exists);
-	trigger_def->tr_tm = tr_tm;
-	trigger_def->op = op;
-	trigger_def->cols = cols;
-	trigger_def->when = when;
-}
 
 static inline void
 create_ck_constraint_parse_def_init(struct create_ck_constraint_parse_def *def)

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -278,12 +278,6 @@ struct create_constraint_def {
 	struct create_entity_def base;
 };
 
-struct create_ck_def {
-	struct create_constraint_def base;
-	/** AST representing check expression. */
-	struct ExprSpan *expr;
-};
-
 struct create_fk_def {
 	struct create_constraint_def base;
 	struct ExprList *child_cols;
@@ -334,15 +328,6 @@ create_trigger_def_init(struct create_trigger_def *trigger_def,
 	trigger_def->op = op;
 	trigger_def->cols = cols;
 	trigger_def->when = when;
-}
-
-static inline void
-create_ck_def_init(struct create_ck_def *ck_def, struct SrcList *table_name,
-		   struct Token *name, struct ExprSpan *expr)
-{
-	create_constraint_def_init(&ck_def->base, table_name, name, false,
-				   ENTITY_TYPE_CK);
-	ck_def->expr = expr;
 }
 
 static inline void

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -214,11 +214,6 @@ struct alter_entity_def {
 	struct SrcList *entity_name;
 };
 
-struct rename_entity_def {
-	struct alter_entity_def base;
-	struct Token new_name;
-};
-
 struct create_entity_def {
 	struct alter_entity_def base;
 	struct Token name;
@@ -314,15 +309,6 @@ alter_entity_def_init(struct alter_entity_def *alter_def,
 	alter_def->entity_name = entity_name;
 	alter_def->entity_type = type;
 	alter_def->alter_action = action;
-}
-
-static inline void
-rename_entity_def_init(struct rename_entity_def *rename_def,
-		       struct SrcList *table_name, struct Token *new_name)
-{
-	alter_entity_def_init(&rename_def->base, table_name, ENTITY_TYPE_TABLE,
-			      ALTER_ACTION_RENAME);
-	rename_def->new_name = *new_name;
 }
 
 static inline void

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -236,19 +236,6 @@ struct create_fk_constraint_parse_def {
 	bool is_used;
 };
 
-struct create_view_def {
-	struct create_entity_def base;
-	/**
-	 * Starting position of CREATE VIEW ... statement.
-	 * It is used to fetch whole statement, which is
-	 * saved as raw string to space options.
-	 */
-	struct Token *create_start;
-	/** List of column aliases (SELECT x AS y ...). */
-	struct ExprList *aliases;
-	struct Select *select;
-};
-
 struct create_trigger_def {
 	struct create_entity_def base;
 	/** One of TK_BEFORE, TK_AFTER, TK_INSTEAD. */
@@ -308,18 +295,6 @@ create_fk_constraint_parse_def_init(struct create_fk_constraint_parse_def *def)
 {
 	rlist_create(&def->fkeys);
 	def->is_used = true;
-}
-
-static inline void
-create_view_def_init(struct create_view_def *view_def, struct Token *name,
-		     struct Token *create, struct ExprList *aliases,
-		     struct Select *select, bool if_not_exists)
-{
-	create_entity_def_init(&view_def->base, ENTITY_TYPE_VIEW, NULL, name,
-			       if_not_exists);
-	view_def->create_start = create;
-	view_def->select = select;
-	view_def->aliases = aliases;
 }
 
 static inline void

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -274,17 +274,6 @@ struct create_trigger_def {
 	struct Expr *when;
 };
 
-struct create_constraint_def {
-	struct create_entity_def base;
-};
-
-struct create_fk_def {
-	struct create_constraint_def base;
-	struct ExprList *child_cols;
-	struct Token *parent_name;
-	struct ExprList *parent_cols;
-};
-
 /** Basic initialisers of parse structures.*/
 static inline void
 alter_entity_def_init(struct alter_entity_def *alter_def,
@@ -308,15 +297,6 @@ create_entity_def_init(struct create_entity_def *create_def,
 }
 
 static inline void
-create_constraint_def_init(struct create_constraint_def *constr_def,
-			   struct SrcList *parent_name, struct Token *name,
-			   bool if_not_exists, enum entity_type entity_type)
-{
-	create_entity_def_init(&constr_def->base, entity_type,
-			       parent_name, name, if_not_exists);
-}
-
-static inline void
 create_trigger_def_init(struct create_trigger_def *trigger_def,
 			struct SrcList *table_name, struct Token *name,
 			int tr_tm, int op, struct IdList *cols,
@@ -328,18 +308,6 @@ create_trigger_def_init(struct create_trigger_def *trigger_def,
 	trigger_def->op = op;
 	trigger_def->cols = cols;
 	trigger_def->when = when;
-}
-
-static inline void
-create_fk_def_init(struct create_fk_def *fk_def, struct SrcList *table_name,
-		   struct Token *name, struct ExprList *child_cols,
-		   struct Token *parent_name, struct ExprList *parent_cols)
-{
-	create_constraint_def_init(&fk_def->base, table_name, name,
-				   false, ENTITY_TYPE_FK);
-	fk_def->child_cols = child_cols;
-	fk_def->parent_name = parent_name;
-	fk_def->parent_cols = parent_cols;
 }
 
 static inline void

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -280,10 +280,6 @@ struct drop_entity_def {
  * structures be consistent. Arguments for drop procedures are
  * the same.
  */
-struct drop_trigger_def {
-	struct drop_entity_def base;
-};
-
 struct drop_index_def {
 	struct drop_entity_def base;
 };
@@ -375,15 +371,6 @@ drop_entity_def_init(struct drop_entity_def *drop_def,
 			      ALTER_ACTION_DROP);
 	drop_def->name = *name;
 	drop_def->if_exist = if_exist;
-}
-
-static inline void
-drop_trigger_def_init(struct drop_trigger_def *drop_trigger_def,
-		      struct SrcList *parent_name, struct Token *name,
-		      bool if_exist)
-{
-	drop_entity_def_init(&drop_trigger_def->base, parent_name, name,
-			     if_exist, ENTITY_TYPE_TRIGGER);
 }
 
 static inline void

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -280,14 +280,6 @@ struct drop_entity_def {
  * structures be consistent. Arguments for drop procedures are
  * the same.
  */
-struct drop_table_def {
-	struct drop_entity_def base;
-};
-
-struct drop_view_def {
-	struct drop_entity_def base;
-};
-
 struct drop_trigger_def {
 	struct drop_entity_def base;
 };
@@ -383,24 +375,6 @@ drop_entity_def_init(struct drop_entity_def *drop_def,
 			      ALTER_ACTION_DROP);
 	drop_def->name = *name;
 	drop_def->if_exist = if_exist;
-}
-
-static inline void
-drop_table_def_init(struct drop_table_def *drop_table_def,
-		    struct SrcList *parent_name, struct Token *name,
-		    bool if_exist)
-{
-	drop_entity_def_init(&drop_table_def->base, parent_name, name, if_exist,
-			     ENTITY_TYPE_TABLE);
-}
-
-static inline void
-drop_view_def_init(struct drop_view_def *drop_view_def,
-		   struct SrcList *parent_name, struct Token *name,
-		   bool if_exist)
-{
-	drop_entity_def_init(&drop_view_def->base, parent_name, name, if_exist,
-			     ENTITY_TYPE_VIEW);
 }
 
 static inline void

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -221,11 +221,6 @@ struct create_entity_def {
 	bool if_not_exist;
 };
 
-struct create_table_def {
-	struct create_entity_def base;
-	struct space *new_space;
-};
-
 struct create_ck_constraint_parse_def {
 	/** List of ck_constraint_parse_def objects. */
 	struct rlist checks;
@@ -300,14 +295,6 @@ create_trigger_def_init(struct create_trigger_def *trigger_def,
 	trigger_def->op = op;
 	trigger_def->cols = cols;
 	trigger_def->when = when;
-}
-
-static inline void
-create_table_def_init(struct create_table_def *table_def, struct Token *name,
-		      bool if_not_exists)
-{
-	create_entity_def_init(&table_def->base, ENTITY_TYPE_TABLE, NULL, name,
-			       if_not_exists);
 }
 
 static inline void

--- a/src/box/sql/parse_def.h
+++ b/src/box/sql/parse_def.h
@@ -291,15 +291,6 @@ struct create_fk_def {
 	struct ExprList *parent_cols;
 };
 
-struct create_index_def {
-	struct create_constraint_def base;
-	/** List of indexed columns. */
-	struct ExprList *cols;
-	/** One of _PRIMARY_KEY, _UNIQUE, _NON_UNIQUE. */
-	enum sql_index_type idx_type;
-	enum sort_order sort_order;
-};
-
 /** Basic initialisers of parse structures.*/
 static inline void
 alter_entity_def_init(struct alter_entity_def *alter_def,
@@ -352,19 +343,6 @@ create_ck_def_init(struct create_ck_def *ck_def, struct SrcList *table_name,
 	create_constraint_def_init(&ck_def->base, table_name, name, false,
 				   ENTITY_TYPE_CK);
 	ck_def->expr = expr;
-}
-
-static inline void
-create_index_def_init(struct create_index_def *index_def,
-		      struct SrcList *table_name,  struct Token *name,
-		      struct ExprList *cols, enum sql_index_type idx_type,
-		      enum sort_order sort_order, bool if_not_exists)
-{
-	create_constraint_def_init(&index_def->base, table_name, name,
-				   if_not_exists, ENTITY_TYPE_INDEX);
-	index_def->cols = cols;
-	index_def->idx_type = idx_type;
-	index_def->sort_order = sort_order;
 }
 
 static inline void

--- a/src/box/sql/prepare.c
+++ b/src/box/sql/prepare.c
@@ -217,7 +217,7 @@ sql_parser_create(struct Parse *parser, uint32_t sql_flags)
 static void
 parser_space_delete(struct Parse *parser)
 {
-	struct space *space = parser->create_column_def.space;
+	struct space *space = parser->space;
 	if (space == NULL)
 		return;
 	assert(space->def->opts.is_ephemeral);

--- a/src/box/sql/prepare.c
+++ b/src/box/sql/prepare.c
@@ -223,7 +223,7 @@ parser_space_delete(struct Parse *parser)
 	assert(space->def->opts.is_ephemeral);
 	uint32_t i = 0;
 	/* If new_space is NULL, the query is ALTER TABLE ADD COLUMNS. */
-	if (parser->create_table_def.new_space == NULL) {
+	if (parser->new_space == NULL) {
 		/*
 		 * Don't delete already existing defs and start from new
 		 * ones.

--- a/src/box/sql/resolve.c
+++ b/src/box/sql/resolve.c
@@ -1574,9 +1574,9 @@ sql_resolve_self_reference(struct Parse *parser, struct space_def *def,
 		return;
 	}
 
-	/* Fake SrcList for parser->create_table_def */
+	/* Fake SrcList for parser->new_space */
 	SrcList sSrc;
-	/* Name context for parser->create_table_def  */
+	/* Name context for parser->new_space  */
 	NameContext sNC;
 
 	memset(&sNC, 0, sizeof(sNC));

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1995,7 +1995,6 @@ struct Parse {
 	union {
 		struct create_ck_def create_ck_def;
 		struct create_fk_def create_fk_def;
-		struct create_index_def create_index_def;
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
 	};
@@ -2679,8 +2678,17 @@ void
 sql_column_add_nullable_action(struct Parse *parser,
 			       enum on_conflict_action nullable_action);
 
+/*
+ * Designate the PRIMARY KEY for the table.
+ *
+ * @param parse Parser context.
+ * @param name Name of the index.
+ * @param col_list Column list of the index.
+ * @param sort_order Sort order in case of column PRIMARY KEY constraint.
+ */
 void
-sqlAddPrimaryKey(struct Parse *parse);
+sqlAddPrimaryKey(struct Parse *parse, struct Token *name,
+		 struct ExprList *col_list, enum sort_order sort_order);
 
 /**
  * Add a new CHECK constraint to the table currently under
@@ -2890,9 +2898,17 @@ sqlIdListDelete(struct IdList *pList);
  * being constructed by a CREATE TABLE statement.
  *
  * @param parse All information about this parse.
+ * @param table Name of the table on which the index will be created.
+ * @param name Name of the index.
+ * @param col_list Column list of the index.
+ * @param idx_type UNIQUE, NOT UNIQUE or PRIMARY KEY type of the index.
+ * @param sort_order Sort order in case of column UNIQUE/PRIMARY KEY constraint.
+ * @param if_not_exists If TRUE do not raise an error when the index exists.
  */
 void
-sql_create_index(struct Parse *parse);
+sql_create_index(struct Parse *parse, struct Token *table, struct Token *name,
+		 struct ExprList *col_list, enum sql_index_type idx_type,
+		 enum sort_order sort_order, bool if_not_exists);
 
 /**
  * This routine will drop an existing named index.  This routine

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1998,7 +1998,6 @@ struct Parse {
 		struct create_index_def create_index_def;
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
-		struct rename_entity_def rename_entity_def;
 	};
 	/**
 	 * Table def or column def is not part of union since
@@ -4033,9 +4032,12 @@ extern int sqlPendingByte;
  * command.
  *
  * @param parse Current parsing context.
+ * @param old_name Name of table to rename.
+ * @param new_name New name of the table.
  */
 void
-sql_alter_table_rename(struct Parse *parse);
+sql_alter_table_rename(struct Parse *parse, struct Token *old_name,
+		       struct Token *new_name);
 
 /**
  * Return the length (in bytes) of the token that begins at z[0].

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2000,9 +2000,7 @@ struct Parse {
 		struct create_view_def create_view_def;
 		struct rename_entity_def rename_entity_def;
 		struct drop_index_def drop_index_def;
-		struct drop_table_def drop_table_def;
 		struct drop_trigger_def drop_trigger_def;
-		struct drop_view_def drop_view_def;
 	};
 	/**
 	 * Table def or column def is not part of union since
@@ -2751,8 +2749,19 @@ sql_create_view(struct Parse *parse_context);
 int
 sql_view_assign_cursors(struct Parse *parse, const char *view_stmt);
 
+/**
+ * This routine is called to do the work of a DROP TABLE and
+ * DROP VIEW statements.
+ *
+ * @param parse_context Current parsing context.
+ * @param table Name of the table.
+ * @param if_exists If TRUE do not raise an error when the table is missing.
+ * @param is_view Flag that shows if space is table or view.
+ */
 void
-sql_drop_table(struct Parse *);
+sql_drop_table(struct Parse *parse_context, struct Token *table, bool if_exists,
+	       bool is_view);
+
 void sqlInsert(Parse *, SrcList *, Select *, IdList *,
 	       enum on_conflict_action);
 

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1993,7 +1993,6 @@ struct Parse {
 	 * from parse.y
 	 */
 	union {
-		struct create_fk_def create_fk_def;
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
 	};
@@ -3719,9 +3718,16 @@ sql_trigger_colmask(Parse *parser, struct sql_trigger *trigger,
  * OR to handle <CREATE TABLE ...>
  *
  * @param parse_context Parsing context.
+ * @param table Name of table where constraint is created.
+ * @param name Constraint name.
+ * @param child_cols Local columns of FOREIGN KEY constraint.
+ * @param parent Foreign table.
+ * @param parent_cols Foreign columns of FOREIGN KEY constraint.
  */
 void
-sql_create_foreign_key(struct Parse *parse_context);
+sql_create_foreign_key(struct Parse *parse_context, struct Token *table,
+		       struct Token *name, struct ExprList *child_cols,
+		       struct Token *parent, struct ExprList *parent_cols);
 
 /** Emit code to drop UNIQUE, tuple FOREIGN KEY or tuple CHECK constraint. */
 void

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1997,14 +1997,19 @@ struct Parse {
 		struct create_view_def create_view_def;
 	};
 	/**
-	 * Table def or column def is not part of union since
+	 * Table def is not part of union since
 	 * information being held must survive till the end of
-	 * parsing of whole <CREATE TABLE> or
-	 * <ALTER TABLE ADD COLUMN> statement (to pass it to
-	 * sqlEndTable() sql_create_column_end() function).
+	 * parsing of whole <CREATE TABLE> statement (to pass it to
+	 * sqlEndTable() function).
 	 */
 	struct create_table_def create_table_def;
-	struct create_column_def create_column_def;
+	/**
+	 * The space into which the column is added in the CREATE TABLE and
+	 * ALTER TABLE ADD COLUMN statements. Note that in the CREATE TABLE
+	 * statement, after column creation begins, this space is the same as
+	 * the new_space created for CREATE TABLE.
+	 */
+	struct space *space;
 	/** Array of default function descriptions. */
 	struct sql_default_func *default_funcs;
 	/** Length of array of default function descriptions. */
@@ -2646,12 +2651,13 @@ struct space *
 sqlStartTable(Parse *, Token *);
 
 /**
- * Add new field to the format of ephemeral space in
- * create_column_def. If it is <ALTER TABLE> create shallow copy
- * of the existing space and add field to its format.
+ * Add new field to the format of ephemeral space in parser.
+ * If it is <ALTER TABLE> create shallow copy of the existing space
+ * and add field to its format.
  */
 void
-sql_create_column_start(struct Parse *parse);
+sql_create_column_start(struct Parse *parse, struct Token *table,
+			struct Token *name, enum field_type type);
 
 /**
  * Emit code to update entry in _space and code to create

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1993,7 +1993,6 @@ struct Parse {
 	 * from parse.y
 	 */
 	union {
-		struct create_ck_def create_ck_def;
 		struct create_fk_def create_fk_def;
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
@@ -2694,10 +2693,16 @@ sqlAddPrimaryKey(struct Parse *parse, struct Token *name,
  * Add a new CHECK constraint to the table currently under
  * construction.
  * @param parser Parsing context.
+ * @param table Name of table where constraint is created.
+ * @param name_token Name of constraint.
+ * @param expr_str String representation of the expression.
+ * @param expr_str_len Length of string representation of expression.
  * @param is_field_ck True if this is a field constraint, false otherwise.
  */
 void
-sql_create_check_contraint(struct Parse *parser, bool is_field_ck);
+sql_create_check_constraint(struct Parse *parser, struct Token *table,
+			    struct Token *name_token, const char *expr_str,
+			    uint32_t expr_str_len, bool is_field_ck);
 
 /** Add a DEFAULT clause to the last created column. */
 void

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1988,14 +1988,6 @@ struct Parse {
 	/** Space triggers are being coded for. */
 	struct space *triggered_space;
 	/**
-	 * One of parse_def structures which are used to
-	 * assemble and carry arguments of DDL routines
-	 * from parse.y
-	 */
-	union {
-		struct create_trigger_def create_trigger_def;
-	};
-	/**
 	 * Description of the new table created in the CREATE TABLE statement.
 	 */
 	struct space *new_space;
@@ -3477,30 +3469,25 @@ void
 sql_materialize_view(struct Parse *parse, const char *name, struct Expr *where,
 		     int cursor);
 
-/**
- * This is called by the parser when it sees a CREATE TRIGGER
- * statement up to the point of the BEGIN before the trigger
- * actions.  A sql_trigger structure is generated based on the
- * information available and stored in parse->parsed_ast.trigger.
- * After the trigger actions have been parsed, the
- * sql_trigger_finish() function is called to complete the trigger
- * construction process.
- */
-void
-sql_trigger_begin(struct Parse *parse);
+/** Create a new `struct sql_trigger` object. */
+struct sql_trigger *
+sql_trigger_new(struct Parse *parser, struct Token *name, struct Token *table,
+		uint8_t time, uint8_t event, struct IdList *columns,
+		struct Expr *when, struct TriggerStep *step_list);
 
 /**
- * This routine is called after all of the trigger actions have
- * been parsed in order to complete the process of building the
- * trigger.
+ * Emit code to write SQL trigger definition to `_trigger`.
  *
- * @param parse Parser context.
- * @param step_list The triggered program.
- * @param token Token that describes the complete CREATE TRIGGER.
+ * @param parser Parsing context.
+ * @param sql The SQL statement that creates the trigger.
+ * @param name Name of the trigger.
+ * @param table Name of table where trigger is created.
+ * @param if_not_exists If TRUE do not raise an error when the trigger exists.
  */
 void
-sql_trigger_finish(struct Parse *parse, struct TriggerStep *step_list,
-		   struct Token *token);
+vdbe_emit_create_trigger(struct Parse *parser, const char *sql,
+			 struct Token *name, struct Token *table,
+			 bool if_not_exists);
 
 /**
  * This function is called from parser to generate drop trigger

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1997,12 +1997,9 @@ struct Parse {
 		struct create_view_def create_view_def;
 	};
 	/**
-	 * Table def is not part of union since
-	 * information being held must survive till the end of
-	 * parsing of whole <CREATE TABLE> statement (to pass it to
-	 * sqlEndTable() function).
+	 * Description of the new table created in the CREATE TABLE statement.
 	 */
-	struct create_table_def create_table_def;
+	struct space *new_space;
 	/**
 	 * The space into which the column is added in the CREATE TABLE and
 	 * ALTER TABLE ADD COLUMN statements. Note that in the CREATE TABLE
@@ -2726,8 +2723,17 @@ void sqlAddCollateType(Parse *, Token *);
 struct coll *
 sql_column_collation(struct space_def *def, uint32_t column, uint32_t *coll_id);
 
+/*
+ * This routine is called to report the termination of a CREATE TABLE statement.
+ *
+ * During this routine byte code for creation of new Tarantool
+ * space and all necessary Tarantool indexes is emitted.
+ *
+ * @param parse Parse context.
+ * @param if_not_exists If TRUE do not raise an error when the table exists.
+ */
 void
-sqlEndTable(struct Parse *parse);
+vdbe_emit_create_table(struct Parse *parse, bool if_not_exists);
 
 /**
  * Create cursor which will be positioned to the space/index.

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2000,7 +2000,6 @@ struct Parse {
 		struct create_view_def create_view_def;
 		struct rename_entity_def rename_entity_def;
 		struct drop_index_def drop_index_def;
-		struct drop_trigger_def drop_trigger_def;
 	};
 	/**
 	 * Table def or column def is not part of union since
@@ -3468,9 +3467,11 @@ sql_trigger_finish(struct Parse *parse, struct TriggerStep *step_list,
  * VDBE code.
  *
  * @param parser Parser context.
+ * @param name Trigger name.
+ * @param if_exists If TRUE do not raise an error when the trigger is missing.
  */
 void
-sql_drop_trigger(struct Parse *parser);
+sql_drop_trigger(struct Parse *parser, struct Token *name, bool if_exists);
 
 /**
  * Drop a trigger given a pointer to that trigger.

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1994,7 +1994,6 @@ struct Parse {
 	 */
 	union {
 		struct create_trigger_def create_trigger_def;
-		struct create_view_def create_view_def;
 	};
 	/**
 	 * Description of the new table created in the CREATE TABLE statement.
@@ -2754,9 +2753,16 @@ vdbe_emit_open_cursor(struct Parse *parse, int cursor, uint32_t index_id,
  * The parser calls this routine in order to create a new VIEW.
  *
  * @param parse_context Current parsing context.
+ * @param sql The SQL statement that creates the view.
+ * @param name name of the view.
+ * @param aliases names of columns of the view.
+ * @param view_select SELECT statement of the view.
+ * @param if_not_exists If TRUE do not raise an error when the view exists.
  */
 void
-sql_create_view(struct Parse *parse_context);
+sql_create_view(struct Parse *parse_context, const char *sql,
+		struct Token *name, struct ExprList *aliases,
+		struct Select *view_select, bool if_not_exists);
 
 /**
  * Compile view, i.e. create struct Select from

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1999,7 +1999,6 @@ struct Parse {
 		struct create_trigger_def create_trigger_def;
 		struct create_view_def create_view_def;
 		struct rename_entity_def rename_entity_def;
-		struct drop_index_def drop_index_def;
 	};
 	/**
 	 * Table def or column def is not part of union since
@@ -2901,9 +2900,13 @@ sql_create_index(struct Parse *parse);
  * implements the DROP INDEX statement.
  *
  * @param parse_context Current parsing context.
+ * @param name Index name.
+ * @param table Name of index table.
+ * @param if_exists If TRUE do not raise an error when the index is missing.
  */
 void
-sql_drop_index(struct Parse *parse_context);
+sql_drop_index(struct Parse *parse_context, struct Token *name,
+	       struct Token *table, bool if_exists);
 
 int sqlSelect(Parse *, Select *, SelectDest *);
 Select *sqlSelectNew(Parse *, ExprList *, SrcList *, Expr *, ExprList *,

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2699,7 +2699,8 @@ sql_create_check_constraint(struct Parse *parser, struct Token *table,
 
 /** Add a DEFAULT clause to the last created column. */
 void
-sql_column_add_default(struct Parse *parser, struct ExprSpan *expr_span);
+sql_column_add_default(struct Parse *parser, struct Expr *expr, const char *str,
+		       uint32_t len);
 
 void sqlAddCollateType(Parse *, Token *);
 

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -2991,10 +2991,10 @@ sql_table_delete_from(struct Parse *parse, struct SrcList *tab_list,
  * Generate a code for TRUNCATE TABLE statement.
  *
  * @param parse Parsing context.
- * @param tab_list List of single table to truncate.
+ * @param table Name of table to truncate.
  */
 void
-sql_table_truncate(struct Parse *parse, struct SrcList *tab_list);
+sql_table_truncate(struct Parse *parse, struct Token *table);
 
 /** Free a WhereInfo structure. */
 void

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -1940,13 +1940,6 @@ struct Parse {
 	/** True, if error should be raised after parsing. */
 	bool is_aborted;
 
-  /**************************************************************************
-  * Fields above must be initialized to zero.  The fields that follow,
-  * down to the beginning of the recursive section, do not need to be
-  * initialized as they will be set before being used.  The boundary is
-  * determined by offsetof(Parse,aColCache).
-  *************************************************************************/
-
 	struct yColCache {
 		int iTable;	/* Table cursor number */
 		i16 iColumn;	/* Table column number */
@@ -1957,14 +1950,6 @@ struct Parse {
 	} aColCache[SQL_N_COLCACHE];	/* One for each column cache entry */
 	int aTempReg[8];	/* Holding area for temporary registers */
 
-  /************************************************************************
-  * Above is constant between recursions.  Below is reset before and after
-  * each recursion.  The boundary between these two regions is determined
-  * using offsetof(Parse,sLastToken) so the sLastToken field must be the
-  * first field in the recursive region.
-  ***********************************************************************/
-
-	Token sLastToken;	/* The last token parsed */
 	/** The line counter. */
 	uint32_t line_count;
 	/**

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -497,7 +497,7 @@ sqlRunParser(Parse * pParse, const char *zSql)
 	i = 0;
 	/* sqlParserTrace(stdout, "parser: "); */
 	pEngine = sqlParserAlloc(new_xmalloc);
-	assert(pParse->create_table_def.new_space == NULL);
+	assert(pParse->new_space == NULL);
 	assert(pParse->parsed_ast.trigger == NULL);
 	assert(pParse->nVar == 0);
 	assert(pParse->pVList == 0);

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -501,14 +501,15 @@ sqlRunParser(Parse * pParse, const char *zSql)
 	assert(pParse->parsed_ast.trigger == NULL);
 	assert(pParse->nVar == 0);
 	assert(pParse->pVList == 0);
+	struct Token last;
+	memset(&last, 0, sizeof(last));
 	while (1) {
 		assert(i >= 0);
 		if (zSql[i] != 0) {
-			pParse->sLastToken.z = &zSql[i];
-			pParse->sLastToken.n =
-			    sql_token(&zSql[i], &tokenType,
-				      &pParse->sLastToken.isReserved);
-			i += pParse->sLastToken.n;
+			last.z = &zSql[i];
+			last.n = sql_token(&zSql[i], &tokenType,
+					   &last.isReserved);
+			i += last.n;
 			if (i > SQL_MAX_SQL_LENGTH) {
 				diag_set(ClientError, ER_SQL_PARSER_LIMIT,
 					 "SQL command length", i,
@@ -534,8 +535,7 @@ sqlRunParser(Parse * pParse, const char *zSql)
 			if (tokenType == TK_ILLEGAL) {
 				diag_set(ClientError, ER_SQL_UNKNOWN_TOKEN,
 					 pParse->line_count, pParse->line_pos,
-					 tt_cstr(pParse->sLastToken.z,
-						 pParse->sLastToken.n));
+					 tt_cstr(last.z, last.n));
 				pParse->is_aborted = true;
 				break;
 			}
@@ -544,13 +544,12 @@ sqlRunParser(Parse * pParse, const char *zSql)
 			pParse->line_pos = 1;
 			continue;
 		} else {
-			sqlParser(pEngine, tokenType, pParse->sLastToken,
-				      pParse);
+			sqlParser(pEngine, tokenType, last, pParse);
 			lastTokenParsed = tokenType;
 			if (pParse->is_aborted)
 				break;
 		}
-		pParse->line_pos += pParse->sLastToken.n;
+		pParse->line_pos += last.n;
 	}
 	sql_code_ast(pParse, &pParse->ast);
 	pParse->zTail = &zSql[i];

--- a/src/box/sql/trigger.c
+++ b/src/box/sql/trigger.c
@@ -59,154 +59,127 @@ sqlDeleteTriggerStep(struct TriggerStep *pTriggerStep)
 	}
 }
 
-void
-sql_trigger_begin(struct Parse *parse)
+/**
+ * Return the space ID by name.
+ *
+ * Note that this function uses the exported API rather than getting
+ * the space ID directly from BOX.
+ */
+static uint32_t
+sql_space_id_by_token(struct Token *table)
+{
+	char *name = sql_name_from_token(table);
+	uint32_t space_id = box_space_id_by_name(name, strlen(name));
+	sql_xfree(name);
+	if (space_id != BOX_ID_NIL || table->z[0] == '"')
+		return space_id;
+	char *old_name = sql_legacy_name_new(table->z, table->n);
+	space_id = box_space_id_by_name(old_name, strlen(old_name));
+	sql_xfree(old_name);
+	return space_id;
+}
+
+struct sql_trigger *
+sql_trigger_new(struct Parse *parser, struct Token *name, struct Token *table,
+		uint8_t time, uint8_t event, struct IdList *columns,
+		struct Expr *when, struct TriggerStep *step_list)
 {
 	/* The new trigger. */
 	struct sql_trigger *trigger = NULL;
-	struct create_trigger_def *trigger_def = &parse->create_trigger_def;
-	struct create_entity_def *create_def = &trigger_def->base;
-	struct alter_entity_def *alter_def = &create_def->base;
-	assert(alter_def->entity_type == ENTITY_TYPE_TRIGGER);
-	assert(alter_def->alter_action == ALTER_ACTION_CREATE);
 
 	char *trigger_name = NULL;
-	if (alter_def->entity_name == NULL)
-		goto trigger_cleanup;
-	assert(alter_def->entity_name->nSrc == 1);
-	assert(create_def->name.n > 0);
-	trigger_name = sql_name_from_token(&create_def->name);
-	if (sqlCheckIdentifierName(parse, trigger_name) != 0)
-		goto trigger_cleanup;
+	assert(name->n > 0);
+	trigger_name = sql_name_from_token(name);
+	if (sqlCheckIdentifierName(parser, trigger_name) != 0)
+		goto error;
 
-	const char *table_name = alter_def->entity_name->a[0].zName;
-	uint32_t space_id = box_space_id_by_name(table_name,
-						 strlen(table_name));
-	if (space_id == BOX_ID_NIL &&
-	    alter_def->entity_name->a[0].legacy_name != NULL) {
-		char *old_name = alter_def->entity_name->a[0].legacy_name;
-		space_id = box_space_id_by_name(old_name, strlen(old_name));
-	}
+	uint32_t space_id = sql_space_id_by_token(table);
 	if (space_id == BOX_ID_NIL) {
-		diag_set(ClientError, ER_NO_SUCH_SPACE, table_name);
-		goto set_tarantool_error_and_cleanup;
-	}
-
-	if (!parse->parse_only) {
-		struct Vdbe *v = sqlGetVdbe(parse);
-		sqlVdbeCountChanges(v);
-		int name_reg = ++parse->nMem;
-		sqlVdbeAddOp4(parse->pVdbe, OP_String8, 0, name_reg, 0,
-			      sql_xstrdup(trigger_name), P4_DYNAMIC);
-		bool no_err = create_def->if_not_exist;
-		vdbe_emit_halt_with_presence_test(parse, BOX_TRIGGER_ID, 0,
-						  name_reg, 1,
-						  ER_TRIGGER_EXISTS,
-						  trigger_name, (no_err != 0),
-						  OP_NoConflict);
+		diag_set(ClientError, ER_NO_SUCH_SPACE,
+			 sql_tt_name_from_token(table));
+		parser->is_aborted = true;
+		goto error;
 	}
 
 	/* Build the Trigger object. */
 	trigger = sql_xmalloc0(sizeof(struct sql_trigger));
 	trigger->space_id = space_id;
 	trigger->zName = trigger_name;
-	trigger_name = NULL;
-	assert(trigger_def->op == TK_INSERT || trigger_def->op == TK_UPDATE ||
-	       trigger_def->op== TK_DELETE);
-	trigger->op = (u8) trigger_def->op;
-	trigger->tr_tm = trigger_def->tr_tm;
-	trigger->pWhen = sqlExprDup(trigger_def->when, EXPRDUP_REDUCE);
-	trigger->pColumns = sqlIdListDup(trigger_def->cols);
-	if ((trigger->pWhen != NULL && trigger->pWhen == NULL) ||
-	    (trigger->pColumns != NULL && trigger->pColumns == NULL))
-		goto trigger_cleanup;
-	assert(parse->parsed_ast.trigger == NULL);
-	parse->parsed_ast.trigger = trigger;
-	parse->parsed_ast_type = AST_TYPE_TRIGGER;
+	assert(event == TK_INSERT || event == TK_UPDATE || event == TK_DELETE);
+	trigger->op = event;
+	trigger->tr_tm = time;
+	trigger->pWhen = sqlExprDup(when, EXPRDUP_REDUCE);
+	trigger->pColumns = sqlIdListDup(columns);
+	trigger->step_list = step_list;
+	sqlIdListDelete(columns);
+	sql_expr_delete(when);
+	return trigger;
 
- trigger_cleanup:
+error:
+	sqlDeleteTriggerStep(step_list);
 	sql_xfree(trigger_name);
-	sqlSrcListDelete(alter_def->entity_name);
-	sqlIdListDelete(trigger_def->cols);
-	sql_expr_delete(trigger_def->when);
-	if (parse->parsed_ast.trigger == NULL)
-		sql_trigger_delete(trigger);
-	else
-		assert(parse->parsed_ast.trigger == trigger);
-
-	return;
-
-set_tarantool_error_and_cleanup:
-	parse->is_aborted = true;
-	goto trigger_cleanup;
+	sqlIdListDelete(columns);
+	sql_expr_delete(when);
+	return NULL;
 }
 
 void
-sql_trigger_finish(struct Parse *parse, struct TriggerStep *step_list,
-		   struct Token *token)
+vdbe_emit_create_trigger(struct Parse *parser, const char *sql,
+			 struct Token *name, struct Token *table,
+			 bool if_not_exists)
 {
-	/* Trigger being finished. */
-	struct sql_trigger *trigger = parse->parsed_ast.trigger;
-
-	parse->parsed_ast.trigger = NULL;
-	if (NEVER(parse->is_aborted) || trigger == NULL)
-		goto cleanup;
-	char *trigger_name = trigger->zName;
-	trigger->step_list = step_list;
-	while (step_list != NULL) {
-		step_list = step_list->pNext;
+	uint32_t space_id = sql_space_id_by_token(table);
+	if (space_id == BOX_ID_NIL) {
+		diag_set(ClientError, ER_NO_SUCH_SPACE,
+			 sql_tt_name_from_token(table));
+		parser->is_aborted = true;
+		return;
 	}
-
-	/* Trigger name for error reporting. */
-	struct Token trigger_name_token;
-	sqlTokenInit(&trigger_name_token, trigger->zName);
 
 	/*
-	 * Generate byte code to insert a new trigger into
-	 * Tarantool for non-parsing mode or export trigger.
+	 * Generate byte code to insert a new trigger into Tarantool
+	 * for non-parsing mode or export trigger.
 	 */
-	if (!parse->parse_only) {
-		/* Make an entry in the _trigger space. */
-		struct Vdbe *v = sqlGetVdbe(parse);
-
-		char *sql_str = sqlMPrintf("CREATE TRIGGER %s", token->z);
-
-		int first_col = parse->nMem + 1;
-		parse->nMem += 3;
-		int record = ++parse->nMem;
-		int sql_str_len = strlen(sql_str);
-		int sql_len = strlen("sql");
-
-		uint32_t opts_buff_sz = mp_sizeof_map(1) +
-					mp_sizeof_str(sql_len) +
-					mp_sizeof_str(sql_str_len);
-		char *opts_buff = sql_xmalloc(opts_buff_sz);
-		char *data = mp_encode_map(opts_buff, 1);
-		data = mp_encode_str(data, "sql", sql_len);
-		data = mp_encode_str(data, sql_str, sql_str_len);
-		sql_xfree(sql_str);
-
-		sqlVdbeAddOp4(v, OP_String8, 0, first_col, 0,
-			      sql_xstrdup(trigger_name), P4_DYNAMIC);
-		sqlVdbeAddOp2(v, OP_Integer, trigger->space_id,
-				  first_col + 1);
-		sqlVdbeAddOp4(v, OP_Blob, opts_buff_sz, first_col + 2,
-				  SQL_SUBTYPE_MSGPACK, opts_buff, P4_DYNAMIC);
-		sqlVdbeAddOp3(v, OP_MakeRecord, first_col, 3, record);
-		int reg = ++parse->nMem;
-		sqlVdbeAddOp2(v, OP_OpenSpace, reg, BOX_TRIGGER_ID);
-		sqlVdbeAddOp2(v, OP_IdxInsert, record, reg);
-		sqlVdbeChangeP5(v, OPFLAG_NCHANGE);
-	} else {
-		parse->parsed_ast.trigger = trigger;
-		parse->parsed_ast_type = AST_TYPE_TRIGGER;
-		trigger = NULL;
+	struct Vdbe *v = sqlGetVdbe(parser);
+	char *trigger_name = sql_name_from_token(name);
+	if (sqlCheckIdentifierName(parser, trigger_name) != 0) {
+		sql_xfree(trigger_name);
+		return;
 	}
 
-cleanup:
-	sql_trigger_delete(trigger);
-	assert(parse->parsed_ast.trigger == NULL || parse->parse_only);
-	sqlDeleteTriggerStep(step_list);
+	/* Check that there is no trigger with the same name. */
+	sqlVdbeCountChanges(v);
+	int name_reg = ++parser->nMem;
+	sqlVdbeAddOp4(parser->pVdbe, OP_String8, 0, name_reg, 0, trigger_name,
+		      P4_DYNAMIC);
+	vdbe_emit_halt_with_presence_test(parser, BOX_TRIGGER_ID, 0, name_reg,
+					  1, ER_TRIGGER_EXISTS, trigger_name,
+					  if_not_exists, OP_NoConflict);
+
+	int first_col = parser->nMem + 1;
+	parser->nMem += 3;
+	int record = ++parser->nMem;
+	int sql_str_len = strlen(sql);
+	int sql_len = strlen("sql");
+
+	uint32_t opts_buff_sz = mp_sizeof_map(1) +
+				mp_sizeof_str(sql_len) +
+				mp_sizeof_str(sql_str_len);
+	char *opts_buff = sql_xmalloc(opts_buff_sz);
+	char *data = mp_encode_map(opts_buff, 1);
+	data = mp_encode_str(data, "sql", sql_len);
+	data = mp_encode_str(data, sql, sql_str_len);
+
+	sqlVdbeAddOp4(v, OP_String8, 0, first_col, 0, sql_xstrdup(trigger_name),
+		      P4_DYNAMIC);
+	sqlVdbeAddOp2(v, OP_Integer, space_id, first_col + 1);
+	sqlVdbeAddOp4(v, OP_Blob, opts_buff_sz, first_col + 2,
+		      SQL_SUBTYPE_MSGPACK, opts_buff, P4_DYNAMIC);
+	sqlVdbeAddOp3(v, OP_MakeRecord, first_col, 3, record);
+	int reg = ++parser->nMem;
+	sqlVdbeAddOp2(v, OP_OpenSpace, reg, BOX_TRIGGER_ID);
+	sqlVdbeAddOp2(v, OP_IdxInsert, record, reg);
+	sqlVdbeChangeP5(v, OPFLAG_NCHANGE);
 }
 
 struct TriggerStep *

--- a/src/box/sql/trigger.c
+++ b/src/box/sql/trigger.c
@@ -326,28 +326,18 @@ vdbe_code_drop_trigger(struct Parse *parser, const char *trigger_name,
 }
 
 void
-sql_drop_trigger(struct Parse *parser)
+sql_drop_trigger(struct Parse *parser, struct Token *name, bool if_exists)
 {
-	struct drop_entity_def *drop_def = &parser->drop_trigger_def.base;
-	struct alter_entity_def *alter_def = &drop_def->base;
-	assert(alter_def->entity_type == ENTITY_TYPE_TRIGGER);
-	assert(alter_def->alter_action == ALTER_ACTION_DROP);
-	struct SrcList *name = alter_def->entity_name;
-	bool no_err = drop_def->if_exist;
-
 	struct Vdbe *v = sqlGetVdbe(parser);
 	sqlVdbeCountChanges(v);
 
-	assert(name->nSrc == 1);
-	const char *trigger_name = name->a[0].zName;
+	const char *trigger_name = sql_name_from_token(name);
 	int name_reg = ++parser->nMem;
-	sqlVdbeAddOp4(v, OP_String8, 0, name_reg, 0, sql_xstrdup(trigger_name),
-		      P4_DYNAMIC);
+	sqlVdbeAddOp4(v, OP_String8, 0, name_reg, 0, trigger_name, P4_DYNAMIC);
 	vdbe_emit_halt_with_presence_test(parser, BOX_TRIGGER_ID, 0, name_reg,
 					  1, ER_NO_SUCH_TRIGGER, trigger_name,
-					  no_err, OP_Found);
+					  if_exists, OP_Found);
 	vdbe_code_drop_trigger(parser, trigger_name, true);
-	sqlSrcListDelete(name);
 }
 
 int

--- a/test/sql-luatest/ddl_test.lua
+++ b/test/sql-luatest/ddl_test.lua
@@ -406,3 +406,17 @@ g.test_12968_primary_key_constraint_parsing = function(cg)
         box.space.t:drop()
     end)
 end
+
+--
+-- Make sure that the CREATE VIEW statement is saved exactly as it was provided.
+--
+g.test_create_view_string_representation = function(cg)
+    cg.server:exec(function()
+        local sql = [[   CREATE VIEW IF NOT EXISTS v AS SELECT id
+                      FROM _space   ; -- note  ]]
+        local _, err = box.execute(sql)
+        t.assert_equals(err, nil)
+        t.assert_equals(box.space._space:get{box.space.v.id}.flags.sql, sql)
+        box.execute([[DROP VIEW v;]]);
+    end)
+end

--- a/test/sql-luatest/triggers_test.lua
+++ b/test/sql-luatest/triggers_test.lua
@@ -806,3 +806,22 @@ g.test_12969_insert_defaults_in_trigger = function(cg)
         box.execute([[DROP TABLE t1;]])
     end)
 end
+
+--
+-- Make sure that the CREATE TRIGGER statement is saved exactly as it was
+-- provided.
+--
+g.test_trigger_str = function(cg)
+    cg.server:exec(function()
+        box.execute([[CREATE TABLE t1(i INT PRIMARY KEY);]])
+        box.execute([[CREATE TABLE t2(i INT PRIMARY KEY);]])
+        local sql = [[    CREATE TRIGGER IF NOT EXISTS t1t AFTER INSERT ON t1
+                      FOR EACH ROW BEGIN INSERT INTO t2 DEFAULT VALUES; END;
+                       -- note   ]]
+        box.execute(sql)
+        t.assert_equals(box.space._trigger:get('t1t').opts.sql, sql)
+        box.execute([[DROP TRIGGER t1t;]])
+        box.execute([[DROP TABLE t2;]])
+        box.execute([[DROP TABLE t1;]])
+    end)
+end


### PR DESCRIPTION
This patch-set reworks the functions called from the parser to construct the VDBE. This will simplify moving these functions to calls after the AST is generated, rather than calling them from the parser.

This patch-set is primarily a refactoring. The only user-visible change is that SQL queries for SQL triggers and views are now stored exactly as provided, without any formatting.

This patch-set also fixes two memory leaks.

Part of #5485 
Closes #13106 