### PR TITLE
[backport 3.6] config: fix a rebootstrapped instance becoming a second master with supervised failover

### DIFF
--- a/changelogs/unreleased/gh-12970-read-only-unless-bootstrap.md
+++ b/changelogs/unreleased/gh-12970-read-only-unless-bootstrap.md
@@ -1,0 +1,9 @@
+## feature/core
+
+* Added a new `box.cfg.read_only` value: `'unless_bootstrap'`. An instance
+  configured this way becomes writable only if it has bootstrapped the
+  replicaset on the current startup and stays read-only if it has recovered
+  from a local snapshot or has joined an already bootstrapped replicaset. The
+  mode is resolved atomically during the initial `box.cfg()` call, so the
+  instance never goes through a transient writable state. The value may
+  be set only during the initial `box.cfg()` call (gh-12970).

--- a/changelogs/unreleased/gh-12970-supervised-rejoin-master-master.md
+++ b/changelogs/unreleased/gh-12970-supervised-rejoin-master-master.md
@@ -1,0 +1,9 @@
+## bugfix/config
+
+* Fixed a bug where an instance rebootstrapped with an empty data directory
+  could start in the RW mode alongside an already appointed leader with
+  `replication.failover = supervised` and `replication.bootstrap_strategy =
+  auto`, if the instance had the lexicographically minimal name in the
+  replicaset. The bootstrap leader candidate now starts with
+  `box.cfg.read_only = 'unless_bootstrap'`, so a rejoined instance never
+  goes through a writable state at all (gh-12970).

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -266,6 +266,13 @@ static const char *box_recovery_state_strs[box_recovery_state_MAX] = {
 /** Whether the triggers for "synced" recovery stage have already run. */
 static bool recovery_state_synced_is_reached;
 
+/**
+ * Whether this instance has bootstrapped the replicaset on the current
+ * startup (created the initial snapshot itself rather than recovered
+ * from a local checkpoint or joined an existing replicaset).
+ */
+static bool is_bootstrap_leader;
+
 /** PATH_MAX is too big and 2K is recommended limit for web address. */
 #define BOX_FEEDBACK_HOST_MAX 2048
 
@@ -627,6 +634,12 @@ bool
 box_is_anon(void)
 {
 	return instance_id == REPLICA_ID_NIL;
+}
+
+bool
+box_is_bootstrap_leader(void)
+{
+	return is_bootstrap_leader;
 }
 
 API_EXPORT int
@@ -5679,7 +5692,6 @@ box_cfg_xc(void)
 		journal_set(NULL);
 	});
 
-	bool is_bootstrap_leader = false;
 	if (box_recovery_triggers_disabled) {
 		space_events_enable(false);
 		txn_events_enable(false);

--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -177,6 +177,8 @@ static bool is_storage_initialized = false;
 /** Set if storage shutdown is started. */
 static bool is_storage_shutdown = false;
 static bool is_ro = true;
+/** Whether the read_only option has been applied at least once. */
+static bool is_ro_cfg_applied;
 static fiber_cond ro_cond;
 
 /**
@@ -609,6 +611,7 @@ void
 box_set_ro(void)
 {
 	is_ro = box_check_ro();
+	is_ro_cfg_applied = true;
 	box_update_ro_summary();
 }
 
@@ -1650,29 +1653,100 @@ box_check_uuid(struct tt_uuid *uuid, const char *name, bool set_diag)
 	return 0;
 }
 
+/**
+ * The box.cfg.read_only setting: a boolean or the string
+ * 'unless_bootstrap'.
+ */
+enum ro_cfg {
+	RO_CFG_FALSE,
+	RO_CFG_TRUE,
+	/**
+	 * Go RW only if this instance has bootstrapped the replicaset
+	 * on the current startup, go RO otherwise (local recovery or
+	 * join to an already bootstrapped replicaset).
+	 */
+	RO_CFG_UNLESS_BOOTSTRAP,
+};
+
+/**
+ * Parse the box.cfg.read_only value. Returns -1 and sets diag if the
+ * value is a string other than 'unless_bootstrap'.
+ */
+static int
+box_check_ro_cfg(enum ro_cfg *out)
+{
+	if (cfg_isboolean("read_only")) {
+		*out = cfg_getb("read_only") ? RO_CFG_TRUE : RO_CFG_FALSE;
+		return 0;
+	}
+	const char *value = cfg_gets("read_only");
+	if (value != NULL && strcmp(value, "unless_bootstrap") == 0) {
+		*out = RO_CFG_UNLESS_BOOTSTRAP;
+		return 0;
+	}
+	diag_set(ClientError, ER_CFG, "read_only",
+		 "the value must be a boolean or the string "
+		 "'unless_bootstrap'");
+	return -1;
+}
+
 static bool
 box_check_ro(void)
 {
-	bool ro = cfg_geti("read_only") != 0;
+	enum ro_cfg mode;
+	if (box_check_ro_cfg(&mode) != 0)
+		diag_raise();
+	/*
+	 * The 'unless_bootstrap' value makes sense only on startup.
+	 * Setting it dynamically is banned: with a leader already
+	 * chosen elsewhere the outcome would be unpredictable, and
+	 * after a whole cluster restart there is no bootstrap leader
+	 * at all, so everyone would go read-only. Note that the value
+	 * left in the configuration does not fail the next startup:
+	 * the initial application is always allowed and resolves to RO
+	 * on a recovery.
+	 */
+	if (mode == RO_CFG_UNLESS_BOOTSTRAP && is_ro_cfg_applied) {
+		tnt_raise(ClientError, ER_CFG, "read_only",
+			  "the 'unless_bootstrap' value may be set only "
+			  "during the initial box.cfg() call");
+	}
 	bool anon = cfg_geti("replication_anon") != 0;
-	if (anon && !ro) {
+	if (anon && mode == RO_CFG_FALSE) {
 		tnt_raise(ClientError, ER_CFG, "read_only",
 			  "the value may be set to false only when "
 			  "replication_anon is false");
 	}
-	return ro;
+	if (anon && mode == RO_CFG_UNLESS_BOOTSTRAP) {
+		tnt_raise(ClientError, ER_CFG, "read_only",
+			  "the value may be set to 'unless_bootstrap' only "
+			  "when replication_anon is false");
+	}
+	/*
+	 * The bootstrap outcome the 'unless_bootstrap' mode resolves
+	 * from is known once the initial box.cfg() call returns and
+	 * the option is applied after that, so the very first RO/RW
+	 * state transition happens with the final resolved value: a
+	 * joined or recovered instance never goes through a transient
+	 * RW state.
+	 */
+	if (mode == RO_CFG_UNLESS_BOOTSTRAP)
+		return !box_is_bootstrap_leader();
+	return mode == RO_CFG_TRUE;
 }
 
 static bool
 box_check_replication_anon(void)
 {
 	bool anon = cfg_geti("replication_anon") != 0;
-	bool ro = cfg_geti("read_only") != 0;
+	enum ro_cfg ro_mode;
+	if (box_check_ro_cfg(&ro_mode) != 0)
+		diag_raise();
 	const char *mode_name = cfg_gets("election_mode");
 	enum election_mode mode = election_mode_by_name(mode_name);
 	if (mode == ELECTION_MODE_INVALID)
 		diag_raise();
-	if (anon && !ro) {
+	if (anon && ro_mode != RO_CFG_TRUE) {
 		tnt_raise(ClientError, ER_CFG, "replication_anon",
 			  "the value may be set to true only when "
 			  "the instance is read-only");
@@ -2141,6 +2215,9 @@ box_check_config(void)
 	if (box_check_replicaset_uuid(&uuid) != 0)
 		diag_raise();
 	if (box_check_election_mode(&election_mode) != 0)
+		diag_raise();
+	enum ro_cfg ro_mode;
+	if (box_check_ro_cfg(&ro_mode) != 0)
 		diag_raise();
 	if (box_check_election_timeout() < 0)
 		diag_raise();
@@ -4872,7 +4949,19 @@ box_process_subscribe(struct iostream *io, const struct xrow_header *header)
 void
 box_process_vote(struct ballot *ballot)
 {
-	ballot->is_ro_cfg = cfg_geti("read_only") != 0;
+	/*
+	 * is_ro_cfg reports whether the configuration unconditionally
+	 * enforces RO, that is whether the value is exactly true. This
+	 * way an 'unless_bootstrap' instance is a valid bootstrap
+	 * leader candidate and does not lose the bootstrap master
+	 * scoring (see replicaset_find_join_master()). The mode cannot
+	 * be resolved via box_is_bootstrap_leader() here: ballots are
+	 * exchanged before the bootstrap leader is elected, when the
+	 * flag is not known yet.
+	 */
+	enum ro_cfg ro_mode = RO_CFG_TRUE;
+	VERIFY(box_check_ro_cfg(&ro_mode) == 0);
+	ballot->is_ro_cfg = ro_mode == RO_CFG_TRUE;
 	const char *mode_name = cfg_gets("election_mode");
 	enum election_mode mode = election_mode_by_name(mode_name);
 	assert(mode != ELECTION_MODE_INVALID);
@@ -5105,6 +5194,9 @@ bootstrap_master(void)
 {
 	/*
 	 * Do not allow to bootstrap a readonly instance as master.
+	 * The 'unless_bootstrap' read_only mode explicitly allows the
+	 * bootstrap: it resolves to RW exactly when the instance
+	 * becomes the bootstrap leader.
 	 *
 	 * Allow an exception for the supervised bootstrap
 	 * strategy, because the command to bootstrap may be
@@ -5112,8 +5204,10 @@ bootstrap_master(void)
 	 * there is no way to change box.cfg.read_only at this
 	 * time.
 	 */
+	enum ro_cfg ro_mode = RO_CFG_TRUE;
+	VERIFY(box_check_ro_cfg(&ro_mode) == 0);
 	if (bootstrap_strategy != BOOTSTRAP_STRATEGY_SUPERVISED &&
-	    cfg_geti("read_only") == 1) {
+	    ro_mode == RO_CFG_TRUE) {
 		tnt_raise(ClientError, ER_BOOTSTRAP_READONLY);
 	}
 	/*
@@ -6000,11 +6094,20 @@ box_broadcast_status(void)
 {
 	char buf[1024];
 	char *w = buf;
+	/*
+	 * As in the ballot, is_ro_cfg reports whether the
+	 * configuration unconditionally enforces RO, that is whether
+	 * the value is exactly true (see box_process_vote()). The
+	 * effective state is reported in is_ro.
+	 */
+	enum ro_cfg ro_mode = RO_CFG_TRUE;
+	VERIFY(box_check_ro_cfg(&ro_mode) == 0);
+	bool is_ro_cfg = ro_mode == RO_CFG_TRUE;
 	w = mp_encode_map(w, 4);
 	w = mp_encode_str0(w, "is_ro");
 	w = mp_encode_bool(w, box_is_ro());
 	w = mp_encode_str0(w, "is_ro_cfg");
-	w = mp_encode_bool(w, cfg_geti("read_only"));
+	w = mp_encode_bool(w, is_ro_cfg);
 	w = mp_encode_str0(w, "status");
 	w = mp_encode_str0(w, box_status());
 	w = mp_encode_str0(w, "dd_version");

--- a/src/box/box.h
+++ b/src/box/box.h
@@ -228,6 +228,15 @@ box_is_waiting_for_own_rows(void);
 bool
 box_is_anon(void);
 
+/**
+ * Check if this instance has bootstrapped the replicaset on the current
+ * startup. Returns false if the instance recovered from a local
+ * checkpoint or joined an already bootstrapped replicaset (including a
+ * rebootstrap into an existing registration).
+ */
+bool
+box_is_bootstrap_leader(void);
+
 /** \cond public */
 
 /**

--- a/src/box/lua/config/applier/box_cfg.lua
+++ b/src/box/lua/config/applier/box_cfg.lua
@@ -178,27 +178,28 @@ end
 
 -- {{{ Set RO/RW
 
-local function wait_if_not_bootstrap_leader()
-    -- Wait until the instance learns its id in the replicaset to
-    -- distinguish a bootstrap leader from a regular replica.
-    --
-    -- Default value for `replication.connect_timeout` is 30 seconds.
-    local TIMEOUT = 30
-    local deadline = fiber.time() + TIMEOUT
-    while box.info.id == 0 do
-        if fiber.time() > deadline then
-            error(string.format(
-                'failed to learn instance id in the replicaset within %d ' ..
-                'seconds; cannot distinguish bootstrap leader from a ' ..
-                'regular replica.', TIMEOUT), 0)
-        end
-        fiber.sleep(0.01)
-    end
-
-    if box.info.id ~= 1 then
-        -- Not really a bootstrap leader, just a replica. Go to RO.
-        box.cfg({read_only = true})
-    end
+-- Replace the 'unless_bootstrap' read_only value with the
+-- equivalent boolean.
+--
+-- The supervised failover coordinator manages the RO/RW mode via
+-- box.cfg({read_only = <boolean>}) and treats the *configured*
+-- box.cfg.read_only value as the source of truth (e.g. the RW
+-- deadline failsafe does nothing if the value is truthy). Leaving
+-- the 'unless_bootstrap' string there would confuse it, so
+-- normalize the value to the boolean it has resolved to.
+--
+-- There is no mode transition here: the assigned boolean is
+-- identical to the already effective RO/RW state.
+--
+-- Note that box.cfg becomes a table before the initial
+-- configuration is finished, so external observers may see the
+-- 'unless_bootstrap' string in box.cfg.read_only while the startup is in
+-- progress. It is fine for the coordinator: the instance is
+-- effectively RO during the whole startup, so there is nothing to
+-- demote, and a truthy value correctly reports that the
+-- configuration does not ask for RW unconditionally.
+local function normalize_read_only()
+    box.cfg({read_only = not box.internal.is_bootstrap_leader()})
 end
 
 local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
@@ -340,18 +341,24 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
         -- * Look over the peer names of the replicaset and choose
         --   the minimal name across all non-anonymous instances
         --   (compare them lexicographically).
-        -- * The instance with the minimal name starts in the RW
-        --   mode to be able to bootstrap the replicaset if there
-        --   is no local snapshot. Otherwise, it starts as usual,
-        --   in RO.
+        -- * The instance with the minimal name and no local
+        --   snapshot starts with read_only = 'unless_bootstrap': it goes RW
+        --   only if it actually bootstraps the replicaset and
+        --   stays RO if the replicaset is already bootstrapped
+        --   (e.g. a new instance with the minimal name is added
+        --   to the configuration, or an existing instance is
+        --   rebootstrapped: its data directory is wiped to rejoin
+        --   it from scratch). The 'unless_bootstrap' mode is resolved by the
+        --   box.cfg() machinery with no transient RW state, so
+        --   such an instance can't become a second master along
+        --   with a leader appointed by the failover coordinator
+        --   (gh-12970).
         -- * All the other instances are started in RO.
-        -- * The instance that is started in RW re-checks, whether
-        --   it was a bootstrap leader (box.info.id == 1) and, if
-        --   not, goes to RO.
         --
         -- The algorithm leans on the replicaset bootstrap process
-        -- that chooses an RW instance as the bootstrap leader.
-        -- bootstrap_strategy 'auto' fits this criteria.
+        -- that chooses the bootstrap leader among the instances
+        -- whose configuration does not enforce RO. The 'unless_bootstrap'
+        -- mode fits this criteria (see box_process_vote()).
         --
         -- As result, all the instances are in RO or one is in RW.
         -- The supervisor (failover agent) manages the RO/RW mode
@@ -369,33 +376,16 @@ local function set_ro_rw(config, box_cfg, post_box_cfg_hooks)
             am_i_bootstrap_leader =
                 snapshot.get_path(configdata._iconfig_def) == nil and
                 instance_name == configdata:bootstrap_leader_name()
-            box_cfg.read_only = not am_i_bootstrap_leader
+            box_cfg.read_only =
+                am_i_bootstrap_leader and 'unless_bootstrap' or true
         end
 
-        -- It is possible that an instance with the minimal
-        -- name (configdata:bootstrap_leader_name()) is added to
-        -- the configuration, when the replicaset is already
-        -- bootstrapped.
-        --
-        -- Ideally, we shouldn't make this instance RW. However,
-        -- we can't differentiate this situation from one, when
-        -- the replicaset bootstrap is needed, before a first
-        -- box.cfg().
-        --
-        -- After box.cfg() returns, we can determine whether the
-        -- instance really became the bootstrap leader using the
-        -- box.info.id == 1 condition.
-        --
-        -- Note that box.ctl.wait_rw() is not sufficient here:
-        -- box_cfg.read_only is set above before the instance
-        -- learns its id, so RW status does not guarantee that
-        -- box.info.id has already been assigned.
-        --
-        -- If box.info.id != 1, then the replicaset was already
-        -- bootstrapped and the instance should go to RO.
+        -- Replace 'unless_bootstrap' with the resolved boolean once box.cfg()
+        -- returns: the failover coordinator expects a boolean in
+        -- box.cfg.read_only (see normalize_read_only()).
         if am_i_bootstrap_leader then
             assert(post_box_cfg_hooks ~= nil)
-            post_box_cfg_hooks:add(wait_if_not_bootstrap_leader)
+            post_box_cfg_hooks:add(normalize_read_only)
         end
     else
         assert(false)

--- a/src/box/lua/load_cfg.lua
+++ b/src/box/lua/load_cfg.lua
@@ -393,7 +393,7 @@ local template_cfg = {
     checkpoint_wal_threshold = 'number',
     wal_queue_max_size  = 'number',
     checkpoint_count    = 'number',
-    read_only           = 'boolean',
+    read_only           = 'boolean, string',
     hot_standby         = 'boolean',
     memtx_use_mvcc_engine = 'boolean',
     txn_isolation = 'string, number',
@@ -1345,11 +1345,15 @@ local function get_option_from_env(option)
     end
 
     if param_type:find('boolean') then
-        assert(param_type == 'boolean')
         if raw_value:lower() == 'false' then
             return false
         elseif raw_value:lower() == 'true' then
             return true
+        end
+        -- A mixed 'boolean, string' option (e.g. read_only): any
+        -- value other than 'true'/'false' is passed as a string.
+        if param_type:find('string') then
+            return raw_value
         end
         error(err_msg_fmt:format(env_var_name, option, '"true" or "false"'))
     end

--- a/src/box/lua/misc.cc
+++ b/src/box/lua/misc.cc
@@ -583,6 +583,19 @@ lbox_read_view_status(struct lua_State *L)
 
 /* }}} */
 
+/**
+ * Returns whether this instance has bootstrapped the replicaset on the
+ * current startup. Allows to distinguish a real bootstrap leader from
+ * an instance that recovered from a local checkpoint or joined an
+ * already bootstrapped replicaset.
+ */
+static int
+lbox_is_bootstrap_leader(struct lua_State *L)
+{
+	lua_pushboolean(L, box_is_bootstrap_leader());
+	return 1;
+}
+
 void
 box_lua_misc_init(struct lua_State *L)
 {
@@ -595,6 +608,7 @@ box_lua_misc_init(struct lua_State *L)
 		{"generate_space_id", lbox_generate_space_id},
 		{"generate_func_id", lbox_generate_func_id},
 		{"memtx_tx_gc", lbox_memtx_tx_gc},
+		{"is_bootstrap_leader", lbox_is_bootstrap_leader},
 		{NULL, NULL}
 	};
 

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -77,6 +77,15 @@ cfg_isnumber(const char *param)
 }
 
 bool
+cfg_isboolean(const char *param)
+{
+	cfg_get(param);
+	bool ret = !!lua_isboolean(tarantool_L, -1);
+	lua_pop(tarantool_L, 1);
+	return ret;
+}
+
+bool
 cfg_getb(const char *param)
 {
 	cfg_get(param);

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -56,6 +56,12 @@ bool
 cfg_isnumber(const char *param);
 
 /**
+ * Test if cfg parameter is a boolean.
+ */
+bool
+cfg_isboolean(const char *param);
+
+/**
  * Gets boolean parameter of cfg.
  * Returns false in case of nil
  */

--- a/test/box-luatest/gh_12970_read_only_unless_bootstrap_test.lua
+++ b/test/box-luatest/gh_12970_read_only_unless_bootstrap_test.lua
@@ -1,0 +1,226 @@
+local justrun = require('luatest.justrun')
+local replica_set = require('luatest.replica_set')
+local server = require('luatest.server')
+local treegen = require('luatest.treegen')
+local t = require('luatest')
+
+local g = t.group()
+
+g.after_each(function(cg)
+    if cg.server ~= nil then
+        cg.server:drop()
+        cg.server = nil
+    end
+    if cg.replica_set ~= nil then
+        cg.replica_set:drop()
+        cg.replica_set = nil
+    end
+    if cg.master ~= nil then
+        cg.master:drop()
+        cg.master = nil
+    end
+    if cg.replica ~= nil then
+        cg.replica:drop()
+        cg.replica = nil
+    end
+end)
+
+-- An instance bootstrapping a new replicaset with read_only =
+-- 'unless_bootstrap' goes RW; the same instance recovering from the
+-- local snapshot goes RO with no transient RW state. Note that the
+-- value left in the configuration does not fail the restart.
+g.test_bootstrap_rw_recovery_ro = function(cg)
+    cg.server = server:new({box_cfg = {read_only = 'unless_bootstrap'}})
+    cg.server:start()
+    cg.server:exec(function()
+        t.assert_equals(box.cfg.read_only, 'unless_bootstrap')
+        t.assert_equals(box.info.ro, false)
+        t.assert_equals(box.internal.is_bootstrap_leader(), true)
+    end)
+    t.assert(cg.server:grep_log('box switched to rw'))
+
+    cg.server:restart()
+    cg.server:exec(function()
+        t.assert_equals(box.cfg.read_only, 'unless_bootstrap')
+        t.assert_equals(box.info.ro, true)
+        t.assert_equals(box.info.ro_reason, 'config')
+        t.assert_equals(box.internal.is_bootstrap_leader(), false)
+        local ok = pcall(box.ctl.wait_rw, 0.1)
+        t.assert_not(ok)
+    end)
+    -- grep_log() with the default reset option looks only after the
+    -- last restart banner: the recovered instance must not go through
+    -- a transient RW state.
+    t.assert_not(cg.server:grep_log('box switched to rw'))
+    -- A positive control that the log is being read.
+    t.assert(cg.server:grep_log('entering the event loop'))
+end
+
+-- An instance joining an existing replicaset with read_only =
+-- 'unless_bootstrap' goes RO with no transient RW state.
+g.test_join_is_ro = function(cg)
+    cg.master = server:new({alias = 'master'})
+    cg.master:start()
+    cg.replica = server:new({
+        alias = 'replica',
+        box_cfg = {
+            read_only = 'unless_bootstrap',
+            replication = {cg.master.net_box_uri},
+        },
+    })
+    cg.replica:start()
+    cg.replica:exec(function()
+        t.assert_equals(box.cfg.read_only, 'unless_bootstrap')
+        t.assert_equals(box.info.ro, true)
+        t.assert_equals(box.internal.is_bootstrap_leader(), false)
+    end)
+    t.assert_not(cg.replica:grep_log('box switched to rw'))
+    t.assert(cg.replica:grep_log('entering the event loop'))
+end
+
+-- In the bootstrap master scoring the 'unless_bootstrap' mode counts
+-- as "the configuration does not enforce RO": such an instance wins
+-- the bootstrap over a read_only = true one.
+g.test_wins_bootstrap_scoring = function(cg)
+    cg.replica_set = replica_set:new({})
+    local uri_ub = server.build_listen_uri('ub', cg.replica_set.id)
+    local uri_ro = server.build_listen_uri('ro', cg.replica_set.id)
+    local replication = {uri_ub, uri_ro}
+    cg.replica_set:build_and_add_server({
+        alias = 'ub',
+        box_cfg = {
+            read_only = 'unless_bootstrap',
+            replication = replication,
+        },
+    })
+    cg.replica_set:build_and_add_server({
+        alias = 'ro',
+        box_cfg = {
+            read_only = true,
+            replication = replication,
+        },
+    })
+    cg.replica_set:start()
+    cg.replica_set:get_server('ub'):exec(function()
+        t.assert_equals(box.info.ro, false)
+        t.assert_equals(box.internal.is_bootstrap_leader(), true)
+    end)
+    cg.replica_set:get_server('ro'):exec(function()
+        t.assert_equals(box.info.ro, true)
+        t.assert_equals(box.internal.is_bootstrap_leader(), false)
+    end)
+end
+
+-- The box.status watcher reports is_ro_cfg the same way as the
+-- ballot: whether the configuration unconditionally enforces RO. The
+-- 'unless_bootstrap' value is not an unconditional RO enforcement;
+-- the effective state is visible in is_ro.
+g.test_status_watcher = function(cg)
+    cg.server = server:new({box_cfg = {read_only = 'unless_bootstrap'}})
+    cg.server:start()
+    local check_status = function(expected_is_ro)
+        local status
+        local w = box.watch('box.status', function(_, value)
+            status = value
+        end)
+        t.helpers.retrying({timeout = 5}, function()
+            t.assert_not_equals(status, nil)
+        end)
+        w:unregister()
+        t.assert_equals(status.is_ro_cfg, false)
+        t.assert_equals(status.is_ro, expected_is_ro)
+    end
+    cg.server:exec(check_status, {false})
+    cg.server:restart()
+    cg.server:exec(check_status, {true})
+end
+
+-- The 'unless_bootstrap' value may be set only during the initial
+-- box.cfg() call: the outcome of a dynamic switch would be
+-- unpredictable when a leader is already chosen elsewhere.
+g.test_dynamic_set_is_forbidden = function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    local check_banned = function()
+        t.assert_error_msg_contains(
+            "the 'unless_bootstrap' value may be set only during " ..
+            "the initial box.cfg() call",
+            box.cfg, {read_only = 'unless_bootstrap'})
+        t.assert_equals(box.cfg.read_only, false)
+        t.assert_equals(box.info.ro, false)
+    end
+    -- Banned right after the bootstrap...
+    cg.server:exec(check_banned)
+    -- ...and after a restart as well.
+    cg.server:restart()
+    cg.server:exec(check_banned)
+end
+
+-- Invalid values are rejected.
+g.test_invalid_value = function(cg)
+    cg.server = server:new()
+    cg.server:start()
+    cg.server:exec(function()
+        t.assert_error_msg_contains(
+            "the value must be a boolean or the string 'unless_bootstrap'",
+            box.cfg, {read_only = 'rw'})
+        t.assert_error_msg_contains(
+            'should be one of types boolean, string',
+            box.cfg, {read_only = 1})
+        -- The configuration is intact.
+        t.assert_equals(box.cfg.read_only, false)
+    end)
+end
+
+-- An invalid value fails the initial box.cfg() call: the instance
+-- refuses to start.
+g.test_invalid_value_on_startup = function()
+    local dir = treegen.prepare_directory({}, {})
+    treegen.write_file(dir, 'main.lua', [[
+        box.cfg({read_only = 'blah'})
+        os.exit(0)
+    ]])
+    local res = justrun.tarantool(dir, {}, {'main.lua'},
+        {nojson = true, stderr = true})
+    t.assert_not_equals(res.exit_code, 0)
+    t.assert_str_contains(res.stderr,
+        "Incorrect value for option 'read_only': " ..
+        "the value must be a boolean or the string 'unless_bootstrap'")
+end
+
+-- 'unless_bootstrap' is not allowed together with replication_anon
+-- (an anonymous replica must be strictly read-only).
+g.test_incompatible_with_anon = function()
+    local dir = treegen.prepare_directory({}, {})
+    treegen.write_file(dir, 'main.lua', [[
+        box.cfg({
+            read_only = 'unless_bootstrap',
+            replication_anon = true,
+        })
+        os.exit(0)
+    ]])
+    local res = justrun.tarantool(dir, {}, {'main.lua'},
+        {nojson = true, stderr = true})
+    t.assert_not_equals(res.exit_code, 0)
+    t.assert_str_contains(res.stderr,
+        'the value may be set to true only when the instance is read-only')
+end
+
+-- TT_READ_ONLY environment variable accepts 'unless_bootstrap' along
+-- with the usual booleans.
+g.test_env_tt_read_only = function(cg)
+    cg.server = server:new({env = {TT_READ_ONLY = 'unless_bootstrap'}})
+    cg.server:start()
+    cg.server:exec(function()
+        t.assert_equals(box.cfg.read_only, 'unless_bootstrap')
+        t.assert_equals(box.info.ro, false)
+    end)
+    cg.server:drop()
+
+    cg.server = server:new({env = {TT_READ_ONLY = 'false'}})
+    cg.server:start()
+    cg.server:exec(function()
+        t.assert_equals(box.cfg.read_only, false)
+        t.assert_equals(box.info.ro, false)
+    end)
+end

--- a/test/config-luatest/supervised_bootstrap_test.lua
+++ b/test/config-luatest/supervised_bootstrap_test.lua
@@ -70,6 +70,88 @@ g.test_basic = function()
     end)
 end
 
+-- gh-12970: rebootstrap (wipe + restart) of the instance with the
+-- minimal name must not bring it up in the RW mode when the
+-- replicaset is already bootstrapped and has an appointed leader.
+--
+-- Before the fix such an instance considered itself a bootstrap
+-- leader (empty data directory + minimal name), started in RW and
+-- the post-box.cfg check passed erroneously, because the instance
+-- rejoined into its old registration with replica id 1. As a
+-- result there were two RW instances in the replicaset.
+--
+-- Now the bootstrap leader candidate starts with read_only =
+-- 'unless_bootstrap' and a rejoined instance not only ends up in RO, but never
+-- reports a writable state at all.
+g.test_rebootstrap_of_min_name_instance_goes_ro = function()
+    local config = cbuilder:new()
+        :use_replicaset('r-001')
+        :set_replicaset_option('replication.failover', 'supervised')
+        :set_replicaset_option('replication.bootstrap_strategy', 'auto')
+        :add_instance('i-001', {})
+        :add_instance('i-002', {})
+        :config()
+
+    local cluster = cluster:new(config)
+    cluster:start()
+
+    -- i-001 has the minimal name, so it bootstraps the replicaset
+    -- and starts in RW. The configured 'unless_bootstrap' value is normalized
+    -- to a boolean after the startup.
+    cluster['i-001']:exec(function()
+        t.assert_equals(box.info.ro, false)
+        t.assert_equals(box.cfg.read_only, false)
+    end)
+
+    -- Imitate the failover coordinator: move the leadership to
+    -- i-002.
+    cluster['i-001']:exec(function()
+        box.cfg({read_only = true})
+    end)
+    cluster['i-002']:exec(function()
+        box.cfg({read_only = false})
+    end)
+
+    -- Rebootstrap i-001: stop it, wipe its data directory and
+    -- start it again. It rejoins the replicaset (from i-002) into
+    -- its old registration.
+    cluster['i-001']:stop()
+    local workdir = fio.pathjoin(cluster._dir, 'var/lib/i-001')
+    for _, file in ipairs(fio.glob(fio.pathjoin(workdir, '*'))) do
+        fio.unlink(file)
+    end
+    cluster['i-001']:start()
+
+    -- The appointed leader must stay RW...
+    cluster['i-002']:exec(function()
+        t.assert_equals(box.info.ro, false)
+    end)
+
+    -- ...and the rebootstrapped instance must NOT become a second
+    -- master: it should end up in RO despite its minimal name and
+    -- empty data directory at startup.
+    cluster['i-001']:exec(function()
+        t.helpers.retrying({timeout = 10}, function()
+            t.assert_equals(box.info.status, 'running')
+            t.assert_equals(box.info.ro, true)
+            t.assert_equals(box.cfg.read_only, true)
+        end)
+    end)
+
+    -- Moreover, it must not go through a transient RW state: the
+    -- log of the new incarnation must not contain the RW
+    -- transition at all.
+    --
+    -- grep_log() with the default reset option looks only after
+    -- the last restart banner, so the first (bootstrap) incarnation
+    -- of i-001, which was legitimately RW, does not affect the
+    -- check.
+    t.assert_not(cluster['i-001']:grep_log('box switched to rw'))
+    -- A positive control that the log is being read: the new
+    -- incarnation joins the replicaset from scratch.
+    t.assert(cluster['i-001']:grep_log('bootstrapping replica from'))
+end
+
 g.test_upscale_is_not_stuck = function()
     local config_1 = cbuilder:new()
         :use_replicaset('r-001')


### PR DESCRIPTION
*(This PR is a backport of #13000 to `archive/3.6` to a future `3.6.5` release.)*

----

With `replication.failover = supervised` and `replication.bootstrap_strategy = auto` the instance with the lexicographically minimal name and an empty data directory starts in RW to be able to bootstrap the replicaset, and a post-box.cfg hook demotes it to RO if it turns out the replicaset already exists. The demotion check is `box.info.id ~= 1`, and it gives a false positive when such an instance is rebootstrapped (stopped, wiped and started again to rejoin the replicaset): the instance gets its old replica id 1 back, passes the check and stays RW alongside the leader appointed by the failover coordinator. Two masters accept writes independently and replication ends up permanently broken with 'Duplicate key exists' errors. We hit this in production, where reseeding a broken replica this way is a routine recovery procedure.

Instead of patching the check, the series removes the guess-then-demote scheme altogether. A new `box.cfg.read_only` value is introduced: `'unless_bootstrap'`, meaning "become writable only if this instance has bootstrapped the replicaset on the current startup, stay read-only otherwise (local recovery or join)". The mode is resolved atomically during the initial `box.cfg()` call: the instance is read-only for the whole duration of the call anyway, and the option is applied when the bootstrap outcome is already known, so the very first RO/RW transition happens with the final value. A rejoined instance never reports a writable state at all and `box.ctl.wait_rw()` watchers cannot observe a transient RW window, which also addresses the concern raised in the issue discussion. The value may be set only during the initial `box.cfg()` call: a dynamic switch is banned as its outcome would be unpredictable with a leader already chosen elsewhere, while the value left in the configuration keeps the next startup working (it resolves to RO on a recovery).

The supervised bootstrap logic in the config applier now simply starts the bootstrap leader candidate with `read_only = 'unless_bootstrap'`. The demotion hook is gone together with its 30-second wait for `box.info.id`, which was a source of startup problems on its own (see #11318). The only thing left in the hook is the normalization of the configured `'unless_bootstrap'` value to the resolved boolean, since the external failover coordinator treats `box.cfg.read_only` as a source of truth.

In effect this implements the minimal-change approach proposed in #11286 for the supervised bootstrap flow (the problem example 1 there).

Closes #12970
