### PR TITLE
lua: use same package.searchroot in all threads

### DIFF
--- a/changelogs/unreleased/gh-12546-setsearchroot-in-app-threads.md
+++ b/changelogs/unreleased/gh-12546-setsearchroot-in-app-threads.md
@@ -1,0 +1,5 @@
+## bugfix/core
+
+* The root directory from which Lua dependencies are loaded was made global:
+  setting it with `package.setsearchroot()` in any thread now affects all
+  threads (gh-12546).

--- a/src/lua/init.c
+++ b/src/lua/init.c
@@ -31,9 +31,7 @@
 #include "lua/init.h"
 #include "lua/utils.h"
 #include "main.h"
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
-#endif
 
 #include <assert.h>
 #include <lua.h>
@@ -76,6 +74,7 @@
 #include "digest.h"
 #include "errinj.h"
 #include "trivia/config.h"
+#include "tt_pthread.h"
 
 #ifdef ENABLE_BACKTRACE
 #include "core/backtrace.h"
@@ -114,6 +113,19 @@ luaopen_zip(lua_State *L);
  * The single Lua state of the transaction processor (tx) thread.
  */
 __thread struct lua_State *tarantool_L;
+
+/**
+ * Path to the search root directory.
+ *
+ * The search root directory is used as the root directory for loading Lua
+ * dependencies from. It affects all application threads.
+ */
+static char *package_searchroot;
+
+/**
+ * Mutex protecting package_searchroot.
+ */
+static pthread_mutex_t package_searchroot_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /**
  * The fiber running the startup Lua script
@@ -393,6 +405,68 @@ ret_nil:
 }
 
 /**
+ * package.searchroot() - returns the path to the search root directory.
+ *
+ * If the search root directory is unset, the path to the current working
+ * directory is returned.
+ */
+static int
+lbox_tarantool_package_searchroot(struct lua_State *L)
+{
+	bool is_set = false;
+	tt_pthread_mutex_lock(&package_searchroot_mutex);
+	if (package_searchroot != NULL) {
+		lua_pushstring(L, package_searchroot);
+		is_set = true;
+	}
+	tt_pthread_mutex_unlock(&package_searchroot_mutex);
+	if (is_set)
+		return 1;
+	char buf[PATH_MAX];
+	char *cwd = getcwd(buf, sizeof(buf));
+	if (cwd == NULL) {
+		diag_set(SystemError, "getcwd");
+		return luaT_push_nil_and_error(L);
+	}
+	lua_pushstring(L, cwd);
+	return 1;
+}
+
+/**
+ * package.setsearchroot() - sets the path to the search root directory.
+ *
+ * If no path is specified, the search root directory is set to the directory
+ * where the calling function's source file is located.
+ *
+ * If box.NULL is passed, the search root directory is unset.
+ */
+static int
+lbox_tarantool_package_setsearchroot(struct lua_State *L)
+{
+	char *new_root;
+	if (luaL_isnull(L, 1)) {
+		new_root = NULL;
+	} else if (lua_isnoneornil(L, 1)) {
+		struct lua_Debug info;
+		VERIFY(lua_getstack(L, 1, &info) == 1);
+		VERIFY(lua_getinfo(L, "S", &info) == 1);
+		char *path = xstrdup(info.source[0] == '@' ?
+				     info.source + 1 : info.source);
+		new_root = abspath(dirname(path));
+		free(path);
+	} else if (lua_type(L, 1) == LUA_TSTRING) {
+		new_root = abspath(lua_tostring(L, 1));
+	} else {
+		return luaL_error(L, "Search root must be a string");
+	}
+	tt_pthread_mutex_lock(&package_searchroot_mutex);
+	free(package_searchroot);
+	package_searchroot = new_root;
+	tt_pthread_mutex_unlock(&package_searchroot_mutex);
+	return 0;
+}
+
+/**
  * Convert lua number or string to lua cdata 64bit number.
  */
 static int
@@ -602,6 +676,11 @@ tarantool_lua_setpaths(struct lua_State *L)
 	lua_concat(L, lua_gettop(L) - top);
 	tarantool_lua_pushpath_env(L, "LUA_CPATH");
 	lua_setfield(L, top, "cpath");
+
+	lua_pushcfunction(L, lbox_tarantool_package_searchroot);
+	lua_setfield(L, top, "searchroot");
+	lua_pushcfunction(L, lbox_tarantool_package_setsearchroot);
+	lua_setfield(L, top, "setsearchroot");
 
 	assert(lua_gettop(L) == top);
 	lua_pop(L, 1); /* package */

--- a/src/lua/loaders.lua
+++ b/src/lua/loaders.lua
@@ -14,24 +14,6 @@ local ROCKS_LUA_TEMPLATES = {
     ROCKS_LUA_PATH .. '/?/init.lua',
 }
 
-local package_searchroot
-
-local function searchroot()
-    return package_searchroot or minifio.cwd()
-end
-
-local function setsearchroot(path)
-    if not path then
-        -- Here we need to get this function caller's sourcedir.
-        path = debug.sourcedir(3)
-    elseif path == box.NULL then
-        path = nil
-    else
-        assert(type(path) == 'string', 'Search root must be a string')
-    end
-    package_searchroot = path and minifio.abspath(path)
-end
-
 local function mksymname(name)
     local mark = string.find(name, "-")
     if mark then name = string.sub(name, mark + 1) end
@@ -92,16 +74,16 @@ end
 local path = {
     package = function() return package.path end,
     cwd = {
-        dot = gen_path_builder(searchroot, LUA_TEMPLATES),
-        rocks = gen_path_builder(searchroot, ROCKS_LUA_TEMPLATES, true),
+        dot = gen_path_builder(package.searchroot, LUA_TEMPLATES),
+        rocks = gen_path_builder(package.searchroot, ROCKS_LUA_TEMPLATES, true),
     }
 }
 
 local cpath = {
     package = function() return package.cpath end,
     cwd = {
-        dot = gen_path_builder(searchroot, LIB_TEMPLATES),
-        rocks = gen_path_builder(searchroot, ROCKS_LIB_TEMPLATES, true),
+        dot = gen_path_builder(package.searchroot, LIB_TEMPLATES),
+        rocks = gen_path_builder(package.searchroot, ROCKS_LIB_TEMPLATES, true),
     }
 }
 
@@ -497,8 +479,6 @@ for index, _ in ipairs(searchers) do
 end
 
 rawset(package, "search", search)
-rawset(package, "searchroot", searchroot)
-rawset(package, "setsearchroot", setsearchroot)
 
 local no_package_loaded = {}
 local raw_require = require

--- a/test/box-luatest/app_threads_module_test.lua
+++ b/test/box-luatest/app_threads_module_test.lua
@@ -16,23 +16,6 @@ local SERVER_OPTS = {
     net_box_credentials = {user = 'admin', password = 'secret'},
 }
 
---
--- FIXME(gh-12546): For server.exec to be able to find the luatest module,
--- searchroot must be set in the test server. For the main thread, this is
--- done automatically by luatest itself, but due to the bug in Tarantool,
--- searchroot isn't propagated to application threads so we have to set it
--- manually. Remove this when the bug is fixed.
---
-local function setsearchroot(server)
-    local searchroot, app_threads = server:exec(function()
-        return package.searchroot(), box.cfg.app_threads
-    end)
-    for i = 1, app_threads do
-        server:eval('package.setsearchroot(...)', {searchroot},
-                    {_thread_id = i})
-    end
-end
-
 g.test_threads_config_propagation = function()
     --
     -- Check that the threads configuration is propagated to box.cfg
@@ -106,7 +89,6 @@ g.test_threads_config_propagation = function()
     --
     -- Check configuration in other threads.
     --
-    setsearchroot(cluster.server)
     for i = 1, 10 do
         local group_name, thread_id
         if i < 2 then
@@ -412,7 +394,6 @@ g.test_threads_call = function()
     --
     -- Usage in other a non-tx thread.
     --
-    setsearchroot(cluster.server)
     cluster.server:exec(function()
         local threads = require('experimental.threads')
         t.assert_covers(threads.info(), {
@@ -594,7 +575,6 @@ g.test_threads_eval = function()
     --
     -- Usage in other a non-tx thread.
     --
-    setsearchroot(cluster.server)
     cluster.server:exec(function()
         local threads = require('experimental.threads')
         t.assert_covers(threads.info(), {

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -15,23 +15,6 @@ local t = require('luatest')
 
 local g = t.group()
 
---
--- FIXME(gh-12546): For server.exec to be able to find the luatest module,
--- searchroot must be set in the test server. For the main thread, this is
--- done automatically by luatest itself, but due to the bug in Tarantool,
--- searchroot isn't propagated to application threads so we have to set it
--- manually. Remove this when the bug is fixed.
---
-local function setsearchroot(server)
-    local searchroot, app_threads = server:exec(function()
-        return package.searchroot(), box.cfg.app_threads
-    end)
-    for i = 1, app_threads do
-        server:eval('package.setsearchroot(...)', {searchroot},
-                    {_thread_id = i})
-    end
-end
-
 g.before_all(function(cg)
     cg.server = server:new({
         box_cfg = {
@@ -41,7 +24,6 @@ g.before_all(function(cg)
         net_box_credentials = {user = 'admin'}
     })
     cg.server:start()
-    setsearchroot(cg.server)
 end)
 
 g.after_all(function(cg)
@@ -734,7 +716,6 @@ g.test_net_replicaset = function()
         net_box_credentials = {user = 'admin', password = 'secret'},
     })
     cluster:start()
-    setsearchroot(cluster.router)
     local connect_cfg = cluster.router:exec(function()
         local net_replicaset = require('internal.net.replicaset')
         return net_replicaset.get_connect_cfg('storage')

--- a/test/box-luatest/gh_12546_setsearchroot_in_app_threads_test.lua
+++ b/test/box-luatest/gh_12546_setsearchroot_in_app_threads_test.lua
@@ -1,0 +1,44 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({
+        box_cfg = {app_threads = 1},
+        net_box_credentials = {user = 'admin'}
+    })
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_setsearchroot = function(cg)
+    local p1 = cg.server:exec(function()
+        return package.searchroot()
+    end)
+    local p2 = cg.server:exec(function()
+        return package.searchroot()
+    end, {}, {_thread_id = 1})
+    t.assert_equals(p1, p2)
+    local p3 = cg.server:exec(function()
+        local fio = require('fio')
+        package.setsearchroot(fio.tempdir())
+        return package.searchroot()
+    end)
+    local p4 = cg.server:exec(function()
+        return package.searchroot()
+    end, {}, {_thread_id = 1})
+    t.assert_equals(p3, p4)
+    local p5 = cg.server:exec(function(path)
+        package.setsearchroot(path)
+        return package.searchroot()
+    end, {p1}, {_thread_id = 1})
+    local p6 = cg.server:exec(function()
+        return package.searchroot()
+    end)
+    t.assert_equals(p5, p6)
+    t.assert_equals(p6, p1)
+end

--- a/test/box-luatest/read_view_test.lua
+++ b/test/box-luatest/read_view_test.lua
@@ -2670,20 +2670,6 @@ g_threads.before_all(function(cg)
         net_box_credentials = {user = 'admin'}
     })
     cg.server:start()
-    --
-    -- FIXME(gh-12546): For server.exec to be able to find the luatest module,
-    -- searchroot must be set in the test server. For the main thread, this is
-    -- done automatically by luatest itself, but due to the bug in Tarantool,
-    -- searchroot isn't propagated to application threads so we have to set it
-    -- manually. Remove this when the bug is fixed.
-    --
-    local searchroot = cg.server:exec(function()
-        return package.searchroot()
-    end)
-    for i = 1, cg.server.box_cfg.app_threads do
-        cg.server:eval('package.setsearchroot(...)', {searchroot},
-                       {_thread_id = i})
-    end
 end)
 
 g_threads.after_all(function(cg)


### PR DESCRIPTION
`package.setsearchroot()` sets the root directory from which dependencies are loaded. Currently, it's thread-local so one has to set it in all application threads in addition to setting it in the main thread. This is inconvenient. In particular, we have to set it in all tests that use the luatest module.

Let's make the variable that stores the search root directory path global so that `package.setsearchroot()` now affects all threads. To protect from MT-races, we protect it with a mutex, which should be fine because the search root is typically updated only at startup and used only when a new module is loaded.

Closes #12546