### PR TITLE
ci: switch Apache Otava to public release

### DIFF
--- a/.github/workflows/perf_micro.yml
+++ b/.github/workflows/perf_micro.yml
@@ -175,11 +175,10 @@ jobs:
         env:
           INFLUXDB_URL: ${{ secrets.INFLUXDB_URL }}
           INFLUXDB_TOKEN: ${{ secrets.INFLUXDB_TOKEN_EXTRACT_RESULTS }}
-      # Beware, Apache Otava is tested against Python 3.8,
-      # 3.9, and 3.10.
+      # Otava 0.8.0 requires Python >= 3.10, see PyPI.
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Run performance results analysis
         # Run on push to the 'master' and release branches or on
         # non-fork pull requests (secrets are unavailable in fork
@@ -189,14 +188,7 @@ jobs:
         run: |
           python3 -m venv venv_otava
           source venv_otava/bin/activate
-          curl -sSL https://install.python-poetry.org | python - --version 1.8.3
-          export PATH="/root/.local/bin:$PATH"
-          git clone https://github.com/apache/otava
-          cd otava
-          # Use intermediate version until the first release,
-          # see https://github.com/apache/otava/issues/51.
-          git reset --hard 73cf53e
-          poetry install -v
+          pip install -v apache-otava==0.8.0
           export OTAVA_CONFIG=$(realpath ../otava.yaml)
           MAGNITUDE=0.2
           otava regressions --magnitude ${MAGNITUDE} tarantool

--- a/.github/workflows/perf_micro.yml
+++ b/.github/workflows/perf_micro.yml
@@ -183,8 +183,6 @@ jobs:
         # Run on push to the 'master' and release branches or on
         # non-fork pull requests (secrets are unavailable in fork
         # pull requests).
-        if: github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name == github.repository
         run: |
           python3 -m venv venv_otava
           source venv_otava/bin/activate


### PR DESCRIPTION
The Apache Otava used for performance testing results analysis is using release process for new versions [1] and there is no sense using intermediate version. The patch switches Apache Otava to the latest release available in PIP. The full changelog is available [2].

1. https://github.com/apache/otava/blob/da316dd2caef3815977b4ea43bf6711b46e47a11/docs/RELEASE.md
2. https://github.com/apache/otava/compare/73cf53e...0.8.0-incubating

NO_CHANGELOG=testing
NO_DOC=testing
NO_TEST=testing