### PR TITLE
CI: run `perf_micro` on regular runner on PR

### DIFF
--- a/.github/workflows/perf_micro.yml
+++ b/.github/workflows/perf_micro.yml
@@ -71,6 +71,14 @@ jobs:
             github.event_name == 'pull_request_target' &&
             contains(github.event.pull_request.labels.*.name, 'performance') ) )
 
+    strategy:
+      matrix:
+        runner_label:
+          - ${{ (github.event_name != 'pull_request' ||
+              (github.event.pull_request.head.repo.full_name == github.repository &&
+               contains(github.event.pull_request.labels.*.name, 'performance'))) &&
+              'performance' || 'regular' }}
+
     # 'performance' label _must_ be set only for the single runner
     # to guarantee that results are not dependent on the machine.
     # For runs whose statistics are not collected, it is OK to use
@@ -79,9 +87,7 @@ jobs:
       - self-hosted
       - Linux
       - x86_64
-      - ${{ (github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository) &&
-          'performance' || 'regular' }}
+      - ${{ matrix.runner_label }}
 
     timeout-minutes: 60
 
@@ -111,8 +117,7 @@ jobs:
         # Run on push to the 'master' and release branches or on
         # non-fork pull requests. The script will fail on regular
         # runners.
-        if: github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository
+        if: matrix.runner_label == 'performance'
         run: sh ./perf/tools/setup_env.sh
       - name: test
         run: make -f .test.mk test-perf
@@ -134,8 +139,7 @@ jobs:
         # Run on push to the 'master' and release branches or on
         # non-fork pull requests (secrets are unavailable in fork
         # pull requests).
-        if: github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository
+        if: matrix.runner_label == 'performance'
         # TODO: For now, use the debug bucket for this PoC.
         # --silent -o /dev/null: Prevent dumping any reply part
         # in the output in case of an error.
@@ -158,8 +162,7 @@ jobs:
         # Run on push to the 'master' and release branches or on
         # non-fork pull requests (secrets are unavailable in fork
         # pull requests).
-        if: github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository
+        if: matrix.runner_label == 'performance'
         run: |
           apt install -y python3-venv
           python3 -m venv venv_influx
@@ -184,8 +187,7 @@ jobs:
         # Run on push to the 'master' and release branches or on
         # non-fork pull requests (secrets are unavailable in fork
         # pull requests).
-        if: github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository
+        if: matrix.runner_label == 'performance'
         run: |
           python3 -m venv venv_otava
           source venv_otava/bin/activate


### PR DESCRIPTION
This patch prevents performance testing from running on a special runner if the pull request does not have the `performance` label.

NO_DOC=CI
NO_TEST=CI
NO_CHANGELOG=CI