### PR TITLE
box: crash on update with delete by json path

### DIFF
--- a/changelogs/unreleased/gh-13027-update-json-path-key-encoding.md
+++ b/changelogs/unreleased/gh-13027-update-json-path-key-encoding.md
@@ -1,0 +1,4 @@
+## bugfix/box
+
+* Fixed a crash on update with delete by JSON path with terminal key when
+  the deleted key in tuple had non-optimal encoding (gh-13027)

--- a/src/box/tuple.c
+++ b/src/box/tuple.c
@@ -509,7 +509,8 @@ tuple_field_go_to_index(const char **field, uint64_t index)
 }
 
 int
-tuple_field_go_to_key(const char **field, const char *key, int len)
+tuple_field_go_to_key(const char **field, const char *key, int len,
+		      const char **field_key)
 {
 	enum mp_type type = mp_typeof(**field);
 	if (type != MP_MAP)
@@ -519,6 +520,8 @@ tuple_field_go_to_key(const char **field, const char *key, int len)
 		type = mp_typeof(**field);
 		if (type == MP_STR) {
 			uint32_t value_len;
+			if (field_key != NULL)
+				*field_key = *field;
 			const char *value = mp_decode_str(field, &value_len);
 			if (value_len == (uint)len &&
 			    memcmp(value, key, len) == 0)
@@ -552,7 +555,8 @@ tuple_go_to_path(const char **data, const char *path, uint32_t path_len,
 			rc = tuple_field_go_to_index(data, token.num);
 			break;
 		case JSON_TOKEN_STR:
-			rc = tuple_field_go_to_key(data, token.str, token.len);
+			rc = tuple_field_go_to_key(data, token.str, token.len,
+						   /*field_key=*/NULL);
 			break;
 		default:
 			assert(token.type == JSON_TOKEN_END);

--- a/src/box/tuple.h
+++ b/src/box/tuple.h
@@ -926,12 +926,14 @@ tuple_field_go_to_index(const char **field, uint64_t index);
  * @param[in][out] field Field to propagate.
  * @param key Key to propagate to.
  * @param len Length of @a key.
+ * @param field_key Pointer to key in @a field.
  *
  * @retval  0 Success, the index was found.
  * @retval -1 Not found.
  */
 int
-tuple_field_go_to_key(const char **field, const char *key, int len);
+tuple_field_go_to_key(const char **field, const char *key, int len,
+		      const char **field_key);
 
 /**
  * Get tuple field by field index, relative JSON path and

--- a/src/box/xrow_update_bar.c
+++ b/src/box/xrow_update_bar.c
@@ -53,21 +53,19 @@ xrow_update_bar_finish(struct xrow_update_field *field)
  *
  * @param op Update operation.
  * @param field Field to locate in.
- * @param[out] key_len_or_index One parameter for two values,
- *        depending on where the target point is located: in an
- *        array or a map. In case of map it is size of a key
- *        before the found point. It is used to find range of the
- *        both key and value in '#' operation to drop the pair.
- *        In case of array it is index of the array element to be
- *        able to check how many fields are left for deletion.
+ * @param[out] index The parameter is set to index in array in case target point
+ *        is located in a array. Otherwise is undefined.
+ * @param[out] field_key The parameter is set to pointer to key in map in case
+ *        target point is located in a map. Otherwise is undefined. NULL is
+ *        valid to ignore this output parameter.
  *
  * @retval 0 Success.
  * @retval -1 Not found or invalid JSON.
  */
 static inline int
 xrow_update_bar_locate(struct xrow_update_op *op,
-		       struct xrow_update_field *field,
-		       int *key_len_or_index)
+		       struct xrow_update_field *field, int *index,
+		       const char **field_key)
 {
 	/*
 	 * Bar update is not flat by definition. It always has a
@@ -88,17 +86,16 @@ xrow_update_bar_locate(struct xrow_update_op *op,
 	struct json_token token;
 	while ((rc = json_lexer_next_token(&op->lexer, &token)) == 0 &&
 	       token.type != JSON_TOKEN_END) {
-
 		switch (token.type) {
 		case JSON_TOKEN_NUM:
 			field->bar.parent = pos;
-			*key_len_or_index = token.num;
+			*index = token.num;
 			rc = tuple_field_go_to_index(&pos, token.num);
 			break;
 		case JSON_TOKEN_STR:
 			field->bar.parent = pos;
-			*key_len_or_index = token.len;
-			rc = tuple_field_go_to_key(&pos, token.str, token.len);
+			rc = tuple_field_go_to_key(&pos, token.str, token.len,
+						   field_key);
 			break;
 		default:
 			assert(token.type == JSON_TOKEN_ANY);
@@ -162,7 +159,8 @@ xrow_update_bar_locate_opt(struct xrow_update_op *op,
 			break;
 		case JSON_TOKEN_STR:
 			field->bar.parent = pos;
-			rc = tuple_field_go_to_key(&pos, token.str, token.len);
+			rc = tuple_field_go_to_key(&pos, token.str, token.len,
+						   /*field_key=*/NULL);
 			break;
 		default:
 			assert(token.type == JSON_TOKEN_ANY);
@@ -266,14 +264,15 @@ xrow_update_op_do_nop_delete(struct xrow_update_op *op,
 {
 	assert(op->opcode == '#');
 	assert(field->type == XUPDATE_NOP);
-	int key_len_or_index = 0;
-	if (xrow_update_bar_locate(op, field, &key_len_or_index) != 0)
+	int index = 0;
+	const char *field_key = NULL;
+	if (xrow_update_bar_locate(op, field, &index, &field_key) != 0)
 		return -1;
 	if (mp_typeof(*field->bar.parent) == MP_ARRAY) {
 		const char *tmp = field->bar.parent;
 		uint32_t size = mp_decode_array(&tmp);
-		if (key_len_or_index + op->arg.del.count > size)
-			op->arg.del.count = size - key_len_or_index;
+		if (index + op->arg.del.count > size)
+			op->arg.del.count = size - index;
 		const char *end = field->bar.point + field->bar.point_size;
 		for (uint32_t i = 1; i < op->arg.del.count; ++i)
 			mp_next(&end);
@@ -281,10 +280,10 @@ xrow_update_op_do_nop_delete(struct xrow_update_op *op,
 	} else {
 		if (op->arg.del.count != 1)
 			return xrow_update_err_delete1(op);
-		/* Take key size into account to delete it too. */
-		key_len_or_index = mp_sizeof_str(key_len_or_index);
-		field->bar.point -= key_len_or_index;
-		field->bar.point_size += key_len_or_index;
+		const char *field_key_end = field_key;
+		mp_next(&field_key_end);
+		field->bar.point = field_key;
+		field->bar.point_size += field_key_end - field_key;
 	}
 	return xrow_update_bar_finish(field);
 }
@@ -295,8 +294,8 @@ xrow_update_op_do_nop_##op_type(struct xrow_update_op *op,			\
 				struct xrow_update_field *field)		\
 {										\
 	assert(field->type == XUPDATE_NOP);					\
-	int key_len_or_index;							\
-	if (xrow_update_bar_locate(op, field, &key_len_or_index) != 0)		\
+	int index;								\
+	if (xrow_update_bar_locate(op, field, &index, /*field_key=*/NULL) != 0)	\
 		return -1;							\
 	const char *data = field->bar.point;					\
 	xrow_update_mp_read_scalar(&data, &field->bar.scalar);			\

--- a/src/box/xrow_update_route.c
+++ b/src/box/xrow_update_route.c
@@ -213,7 +213,8 @@ xrow_update_route_branch(struct xrow_update_field *field,
 			break;
 		case JSON_TOKEN_STR:
 			rc = tuple_field_go_to_key(&next_pos, new_token.str,
-						   new_token.len);
+						   new_token.len,
+						   /*field_key=*/NULL);
 			break;
 		default:
 			unreachable();

--- a/test/box-luatest/gh_13027_update_json_path_encoding_mismatch_test.lua
+++ b/test/box-luatest/gh_13027_update_json_path_encoding_mismatch_test.lua
@@ -1,0 +1,14 @@
+local msgpack = require('msgpack')
+local t = require('luatest')
+
+local g = t.group()
+
+-- Delete by json path key when key in tuple is encoded not optimally.
+g.test_gh_13027 = function()
+    -- {1, {a = 2, b = 3}} with 'a' encoded as STR8.
+    local raw = "\x92\x01\x82\xd9\x01a\x02\xa1b\x03"
+    -- This construction creates [t] instead of expected t.
+    local x = box.tuple.new(msgpack.object_from_raw(raw))
+    local u = x:update({{'#', '[1][2].a', 1}})
+    t.assert_equals(u:totable(), {{1, {b = 3}}})
+end


### PR DESCRIPTION
Deletion using JSON path with terminal key may result in "bar" optimization (basically isolated update deep in the tuple). In this case we make a copy of original tuple with map header updated to size - 1 and copy of map values except the deleted key/value pair (see `xrow_update_bar_store()`). The deleted key/value is defined by bar.point, bar.point_size. But in `xrow_update_op_do_nop_delete()` this pair is incorrectly set if key in tuple has different encoding then in update ops. In MsgPack different encoding is not prohibited.

Closes #13027