### PR TITLE
box: store read view reference counter in Lua

### DIFF
--- a/src/box/lua/read_view.c
+++ b/src/box/lua/read_view.c
@@ -177,6 +177,9 @@ lbox_push_space_read_view(struct lua_State *L,
  *     -- Read view handle (cdata).
  *     _crv = <cdata:struct read_view_handle *>,
  *
+ *     -- Pointer to the read view object serialized as a %p-formatted string.
+ *     _ptr = <string>
+ *
  *     id = <number>,                            -- read view id
  *     name = <string>,                          -- read view name
  *     is_system = <bool>,                       -- system?
@@ -225,6 +228,9 @@ lbox_new_read_view(struct lua_State *L, struct read_view *rv)
 		L, CTID_STRUCT_READ_VIEW_HANDLE) = rvh;
 	lua_setfield(L, -2, "_crv");
 
+	lua_pushfstring(L, "%p", rv);
+	lua_setfield(L, -2, "_ptr");
+
 	/* Create a space table. */
 	lua_newtable(L);
 	struct space_read_view_handle *space;
@@ -268,69 +274,6 @@ lbox_read_view_open(struct lua_State *L)
 }
 
 /**
- * Pushes a pointer to the given read view encoded as a %p-formatted string
- * to the Lua stack. See also lbox_check_read_view_ptr_str.
- */
-static void
-lbox_push_read_view_ptr_str(struct lua_State *L, struct read_view *rv)
-{
-	lua_pushfstring(L, "%p", rv);
-}
-
-/**
- * Returns a pointer to a read view encoded as a %p-formatted string at
- * the given index in the Lua stack. See also lbox_push_read_view_ptr_str.
- */
-static struct read_view *
-lbox_check_read_view_ptr_str(struct lua_State *L, int idx)
-{
-	struct read_view *rv = NULL;
-	VERIFY(sscanf(luaL_checkstring(L, idx), "%p", &rv) == 1);
-	return rv;
-}
-
-/**
- * Increments the usage counter of a read view.
- * Takes a read view id.
- * Returns a pointer to the read view encoded as a %p-formatted string.
- * On error, raises a Lua exception.
- */
-static int
-lbox_read_view_acquire(struct lua_State *L)
-{
-	assert(cord_is_main());
-	uint64_t id = luaL_checkuint64(L, 1);
-	struct read_view *rv = read_view_by_id(id);
-	if (rv == NULL || rv->is_close_pending) {
-		diag_set(ClientError, ER_NO_SUCH_READ_VIEW);
-		return luaT_error(L);
-	}
-	if (rv->is_system) {
-		diag_set(ClientError, ER_READ_VIEW_BUSY);
-		return luaT_error(L);
-	}
-	read_view_pin(rv);
-	lbox_push_read_view_ptr_str(L, rv);
-	return 1;
-}
-
-/**
- * Decrements the usage counter of a read view and deletes the read view
- * if it was closed and has no more users.
- * Takes a pointer to a read view encoded as a %p-formatted string.
- */
-static int
-lbox_read_view_release(struct lua_State *L)
-{
-	assert(cord_is_main());
-	struct read_view *rv = lbox_check_read_view_ptr_str(L, 1);
-	read_view_unpin(rv);
-	if (rv->pin_count == 0 && rv->is_close_pending)
-		read_view_delete(rv);
-	return 0;
-}
-
-/**
  * Reuses an existing database read view.
  * Takes a pointer to a read view encoded as a %p-formatted string.
  * On error, raises a Lua exception.
@@ -338,7 +281,8 @@ lbox_read_view_release(struct lua_State *L)
 static int
 lbox_read_view_reuse(struct lua_State *L)
 {
-	struct read_view *rv = lbox_check_read_view_ptr_str(L, 1);
+	struct read_view *rv;
+	VERIFY(sscanf(luaL_checkstring(L, 1), "%p", &rv) == 1);
 	if (lbox_new_read_view(L, rv) != 0)
 		return luaT_error_at(L, 2);
 	return 1;
@@ -369,24 +313,14 @@ lbox_read_view_list(struct lua_State *L)
 }
 
 /**
- * Given a read view object (a table that has the 'id' field), pushes
- * the read view status string ('open', 'closed', 'close_pending') to
- * the Lua stack.
+ * Returns true if the read view with the given id exists.
  */
 static int
-lbox_read_view_status(struct lua_State *L)
+lbox_read_view_exists(struct lua_State *L)
 {
 	assert(cord_is_main());
-	lua_getfield(L, 1, "id");
-	uint64_t id = luaL_checkuint64(L, -1);
-	struct read_view *rv = read_view_by_id(id);
-	if (rv == NULL) {
-		lua_pushliteral(L, "closed");
-	} else if (rv->is_close_pending) {
-		lua_pushliteral(L, "close_pending");
-	} else {
-		lua_pushliteral(L, "open");
-	}
+	uint64_t id = luaL_checkuint64(L, 1);
+	lua_pushboolean(L, read_view_by_id(id) != NULL);
 	return 1;
 }
 
@@ -396,11 +330,9 @@ lbox_read_view_status(struct lua_State *L)
  *
  * The behavior of this function differs between the main thread and
  * application threads:
- *  - The main thread closes the core read view if it has no users,
- *    otherwise it marks the read view as "close pending" to be closed
- *    as soon as the last user is gone.
- *  - An application thread returns a pointer to the core read view
- *    to be passed to the main thread for release.
+ *  - The main thread deletes the core read view object immediately.
+ *  - An application thread returns the read view id to be passed to
+ *    the main thread for release.
  */
 static int
 lbox_read_view_close(struct lua_State *L)
@@ -414,15 +346,10 @@ lbox_read_view_close(struct lua_State *L)
 	}
 	read_view_handle_delete(rvh);
 	if (cord_is_main()) {
-		assert(!rv->is_close_pending);
-		if (rv->pin_count == 0) {
-			read_view_delete(rv);
-		} else {
-			rv->is_close_pending = true;
-		}
+		read_view_delete(rv);
 		return 0;
 	} else {
-		lbox_push_read_view_ptr_str(L, rv);
+		luaL_pushuint64(L, rv->id);
 		return 1;
 	}
 }
@@ -629,11 +556,9 @@ box_lua_read_view_init(struct lua_State *L)
 	int rc;
 	const struct luaL_Reg module_methods[] = {
 		{"open", lbox_read_view_open},
-		{"acquire", lbox_read_view_acquire},
-		{"release", lbox_read_view_release},
 		{"reuse", lbox_read_view_reuse},
 		{"list", lbox_read_view_list},
-		{"status", lbox_read_view_status},
+		{"exists", lbox_read_view_exists},
 		{"close", lbox_read_view_close},
 		{"index_get", lbox_index_read_view_get},
 		{"index_count", lbox_index_read_view_count},

--- a/src/box/lua/read_view.lua
+++ b/src/box/lua/read_view.lua
@@ -67,11 +67,6 @@ local iterator_pos_end = ffi.new('const char *[1]')
 
 local internal = box.internal.read_view
 
-if fiber._internal.cord_is_main then
-    threads.export('box.internal.read_view.acquire', internal.acquire)
-    threads.export('box.internal.read_view.release', internal.release)
-end
-
 -- box.read_view.open() options template.
 local READ_VIEW_OPTIONS_TEMPLATE = {
     name = 'string',
@@ -145,7 +140,15 @@ local read_view_methods = {}
 local read_view_properties = {
     -- System read views are closed asynchronously so we have to query
     -- the status.
-    status = internal.status,
+    status = function(self)
+        if self._status ~= nil then
+            return self._status
+        elseif internal.exists(self.id) then
+            return 'open'
+        else
+            return 'closed'
+        end
+    end
 }
 
 local read_view_mt = {
@@ -226,12 +229,12 @@ end
 -- sends a request to release the read view to the main thread.
 --
 local function read_view_close(crv, warn)
-    local ptr = internal.close(crv, warn)
-    if ptr ~= nil then
+    local id = internal.close(crv, warn)
+    if id ~= nil then
         assert(not fiber._internal.cord_is_main)
         -- threads.call() yields while we can't yield in this function
         -- because it may be called by the garbage collector.
-        fiber.new(threads.call, 'tx', 'box.internal.read_view.release', {ptr})
+        fiber.new(threads.call, 'tx', 'box.internal.read_view.release', {id})
     end
 end
 
@@ -267,7 +270,7 @@ function box.read_view.open(opts)
         -- If the read view is already in the thread-local registry and
         -- it has an active handle, there's no need to create a new one.
         rv = read_view_registry[opts.id]
-        if rv ~= nil and rv._crv ~= nil then
+        if rv ~= nil and rv.status == 'open' and rv._crv ~= nil then
             return rv
         end
         -- Ask the main thread to pin the read view with the given id
@@ -283,13 +286,10 @@ function box.read_view.open(opts)
         ok, ret = pcall(internal.reuse, ptr)
         if not ok then
             -- Don't forget to unpin the read view on error.
-            threads.call('tx', 'box.internal.read_view.release', {ptr})
+            threads.call('tx', 'box.internal.read_view.release', {opts.id})
             box.error(ret, 2)
         end
         rv = ret
-        -- Reset the status field because application threads can't call
-        -- internal.status.
-        rv.status = 'open'
     else
         if not fiber._internal.cord_is_main then
             box.error(box.error.UNSUPPORTED, 'Application thread',
@@ -315,6 +315,8 @@ function box.read_view.open(opts)
             end
         end
     end
+    rv._refs = 0
+    rv._status = 'open'
     ffi.gc(rv._crv, read_view_gc)
     return register_read_view(rv)
 end
@@ -359,6 +361,16 @@ function read_view_methods:close()
         -- System read view. Can't be closed.
         box.error(box.error.READ_VIEW_BUSY, 2)
     end
+    if self._refs == 0 then
+        self:_do_close()
+    else
+        self._status = 'close_pending'
+    end
+end
+
+function read_view_methods:_do_close()
+    assert(self.status ~= 'closed')
+    assert(self._crv ~= nil)
     for _, space in pairs(self.space) do
         for _, index in pairs(space.index) do
             -- Reset cdata because it's going to be invalidated by 'close'.
@@ -370,11 +382,78 @@ function read_view_methods:close()
     read_view_close(self._crv)
     ffi.gc(self._crv, nil)
     self._crv = nil
-    if not fiber._internal.cord_is_main then
-        -- Reset the status field because application threads can't call
-        -- internal.status.
-        self.status = 'closed'
+    self._status = 'closed'
+end
+
+--
+-- Map: id -> referenced read view.
+--
+-- Used to prevent the garbage collector from deleting read views referenced
+-- in other threads.
+--
+local referenced_read_views = {}
+
+--
+-- Acquires a reference to this read view.
+--
+-- A referenced read view isn't closed immediately. Instead, its status is
+-- changed to 'close_pending' and remains so until the last reference to it
+-- is gone, after which it's closed for real.
+--
+function read_view_methods:_acquire()
+    assert(self.status == 'open')
+    assert(self._crv ~= nil)
+    assert(self._refs >= 0)
+    if self._refs == 0 then
+        referenced_read_views[self.id] = self
+    else
+        assert(referenced_read_views[self.id] == self)
     end
+    self._refs = self._refs + 1
+end
+
+--
+-- Releases a reference to this read view.
+--
+-- If the read view was closed (its status is 'close_pending'), it will be
+-- deleted as soon as the last reference to it is gone.
+--
+function read_view_methods:_release()
+    assert(self.status ~= 'closed')
+    assert(self._crv ~= nil)
+    assert(self._refs > 0)
+    self._refs = self._refs - 1
+    if self._refs == 0 then
+        referenced_read_views[self.id] = nil
+        if self.status == 'close_pending' then
+            self:_do_close()
+        end
+    end
+end
+
+if fiber._internal.cord_is_main then
+    -- Acquires a reference to a read view in the main thread.
+    -- Returns a pointer to the referenced read view.
+    threads.export('box.internal.read_view.acquire', function(id)
+        local rv = read_view_registry[id]
+        -- System read views are added to the Lua registry on demand so
+        -- to raise a proper error on an attempt to acquire a reference
+        -- to a system read view, we also check the C registry.
+        if internal.exists(id) and (rv == nil or rv._crv == nil) then
+            box.error(box.error.READ_VIEW_BUSY)
+        end
+        if rv == nil or rv.status ~= 'open' then
+            box.error(box.error.NO_SUCH_READ_VIEW)
+        end
+        rv:_acquire()
+        return rv._ptr
+    end)
+    -- Releases a reference to a read view in the main thread.
+    threads.export('box.internal.read_view.release', function(id)
+        local rv = read_view_registry[id]
+        assert(rv ~= nil)
+        rv:_release()
+    end)
 end
 
 --

--- a/src/box/read_view.c
+++ b/src/box/read_view.c
@@ -228,8 +228,6 @@ read_view_new(const struct read_view_opts *opts)
 	rv->id = next_read_view_id++;
 	assert(opts->name != NULL);
 	rv->name = xstrdup(opts->name);
-	rv->pin_count = 0;
-	rv->is_close_pending = false;
 	rv->is_system = opts->is_system;
 	rv->disable_decompression = opts->disable_decompression;
 	rv->timestamp = ev_monotonic_now(loop());
@@ -264,7 +262,6 @@ void
 read_view_delete(struct read_view *rv)
 {
 	assert(cord_is_main());
-	assert(rv->pin_count == 0);
 	read_view_unregister(rv);
 	struct space_read_view *space_rv, *next_space_rv;
 	rlist_foreach_entry_safe(space_rv, &rv->spaces, link,

--- a/src/box/read_view.h
+++ b/src/box/read_view.h
@@ -124,16 +124,6 @@ struct read_view {
 	/** Read view name. Used for introspection. */
 	char *name;
 	/**
-	 * Number of users referring to this read view.
-	 * A read view must not be deleted until it's 0.
-	 */
-	int pin_count;
-	/**
-	 * Set if the read view should be closed as soon as the last user stops
-	 * using it (pin_count hits 0).
-	 */
-	bool is_close_pending;
-	/**
 	 * Set if this read view is needed for system purposes (for example, to
 	 * make a checkpoint). Initialized with read_view_opts::is_system.
 	 */
@@ -268,19 +258,6 @@ read_view_new(const struct read_view_opts *opts);
  */
 void
 read_view_delete(struct read_view *rv);
-
-static inline void
-read_view_pin(struct read_view *rv)
-{
-	rv->pin_count++;
-}
-
-static inline void
-read_view_unpin(struct read_view *rv)
-{
-	assert(rv->pin_count > 0);
-	rv->pin_count--;
-}
 
 /**
  * Looks up an open read view by id.


### PR DESCRIPTION
Currently, it's stored in the C structure, which is fine for now because it's used only for acquiring references in application threads. However, we're planning to let Lua code take a reference to a read view to prevent it from closing and it sounds logical to reuse the existing reference counting mechanism for that. To prepare for that, let's store references in Lua.

Needed for #13037