### PR TITLE
Allow to take local references to read view object

### DIFF
--- a/changelogs/unreleased/gh-13037-read-view-refs-info.md
+++ b/changelogs/unreleased/gh-13037-read-view-refs-info.md
@@ -1,0 +1,4 @@
+## feature/core
+
+* Added a new option `refs` to the read view method `:info()` that makes it
+  include a list of read view reference holders into the output (gh-13037).

--- a/changelogs/unreleased/gh-13037-read-view-with.md
+++ b/changelogs/unreleased/gh-13037-read-view-with.md
@@ -1,0 +1,5 @@
+## feature/core
+
+* Introduced the new read view method `:with()`, which calls a function
+  with a guarantee that the read view object will not be closed until
+  the function returns (gh-13037).

--- a/src/box/lua/read_view.lua
+++ b/src/box/lua/read_view.lua
@@ -5,6 +5,7 @@ local fiber = require('fiber')
 local threads = require('experimental.threads')
 
 local check_index_arg = box.internal.check_index_arg
+local check_param = utils.check_param
 local check_param_table = utils.check_param_table
 local check_primary_index = box.internal.check_primary_index
 local check_iterator_type = box.internal.check_iterator_type
@@ -345,6 +346,30 @@ function read_view_methods:info()
 end
 
 read_view_mt.__serialize = read_view_methods.info
+
+function read_view_methods:_with_tail(status, ...)
+    self:_release()
+    if not status then
+        local err = ...
+        error(err, 0)
+    end
+    return ...
+end
+
+--
+-- Calls a function ensuring that the read view isn't closed until the function
+-- returns. The function is passed the read view object followed by the passed
+-- arguments.
+--
+function read_view_methods:with(func, ...)
+    check_read_view_arg(self, 'with', 2)
+    check_param(func, 'function object', 'function', 2)
+    if self.status ~= 'open' then
+        box.error(box.error.READ_VIEW_CLOSED, 2)
+    end
+    self:_acquire()
+    return self:_with_tail(pcall(func, self, ...))
+end
 
 --
 -- If the given read view was created with box.read_view.open(), the function

--- a/src/box/lua/read_view.lua
+++ b/src/box/lua/read_view.lua
@@ -74,6 +74,11 @@ local READ_VIEW_OPTIONS_TEMPLATE = {
     id = 'number',
 }
 
+-- box.read_view.info() options template.
+local READ_VIEW_INFO_TEMPLATE = {
+    refs = 'boolean',
+}
+
 local function check_read_view_arg(rv, method, level)
     if type(rv) ~= 'table' then
         local fmt = 'Use read_view:%s(...) instead of read_view.%s(...)'
@@ -226,6 +231,21 @@ function box.read_view.list()
 end
 
 --
+-- Returns a path used to acquire a reference to a read view in a thread.
+--
+local function thread_ref_path()
+    local info = threads.info()
+    return {'thread', info.group_name, info.thread_id}
+end
+
+--
+-- Returns a path used to acquire a reference to a read view in a fiber.
+--
+local function fiber_ref_path()
+    return {'fiber', fiber.id()}
+end
+
+--
 -- Wrapper around internal.close() that, if called in an application thread,
 -- sends a request to release the read view to the main thread.
 --
@@ -235,7 +255,8 @@ local function read_view_close(crv, warn)
         assert(not fiber._internal.cord_is_main)
         -- threads.call() yields while we can't yield in this function
         -- because it may be called by the garbage collector.
-        fiber.new(threads.call, 'tx', 'box.internal.read_view.release', {id})
+        fiber.new(threads.call, 'tx', 'box.internal.read_view.release',
+                  {id, thread_ref_path()})
     end
 end
 
@@ -277,7 +298,8 @@ function box.read_view.open(opts)
         -- Ask the main thread to pin the read view with the given id
         -- and create a local handle for it.
         local ret = utils.call_at(2, threads.call, 'tx',
-                                  'box.internal.read_view.acquire', {opts.id})
+                                  'box.internal.read_view.acquire',
+                                  {opts.id, thread_ref_path()})
         -- We should never get here when called from the main thread because
         -- the read view registry maintained by the main thread is supposed to
         -- store all usable read views.
@@ -287,7 +309,8 @@ function box.read_view.open(opts)
         ok, ret = pcall(internal.reuse, ptr)
         if not ok then
             -- Don't forget to unpin the read view on error.
-            threads.call('tx', 'box.internal.read_view.release', {opts.id})
+            threads.call('tx', 'box.internal.read_view.release',
+                         {opts.id, thread_ref_path()})
             box.error(ret, 2)
         end
         rv = ret
@@ -316,7 +339,11 @@ function box.read_view.open(opts)
             end
         end
     end
-    rv._refs = 0
+    -- Each read view reference is identified by path {key1, key2, ...} in
+    -- the _refs table. At the leaf sub-table of each path a reference counter
+    -- is stored under the key _count so that the same reference path may be
+    -- taken multiple times.
+    rv._refs = {}
     rv._status = 'open'
     ffi.gc(rv._crv, read_view_gc)
     return register_read_view(rv)
@@ -332,9 +359,14 @@ end
 --  - 'signature' - box.info.signature at the time of read view open.
 --  - 'status' - 'open', 'closed', or 'close_pending'.
 --
-function read_view_methods:info()
+-- If opts.refs is true, adds 'refs' key to the info table that stores
+-- a list of references taken for this read view.
+--
+function read_view_methods:info(opts)
     check_read_view_arg(self, 'info', 2)
-    return {
+    opts = opts or {}
+    check_param_table(opts, READ_VIEW_INFO_TEMPLATE, 2)
+    local info = {
         id = self.id,
         name = self.name,
         is_system = self.is_system,
@@ -343,12 +375,16 @@ function read_view_methods:info()
         signature = self.signature,
         status = self.status,
     }
+    if opts.refs then
+        info.refs = self:_refs_info()
+    end
+    return info
 end
 
 read_view_mt.__serialize = read_view_methods.info
 
 function read_view_methods:_with_tail(status, ...)
-    self:_release()
+    self:_release(fiber_ref_path())
     if not status then
         local err = ...
         error(err, 0)
@@ -367,7 +403,11 @@ function read_view_methods:with(func, ...)
     if self.status ~= 'open' then
         box.error(box.error.READ_VIEW_CLOSED, 2)
     end
-    self:_acquire()
+    if self._crv == nil then
+        -- System read view. Can't be used.
+        box.error(box.error.READ_VIEW_BUSY, 2)
+    end
+    self:_acquire(fiber_ref_path())
     return self:_with_tail(pcall(func, self, ...))
 end
 
@@ -386,7 +426,7 @@ function read_view_methods:close()
         -- System read view. Can't be closed.
         box.error(box.error.READ_VIEW_BUSY, 2)
     end
-    if self._refs == 0 then
+    if next(self._refs) == nil then
         self:_do_close()
     else
         self._status = 'close_pending'
@@ -425,16 +465,26 @@ local referenced_read_views = {}
 -- changed to 'close_pending' and remains so until the last reference to it
 -- is gone, after which it's closed for real.
 --
-function read_view_methods:_acquire()
+function read_view_methods:_acquire(path)
     assert(self.status == 'open')
     assert(self._crv ~= nil)
-    assert(self._refs >= 0)
-    if self._refs == 0 then
+    if next(self._refs) == nil then
         referenced_read_views[self.id] = self
     else
         assert(referenced_read_views[self.id] == self)
     end
-    self._refs = self._refs + 1
+    local ref = self._refs
+    for _, key in ipairs(path) do
+        if ref[key] == nil then
+            ref[key] = {}
+        end
+        ref = ref[key]
+    end
+    if ref._count ~= nil then
+        ref._count = ref._count + 1
+    else
+        ref._count = 1
+    end
 end
 
 --
@@ -443,12 +493,29 @@ end
 -- If the read view was closed (its status is 'close_pending'), it will be
 -- deleted as soon as the last reference to it is gone.
 --
-function read_view_methods:_release()
+function read_view_methods:_release(path)
     assert(self.status ~= 'closed')
     assert(self._crv ~= nil)
-    assert(self._refs > 0)
-    self._refs = self._refs - 1
-    if self._refs == 0 then
+    local ref_path = {}
+    local ref = self._refs
+    for _, key in ipairs(path) do
+        table.insert(ref_path, ref)
+        assert(ref[key] ~= nil)
+        ref = ref[key]
+    end
+    assert(ref._count > 0)
+    ref._count = ref._count - 1
+    if ref._count == 0 then
+        ref._count = nil
+    end
+    for i = #path, 1, -1 do
+        local key = path[i]
+        if next(ref_path[i][key]) ~= nil then
+            break
+        end
+        ref_path[i][key] = nil
+    end
+    if next(self._refs) == nil then
         referenced_read_views[self.id] = nil
         if self.status == 'close_pending' then
             self:_do_close()
@@ -456,10 +523,35 @@ function read_view_methods:_release()
     end
 end
 
+--
+-- Returns a list of references taken for this read view.
+--
+-- Assumes there are two types of references: fiber and thread.
+--
+function read_view_methods:_refs_info()
+    local info = {}
+    for group_name, group_refs in pairs(self._refs.thread or {}) do
+        for thread_id in pairs(group_refs) do
+            table.insert(info, {
+                type = 'thread',
+                group_name = group_name,
+                thread_id = thread_id
+            })
+        end
+    end
+    for fid in pairs(self._refs.fiber or {}) do
+        table.insert(info, {
+            type = 'fiber',
+            fid = fid,
+        })
+    end
+    return info
+end
+
 if fiber._internal.cord_is_main then
     -- Acquires a reference to a read view in the main thread.
     -- Returns a pointer to the referenced read view.
-    threads.export('box.internal.read_view.acquire', function(id)
+    threads.export('box.internal.read_view.acquire', function(id, path)
         local rv = read_view_registry[id]
         -- System read views are added to the Lua registry on demand so
         -- to raise a proper error on an attempt to acquire a reference
@@ -470,14 +562,14 @@ if fiber._internal.cord_is_main then
         if rv == nil or rv.status ~= 'open' then
             box.error(box.error.NO_SUCH_READ_VIEW)
         end
-        rv:_acquire()
+        rv:_acquire(path)
         return rv._ptr
     end)
     -- Releases a reference to a read view in the main thread.
-    threads.export('box.internal.read_view.release', function(id)
+    threads.export('box.internal.read_view.release', function(id, path)
         local rv = read_view_registry[id]
         assert(rv ~= nil)
-        rv:_release()
+        rv:_release(path)
     end)
 end
 

--- a/test/box-luatest/gh_8260_system_read_view_list_test.lua
+++ b/test/box-luatest/gh_8260_system_read_view_list_test.lua
@@ -94,11 +94,13 @@ g_object.test_autocomplete = function(cg)
             'test_rv.signature',
             'test_rv.status',
             'test_rv.info(',
+            'test_rv.with(',
             'test_rv.close(',
         })
         t.assert_items_equals(complete('test_rv:'), {
             'test_rv:',
             'test_rv:info(',
+            'test_rv:with(',
             'test_rv:close(',
         })
     end)
@@ -148,8 +150,8 @@ g_status.test_status = function(cg)
     end)
 end
 
--- Checks read_view:close() method.
-g_status.test_close = function(cg)
+-- Checks that a system read view can't be used or closed.
+g_status.test_busy = function(cg)
     cg.server:exec(function()
         local fiber = require('fiber')
         box.space.test:replace({1, 'close'})
@@ -160,10 +162,14 @@ g_status.test_close = function(cg)
         local l = box.read_view.list()
         t.assert_equals(#l, 1)
         local rv = l[1]
-        t.assert_error_msg_equals('The read view is busy', rv.close, rv)
+        local err = {type = 'ClientError', name = 'READ_VIEW_BUSY'}
+        t.assert_error_covers(err, rv.with, rv, function() end)
+        t.assert_error_covers(err, rv.close, rv)
         box.error.injection.set('ERRINJ_SNAP_WRITE_DELAY', false)
         t.assert(f:join())
-        t.assert_error_msg_equals('The read view is closed', rv.close, rv)
+        err = {type = 'ClientError', name = 'READ_VIEW_CLOSED'}
+        t.assert_error_covers(err, rv.with, rv, function() end)
+        t.assert_error_covers(err, rv.close, rv)
     end)
 end
 

--- a/test/box-luatest/read_view_test.lua
+++ b/test/box-luatest/read_view_test.lua
@@ -95,6 +95,9 @@ g.test_invalid_usage = function(cg)
             "Use read_view:info(...) instead of read_view.info(...)",
             rv.info)
         t.assert_error_msg_contains(
+            "Use read_view:with(...) instead of read_view.with(...)",
+            rv.with)
+        t.assert_error_msg_contains(
             "Use index:get(...) instead of index.get(...)",
             rv.space._space.index.primary.get)
         t.assert_error_msg_contains(
@@ -192,11 +195,13 @@ g.test_autocomplete = function(cg)
             'test_rv.status',
             'test_rv.space',
             'test_rv.info(',
+            'test_rv.with(',
             'test_rv.close(',
         })
         t.assert_items_equals(complete('test_rv:'), {
             'test_rv:',
             'test_rv:info(',
+            'test_rv:with(',
             'test_rv:close(',
         })
         rv:close()
@@ -2390,6 +2395,92 @@ g.test_read_view_get_after_space_drop = function(cg)
                       '(expected 1, got 0)'
         }, rv.space.test.get, rv.space.test, {})
         rv:close()
+    end)
+end
+
+g.test_with = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local s = box.schema.space.create('test')
+        s:create_index('primary')
+        s:insert({1})
+        s:insert({2})
+        s:insert({3})
+        local rv = box.read_view.open()
+        t.assert_error_covers({
+            type = 'IllegalParams',
+            message = 'function object should be a function',
+        }, rv.with, rv)
+        rv:with(function(rv_inner)
+            t.assert_is(rv_inner, rv)
+        end)
+        -- Returning a value.
+        t.assert_equals(rv:with(function(rv_inner)
+            return rv_inner.space.test:select()
+        end), {{1}, {2}, {3}})
+        -- Multi-return.
+        t.assert_equals({rv:with(function(rv_inner)
+            return rv_inner.space.test:get(1),
+                   rv_inner.space.test:get(2),
+                   rv_inner.space.test:get(3)
+        end)}, {{1}, {2}, {3}})
+        -- Passing arguments.
+        rv:with(function(rv_inner, a, b, c)
+            t.assert_equals(rv_inner.space.test:get(1), a)
+            t.assert_equals(rv_inner.space.test:get(2), b)
+            t.assert_equals(rv_inner.space.test:get(3), c)
+        end, {1}, {2}, {3})
+        -- Raising an error.
+        t.assert_equals({pcall(rv.with, rv, function()
+            error('foobar', 0)
+        end)}, {false, 'foobar'})
+        -- Calling with() on a closed read view.
+        rv:close()
+        t.assert_equals(rv.status, 'closed')
+        t.assert_error_covers({
+            type = 'ClientError',
+            name ='READ_VIEW_CLOSED'
+        }, rv.with, rv, function() end)
+        -- Postponing close() using with().
+        rv = box.read_view.open()
+        local f1 = fiber.new(function()
+            return rv:with(function(rv_inner)
+                fiber.sleep(1000)
+                return rv_inner.space.test:select()
+            end)
+        end)
+        f1:set_joinable(true)
+        local f2 = fiber.new(function()
+            return rv:with(function(rv_inner_1)
+                return rv_inner_1:with(function(rv_inner_2)
+                    fiber.sleep(1000)
+                    return rv_inner_2.space.test:select()
+                end)
+            end)
+        end)
+        f2:set_joinable(true)
+        fiber.yield()
+        t.assert_equals(rv.status, 'open')
+        rv:close()
+        t.assert_equals(rv.status, 'close_pending')
+        t.assert_error_covers({
+            type = 'ClientError',
+            name ='READ_VIEW_CLOSED'
+        }, rv.with, rv, function() end)
+        f1:wakeup()
+        t.assert_equals({f1:join(10)}, {true, s:select()})
+        t.assert_equals(rv.status, 'close_pending')
+        t.assert_error_covers({
+            type = 'ClientError',
+            name ='READ_VIEW_CLOSED'
+        }, rv.with, rv, function() end)
+        f2:wakeup()
+        t.assert_equals({f2:join(10)}, {true, s:select()})
+        t.assert_equals(rv.status, 'closed')
+        t.assert_error_covers({
+            type = 'ClientError',
+            name ='READ_VIEW_CLOSED'
+        }, rv.with, rv, function() end)
     end)
 end
 

--- a/test/box-luatest/read_view_test.lua
+++ b/test/box-luatest/read_view_test.lua
@@ -2467,6 +2467,10 @@ g.test_with = function(cg)
             type = 'ClientError',
             name ='READ_VIEW_CLOSED'
         }, rv.with, rv, function() end)
+        t.assert_items_equals(rv:info({refs = true}).refs, {
+            {type = 'fiber', fid = f1:id()},
+            {type = 'fiber', fid = f2:id()},
+        })
         f1:wakeup()
         t.assert_equals({f1:join(10)}, {true, s:select()})
         t.assert_equals(rv.status, 'close_pending')
@@ -2474,6 +2478,9 @@ g.test_with = function(cg)
             type = 'ClientError',
             name ='READ_VIEW_CLOSED'
         }, rv.with, rv, function() end)
+        t.assert_items_equals(rv:info({refs = true}).refs, {
+            {type = 'fiber', fid = f2:id()},
+        })
         f2:wakeup()
         t.assert_equals({f2:join(10)}, {true, s:select()})
         t.assert_equals(rv.status, 'closed')
@@ -2481,6 +2488,7 @@ g.test_with = function(cg)
             type = 'ClientError',
             name ='READ_VIEW_CLOSED'
         }, rv.with, rv, function() end)
+        t.assert_items_equals(rv:info({refs = true}).refs, {})
     end)
 end
 
@@ -2936,6 +2944,7 @@ g_threads.test_close_pending = function(cg)
     -- Check that a read view isn't deleted until every thread using it
     -- closes it.
     cg.server:exec(function()
+        local fun = require('fun')
         local threads = require('experimental.threads')
         local rv = box.read_view.open()
         threads.eval('app', [[
@@ -2947,6 +2956,11 @@ g_threads.test_close_pending = function(cg)
             type = 'ClientError',
             name = 'READ_VIEW_CLOSED',
         }, rv.close, rv)
+        t.assert_items_equals(
+            rv:info({refs = true}).refs,
+            fun.map(function(i)
+                return {type = 'thread', group_name = 'app', thread_id = i}
+            end, fun.range(1, 4)):totable())
 
         -- The read view is still usable in application threads.
         t.assert_equals(threads.eval('app', [[
@@ -2967,6 +2981,11 @@ g_threads.test_close_pending = function(cg)
         }, threads.eval, 'app', [[
             box.read_view.open({id = ...})
         ]], {rv.id}, {target = 1})
+        t.assert_items_equals(
+            rv:info({refs = true}).refs,
+            fun.map(function(i)
+                return {type = 'thread', group_name = 'app', thread_id = i}
+            end, fun.range(2, 4)):totable())
 
         -- The read view status doesn't change after it's removed from
         -- the local registry by the garbage collector.
@@ -2984,6 +3003,11 @@ g_threads.test_close_pending = function(cg)
         }, threads.eval, 'app', [[
             box.read_view.open({id = ...})
         ]], {rv.id}, {target = 1})
+        t.assert_items_equals(
+            rv:info({refs = true}).refs,
+            fun.map(function(i)
+                return {type = 'thread', group_name = 'app', thread_id = i}
+            end, fun.range(2, 4)):totable())
 
         -- The read view is deleted as soon as all threads close it.
         for i = 2, box.cfg.app_threads do
@@ -2996,6 +3020,7 @@ g_threads.test_close_pending = function(cg)
         t.helpers.retrying({}, function()
             t.assert_equals(rv.status, 'closed')
         end)
+        t.assert_items_equals(rv:info({refs = true}).refs, {})
         rv = nil -- luacheck: ignore
         for _ = 1, 5 do collectgarbage('collect') end
         t.assert_equals(box.read_view.list(), {})


### PR DESCRIPTION
This patch adds the new read view method `:with()` which executes a function with a guarantee that the read view won't be deleted until the function returns. It also adds a list of all read view reference holders to `:info()` output. For more details, see the issue description and the comments to the individual commits.

Closes #13037