### PR TITLE
Follow-up fixes for the `gh_review` tool tests

### DIFF
--- a/test/tool-luatest/gh_review_test.lua
+++ b/test/tool-luatest/gh_review_test.lua
@@ -181,7 +181,8 @@ spec.loader.exec_module(m)
 print(json.dumps(%s))
 ]]):format(json.encode(TOOL), expr)
     local ph = popen.new({PYTHON, '-c', script},
-                         {env = {PATH = os.getenv('PATH')},
+                         {env = {PATH = os.getenv('PATH'),
+                                 PYTHONDONTWRITEBYTECODE = '1'},
                           stdout = popen.opts.PIPE,
                           stderr = popen.opts.PIPE})
     t.assert(ph)

--- a/test/tool-luatest/gh_review_test.lua
+++ b/test/tool-luatest/gh_review_test.lua
@@ -214,6 +214,7 @@ local function write_file(dir, name, lines)
 end
 
 g.before_all(function(cg)
+    t.skip_if(not fio.path.exists(TOOL), 'gh-review.py is unavailable')
     -- popen.new() does not resolve the program name via PATH - find
     -- the interpreter's absolute path. Also skip when there is none.
     local ph = popen.shell('command -v ' .. PYTHON, 'r')


### PR DESCRIPTION
- Skip the tests when the tool is unavailable (needed for EE gitlab test flow)
- Prevent the tests from leaving dirty `tools/__pycache__` folder