### PR TITLE
Fixed issue that didn't allow to use standalone sequences in yielding and concurrent transactions

### DIFF
--- a/changelogs/unreleased/gh-11266-cannot-use-standalone-sequence-in-yielding-transaction.md
+++ b/changelogs/unreleased/gh-11266-cannot-use-standalone-sequence-in-yielding-transaction.md
@@ -1,0 +1,4 @@
+## bugfix/box/sequence
+
+* Standalone sequences can now be used in yielding and concurrent transactions
+  (gh-11266).

--- a/src/box/memtx_engine.cc
+++ b/src/box/memtx_engine.cc
@@ -819,7 +819,8 @@ memtx_engine_prepare(struct engine *engine, struct txn *txn)
 			if (stmt->engine != engine)
 				continue;
 			assert(stmt->space->engine == engine);
-			memtx_tx_history_prepare_stmt(stmt);
+			if (stmt->space->def->id != BOX_SEQUENCE_DATA_ID)
+				memtx_tx_history_prepare_stmt(stmt);
 		}
 	}
 	return 0;

--- a/src/box/schema.cc
+++ b/src/box/schema.cc
@@ -254,9 +254,12 @@ sc_space_new(uint32_t id, const char *name,
 	space_cache_replace(NULL, space);
 	if (replace_trigger)
 		trigger_add(&space->on_replace, replace_trigger);
-	struct trigger *t = (struct trigger *) malloc(sizeof(*t));
-	trigger_create(t, on_replace_dd_system_space, NULL, (trigger_f0) free);
-	trigger_add(&space->on_replace, t);
+	if (id != BOX_SEQUENCE_DATA_ID) {
+		struct trigger *t = (struct trigger *)xmalloc(sizeof(*t));
+		trigger_create(t, on_replace_dd_system_space,
+			       NULL, (trigger_f0)free);
+		trigger_add(&space->on_replace, t);
+	}
 	/*
 	 * Data dictionary spaces are fully built since:
 	 * - they contain data right from the start

--- a/test/box-luatest/gh_11266_cannot_use_standalone_sequence_in_yielding_transaction_test.lua
+++ b/test/box-luatest/gh_11266_cannot_use_standalone_sequence_in_yielding_transaction_test.lua
@@ -1,0 +1,79 @@
+local server = require('luatest.server')
+local t = require('luatest')
+
+local g = t.group()
+
+g.before_each(function(cg)
+    cg.server = server:new{box_cfg = {memtx_use_mvcc_engine = true}}
+    cg.server:start()
+end)
+
+g.after_each(function(cg)
+    cg.server:stop()
+end)
+
+local function test_standalone_sequence_usage_in_yielding_transaction(engine)
+    local fiber = require('fiber')
+
+    local seq = box.schema.sequence.create('test')
+    local s = box.schema.space.create('test', {engine = engine})
+    s:create_index('primary')
+
+    box.begin()
+    local id = seq:next()
+    fiber.yield()
+    s:insert({id, 'x'})
+    box.commit()
+
+    t.assert_equals(s:get({id}), {id, 'x'})
+end
+
+g.test_standalone_sequence_usage_in_yielding_transaction_memtx = function(cg)
+    local engine = 'memtx'
+    cg.server:exec(test_standalone_sequence_usage_in_yielding_transaction,
+                   {engine})
+end
+
+g.test_standalone_sequence_usage_in_yielding_transaction_vinyl = function(cg)
+    local engine = 'vinyl'
+    cg.server:exec(test_standalone_sequence_usage_in_yielding_transaction,
+                   {engine})
+end
+
+local function test_standalone_sequence_usage_from_concurrent_transactions(
+        engine)
+    local fiber = require('fiber')
+
+    local seq = box.schema.sequence.create('test')
+    local s = box.schema.space.create('test', {engine = engine})
+    s:create_index('primary')
+
+    box.begin()
+    s:insert({seq:next(), 'x'})
+
+    local f = fiber.new(box.atomic, function()
+        s:insert({seq:next(), 'y'})
+    end)
+    f:set_joinable(true)
+    f:join()
+
+    box.commit()
+
+    local tuples = s:select({1}, {iterator = 'ge'})
+    t.assert_equals(tuples[1], {1, 'x'})
+    t.assert_equals(tuples[2], {2, 'y'})
+end
+
+g.test_standalone_sequence_usage_from_concurrent_transactions_memtx = function(
+        cg)
+    local engine = 'memtx'
+    cg.server:exec(test_standalone_sequence_usage_from_concurrent_transactions,
+                   {engine})
+end
+
+g.test_standalone_sequence_usage_from_concurrent_transactions_memtx = function(
+        cg)
+    local engine = 'vinyl'
+    cg.server:exec(test_standalone_sequence_usage_from_concurrent_transactions,
+                   {engine})
+end


### PR DESCRIPTION
Fixed issue that didn't allow using standalone sequences in yielding and concurrent transactions.

Closes #11266 

NO_DOC=bugfix