### PR TITLE
connpool: reconnect on instance URI change

### DIFF
--- a/changelogs/unreleased/connpool-reconnect-on-uri-change.md
+++ b/changelogs/unreleased/connpool-reconnect-on-uri-change.md
@@ -1,0 +1,6 @@
+## bugfix/config
+
+* The `experimental.connpool` module now closes cached connections and
+  re-establishes them on configuration reload if the peer URI of an
+  instance has been changed, including credentials and SSL parameters
+  such as certificate paths (part of tarantool/tarantool-ee#1660).

--- a/src/box/lua/config/applier/connpool.lua
+++ b/src/box/lua/config/applier/connpool.lua
@@ -13,7 +13,20 @@ local function apply(config)
     log.verbose(('connpool.apply: set idle timeout to %d'):format(idle_timeout))
 end
 
+local function post_apply(_config)
+    -- require() it here to avoid a circular dependency.
+    local connpool = require('experimental.connpool')
+
+    -- The URIs are reloaded here and not in apply(), because
+    -- config:instance_uri() returns URIs of the new configuration
+    -- only after all the appliers are done.
+    connpool._reload_uris()
+
+    log.verbose('connpool.post_apply: reloaded instance URIs')
+end
+
 return {
     name = 'connpool',
     apply = apply,
+    post_apply = post_apply,
 }

--- a/src/box/lua/connpool.lua
+++ b/src/box/lua/connpool.lua
@@ -165,6 +165,61 @@ function pool_methods.get_connection(self, instance_name)
     return self._connections[instance_name]
 end
 
+-- config:instance_uri() raises an error on an instance unknown to
+-- the current configuration, so resolve instances removed from
+-- the topology to nil instead. Errors on a known instance (e.g. a
+-- misconfigured URI or credentials) are forwarded.
+local function instance_uri_or_nil(instance_name)
+    if config:instances()[instance_name] == nil then
+        return nil
+    end
+    return config:instance_uri('peer', {instance = instance_name})
+end
+
+--- Close and reconnect cached connections whose instance URI has
+--- been changed by a configuration reload. Connections to
+--- instances removed from the configuration are closed and
+--- evicted.
+function pool_methods.reload_uris(self)
+    -- Collect the instances first: instance_uri_or_nil() does not
+    -- yield, so the collected names are consistent with the cache.
+    local to_evict = {}
+    local to_reconnect = {}
+    for name, conn in pairs(self._connections) do
+        local uri = instance_uri_or_nil(name)
+        if uri == nil then
+            table.insert(to_evict, name)
+        elseif not table.equals(uri, conn._uri) then
+            table.insert(to_reconnect, name)
+        end
+    end
+
+    for _, name in ipairs(to_evict) do
+        local conn = self._connections[name]
+        self._connections[name] = nil
+        conn:close()
+    end
+
+    for _, name in ipairs(to_reconnect) do
+        -- The loop yields, so re-fetch the connection and re-check
+        -- the URI: the cache may have been changed by the
+        -- watchdogs or a concurrent connect().
+        local conn = self._connections[name]
+        local uri = instance_uri_or_nil(name)
+        if conn ~= nil and uri ~= nil and
+           not table.equals(uri, conn._uri) then
+            -- The closed connection is kept in the cache, so
+            -- connect() inherits its deadline and reconnect mark.
+            conn:close()
+            self:connect(name, {
+                ttl = 0,
+                wait_connected = false,
+                fetch_schema = conn.opts.fetch_schema,
+            })
+        end
+    end
+end
+
 --- Connect to an instance or receive a cached connection by
 --- name.
 ---
@@ -200,6 +255,8 @@ function pool_methods.connect(self, instance_name, opts)
             return nil, msg:format(instance_name, res.message)
         end
         conn = res
+        -- Used by reload_uris() to detect configuration changes.
+        conn._uri = table.deepcopy(uri)
         self._connections[instance_name] = conn
         local function mode(conn)
             if conn.state == 'active' then
@@ -375,6 +432,10 @@ local pool = create_pool()
 
 local function set_idle_timeout(idle_timeout)
     pool:set_idle_timeout(idle_timeout)
+end
+
+local function reload_uris()
+    pool:reload_uris()
 end
 
 local function connect(instance_name, opts)
@@ -765,4 +826,7 @@ return {
     call = call,
 
     set_idle_timeout = set_idle_timeout,
+
+    -- Internal API for the config applier, not for public use.
+    _reload_uris = reload_uris,
 }

--- a/test/config-luatest/rpc_test.lua
+++ b/test/config-luatest/rpc_test.lua
@@ -2,6 +2,7 @@
 
 local t = require('luatest')
 local fiber = require('fiber')
+local fio = require('fio')
 local fun = require('fun')
 local treegen = require('luatest.treegen')
 local server = require('luatest.server')
@@ -1387,5 +1388,194 @@ g.test_does_not_wait_if_recently_checked = function()
 
         t.assert_equals(_G.connects, cur_connects)
         t.assert_lt(elapsed_time, CONNECT_TIMEOUT)
+    end)
+end
+
+local function build_two_instances_config()
+    return cbuilder:new()
+        :set_global_option('credentials.users.myuser',
+            {password =  'secret',
+             roles = { 'replication' },
+             privileges = {{permissions = {'execute'}, universe = true}}})
+        :set_global_option('iproto.advertise.peer.login', 'myuser')
+        :add_instance('i-001', { database = { mode = 'rw' } })
+        :add_instance('i-002', {})
+        :config()
+end
+
+-- Add a counter to count netbox.connect() calls.
+local function add_netbox_connect_counter(cluster)
+    treegen.write_file(cluster._dir, 'override/net/box.lua',
+        string.dump(function()
+            local loaders = require('internal.loaders')
+
+            rawset(_G, 'connects', 0)
+
+            local builtin_netbox = loaders.builtin['net.box']
+            local builtin_connect = builtin_netbox.connect
+            builtin_netbox.connect = function(...)
+                _G.connects = _G.connects + 1
+                return builtin_connect(...)
+            end
+
+            return builtin_netbox
+        end))
+end
+
+g.test_reconnects_on_peer_uri_change = function()
+    local config = build_two_instances_config()
+    local cluster = cluster:new(config)
+
+    add_netbox_connect_counter(cluster)
+
+    cluster:start()
+
+    cluster['i-001']:exec(function()
+        local connpool = require('experimental.connpool')
+
+        local conn = connpool.connect('i-002')
+        t.assert_equals(conn.state, 'active')
+        t.assert_equals(_G.connects, 1)
+        rawset(_G, 'i2_conn', conn)
+    end)
+
+    -- Advertise i-002 by an equivalent URI pointing to the same
+    -- unix socket by an absolute path.
+    local new_config = cbuilder:new(config)
+        :set_instance_option('i-002', 'iproto.advertise.peer.uri',
+                             ('unix/:%s/i-002.iproto'):format(cluster._dir))
+        :config()
+    cluster:reload(new_config)
+
+    cluster['i-001']:exec(function()
+        local connpool = require('experimental.connpool')
+
+        -- The old connection has been closed by the reload and
+        -- replaced with a new one.
+        t.assert_equals(_G.i2_conn.state, 'closed')
+
+        local conn = connpool.connect('i-002')
+        t.assert_equals(conn.state, 'active')
+        t.assert_not_equals(conn, _G.i2_conn)
+        t.assert_equals(_G.connects, 2)
+    end)
+end
+
+g.test_no_reconnect_without_uri_change = function()
+    local config = build_two_instances_config()
+    local cluster = cluster:new(config)
+
+    add_netbox_connect_counter(cluster)
+
+    cluster:start()
+
+    cluster['i-001']:exec(function()
+        local connpool = require('experimental.connpool')
+
+        local conn = connpool.connect('i-002')
+        t.assert_equals(conn.state, 'active')
+        rawset(_G, 'i2_conn', conn)
+    end)
+
+    -- Reload with a change unrelated to the instance URIs.
+    local new_config = cbuilder:new(config)
+        :set_global_option('connpool.idle_timeout', 3600)
+        :config()
+    cluster:reload(new_config)
+
+    cluster['i-001']:exec(function()
+        local connpool = require('experimental.connpool')
+
+        t.assert_equals(_G.i2_conn.state, 'active')
+        t.assert_is(connpool.connect('i-002'), _G.i2_conn)
+        t.assert_equals(_G.connects, 1)
+    end)
+end
+
+g.test_evicts_connection_to_removed_instance = function()
+    local config = cbuilder:new(build_two_instances_config())
+        :add_instance('i-003', {})
+        :config()
+    local cluster = cluster:new(config)
+
+    cluster:start()
+
+    cluster['i-001']:exec(function()
+        local connpool = require('experimental.connpool')
+
+        local conn = connpool.connect('i-003')
+        t.assert_equals(conn.state, 'active')
+        rawset(_G, 'i3_conn', conn)
+    end)
+
+    -- Remove i-003 from the configuration. The instance itself
+    -- keeps running, so the cached connection stays alive until
+    -- connpool evicts it.
+    local new_config = cbuilder:new(config)
+        :set_replicaset_option('instances.i-003', nil)
+        :config()
+    cluster:sync(new_config)
+
+    cluster['i-001']:exec(function()
+        local config = require('config')
+
+        config:reload()
+        t.assert_equals(_G.i3_conn.state, 'closed')
+    end)
+end
+
+g.test_reconnects_on_ssl_cert_change = function()
+    t.tarantool.skip_if_not_enterprise(
+        'The iproto.ssl option is supported only by Tarantool ' ..
+        'Enterprise Edition')
+
+    local cert_dir = fio.pathjoin(fio.abspath(os.getenv('SOURCEDIR') or '.'),
+                                  'test/enterprise-luatest/ssl_cert')
+
+    local config = cbuilder:new(build_two_instances_config())
+        :set_global_option('iproto.listen', {{
+            uri = 'unix/:./{{ instance_name }}.iproto',
+            params = {transport = 'ssl'},
+        }})
+        :set_global_option('iproto.ssl', {
+            ssl_cert = fio.pathjoin(cert_dir, 'server.crt'),
+            ssl_key = fio.pathjoin(cert_dir, 'server.key'),
+        })
+        :config()
+    local cluster = cluster:new(config)
+
+    add_netbox_connect_counter(cluster)
+
+    cluster:start()
+
+    cluster['i-001']:exec(function()
+        local connpool = require('experimental.connpool')
+
+        local conn = connpool.connect('i-002')
+        t.assert_equals(conn.state, 'active')
+        rawset(_G, 'i2_conn', conn)
+    end)
+
+    -- Rotate the SSL certificates.
+    local new_config = cbuilder:new(config)
+        :set_global_option('iproto.ssl', {
+            ssl_cert = fio.pathjoin(cert_dir, 'server_2.crt'),
+            ssl_key = fio.pathjoin(cert_dir, 'server_2.key'),
+        })
+        :config()
+    cluster:reload(new_config)
+
+    cluster['i-001']:exec(function()
+        local connpool = require('experimental.connpool')
+
+        -- The old connection has been closed by the reload and
+        -- replaced with a one using the new certificates.
+        t.assert_equals(_G.i2_conn.state, 'closed')
+
+        local conn = connpool.connect('i-002')
+        t.assert_equals(conn.state, 'active')
+        t.assert_not_equals(conn, _G.i2_conn)
+        t.assert_equals(conn:eval('return true'), true)
+        t.assert_equals(_G.connects, 2)
     end)
 end


### PR DESCRIPTION
The connection pool caches connections by instance name and never
revisits them while they stay healthy. A configuration reload that
changes an instance URI (its address, credentials, or SSL
parameters such as certificate paths) had no effect on the
established connections: the pool kept using the old ones.

Remember the resolved URI on each pooled connection and compare it
with the freshly resolved one when a new configuration is applied.
Connections whose URI has changed are closed and re-established
with the new parameters, keeping their idle deadlines. Connections
to instances removed from the configuration are closed and evicted.

Note that a change of certificate file contents under an unchanged
path is not detected. Such connections keep working with the old
certificates until they break and get re-established by the failed
connection watchdog.

Part of tarantool/tarantool-ee#1660

NO_DOC=bugfix
