### PR TITLE
build: fix compiler warnings

### DIFF
--- a/src/box/box.cc
+++ b/src/box/box.cc
@@ -6643,7 +6643,7 @@ box_generate_unique_id(uint32_t space_id, uint32_t index_id,
 	assert(new_id != NULL);
 
 	*new_id = id_range_end;
-	char key_buf[16];
+	char key_buf[16] = {};
 	char *key_end = key_buf;
 	key_end = mp_encode_array(key_end, 1);
 	key_end = mp_encode_uint(key_end, id_range_end);

--- a/src/lua/msgpack.c
+++ b/src/lua/msgpack.c
@@ -721,9 +721,9 @@ static int
 lua_decode_array_header(lua_State *L)
 {
 	const char *func_name = "msgpack.decode_array_header";
-	const char *data;
-	uint32_t cdata_type;
-	ptrdiff_t size;
+	const char *data = NULL;
+	uint32_t cdata_type = 0;
+	ptrdiff_t size = 0;
 	verify_decode_header_args(L, func_name, &data, &cdata_type, &size);
 
 	if (mp_typeof(*data) != MP_ARRAY)
@@ -747,9 +747,9 @@ static int
 lua_decode_map_header(lua_State *L)
 {
 	const char *func_name = "msgpack.decode_map_header";
-	const char *data;
-	uint32_t cdata_type;
-	ptrdiff_t size;
+	const char *data = NULL;
+	uint32_t cdata_type = 0;
+	ptrdiff_t size = 0;
 	verify_decode_header_args(L, func_name, &data, &cdata_type, &size);
 
 	if (mp_typeof(*data) != MP_MAP)


### PR DESCRIPTION
The `key_buf` stack buffer is filled via `mp_encode_array()` and `mp_encode_uint()` before being passed to `box_index_iterator()`. However, those are external msgpuck functions, so the compiler cannot see through them and, after inlining, emits a -Wmaybe-uninitialized warning for the buffer content. Zero-initialize the buffer to silence the warning.

In `lua_decode_array_header()` and `lua_decode_map_header()` the data, `cdata_type` and size locals are filled by
`verify_decode_header_args()` via output parameters. The compiler cannot see through the external `luaL_checkconstchar()` and `luaL_checkinteger()` calls, so after inlining it cannot prove the writes happen and emits -Wmaybe-uninitialized warning. Zero-initialize the locals to silence the diagnostics.

Fixes above are pure build fix; no behavior is changed.

NO_DOC=codehealth
NO_CHANGELOG=no functional changes
NO_TEST=codehealth