### PR TITLE
httpc: stop parsing incomplete response headers

### DIFF
--- a/changelogs/unreleased/gh-5937-http-client-incomplete-header.md
+++ b/changelogs/unreleased/gh-5937-http-client-incomplete-header.md
@@ -1,0 +1,4 @@
+## bugfix/lua/http client
+
+* Fixed an infinite loop when an HTTP response has an incomplete header
+  section (gh-5937).

--- a/src/lib/http_parser/http_parser.c
+++ b/src/lib/http_parser/http_parser.c
@@ -428,6 +428,9 @@ http_parse_header_line(struct http_parser *prsr, const char **bufp,
 		}
 	}
 
+	*bufp = p;
+	return HTTP_PARSE_CONTINUE;
+
 skipped_status:
 	*bufp = p + 1;
 	return HTTP_PARSE_CONTINUE;

--- a/src/lua/httpc.c
+++ b/src/lua/httpc.c
@@ -122,10 +122,12 @@ parse_headers(lua_State *L, const char *buffer, size_t len,
 	const char *end_buf = buffer + len;
 	lua_pushstring(L, "headers");
 	lua_newtable(L);
-	while (true) {
+	while (buffer < end_buf) {
 		int rc = http_parse_header_line(&parser, &buffer, end_buf,
 						max_header_name_len);
-		if (rc == HTTP_PARSE_INVALID || rc == HTTP_PARSE_CONTINUE) {
+		if (rc == HTTP_PARSE_INVALID)
+			break;
+		if (rc == HTTP_PARSE_CONTINUE) {
 			continue;
 		}
 		if (rc == HTTP_PARSE_DONE) {

--- a/test/app-luatest/http_client_test.lua
+++ b/test/app-luatest/http_client_test.lua
@@ -3,6 +3,7 @@ local json = require('json')
 local fiber = require('fiber')
 local uri = require('uri')
 local os = require('os')
+local socket = require('socket')
 local t = require('luatest')
 
 local g = t.group('http_client', {
@@ -229,6 +230,19 @@ g.test_cancel_and_errinj = function(cg)
     r = ch:get()
     t.assert_equals(r.status, 200, "No hangs in errinj")
     errinj.set('ERRINJ_HTTP_RESPONSE_ADD_WAIT', false)
+end
+
+g.test_incomplete_response_headers = function()
+    local handler = function(s)
+        s:write('HTTP/1.1 200 OK\r\nContent-Type: text/plain')
+        fiber.sleep(1)
+    end
+    local server = socket.tcp_server('127.0.0.1', 0, handler)
+    local url = 'http://127.0.0.1:' .. server:name().port
+    local response = client.get(url, {timeout = 0.01})
+    server:close()
+
+    t.assert_equals(response.status, 408)
 end
 
 g.test_post_and_get = function(cg)

--- a/test/unit/http_parser.c
+++ b/test/unit/http_parser.c
@@ -44,10 +44,33 @@ test_protocol_version(void)
 	check_plan();
 }
 
+static void
+test_incomplete_header(void)
+{
+	const char *header = "Content-Type: text/plain";
+	const char *end = header + strlen(header);
+	char buf[32];
+	struct http_parser parser;
+	int rc;
+
+	plan(2);
+	header();
+
+	http_parser_create(&parser);
+	parser.hdr_name = buf;
+	rc = http_parse_header_line(&parser, &header, end, lengthof(buf));
+	is(HTTP_PARSE_CONTINUE, rc, "incomplete header needs more data");
+	ok(header == end, "parser stops at the end of the input buffer");
+
+	footer();
+	check_plan();
+}
+
 int
 main(void)
 {
-	plan(1);
+	plan(2);
 	test_protocol_version();
+	test_incomplete_header();
 	return check_plan();
 }


### PR DESCRIPTION
Closes #5937.

The Lua HTTP client can enter an infinite loop when a response header section ends without the terminating empty line. The header parser advances beyond the input buffer and returns CONTINUE, while parse_headers() retries unconditionally.

This change keeps the parser at the end of incomplete input, bounds the outer parsing loop, and stops on invalid input. It adds both a parser unit test and an HTTP client regression test with a server that leaves the response headers incomplete until the client timeout expires.

Testing on Debian 13 aarch64, Debug build:

- app-luatest/http_client_test.lua passes
- test/unit/http_parser.test passes
- luacheck: 0 warnings, 0 errors
- checkpatch: 0 errors

Without the production-code changes, the new HTTP client test hangs and is terminated by the external test watchdog.