### PR TITLE
box: expose minimal box.info to application threads

### DIFF
--- a/changelogs/unreleased/gh-12787-box-info-in-app-threads.md
+++ b/changelogs/unreleased/gh-12787-box-info-in-app-threads.md
@@ -1,0 +1,5 @@
+## feature/core
+
+* The following `box.info` fields can now be accessed in application threads:
+  `package`, `version`, `id`, `uuid`, `name`, `replicaset.uuid`,
+  `replicaset.name`, `cluster.name`.

--- a/src/box/lua/app_threads.lua
+++ b/src/box/lua/app_threads.lua
@@ -1,8 +1,11 @@
 local errno = require('errno')
+local fiber = require('fiber')
 local ffi = require('ffi')
 local net = require('net.box')
 local socket = require('socket')
+local tarantool = require('tarantool')
 local utils = require('internal.utils')
+local uuid = require('uuid')
 
 ffi.cdef([[
     void
@@ -260,6 +263,51 @@ function thread_group_methods:eval(expr, args, opts)
     return self:_dispatch(thread_eval_cb, {expr, args}, opts)
 end
 
+local function box_info_init()
+    local box_info = {
+        package = tarantool.package,
+        version = tarantool.version,
+        id = box.NULL,
+        uuid = uuid.NULL,
+        name = box.NULL,
+        replicaset = {
+            uuid = uuid.NULL,
+            name = box.NULL,
+        },
+        cluster = {
+            name = box.NULL,
+        },
+    }
+    local box_info_call = function()
+        return box_info
+    end
+    box.info = setmetatable({
+        package = tarantool.package,
+        version = tarantool.version,
+    }, {
+        __index = box_info,
+        __call = box_info_call,
+        __serialize = box_info_call,
+    })
+    local on_box_info_update = fiber.cond()
+    threads_conn:watch('box.id', function(_k, v)
+        box_info.id = v.id
+        box_info.uuid = v.instance_uuid
+        box_info.name = v.instance_name
+        box_info.replicaset.uuid = v.replicaset_uuid
+        box_info.replicaset.name = v.replicaset_name
+        box_info.cluster.name = v.cluster_name
+        on_box_info_update:broadcast()
+    end)
+    -- Wait until box.info is initialized so that code executed in application
+    -- threads can read it right after box.cfg() is done. Note, we have to keep
+    -- the watcher since instance, replicaset, and cluster names can be set
+    -- after recovery.
+    while box_info.id == box.NULL do
+        on_box_info_update:wait()
+    end
+end
+
 --
 -- Initializes the subsystem in the current thread.
 --
@@ -268,7 +316,8 @@ function box.internal.threads.init(cfg, group_name, id_in_group, conn_fd)
     threads_cfg = cfg
     this_group_name = group_name
     this_thread_id_in_group = id_in_group
-    if group_name ~= 'tx' then
+    local is_main = (group_name == 'tx')
+    if not is_main then
         ffi.C.cord_set_name(string.format('%s%d', group_name, id_in_group))
     end
     threads_conn = net.from_fd(conn_fd, {
@@ -281,6 +330,9 @@ function box.internal.threads.init(cfg, group_name, id_in_group, conn_fd)
         _disable_graceful_shutdown = true,
     })
     init_thread_groups(cfg)
+    if not is_main then
+        box_info_init()
+    end
 end
 
 --

--- a/src/box/lua/recovery_point_manager.lua
+++ b/src/box/lua/recovery_point_manager.lua
@@ -156,12 +156,11 @@ end
 -- The default label for a recovery point: <instance>.<manager>.<uuid>, with a
 -- fresh uuid on each call. The instance segment is the instance name, its uuid
 -- when the name is unset, or is omitted entirely when the instance is
--- unconfigured (box.info is also absent in an application thread).
+-- unconfigured.
 --
 local function manager_default_label(manager)
-    local info = box.info
-    local instance = info ~= nil and (info.name ~= box.NULL and info.name
-        or info.uuid ~= uuid.NULL and info.uuid)
+    local instance = (box.info.name ~= box.NULL and box.info.name or
+                      box.info.uuid ~= uuid.NULL and box.info.uuid)
     if instance then
         return string.format('%s.%s.%s', instance, manager.name, uuid.str())
     end

--- a/test/box-luatest/app_threads_test.lua
+++ b/test/box-luatest/app_threads_test.lua
@@ -93,16 +93,16 @@ g.test_call_eval = function(cg)
     local conn = net.connect(cg.server.net_box_uri,
                              cg.server.net_box_credentials)
     -- Call a box function in the main thread.
-    t.assert_covers(conn:call('box.info', {}, {_thread_id = 0}),
-                    {status = 'running'})
+    t.assert_equals(conn:call('box.ctl.is_recovery_finished',
+                              {}, {_thread_id = 0}), true)
     -- Check that the box function is unavailable in an application thread.
     local err = {
         type = 'ClientError',
         name = 'NO_SUCH_PROC',
-        func = 'box.info',
+        func = 'box.ctl.is_recovery_finished',
     }
-    t.assert_error_covers(err, conn.call, conn, 'box.info', {},
-                          {_thread_id = 1})
+    t.assert_error_covers(err, conn.call, conn, 'box.ctl.is_recovery_finished',
+                          {}, {_thread_id = 1})
     -- Register a function in an application thread.
     conn:eval([[rawset(_G, 'test_func', function() return 42 end)]], {},
               {_thread_id = 1})
@@ -818,8 +818,7 @@ g.test_recovery_point_manager = function(cg)
     cg.server:exec(function()
         local rp = box.backup.recovery_point
         t.assert_type(rp.manager_create, 'function')
-        -- Neither box.info nor config is available in an application thread.
-        t.assert_equals(box.info, nil)
+        -- config is unavailable in an application thread.
         t.assert_equals(pcall(require, 'config'), false)
 
         local created = {}
@@ -838,13 +837,14 @@ g.test_recovery_point_manager = function(cg)
         -- No config -> no alerts namespace, but the manager still runs.
         t.assert_equals(m.alert_namespace, nil)
 
-        -- The loop creates points. With no box.info the label carries no
-        -- instance segment: <manager>.<uuid>.
+        -- The loop creates points.
         t.helpers.retrying({timeout = 10}, function()
             t.assert_ge(#created, 2)
         end)
         for _, label in ipairs(created) do
-            t.assert_str_matches(label, 'thr%.[^.]+')
+            local uuid = '%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-' ..
+                         '%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x'
+            t.assert_str_matches(label, uuid .. '%.thr%.' .. uuid)
         end
 
         m:drop()

--- a/test/box-luatest/gh_12787_box_info_in_app_threads_test.lua
+++ b/test/box-luatest/gh_12787_box_info_in_app_threads_test.lua
@@ -1,0 +1,81 @@
+local t = require('luatest')
+local server = require('luatest.server')
+
+local g = t.group()
+
+g.before_all(function(cg)
+    cg.server = server:new({
+        box_cfg = {app_threads = 1},
+        net_box_credentials = {user = 'admin'}
+    })
+    cg.server:start()
+end)
+
+g.after_all(function(cg)
+    cg.server:drop()
+end)
+
+g.test_box_info = function(cg)
+    local main_box_info = cg.server:exec(function()
+        local tarantool = require('tarantool')
+        t.assert_equals(box.info, {
+            package = tarantool.package,
+            version = tarantool.version,
+        })
+        return box.info()
+    end)
+    local box_info = cg.server:exec(function(main_box_info)
+        local yaml = require('yaml')
+        local tarantool = require('tarantool')
+        t.assert_equals(box.info, {
+            package = tarantool.package,
+            version = tarantool.version,
+        })
+        local expected = {}
+        for _, k in ipairs({
+            'package', 'version', 'id', 'uuid', 'name',
+            'replicaset', 'cluster',
+        }) do
+            t.assert_is_not(main_box_info[k], nil)
+            expected[k] = main_box_info[k]
+        end
+        local box_info = box.info()
+        t.assert_equals(box_info, expected)
+        t.assert_equals(yaml.decode(yaml.encode(box.info)), expected)
+        for k, v in pairs(expected) do
+            t.assert_equals(box_info[k], v, k)
+        end
+        return box_info
+    end, {main_box_info}, {_thread_id = 1})
+    --
+    -- Set instance, replicaset, and cluster names and check that
+    -- they are propagated to application threads.
+    --
+    cg.server:exec(function()
+        box.cfg({
+            instance_name = 'test_instance',
+            replicaset_name = 'test_replicaset',
+            cluster_name = 'test_cluster',
+        })
+        t.assert_covers(box.info(), {
+            name = 'test_instance',
+            replicaset = {name = 'test_replicaset'},
+            cluster = {name = 'test_cluster'},
+        })
+    end)
+    box_info.name = 'test_instance'
+    box_info.replicaset.name = 'test_replicaset'
+    box_info.cluster.name = 'test_cluster'
+    cg.server:exec(function(box_info)
+        t.helpers.retrying({}, function()
+            t.assert_equals(box.info(), box_info)
+        end)
+    end, {box_info}, {_thread_id = 1})
+    --
+    -- Check that box.info() is restored after restart.
+    --
+    cg.server:restart()
+    cg.server:exec(function(box_info)
+        t.assert_equals(box.info(), box_info)
+    end, {box_info}, {_thread_id = 1})
+end


### PR DESCRIPTION
This patch exposes the following box.info fields to application threads:
 - box.info.package
 - box.info.version
 - box.info.id
 - box.info.uuid
 - box.info.name
 - box.info.replicaset.uuid
 - box.info.replicaset.name
 - box.info.cluster.name

The 'package' and 'version' fields are initialized at startup while other fields are updated on 'box.id' broadcast.

The exported fields may be useful, for example, for enriching errors with information about the instance where an error originated from.

Closes #12787