### PR TITLE
config: don't override pinned module search root

### DIFF
--- a/src/box/lua/config/init.lua
+++ b/src/box/lua/config/init.lua
@@ -86,6 +86,23 @@ local function set_searchroot(iconfig, vars)
     if work_dir == nil then
         return
     end
+    -- `package.setsearchroot()` is a public API and the root can
+    -- be pinned manually (e.g. luatest pins it for the test
+    -- servers it spawns). An unset root falls back to the
+    -- current directory. Respect non-default values and don't
+    -- override.
+    --
+    -- A root explicitly pinned to the current directory is
+    -- indistinguishable from an unset one and is overridden here.
+    -- It is going to be resolved when a chdir to process.work_dir
+    -- is performed at this point instead of the search root
+    -- change, see gh-13086.
+    local searchroot = package.searchroot()
+    if searchroot ~= fio.cwd() then
+        log.verbose('the module search root is not set: it is already ' ..
+                    'pinned to %q', searchroot)
+        return
+    end
     -- The variables are substituted later, when the configdata
     -- object is constructed. Substitute the name variables here
     -- in the same way. The other ones (config.context.*) can't be

--- a/test/config-luatest/work_dir_test.lua
+++ b/test/config-luatest/work_dir_test.lua
@@ -1,7 +1,9 @@
 local fun = require('fun')
+local fio = require('fio')
 local yaml = require('yaml')
 local t = require('luatest')
 local treegen = require('luatest.treegen')
+local justrun = require('luatest.justrun')
 local server = require('luatest.server')
 local helpers = require('test.config-luatest.helpers')
 
@@ -48,4 +50,46 @@ g.test_relative_config_path = function(g)
         config:reload()
     end)
     server_is_ok(g.server)
+end
+
+-- An explicitly pinned module search root is respected:
+-- process.work_dir must not override it. For example, luatest
+-- pins the search root for the test servers it spawns and the
+-- luatest module itself may be resolvable only through it.
+g.test_pinned_searchroot = function()
+    local dir = treegen.prepare_directory({}, {})
+    treegen.write_file(dir, 'pinned/.rocks/share/tarantool/mymod.lua',
+                       'return {}')
+    treegen.write_file(dir, 'wd/main.lua', [[
+        require('mymod')
+        print('mymod is loaded')
+        os.exit(0)
+    ]])
+    local config = [[
+    process:
+      work_dir: wd
+
+    app:
+      file: main.lua
+
+    groups:
+      group-001:
+        replicasets:
+          replicaset-001:
+            instances:
+              instance-001: {}
+    ]]
+    treegen.write_file(dir, 'config.yaml', config)
+
+    -- LUA_PATH is emptied to not resolve anything from the
+    -- testing environment: mymod is resolvable only through the
+    -- pinned search root.
+    local res = justrun.tarantool(dir, {LUA_PATH = ''}, {
+        '-e', ('package.setsearchroot(%q)'):format(
+            fio.pathjoin(dir, 'pinned')),
+        '--name', 'instance-001', '--config', 'config.yaml',
+    }, {nojson = true, stderr = true, quote_args = true,
+        setsearchroot = false})
+    t.assert_equals(res.exit_code, 0, res.stderr)
+    t.assert_str_contains(res.stdout, 'mymod is loaded')
 end


### PR DESCRIPTION
Commit dea00284955d ("config: set module search root to work_dir")
pointed the module search root to the configured `process.work_dir`
right before the configdata construction, overriding a search root
that was possibly already pinned.

`package.setsearchroot()` is a public API. For example, luatest pins
the search root for the test servers it spawns, and in some testing
environments the luatest module itself is resolvable only through
it. Overriding the root broke `require('luatest')` when
`process.work_dir` was configured.

Respect the explicitly set search root and don't override it in the
Tarantool configuration. An unset root falls back to the current
directory, so a value that differs from the current directory
means an explicit setting set directly from Lua.

NO_DOC=bugfix
NO_CHANGELOG=fixes a not yet released commit
