### PR TITLE
lua: fix json encoding of serialized key

### DIFF
--- a/changelogs/unreleased/gh-12726-fix-json-encode-serialized.md
+++ b/changelogs/unreleased/gh-12726-fix-json-encode-serialized.md
@@ -1,0 +1,4 @@
+## bugfix/lua
+
+* Fixed the error in the JSON encoder when an encoded key in the map has
+  `__serialize` metamethod (gh-12726).

--- a/test/app-tap/json.test.lua
+++ b/test/app-tap/json.test.lua
@@ -25,7 +25,7 @@ test:plan(1)
 
 test:test("json", function(test)
     local serializer = require('json')
-    test:plan(82)
+    test:plan(83)
 
     test:test("unsigned", common.test_unsigned, serializer)
     test:test("signed", common.test_signed, serializer)
@@ -313,6 +313,15 @@ test:test("json", function(test)
     test:is(err_msg,
             "Expected value but found invalid token on line 1 at character 1 here ' >> a'",
             'mem-leak test for .decode error with options')
+    --
+    -- gh-12726: Check that we used an original key while
+    -- iterating, not its serialized form.
+    --
+    local meta_obj = setmetatable({}, {__serialize = function()
+        return 'serialized'
+    end})
+    test:is(j.encode({[meta_obj] = 'value'}), '{"serialized":"value"}',
+            'encoding with serialized object as the key')
 end)
 
 os.exit(test:check() and 0 or 1)

--- a/third_party/lua-cjson/lua_cjson.c
+++ b/third_party/lua-cjson/lua_cjson.c
@@ -319,7 +319,11 @@ static void json_append_object(lua_State *l, struct luaL_serializer *cfg,
             comma = 1;
 
         struct luaL_field field;
-        luaL_checkfield(l, cfg, -2, &field);
+        /* Push a copy of the key on top of the stack. */
+        lua_pushvalue(l, -2);
+        /* const table, (table ?), key_idx, key, value, key */
+        luaL_checkfield(l, cfg, -3, &field);
+        /* const table, (table ?), key_idx, key_ser, value, key */
         switch (field.type) {
         case MP_UINT:
             strbuf_append_char(json, '"');
@@ -340,6 +344,8 @@ static void json_append_object(lua_State *l, struct luaL_serializer *cfg,
             break;
         }
 
+        /* Replace the serialized key with the original form. */
+        lua_replace(l, -3);
         /* const table, (table ?), key_idx, key, value */
         json_append_data(l, cfg, current_depth, json);
         lua_pop(l, 1);


### PR DESCRIPTION
When encoding the key with the metamethod `__serialize`, the serialized result is used for iteration in `lua_next()` instead of the original key. This leads to the error "invalid key to 'next'".

This patch fixes this by preserving the original key object on the stack and replacing the serialized form when necessary.

Fixes #12726

NO_DOC=bugfix