### PR TITLE
CI: change docker image for clang-related jobs

### DIFF
--- a/.github/workflows/debug_asan_clang.yml
+++ b/.github/workflows/debug_asan_clang.yml
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 60
 
     container:
-      image: docker.io/tarantool/testing:ubuntu-jammy-clang19
+      image: docker.io/tarantool/testing:ubuntu-jammy
       # Mount /dev to the container to be able to mount a disk image inside it
       # for successful run of the .github/actions/environment action.
       volumes:

--- a/.github/workflows/release_asan_clang.yml
+++ b/.github/workflows/release_asan_clang.yml
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 60
 
     container:
-      image: docker.io/tarantool/testing:ubuntu-jammy-clang19
+      image: docker.io/tarantool/testing:ubuntu-jammy
       # Mount /dev to the container to be able to mount a disk image inside it
       # for successful run of the .github/actions/environment action.
       volumes:

--- a/.github/workflows/release_clang.yml
+++ b/.github/workflows/release_clang.yml
@@ -58,7 +58,7 @@ jobs:
     timeout-minutes: 60
 
     container:
-      image: docker.io/tarantool/testing:ubuntu-jammy-clang19
+      image: docker.io/tarantool/testing:ubuntu-jammy
       # Mount /dev to the container to be able to mount a disk image inside it
       # for successful run of the .github/actions/environment action.
       volumes:

--- a/.github/workflows/release_lto_clang.yml
+++ b/.github/workflows/release_lto_clang.yml
@@ -58,7 +58,7 @@ jobs:
     timeout-minutes: 60
 
     container:
-      image: docker.io/tarantool/testing:ubuntu-jammy-clang19
+      image: docker.io/tarantool/testing:ubuntu-jammy
       # Mount /dev to the container to be able to mount a disk image inside it
       # for successful run of the .github/actions/environment action.
       volumes:


### PR DESCRIPTION
This patch changes Docker image
```
docker.io/tarantool/testing:ubuntu-jammy-clang19
```
to
```
docker.io/tarantool/testing:ubuntu-jammy
```
for CI jobs that use `clang`. This is done because the second Docker image is maintained and updated, while the first one is not.

NO_DOC=CI
NO_TEST=CI
NO_CHANGELOG=CI