### PR TITLE
box: allow listing local read views in application threads

### DIFF
--- a/src/box/lua/read_view.lua
+++ b/src/box/lua/read_view.lua
@@ -191,26 +191,31 @@ end
 box.read_view = {}
 
 --
--- Returns an array of all open read views sorted by id, ascending.
+-- Returns an array of all read views opened in the current thread,
+-- sorted by id, ascending.
 --
 -- Since read view ids grow incrementally and never wrap around,
 -- the most recent read view will always be last.
 --
 function box.read_view.list()
-    if not fiber._internal.cord_is_main then
-        box.error(box.error.UNSUPPORTED, 'Application thread',
-                  'listing read views', 2)
-    end
     local list = {}
-    for _, rv in ipairs(internal.list()) do
-        local registered_rv = read_view_registry[rv.id]
-        if registered_rv == nil then
-            -- This is a new read view object that hasn't been used from Lua
-            -- yet. Add it to the registry for the next listing to return the
-            -- same object.
-            registered_rv = register_read_view(rv)
+    if fiber._internal.cord_is_main then
+        -- Use internal.list in the main thread to include system read views
+        -- into the listing.
+        for _, rv in ipairs(internal.list()) do
+            local registered_rv = read_view_registry[rv.id]
+            if registered_rv == nil then
+                -- This is a new read view object that hasn't been used from
+                -- Lua yet. Add it to the registry for the next listing to
+                -- return the same object.
+                registered_rv = register_read_view(rv)
+            end
+            table.insert(list, registered_rv)
         end
-        table.insert(list, registered_rv)
+    else
+        for _, rv in pairs(read_view_registry) do
+            table.insert(list, rv)
+        end
     end
     table.sort(list, function(rv1, rv2) return rv1.id < rv2.id end)
     return list

--- a/test/box-luatest/read_view_test.lua
+++ b/test/box-luatest/read_view_test.lua
@@ -2715,12 +2715,6 @@ g_threads.test_unsupported = function(cg)
             type = 'ClientError',
             name = 'UNSUPPORTED',
             message = 'Application thread does not support ' ..
-                      'listing read views',
-        }, box.read_view.list)
-        t.assert_error_covers({
-            type = 'ClientError',
-            name = 'UNSUPPORTED',
-            message = 'Application thread does not support ' ..
                       'creating a new read view',
         }, box.read_view.open)
     end, {}, {_thread_id = 1})
@@ -3004,5 +2998,48 @@ g_threads.after_test('test_data_access', function(cg)
         if box.space.test ~= nil then
             box.space.test:drop()
         end
+    end)
+end)
+
+g_threads.test_list = function(cg)
+    local rv_ids = cg.server:exec(function()
+        local rvs = {}
+        rawset(_G, 'test_rvs', rvs)
+        local rv_ids = {}
+        for i = 1, 3 do
+            rvs[i] = box.read_view.open({name = 'test' .. i})
+            table.insert(rv_ids, rvs[i].id)
+        end
+        return rv_ids
+    end)
+    cg.server:exec(function(rv_ids)
+        t.assert_equals(box.read_view.list(), {})
+        local rv1 = box.read_view.open({id = rv_ids[1]})
+        local rv2 = box.read_view.open({id = rv_ids[2]})
+        t.assert_equals(box.read_view.list(), {rv1, rv2})
+        rv2:close()
+        rv2 = nil -- luacheck: ignore
+        for _ = 1, 5 do collectgarbage('collect') end
+        t.assert_equals(box.read_view.list(), {rv1})
+    end, {rv_ids}, {_thread_id = 1})
+    cg.server:exec(function(rv_ids)
+        t.assert_equals(box.read_view.list(), {})
+        local rv1 = box.read_view.open({id = rv_ids[1]})
+        local rv2 = box.read_view.open({id = rv_ids[2]})
+        local rv3 = box.read_view.open({id = rv_ids[3]})
+        t.assert_equals(box.read_view.list(), {rv1, rv2, rv3})
+        rv3:close()
+        rv3 = nil -- luacheck: ignore
+        for _ = 1, 5 do collectgarbage('collect') end
+        t.assert_equals(box.read_view.list(), {rv1, rv2})
+    end, {rv_ids}, {_thread_id = 2})
+    cg.server:exec(function()
+        t.assert_equals(box.read_view.list(), rawget(_G, 'test_rvs'))
+    end)
+end
+
+g_threads.after_test('test_list', function(cg)
+    cg.server:exec(function()
+        rawset(_G, 'test_rvs', nil)
     end)
 end)


### PR DESCRIPTION
It may be useful for figuring out why a read view isn't deleted. Note that, in constrat to the main thread, which lists all read views, including read views created for system purposes, application threads only list local read views, i.e. read views opened by id in the current thread.

Follow-up #12951