### PR TITLE
ci: switch Apache Otava to public release

### DIFF
--- a/.github/workflows/perf_micro.yml
+++ b/.github/workflows/perf_micro.yml
@@ -189,17 +189,9 @@ jobs:
         run: |
           python3 -m venv venv_otava
           source venv_otava/bin/activate
-          curl -sSL https://install.python-poetry.org | python - --version 1.8.3
-          export PATH="/root/.local/bin:$PATH"
-          git clone https://github.com/apache/otava
-          cd otava
-          # Use intermediate version until the first release,
-          # see https://github.com/apache/otava/issues/51.
-          git reset --hard 73cf53e
-          poetry install -v
-          export OTAVA_CONFIG=$(realpath ../otava.yaml)
+          pip install -v apache-otava==0.8.0
+          export OTAVA_CONFIG=$(realpath otava.yaml)
           MAGNITUDE=0.2
-          otava regressions --magnitude ${MAGNITUDE} tarantool
           otava analyze --magnitude ${MAGNITUDE} tarantool
       - name: Send VK Teams message on failure
         if: failure()


### PR DESCRIPTION
The Apache Otava used for performance testing results analysis is using release process for new versions [1] and there is no sense using intermediate version. The patch switches Apache Otava to the latest release available in PIP. The full changelog is available [2].

1. https://github.com/apache/otava/blob/da316dd2caef3815977b4ea43bf6711b46e47a11/docs/RELEASE.md
2. https://github.com/apache/otava/compare/73cf53e...0.8.0-incubating

NO_CHANGELOG=testing
NO_DOC=testing
NO_TEST=testing