### PR TITLE
extra: fix typo in dependencies.yaml (c-ares ver)

### DIFF
--- a/extra/dependencies.yaml
+++ b/extra/dependencies.yaml
@@ -2,7 +2,7 @@
 # 1. https://github.com/tarantool/tarantool/wiki/Dependency-Management
 dependencies:
   - name: c-ares
-    version: 1.88.1
+    version: 1.18.1
   - name: c-dt
     version: 5bd1b4e651b597c106976f08d4c05b9ccb3efabd
   - name: decNumber


### PR DESCRIPTION
Just fixed a mistake in the version number: 1.88.1 is a typo, it should be 1.18.1.