### PR TITLE
test: don't write to user's readline history file

### DIFF
--- a/test/app-luatest/gh_4317_console_backslash_test.lua
+++ b/test/app-luatest/gh_4317_console_backslash_test.lua
@@ -38,7 +38,13 @@ g.test_using_backslash_on_local_console = function()
                               [[bbb\n]] ..
                               [=[]])]=]
 
-    local cmd = "printf '%s' | INPUTRC=/dev/null %s -i 2>/dev/null"
+    -- Unset XDG_STATE_HOME and HOME environment variables to skip readline
+    -- history file write. Otherwise it clogs user's own history.
+    --
+    -- Also, reset readline configuration using the INPUTRC environment
+    -- variable.
+    local cmd = "unset XDG_STATE_HOME; unset HOME; " ..
+        "printf '%s' | INPUTRC=/dev/null %s -i 2>/dev/null"
     cmd = (cmd):format(tarantool_command, TARANTOOL_PATH)
     local fh = io.popen(cmd, 'r')
 

--- a/test/app-luatest/gh_5064_console_ignore_i_flag_without_tty_test.lua
+++ b/test/app-luatest/gh_5064_console_ignore_i_flag_without_tty_test.lua
@@ -12,9 +12,14 @@ tarantool> ]]
 local TARANTOOL_PATH = arg[-1]
 
 g.test_console_ignores_i_flag_without_tty = function()
-    -- Suppress prompt changes by custom readline config to simplify assertions.
-    local cmd = [[printf '42\n' | ]] .. 'INPUTRC=non_existent_file ' ..
-                TARANTOOL_PATH .. [[ -i 2>/dev/null]]
+    -- Unset XDG_STATE_HOME and HOME environment variables to skip readline
+    -- history file write. Otherwise it clogs user's own history.
+    --
+    -- Suppress prompt changes by custom readline config to simplify assertions
+    -- using the INPUTRC environment variable.
+    local cmd = ("unset XDG_STATE_HOME; unset HOME; " ..
+        "printf '42\n' | INPUTRC=non_existent_file %s " ..
+        "-i 2>/dev/null"):format(TARANTOOL_PATH)
     local fh = io.popen(cmd, 'r')
 
     -- Readline on CentOS 7 produces \e[?1034h escape sequence before tarantool> prompt, remove it.

--- a/test/app-luatest/gh_6200_lua_cjson_escapes_slash_test.lua
+++ b/test/app-luatest/gh_6200_lua_cjson_escapes_slash_test.lua
@@ -79,6 +79,9 @@ local function popen_test_json_log()
         stdout = popen.opts.PIPE,
         stderr = popen.opts.PIPE,
         stdin = popen.opts.PIPE,
+        -- Unset XDG_STATE_HOME and HOME environment variables to skip readline
+        -- history file write. Otherwise it clogs user's own history.
+        env = {},
     })
     t.assert(ph, 'process is not up')
 

--- a/test/app-luatest/gh_6817_console_memory_leak_test.lua
+++ b/test/app-luatest/gh_6817_console_memory_leak_test.lua
@@ -24,6 +24,13 @@ g.before_test('test_console_mem_leak', function()
     g.console_write = function(command)
         ffi.C.write(g.console_write_fd, command, string.len(command))
     end
+
+    -- Unset XDG_STATE_HOME and HOME environment variables to skip readline
+    -- history file write. Otherwise it clogs user's own history.
+    g.XDG_STATE_HOME = os.getenv('XDG_STATE_HOME')
+    g.HOME = os.getenv('HOME')
+    os.setenv('XDG_STATE_HOME', nil)
+    os.setenv('HOME', nil)
 end)
 
 g.after_test('test_console_mem_leak', function()
@@ -31,6 +38,9 @@ g.after_test('test_console_mem_leak', function()
     t.assert_equals(ffi.C.close(0), 0)
     g.console_write = nil
     g.console_write_fd = nil
+
+    os.setenv('XDG_STATE_HOME', g.XDG_STATE_HOME)
+    os.setenv('HOME', g.HOME)
 end)
 
 -- Checks that ASAN doesn't detect any memory leaks when console is used.

--- a/test/app-tap/gh-2717-no-quit-sigint.test.lua
+++ b/test/app-tap/gh-2717-no-quit-sigint.test.lua
@@ -18,8 +18,17 @@ local prompt = 'tarantool> '
 local TARANTOOL_PATH = arg[-1]
 local test = tap.test('gh-2717-no-quit-sigint')
 
+-- Unset XDG_STATE_HOME and HOME environment variables to skip readline
+-- history file write. Otherwise it clogs user's own history.
+--
+-- Also, reset readline configuration using the INPUTRC environment
+-- variable.
+local interactive_tarantool_env = {
+    ['INPUTRC'] = 'non_existent_file',
+}
+
 test:plan(8)
-local cmd = 'INPUTRC=non_existent_file ' .. TARANTOOL_PATH .. ' -i 2>&1'
+local cmd = TARANTOOL_PATH .. ' -i 2>&1'
 local ph = popen.new({cmd}, {
     shell = true,
     setsid = true,
@@ -27,6 +36,7 @@ local ph = popen.new({cmd}, {
     stdout = popen.opts.PIPE,
     stderr = popen.opts.DEVNULL,
     stdin = popen.opts.PIPE,
+    env = interactive_tarantool_env,
 })
 assert(ph, 'process is not up')
 
@@ -64,7 +74,7 @@ ph:close()
 --
 -- gh-7109: Ctrl+C does not break multiline input.
 --
-local cmd = 'INPUTRC=non_existent_file ' .. TARANTOOL_PATH .. ' -i 2>&1'
+local cmd = TARANTOOL_PATH .. ' -i 2>&1'
 ph = popen.new({cmd}, {
     shell = true,
     setsid = true,
@@ -72,6 +82,7 @@ ph = popen.new({cmd}, {
     stdout = popen.opts.PIPE,
     stderr = popen.opts.DEVNULL,
     stdin = popen.opts.PIPE,
+    env = interactive_tarantool_env,
 })
 assert(ph, 'process is not up')
 
@@ -158,7 +169,7 @@ local ph_server = popen.shell('INPUTRC=non_existent_file ' .. TARANTOOL_PATH
 local f = process_timeout.open_with_timeout(log_file, file_open_timeout)
 assert(f, 'error while opening ' .. log_file)
 
-cmd = 'INPUTRC=non_existent_file ' .. TARANTOOL_PATH .. ' -i 2>&1'
+cmd = TARANTOOL_PATH .. ' -i 2>&1'
 local ph_client = popen.new({cmd}, {
     shell = true,
     setsid = true,
@@ -166,6 +177,7 @@ local ph_client = popen.new({cmd}, {
     stdout = popen.opts.PIPE,
     stderr = popen.opts.DEVNULL,
     stdin = popen.opts.PIPE,
+    env = interactive_tarantool_env,
 })
 assert(ph_client, 'the nested console is not up')
 
@@ -222,7 +234,7 @@ os.remove(snap_file)
 --
 -- Testing case when the client and instance are called in the same console.
 --
-cmd = 'INPUTRC=non_existent_file ' .. TARANTOOL_PATH .. ' -i 2>&1'
+cmd = TARANTOOL_PATH .. ' -i 2>&1'
 ph = popen.new({cmd}, {
     shell = true,
     setsid = true,
@@ -230,6 +242,7 @@ ph = popen.new({cmd}, {
     stdout = popen.opts.PIPE,
     stderr = popen.opts.DEVNULL,
     stdin = popen.opts.PIPE,
+    env = interactive_tarantool_env,
 })
 assert(ph, 'process is not up')
 

--- a/test/box/gh-4703-on_shutdown-bug.result
+++ b/test/box/gh-4703-on_shutdown-bug.result
@@ -30,7 +30,9 @@ test_run:cmd("setopt delimiter ''");
  | ---
  | - true
  | ...
-server = io.popen('tarantool -i', 'w')
+-- Unset XDG_STATE_HOME and HOME environment variables to skip readline
+-- history file write. Otherwise it clogs user's own history.
+server = io.popen('unset XDG_STATE_HOME; unset HOME; tarantool -i', 'w')
  | ---
  | ...
 server:write(on_shutdown_cmd)

--- a/test/box/gh-4703-on_shutdown-bug.test.lua
+++ b/test/box/gh-4703-on_shutdown-bug.test.lua
@@ -13,7 +13,9 @@ on_shutdown_cmd = "box.ctl.on_shutdown(function() local fio = require('fio') "..
                    "fio.open('"..file_name.."', "..
                    "{'O_CREAT', 'O_TRUNC', 'O_WRONLY'}, 777):close() end)\n";
 test_run:cmd("setopt delimiter ''");
-server = io.popen('tarantool -i', 'w')
+-- Unset XDG_STATE_HOME and HOME environment variables to skip readline
+-- history file write. Otherwise it clogs user's own history.
+server = io.popen('unset XDG_STATE_HOME; unset HOME; tarantool -i', 'w')
 server:write(on_shutdown_cmd)
 server:close()
 fio.path.lexists(file_name) == true


### PR DESCRIPTION
If `tarantool -i` is run from a test, it writes console commands to `${HOME}/.tarantool_history` (or to an appropriate file in `${XDG_STATE_HOME}`). The testing commands interfere with user's history and it is undesirable.

Most of modern tests that need the interactive console are written using the `interactive_tarantool` helper, which resets environment variables (including `XDG_STATE_HOME` and `HOME`) that effectively disables the history file write. However, there are old/specific tests that execute `tarantool -i` directly and we have to discard these variable here as well.

The patch discards parent's environment at whole or specifically discards `XDG_STATE_HOME` and `HOME` environment variables (what is simpler, case by case) in tests that use `tarantool -i` without the `interactive_tarantool` helper. Some of them are worthful to port to the helper, but here I just do a little adjustment to don't clog the history file.

Fixes #10697