### PR TITLE
sql: rework `sql_*_compile()`

### DIFF
--- a/changelogs/unreleased/gh-13067-assertion-on-wrong-trigger-and-view-definition.md
+++ b/changelogs/unreleased/gh-13067-assertion-on-wrong-trigger-and-view-definition.md
@@ -1,0 +1,5 @@
+## bugfix/sql
+
+* Fixed assertions that occurred due to insertion of an incorrect trigger
+  definition into `_trigger` or insertion of an incorrect view definition
+  into `_space` (gh-13067).

--- a/extra/mkkeywordhash.c
+++ b/extra/mkkeywordhash.c
@@ -210,7 +210,7 @@ static Keyword aKeywordTable[] = {
   { "ENABLE",                 "TK_ENABLE",      false },
   { "FETCH",                  "TK_STANDARD",    true  },
   { "FLOAT",                  "TK_STANDARD",    true  },
-  { "FUNCTION",               "TK_FUNCTION_KW", true  },
+  { "FUNCTION",               "TK_STANDARD",    true  },
   { "GET",                    "TK_STANDARD",    true  },
   { "GRANT",                  "TK_STANDARD",    true  },
   { "INT",                    "TK_INT",         true  },

--- a/src/box/sql.h
+++ b/src/box/sql.h
@@ -74,34 +74,22 @@ struct space_def;
 struct func;
 
 /**
- * Perform parsing of provided expression. This is done by
- * surrounding the expression w/ 'SELECT ' prefix and perform
- * convetional parsing. Then extract result expression value from
- * stuct Select and return it.
- *
- * @param expr Expression to parse.
- * @param expr_len Length of @an expr.
+ * Perform parsing of provided function definition.
+ * Return the parsed expression on success, or NULL on error.
  */
 struct Expr *
-sql_expr_compile(const char *expr, int expr_len);
+sql_expr_compile(const char *expr);
 
 /**
- * This routine executes parser on 'CREATE VIEW ...' statement
- * and loads content of SELECT into internal structs as result.
- *
- * @param view_stmt String containing 'CREATE VIEW' statement.
- * @retval AST of SELECT statement on success, NULL otherwise.
+ * Perform parsing of provided view definition.
+ * Return the parsed SELECT on success, or NULL on error.
  */
 struct Select *
 sql_view_compile(const char *view_stmt);
 
 /**
- * Perform parsing of provided SQL request and construct trigger AST.
- * @param db SQL context handle.
- * @param sql request to parse.
- *
- * @retval NULL on error
- * @retval not NULL sql_trigger AST pointer on success.
+ * Perform parsing of provided trigger definition.
+ * Return the parsed SQL TRIGGER on success, or NULL on error.
  */
 struct sql_trigger *
 sql_trigger_compile(const char *sql);

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -2467,9 +2467,7 @@ struct func_sql_expr {
 struct func *
 func_sql_expr_new(const struct func_def *def)
 {
-	const char *body = def->body;
-	uint32_t body_len = body == NULL ? 0 : strlen(body);
-	struct Expr *expr = sql_expr_compile(body, body_len);
+	struct Expr *expr = sql_expr_compile(def->body);
 	if (expr == NULL)
 		return NULL;
 	struct Parse parser;

--- a/src/box/sql/parse.y
+++ b/src/box/sql/parse.y
@@ -382,26 +382,18 @@ ifexists(A) ::= .            {A = 0;}
 ///////////////////// The CREATE VIEW statement /////////////////////////////
 //
 cmd ::= createkw VIEW ifnotexists(E) nm(Y) eidlist_opt(C) AS select_old(S). {
-  if (!pParse->parse_only) {
-    pParse->initiateTTrans = true;
-    sql_create_view(pParse, pParse->zTail, &Y, C, S, E);
-  } else {
-    sql_expr_list_delete(C);
-    pParse->parsed_ast_type = AST_TYPE_SELECT;
-    pParse->parsed_ast.select = S;
-  }
+  pParse->initiateTTrans = true;
+  sql_create_view(pParse, pParse->zTail, &Y, C, S, E);
+}
+cmd ::= VIEW_ENTRY createkw VIEW ifnotexists nm eidlist_opt AS select_old(S). {
+  pParse->parsed_ast_type = AST_TYPE_SELECT;
+  pParse->parsed_ast.select = S;
 }
 
 //////////////////////// The SELECT statement /////////////////////////////////
 //
 cmd ::= select_old(X).  {
   SelectDest dest = {SRT_Output, 0, 0, 0, 0, 0, 0};
-  if(pParse->parse_only) {
-    diag_set(ClientError, ER_SQL_PARSER_GENERIC,
-             "Failed to parse SQL expression");
-    pParse->is_aborted = true;
-    return;
-  }
   sqlSelect(pParse, X, &dest);
   sql_select_delete(X);
 }
@@ -1320,13 +1312,7 @@ cmd ::= PRAGMA nm(X) LP nm(Y) RP.         {
 cmd ::= PRAGMA nm(X) LP nm(Y) DOT nm(Z) RP.  {
     sqlPragma(pParse,&X,&Y,&Z);
 }
-cmd ::= FUNCTION_KW(T) expr_old(E). {
-  if (!pParse->is_expr) {
-    diag_set(ClientError, ER_SQL_SYNTAX_NEAR_TOKEN, pParse->line_count,
-             tt_cstr(T.z, T.n));
-    pParse->is_aborted = true;
-    return;
-  }
+cmd ::= FUNCTION_ENTRY expr_old(E). {
   pParse->parsed_ast_type = AST_TYPE_EXPR;
   pParse->parsed_ast.expr = E.pExpr;
 }
@@ -1341,18 +1327,17 @@ cmd ::= SHOW CREATE TABLE. {
 
 //////////////////////////// The CREATE TRIGGER command /////////////////////
 
-cmd ::= createkw TRIGGER ifnotexists(E) nm(N) trigger_time(C) trigger_event(D)
-        ON nm(T) foreach_clause when_clause(G) BEGIN trigger_cmd_list(S) END. {
-  if (pParse->parse_only) {
-    pParse->parsed_ast_type = AST_TYPE_TRIGGER;
-    pParse->parsed_ast.trigger = sql_trigger_new(pParse, &N, &T, C, D.a,
-                                                 id_list_from_ast(D.b), G, S);
-  } else {
-    sql_expr_delete(G);
-    sqlDeleteTriggerStep(S);
-    pParse->initiateTTrans = true;
-    vdbe_emit_create_trigger(pParse, pParse->zTail, &N, &T, E);
-  }
+cmd ::= createkw TRIGGER ifnotexists(E) nm(N) trigger_time trigger_event
+        ON nm(T) foreach_clause when_clause BEGIN trigger_cmd_list END. {
+  pParse->initiateTTrans = true;
+  vdbe_emit_create_trigger(pParse, pParse->zTail, &N, &T, E);
+}
+cmd ::= TRIGGER_ENTRY createkw TRIGGER ifnotexists nm(N) trigger_time(C)
+        trigger_event(D) ON nm(T) foreach_clause when_clause(G)
+        BEGIN trigger_cmd_list(S) END. {
+  pParse->parsed_ast_type = AST_TYPE_TRIGGER;
+  pParse->parsed_ast.trigger = sql_trigger_new(pParse, &N, &T, C, D.a,
+                                               id_list_from_ast(D.b), G, S);
 }
 
 %type trigger_time {int}

--- a/src/box/sql/prepare.c
+++ b/src/box/sql/prepare.c
@@ -47,7 +47,7 @@ sql_stmt_compile(const char *zSql, struct Vdbe *pReprepare)
 	sql_parser_create(&sParse, current_session()->sql_flags);
 	sParse.pReprepare = pReprepare;
 
-	sqlRunParser(&sParse, zSql);
+	sql_parse_statement(&sParse, zSql);
 	if (sParse.is_aborted) {
 		sql_parser_destroy(&sParse);
 		return NULL;
@@ -108,71 +108,50 @@ sql_stmt_compile(const char *zSql, struct Vdbe *pReprepare)
 }
 
 struct Expr *
-sql_expr_compile(const char *expr, int expr_len)
+sql_expr_compile(const char *sql)
 {
-	const char *outer = "FUNCTION ";
-	int len = strlen(outer) + expr_len;
+	if (sql == NULL || sql[0] == '\0') {
+		diag_set(ClientError, ER_SQL_PARSER_GENERIC,
+			 "Function definition cannot be empty");
+		return NULL;
+	}
 
 	struct Parse parser;
 	sql_parser_create(&parser, SQL_DEFAULT_FLAGS);
-	/*
-	 * Since SELECT token is added to the original expression,
-	 * to make error message display correct position we should
-	 * account its length.
-	 */
-	parser.line_pos -= strlen(outer);
 	parser.parse_only = true;
-	parser.is_expr = true;
-
-	struct Expr *expression = NULL;
-	char *stmt = xregion_alloc(&parser.region, len + 1);
-	snprintf(stmt, len + 1, "%s%.*s", outer, expr_len, expr);
-
-	if (sqlRunParser(&parser, stmt) == 0) {
-		assert(parser.parsed_ast_type == AST_TYPE_EXPR);
-		expression = parser.parsed_ast.expr;
-		parser.parsed_ast.expr = NULL;
-	}
+	struct Expr *expr = sql_parse_function(&parser, sql);
 	sql_parser_destroy(&parser);
-	return expression;
+	return expr;
 }
 
 struct Select *
-sql_view_compile(const char *view_stmt)
+sql_view_compile(const char *sql)
 {
+	assert(sql != NULL && sql[0] != '\0');
+
 	struct Parse parser;
 	sql_parser_create(&parser, SQL_DEFAULT_FLAGS);
 	parser.parse_only = true;
-
-	struct Select *select = NULL;
-
-	if (sqlRunParser(&parser, view_stmt) != 0 ||
-	    parser.parsed_ast_type != AST_TYPE_SELECT) {
-		diag_set(ClientError, ER_SQL_EXECUTE, view_stmt);
-	} else {
-		select = parser.parsed_ast.select;
-		parser.parsed_ast.select = NULL;
-	}
-
+	struct Select *res = sql_parse_view(&parser, sql);
 	sql_parser_destroy(&parser);
-	return select;
+	return res;
 }
 
 struct sql_trigger *
 sql_trigger_compile(const char *sql)
 {
+	if (sql == NULL || sql[0] == '\0') {
+		diag_set(ClientError, ER_SQL_PARSER_GENERIC,
+			 "Trigger definition cannot be empty");
+		return NULL;
+	}
+
 	struct Parse parser;
 	sql_parser_create(&parser, SQL_DEFAULT_FLAGS);
 	parser.parse_only = true;
-	struct sql_trigger *trigger = NULL;
-	if (sqlRunParser(&parser, sql) == 0 &&
-	    parser.parsed_ast_type == AST_TYPE_TRIGGER) {
-		trigger = parser.parsed_ast.trigger;
-		parser.parsed_ast.trigger = NULL;
-	}
-
+	struct sql_trigger *res = sql_parse_trigger(&parser, sql);
 	sql_parser_destroy(&parser);
-	return trigger;
+	return res;
 }
 
 /*

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -303,14 +303,7 @@ sql_vsnprintf(int, char *, const char *, va_list);
 #define MATCH_ONE_WILDCARD '_'
 #define MATCH_ALL_WILDCARD '%'
 
-/**
- * Compile the UTF-8 encoded SQL statement into
- * a statement handle (struct Vdbe).
- *
- * @param sql UTF-8 encoded SQL statement.
- * @param re_prepared VM being re-compiled. Can be NULL.
- * @retval stmt A pointer to the compiled statement.
- */
+/** Compile the UTF-8 encoded SQL statement into a statement handle. */
 struct Vdbe *
 sql_stmt_compile(const char *sql, struct Vdbe *re_prepared);
 
@@ -2000,8 +1993,6 @@ struct Parse {
 	bool initiateTTrans;	/* Initiate Tarantool transaction */
 	/** If set - do not emit byte code at all, just parse.  */
 	bool parse_only;
-	/** If true, then parsed_ast_type should be EXPR after parsing. */
-	bool is_expr;
 	/** Type of parsed_ast member. */
 	enum ast_type parsed_ast_type;
 	/** SQL options which were used to compile this VDBE. */
@@ -2414,7 +2405,34 @@ char *
 sql_escaped_name_new(const char *name);
 
 int sqlKeywordCode(const unsigned char *, int);
-int sqlRunParser(Parse *, const char *);
+
+/**
+ * Run the parser on the given SQL string.
+ * Return 0 on success, -1 otherwise.
+ */
+int
+sql_parse_statement(struct Parse *parser, const char *sql);
+
+/**
+ * Run the parser on the given function definition.
+ * Return the parsed expression on success, or NULL on error.
+ */
+struct Expr *
+sql_parse_function(struct Parse *parser, const char *sql);
+
+/**
+ * Run the parser on the given view definition.
+ * Return the parsed SELECT on success, or NULL on error.
+ */
+struct Select *
+sql_parse_view(struct Parse *parser, const char *sql);
+
+/**
+ * Run the parser on the given trigger definition.
+ * Return the parsed SQL TRIGGER on success, or NULL on error.
+ */
+struct sql_trigger *
+sql_parse_trigger(struct Parse *parser, const char *sql);
 
 /**
  * This routine is called after a single SQL statement has been

--- a/src/box/sql/tokenize.c
+++ b/src/box/sql/tokenize.c
@@ -476,16 +476,9 @@ sql_code_ast(struct Parse *parse, struct sql_ast *ast)
 		sql_finish_coding(parse);
 }
 
-/**
- * Run the parser on the given SQL string.
- *
- * @param pParse Parser context.
- * @param zSql SQL string.
- * @retval 0 on success.
- * @retval -1 on error.
- */
-int
-sqlRunParser(Parse * pParse, const char *zSql)
+/** Run the parser on the given SQL string. */
+static int
+sql_run_parser(struct Parse *pParse, const char *zSql, int seed_token)
 {
 	int i;			/* Loop counter */
 	void *pEngine;		/* The LEMON-generated LALR(1) parser */
@@ -503,6 +496,10 @@ sqlRunParser(Parse * pParse, const char *zSql)
 	assert(pParse->pVList == 0);
 	struct Token last;
 	memset(&last, 0, sizeof(last));
+	if (seed_token != 0) {
+		last.z = zSql;
+		sqlParser(pEngine, seed_token, last, pParse);
+	}
 	while (1) {
 		assert(i >= 0);
 		if (zSql[i] != 0) {
@@ -555,4 +552,43 @@ sqlRunParser(Parse * pParse, const char *zSql)
 	pParse->zTail = &zSql[i];
 	sqlParserFree(pEngine, free);
 	return pParse->is_aborted ? -1 : 0;
+}
+
+int
+sql_parse_statement(struct Parse *parser, const char *sql)
+{
+	return sql_run_parser(parser, sql, 0);
+}
+
+struct Expr *
+sql_parse_function(struct Parse *parser, const char *sql)
+{
+	if (sql_run_parser(parser, sql, TK_FUNCTION_ENTRY) != 0)
+		return NULL;
+	assert(parser->parsed_ast_type == AST_TYPE_EXPR);
+	struct Expr *res = parser->parsed_ast.expr;
+	parser->parsed_ast.expr = NULL;
+	return res;
+}
+
+struct Select *
+sql_parse_view(struct Parse *parser, const char *sql)
+{
+	if (sql_run_parser(parser, sql, TK_VIEW_ENTRY) != 0)
+		return NULL;
+	assert(parser->parsed_ast_type == AST_TYPE_SELECT);
+	struct Select *res = parser->parsed_ast.select;
+	parser->parsed_ast.select = NULL;
+	return res;
+}
+
+struct sql_trigger *
+sql_parse_trigger(struct Parse *parser, const char *sql)
+{
+	if (sql_run_parser(parser, sql, TK_TRIGGER_ENTRY) != 0)
+		return NULL;
+	assert(parser->parsed_ast_type == AST_TYPE_TRIGGER);
+	struct sql_trigger *res = parser->parsed_ast.trigger;
+	parser->parsed_ast.trigger = NULL;
+	return res;
 }

--- a/test/sql-luatest/sql_func_expr_test.lua
+++ b/test/sql-luatest/sql_func_expr_test.lua
@@ -64,17 +64,14 @@ end
 -- Make sure SQL_EXPRESSION function parsed properly.
 g.test_sql_func_expr_2 = function()
     g.server:exec(function()
+        local func_create = box.schema.func.create
         local def = {language = 'SQL_EXPR', is_deterministic = true, body = ''}
-        t.assert_error_msg_content_equals(
-            "Syntax error at line 1 near ' '",
-            function() box.schema.func.create('a1', def) end
-        )
+        local exp_err = "Function definition cannot be empty"
+        t.assert_error_msg_content_equals(exp_err, func_create, 'a1', def)
 
         def.body = ' '
-        t.assert_error_msg_content_equals(
-            "Syntax error at line 1 near '  '",
-            function() box.schema.func.create('a1', def) end
-        )
+        exp_err = "Syntax error at line 1 near ' '"
+        t.assert_error_msg_content_equals(exp_err, func_create, 'a1', def)
 
         def.body = '1, 1 '
         t.assert_error_msg_content_equals(
@@ -173,5 +170,21 @@ g.test_sql_func_expr_5 = function()
         t.assert_equals(s:insert{4, 5}, {4, 5})
         box.space.test:drop()
         box.schema.func.drop('abc')
+    end)
+end
+
+--
+-- Make sure that the body of a SQL expression function cannot be
+-- parsed outside the function.
+--
+g.test_sql_expr_parsing = function()
+    g.server:exec(function()
+        local _, err = box.execute([[FUNCTION a * b > 10]])
+        local exp_err = "Syntax error at line 1 near 'FUNCTION'"
+        t.assert_equals(err.message, exp_err)
+
+        _, err = box.execute([[a * b > 10]])
+        exp_err = "Syntax error at line 1 near 'a'"
+        t.assert_equals(err.message, exp_err)
     end)
 end

--- a/test/sql-luatest/triggers_test.lua
+++ b/test/sql-luatest/triggers_test.lua
@@ -825,3 +825,30 @@ g.test_trigger_str = function(cg)
         box.execute([[DROP TABLE t1;]])
     end)
 end
+
+--
+-- Make sure that no assertion when inserting an invalid trigger definition
+-- into _trigger.
+--
+g.test_wrong_trigger_def = function(cg)
+    cg.server:exec(function()
+        box.execute([[CREATE TABLE t (i INT PRIMARY KEY);]])
+        local _trigger = box.space._trigger
+        local def = {'asd', box.space.t.id, {sql = ''}}
+        local exp_err = {
+            details = "Trigger definition cannot be empty",
+            message = "Trigger definition cannot be empty",
+            name = "SQL_PARSER_GENERIC",
+        }
+        t.assert_error_covers(exp_err, _trigger.insert, _trigger, def)
+
+        def = {'asd', box.space.t.id, {sql = 'INSERT INTO t VALUES (1);'}}
+        exp_err = {
+            message = "Syntax error at line 1 near 'INSERT'",
+            name = "SQL_SYNTAX_NEAR_TOKEN",
+            token = "INSERT",
+        }
+        t.assert_error_covers(exp_err, _trigger.insert, _trigger, def)
+        box.execute([[DROP TABLE t;]])
+    end)
+end

--- a/test/sql-luatest/view_test.lua
+++ b/test/sql-luatest/view_test.lua
@@ -81,7 +81,7 @@ g.test_view = function(cg)
         box.space.test:drop()
         -- This case must fail since parser converts it to expr AST.
         raw_sp[6].sql = 'SELECT 1;'
-        exp_err = "Failed to execute SQL statement: SELECT 1;"
+        exp_err = "Syntax error at line 1 near 'SELECT'"
         t.assert_error_msg_equals(exp_err, _space.replace, _space, raw_sp)
 
         box.execute("DROP VIEW v1;")
@@ -453,5 +453,26 @@ g.test_13009_adding_column_unique = function(cg)
         _, err = box.execute(sql)
         t.assert_equals(tostring(err), exp_err)
         box.execute([[DROP VIEW v;]])
+    end)
+end
+
+--
+-- Make sure that no assertion when inserting an invalid view definition
+-- into _space.
+--
+g.test_wrong_view_def = function(cg)
+    cg.server:exec(function()
+        box.execute([[CREATE TABLE t (i INT PRIMARY KEY);]])
+        local _space = box.space._space
+        local format = {{type = 'integer', name = 'i'}}
+        local flags = {sql = 'INSERT INTO t VALUES (1);', view = true}
+        local def = {1000, 1, 'view', 'memtx', 1, flags, format}
+        local exp_err = {
+            message = "Syntax error at line 1 near 'INSERT'",
+            name = "SQL_SYNTAX_NEAR_TOKEN",
+            token = "INSERT",
+        }
+        t.assert_error_covers(exp_err, _space.insert, _space, def)
+        box.execute([[DROP TABLE t;]])
     end)
 end


### PR DESCRIPTION
This patch reworks the process of creating functions, views, and triggers. We will now parse all these cases, as well as the general case, separately. To achieve this, we'll use a special token identifier for all cases except general SQL query execution. Since there's no string representation of the token for these identifiers, we'll avoid most potential issues associated with providing an incorrect query as trigger, view, and function definitions.

Part of #5485
Closes #13067

NO_DOC=bugfix