### PR TITLE
[backport 2.11] ci: install luacheck only if not installed

### DIFF
--- a/.github/actions/install-deps-debian/action.yml
+++ b/.github/actions/install-deps-debian/action.yml
@@ -29,6 +29,14 @@ runs:
         && tar -xvf cmake-3.26.0-linux-$(uname -i).tar.gz -C /usr/local --strip-components=1 \
         && rm cmake-3.26.0-linux-$(uname -i).tar.gz
 
-        luarocks install luacheck 0.26.1
+        # (Re)install luacheck only if it is not installed (or if another
+        # version is installed).
+        #
+        # This reduces amount of failures when connectivity to luarocks.org is
+        # unreliable. See the following issues for details:
+        #
+        # https://github.com/tarantool/tarantool/issues/12600
+        # https://github.com/tarantool/tarantool/issues/12783
+        luarocks show luacheck 0.26.1 || luarocks install luacheck 0.26.1
         gem install coveralls-lcov
       shell: bash


### PR DESCRIPTION
*(This PR is a backport of #13096 to `release/2.11` to a future `2.11.10` release.)*

----

The `perf_micro` workflow experiences connectivity failures with luarocks.org and fails on `luacheck` installation. The workflow is run on a separate pinned machine, so the if-installed check should mostly help with this problem.

The same solution was accepted for LuaJIT repository (tarantool's fork) in https://github.com/tarantool/luajit/commit/85807f88819289fab5c334621c52471279aa8d4b.

Relates to #12600
Relates to #12783