### PR TITLE
lua: bump metrics module

### DIFF
--- a/changelogs/unreleased/bump-metrics-to-1.8.3.md
+++ b/changelogs/unreleased/bump-metrics-to-1.8.3.md
@@ -1,0 +1,9 @@
+## feature/metrics
+
+* Updated the metrics submodule to 1.8.3.
+
+  Changes since 1.8.1:
+
+  * Added EmmyLua analyzer support and annotations ([gh-551][mgh-551]).
+
+[mgh-551]: https://github.com/tarantool/metrics/pull/551


### PR DESCRIPTION
Bump metric package submodule to 1.8.3.

Needed for #13020