### PR TITLE
changelog: cleanup 3.8.1 changelogs

### DIFF
--- a/changelogs/unreleased/config-searchroot-work-dir.md
+++ b/changelogs/unreleased/config-searchroot-work-dir.md
@@ -1,9 +1,0 @@
-## bugfix/config
-
-* Modules installed into the configured `process.work_dir` (for example,
-  into its `.rocks` directory) are now resolvable, and a relative `app.file`
-  path is interpreted against the working directory even before the first
-  `box.cfg()` call. In particular, roles and an application marked with
-  the `early_load` tag can now be loaded from the working directory, and
-  the configuration defaults that depend on the installed vshard version
-  are applied at first startup.

--- a/changelogs/unreleased/config-vshard-check-before-box-cfg.md
+++ b/changelogs/unreleased/config-vshard-check-before-box-cfg.md
@@ -1,6 +1,0 @@
-## bugfix/config
-
-* An unavailable or outdated vshard module for a configured sharding role,
-  as well as a configured sharding option that requires a newer vshard, is
-  now reported before the first `box.cfg()` call, so a misconfigured instance
-  fails fast instead of failing after a potentially long database recovery.

--- a/changelogs/unreleased/config-vshard-in-work-dir.md
+++ b/changelogs/unreleased/config-vshard-in-work-dir.md
@@ -1,9 +1,0 @@
-## bugfix/config
-
-* Fixed a spurious `The vshard-ee/vshard module is not available`
-  configuration validation error on startup when the vshard module is
-  installed into the configured `process.work_dir` and the process is started
-  from a different directory, or when an instance without a sharding role
-  inherits a global sharding option, such as `sharding.bucket_count`
-  (gh-12928). The availability of vshard and its minimum version are now
-  checked only on instances with a configured sharding role.

--- a/changelogs/unreleased/gh-11028-missing-system-space-rows.md
+++ b/changelogs/unreleased/gh-11028-missing-system-space-rows.md
@@ -1,4 +1,0 @@
-## bugfix/replication
-
-* Fixed an ordering bug in WAL batching that could make a joining replica miss
-  rows written by the master (gh-11028).

--- a/changelogs/unreleased/gh-12404-validate-field-constraints-on-upsert.md
+++ b/changelogs/unreleased/gh-12404-validate-field-constraints-on-upsert.md
@@ -1,7 +1,0 @@
-## bugfix/vinyl
-
-* In some cases, vinyl deferred UPSERT field constraint checks until a
-  read or a compaction. A violating UPSERT could then be skipped without
-  returning an error to the client. Constraints are now validated at
-  UPSERT time when update operations may modify constrained columns,
-  matching Memtx behavior (gh-12404).

--- a/changelogs/unreleased/gh-12546-setsearchroot-in-app-threads.md
+++ b/changelogs/unreleased/gh-12546-setsearchroot-in-app-threads.md
@@ -1,5 +1,0 @@
-## bugfix/core
-
-* The root directory from which Lua dependencies are loaded was made global:
-  setting it with `package.setsearchroot()` in any thread now affects all
-  threads (gh-12546).

--- a/changelogs/unreleased/gh-12556-wal-sync-before-cfg.md
+++ b/changelogs/unreleased/gh-12556-wal-sync-before-cfg.md
@@ -1,4 +1,0 @@
-## bugfix/core
-
-* Fixed a crash on calling `box.ctl.wal_sync()` before `box.cfg{}`.
-  Now it raises an `ER_UNCONFIGURED` error in this case (gh-12556).

--- a/changelogs/unreleased/gh-12726-fix-json-encode-serialized.md
+++ b/changelogs/unreleased/gh-12726-fix-json-encode-serialized.md
@@ -1,4 +1,0 @@
-## bugfix/lua
-
-* Fixed the error in the JSON encoder when an encoded key in the map has
-  `__serialize` metamethod (gh-12726).

--- a/changelogs/unreleased/gh-12805-fix-proxy-auth.md
+++ b/changelogs/unreleased/gh-12805-fix-proxy-auth.md
@@ -1,4 +1,0 @@
-## bugfix/lua/http client
-
-* Fixed a regression of authorization on an HTTP proxy or a target HTTP(S) host
-  using the Basic algorithm (gh-12805).

--- a/changelogs/unreleased/gh-12936-app-threads-coio-hang-fix.md
+++ b/changelogs/unreleased/gh-12936-app-threads-coio-hang-fix.md
@@ -1,4 +1,0 @@
-## bugfix/core
-
-* Fixed a bug where Tarantool could hang at startup when application threads
-  were configured (gh-12936).

--- a/changelogs/unreleased/gh-12968-primary-key-with-autoinc.md
+++ b/changelogs/unreleased/gh-12968-primary-key-with-autoinc.md
@@ -1,4 +1,0 @@
-## bugfix/sql
-
-* Fixed an inability to set both the sort order and the AUTOINCREMENT property
-  on columns in a PRIMARY KEY table constraint at the same time (gh-12968).

--- a/changelogs/unreleased/gh-12970-read-only-unless-bootstrap.md
+++ b/changelogs/unreleased/gh-12970-read-only-unless-bootstrap.md
@@ -1,9 +1,0 @@
-## feature/core
-
-* Added a new `box.cfg.read_only` value: `'unless_bootstrap'`. An instance
-  configured this way becomes writable only if it has bootstrapped the
-  replicaset on the current startup and stays read-only if it has recovered
-  from a local snapshot or has joined an already bootstrapped replicaset. The
-  mode is resolved atomically during the initial `box.cfg()` call, so the
-  instance never goes through a transient writable state. The value may
-  be set only during the initial `box.cfg()` call (gh-12970).

--- a/changelogs/unreleased/gh-12970-supervised-rejoin-master-master.md
+++ b/changelogs/unreleased/gh-12970-supervised-rejoin-master-master.md
@@ -1,9 +1,0 @@
-## bugfix/config
-
-* Fixed a bug where an instance rebootstrapped with an empty data directory
-  could start in the RW mode alongside an already appointed leader with
-  `replication.failover = supervised` and `replication.bootstrap_strategy =
-  auto`, if the instance had the lexicographically minimal name in the
-  replicaset. The bootstrap leader candidate now starts with
-  `box.cfg.read_only = 'unless_bootstrap'`, so a rejoined instance never
-  goes through a writable state at all (gh-12970).

--- a/changelogs/unreleased/gh-13010-fix-trigerring-assertion-at-repeat-adding-column-with-constraint.md
+++ b/changelogs/unreleased/gh-13010-fix-trigerring-assertion-at-repeat-adding-column-with-constraint.md
@@ -1,4 +1,0 @@
-## bugfix/sql
-
-* Fixed a bug where the foreign field ID for a field foreign key
-  was lost after executing an `ALTER TABLE ADD COLUMN` statement (gh-13010).

--- a/changelogs/unreleased/gh-13027-update-json-path-key-encoding.md
+++ b/changelogs/unreleased/gh-13027-update-json-path-key-encoding.md
@@ -1,4 +1,0 @@
-## bugfix/box
-
-* Fixed a crash on update with delete by JSON path with terminal key when
-  the deleted key in tuple had non-optimal encoding (gh-13027)

--- a/changelogs/unreleased/ghs-163-check-privileges-on-drop-trigger.md
+++ b/changelogs/unreleased/ghs-163-check-privileges-on-drop-trigger.md
@@ -1,5 +1,0 @@
-## feature/sql
-
-* Added permission checks when dropping a trigger in SQL.
-  Now only users with 'alter' privileges on a table can drop
-  triggers for that table (ghs-163).

--- a/src/box/lua/upgrade.lua
+++ b/src/box/lua/upgrade.lua
@@ -2311,6 +2311,7 @@ local downgrade_versions = {
     "3.7.0",
     "3.7.1",
     "3.8.0",
+    "3.8.1",
     -- DOWNGRADE VERSIONS END
 }
 


### PR DESCRIPTION
Remove all changelogs reported in release notes for 3.8.1.

NO_CHANGELOG=changelog
NO_DOC=changelog
NO_TEST=changelog
