### PR TITLE
evio: verify invariants in Debug build

### DIFF
--- a/src/lib/core/evio.c
+++ b/src/lib/core/evio.c
@@ -556,12 +556,21 @@ evio_service_create(struct ev_loop *loop, struct evio_service *service,
 	service->on_accept_param = on_accept_param;
 	service->entry_count = 0;
 	rlist_create(&service->entries);
+#ifndef NDEBUG
+	service->src = NULL;
+	service->refs = 0;
+#endif
 }
 
 void
 evio_service_attach(struct evio_service *dst, const struct evio_service *src)
 {
 	assert(dst->entry_count == 0);
+#ifndef NDEBUG
+	assert(dst->src == NULL);
+	dst->src = (struct evio_service *)src;
+	++dst->src->refs;
+#endif
 	struct evio_service_entry *src_entry;
 	rlist_foreach_entry(src_entry, &src->entries, link) {
 		struct evio_service_entry *dst_entry =
@@ -575,6 +584,11 @@ evio_service_attach(struct evio_service *dst, const struct evio_service *src)
 void
 evio_service_detach(struct evio_service *service)
 {
+#ifndef NDEBUG
+	if (service->src != NULL)
+		--service->src->refs;
+	service->src = NULL;
+#endif
 	if (service->entry_count == 0)
 		return;
 	struct evio_service_entry *entry, *tmp;
@@ -600,6 +614,17 @@ evio_service_listen(struct evio_service *service)
 void
 evio_service_stop(struct evio_service *service)
 {
+	/*
+	 * Invariant: stop is not called on an attached
+	 * service.
+	 */
+	assert(service->src == NULL);
+	/*
+	 * Invariant: all the previously attached services are
+	 * detached before stopping the service.
+	 */
+	assert(service->refs == 0);
+
 	if (service->entry_count == 0)
 		return;
 	say_info("%s: stopped", evio_service_name(service));

--- a/src/lib/core/evio.h
+++ b/src/lib/core/evio.h
@@ -34,6 +34,7 @@
  * Asynchronous IO in libev event loop.
  * Requires a running libev loop.
  */
+#include <assert.h>
 #include <stdbool.h>
 #include "tarantool_ev.h"
 #include "sio.h"
@@ -55,12 +56,46 @@ extern "C" {
  * a fiber and use coio.h (cooperative multi-tasking I/O)) API.
  *
  * How to use a service:
+ *
  * struct evio_service service;
  * evio_service_create(loop(), &service, ..., on_accept_cb, ...);
- * evio_service_bind(&service);
- * evio_service_listen(&service);
+ * evio_service_start(&service, ...);
  * ...
  * evio_service_stop(&service);
+ *
+ * Note: evio_service_create() doesn't allocate resources, so
+ * there is no opposite evio_service_destroy().
+ *
+ * If on_accept_cb is NULL, the service performs bind+listen on
+ * evio_service_start(), but doesn't perform accept. It is useful
+ * to listen from one thread, but do accepts from other ones.
+ *
+ * evio_service_attach() serves exactly this purpose: it keeps
+ * the event loop and the accept callback, but uses the
+ * listening socket from the source service.
+ *
+ * // thread 1
+ * struct evio_service listen_service;
+ * evio_service_create(loop(), &listen_service, ..., NULL, ...);
+ * evio_service_start(&listen_service, ...);
+ * ...
+ * evio_service_stop(&listen_service);
+ *
+ * // thread 2
+ * struct evio_service accept_service;
+ * evio_service_create(loop(), &accept_service, ..., on_accept_cb, ...);
+ * evio_service_attach(&accept_service, &listen_service);
+ * ...
+ * evio_service_detach(&accept_service);
+ *
+ * The attached service only uses the socket and doesn't own it.
+ * evio_service_stop() on an attached service would close the
+ * listening socket for the parent service and all the other
+ * attaches services, it is incorrect. Use evio_service_detach()
+ * to stop accepting incoming connections.
+ *
+ * Also, detach all the child services before calling
+ * evio_service_stop() on the parent one.
  */
 struct evio_service_entry;
 struct evio_service;
@@ -80,17 +115,21 @@ struct evio_service {
 	char name[SERVICE_NAME_MAXLEN];
 	/**
 	 * A callback invoked on every accepted client socket.
-	 * If a callback returned != 0, the accepted socket is
-	 * closed and the error is logged.
 	 *
-	 * On success the callback must move the IO stream object
-	 * it was passed.
+	 * The callback must move the IO stream object it was
+	 * passed or close it.
 	 */
 	evio_accept_f on_accept;
-	/**  The iproto_thread used in the callback above */
+	/** The parameter passed to on_accept on every call. */
 	void *on_accept_param;
 	/** Event loop */
 	ev_loop *loop;
+#ifndef NDEBUG
+	/** A service the given one attached to (if any). */
+	struct evio_service *src;
+	/** Count of attached services. */
+	size_t refs;
+#endif
 };
 
 /**


### PR DESCRIPTION
Now, the following invariants are enforced in the Debug build using assert() calls:

* `evio_service_stop()` must not be called on a service that attached to another service (otherwise it would close the socket for all the users).
* `evio_service_stop()` must be called only after all the previously attached services are detached.

However, calling `evio_service_detach()` on a service that was started (not attached) is allowed. It seems a legal use: one may want to end using the service while keeping the socket open.

Implemented by storing a pointer to the original service inside the attached service and counting attached services in the original service.

While I'm here, updated and clarified the API and usage comments.