### PR TITLE
sql: fix metadata for bind variables

### DIFF
--- a/changelogs/unreleased/gh-12733-fix-work-of-numeric-bind-variables.md
+++ b/changelogs/unreleased/gh-12733-fix-work-of-numeric-bind-variables.md
@@ -1,0 +1,4 @@
+## bugfix/sql
+
+* Now the number of a numeric bind variable always corresponds to
+  its position in the provided array of bind variables (gh-12733).

--- a/changelogs/unreleased/gh-6551-fix-metadata-types-for-bind-variables.md
+++ b/changelogs/unreleased/gh-6551-fix-metadata-types-for-bind-variables.md
@@ -1,0 +1,3 @@
+## bugfix/sql
+
+* Now commands with bind variables have right types in metadata (gh-6551).

--- a/src/box/bind.c
+++ b/src/box/bind.c
@@ -174,6 +174,19 @@ sql_bind_list_decode(const char *data, struct sql_bind **out_bind)
 }
 
 int
+sql_bind(struct Vdbe *stmt, const struct sql_bind *bind, uint32_t bind_count)
+{
+	assert(stmt != NULL);
+	uint32_t pos = 1;
+	for (uint32_t i = 0; i < bind_count; pos = ++i + 1) {
+		if (sql_bind_column(stmt, &bind[i], pos) != 0)
+			return -1;
+	}
+	sql_set_types(stmt, bind, bind_count);
+	return 0;
+}
+
+int
 sql_bind_column(struct Vdbe *stmt, const struct sql_bind *p, uint32_t pos)
 {
 	if (p->name != NULL) {

--- a/src/box/bind.h
+++ b/src/box/bind.h
@@ -139,17 +139,8 @@ sql_bind_column(struct Vdbe *stmt, const struct sql_bind *p, uint32_t pos);
  * @retval  0 Success.
  * @retval -1 Client or memory error.
  */
-static inline int
-sql_bind(struct Vdbe *stmt, const struct sql_bind *bind, uint32_t bind_count)
-{
-	assert(stmt != NULL);
-	uint32_t pos = 1;
-	for (uint32_t i = 0; i < bind_count; pos = ++i + 1) {
-		if (sql_bind_column(stmt, &bind[i], pos) != 0)
-			return -1;
-	}
-	return 0;
-}
+int
+sql_bind(struct Vdbe *stmt, const struct sql_bind *bind, uint32_t bind_count);
 
 #if defined(__cplusplus)
 } /* extern "C" { */

--- a/src/box/execute.c
+++ b/src/box/execute.c
@@ -224,20 +224,21 @@ sql_unprepare(uint32_t stmt_id)
  * @retval -1 Error.
  */
 static inline int
-sql_execute(struct Vdbe *stmt, struct port *port, struct region *region)
+sql_execute(struct Vdbe *stmt, struct port *port, struct region *region,
+	    const struct sql_bind *bind, uint32_t bind_count)
 {
 	int rc, column_count = sql_column_count(stmt);
 	rmean_collect(rmean_box, IPROTO_EXECUTE, 1);
 	if (column_count > 0) {
 		/* Either ROW or DONE or ERROR. */
-		while ((rc = sql_step(stmt)) == SQL_ROW) {
+		while ((rc = sql_step(stmt, bind, bind_count)) == SQL_ROW) {
 			if (sql_row_to_port(stmt, region, port) != 0)
 				return -1;
 		}
 		assert(rc == SQL_DONE || rc != 0);
 	} else {
 		/* No rows. Either DONE or ERROR. */
-		rc = sql_step(stmt);
+		rc = sql_step(stmt, bind, bind_count);
 		assert(rc != SQL_ROW && rc != 0);
 	}
 	if (rc != SQL_DONE)
@@ -277,7 +278,7 @@ sql_execute_prepared(uint32_t stmt_id, const struct sql_bind *bind,
 	enum sql_serialization_format format = sql_column_count(stmt) > 0 ?
 					       DQL_EXECUTE : DML_EXECUTE;
 	port_sql_create(port, stmt, format, false);
-	if (sql_execute(stmt, port, region) != 0) {
+	if (sql_execute(stmt, port, region, bind, bind_count) != 0) {
 		port_destroy(port);
 		sql_stmt_reset(stmt);
 		return -1;
@@ -301,7 +302,7 @@ sql_prepare_and_execute(const char *sql, int len, const struct sql_bind *bind,
 					   DQL_EXECUTE : DML_EXECUTE;
 	port_sql_create(port, stmt, format, true);
 	if (sql_bind(stmt, bind, bind_count) == 0 &&
-	    sql_execute(stmt, port, region) == 0)
+	    sql_execute(stmt, port, region, bind, bind_count) == 0)
 		return 0;
 	port_destroy(port);
 	return -1;

--- a/src/box/sql/expr.c
+++ b/src/box/sql/expr.c
@@ -1245,8 +1245,8 @@ sqlExprAssignVarNumber(Parse * pParse, Expr * pExpr, u32 n)
 			if (x > pParse->nVar) {
 				pParse->nVar = (int)x;
 				doAdd = 1;
-			} else if (sqlVListNumToName(pParse->pVList, x) ==
-				   0) {
+			} else if (sql_find_var_by_name(pParse->pVList, z)
+				   == 0) {
 				doAdd = 1;
 			}
 		} else {
@@ -3685,10 +3685,9 @@ sqlExprCodeTarget(Parse * pParse, Expr * pExpr, int target)
 			sqlVdbeAddOp2(v, OP_Variable, pExpr->iColumn,
 					  target);
 			assert(pExpr->u.zToken[1] != 0);
-			const char *z = sqlVListNumToName(pParse->pVList,
-							  pExpr->iColumn);
-			assert(pExpr->u.zToken[0] == '$' ||
-			       strcmp(pExpr->u.zToken, z) == 0);
+			const char *z =
+				sql_find_var_by_name(pParse->pVList,
+						     pExpr->u.zToken);
 			/* Indicate VList may no longer be enlarged */
 			pParse->pVList[0] = 0;
 			sqlVdbeAppendP4(v, (char *)z, P4_STATIC);

--- a/src/box/sql/func.c
+++ b/src/box/sql/func.c
@@ -2551,7 +2551,7 @@ func_sql_expr_call(struct func *func, struct port *args, struct port *ret)
 	if (sql_bind_ptr(stmt, 1, ref) != 0)
 		goto error;
 
-	if (sql_step(stmt) != SQL_ROW)
+	if (sql_step(stmt, NULL, 0) != SQL_ROW)
 		goto error;
 
 	uint32_t res_size;
@@ -2560,7 +2560,7 @@ func_sql_expr_call(struct func *func, struct port *args, struct port *ret)
 		goto error;
 	port_c_add_mp(ret, pos, pos + res_size);
 
-	if (sql_step(stmt) != SQL_DONE)
+	if (sql_step(stmt, NULL, 0) != SQL_DONE)
 		goto error;
 
 	sql_stmt_reset(stmt);

--- a/src/box/sql/mem.c
+++ b/src/box/sql/mem.c
@@ -49,6 +49,7 @@
 #include "mp_decimal.h"
 #include "mp_uuid.h"
 #include "mp_util.h"
+#include "box/bind.h"
 
 #define CMP_OLD_NEW(a, b, type) (((a) > (type)(b)) - ((a) < (type)(b)))
 
@@ -304,6 +305,80 @@ mem_delete(struct Mem *v)
 		return;
 	mem_destroy(v);
 	sql_xfree(v);
+}
+
+int
+sql_mem_create_from_bind(struct Mem *mem, const struct sql_bind *bind)
+{
+	Mem *pVar;
+	if (bind != NULL) {
+		pVar = sql_xmalloc(sizeof(Mem));
+		mem_create(pVar);
+		switch (bind->type) {
+		case MP_INT:
+			mem_set_int(pVar, bind->i64);
+			break;
+		case MP_UINT:
+			mem_set_uint(pVar, bind->i64);
+			break;
+		case MP_BOOL:
+			mem_set_bool(pVar, bind->b);
+			break;
+		case MP_DOUBLE:
+		case MP_FLOAT:
+			mem_set_double(pVar, bind->d);
+			break;
+		case MP_STR:
+			/*
+			 * Parameters are allocated within message pack,
+			 * received from the iproto thread.
+			 * IProto thread now is waiting for the response
+			 * and it will not free the packet
+			 * until sql_stmt_finalize. So there is no need
+			 * to copy the packet and we can use SQL_STATIC.
+			 */
+			mem_set_str_static(pVar, (char *)bind->s, bind->bytes);
+			break;
+		case MP_NIL:
+			break;
+		case MP_BIN:
+			mem_set_bin_static(pVar, (char *)bind->s, bind->bytes);
+			break;
+		case MP_ARRAY:
+			mem_set_array_static(pVar, (char *)bind->s,
+					     bind->bytes);
+			break;
+		case MP_MAP:
+			mem_set_map_static(pVar, (char *)bind->s, bind->bytes);
+			break;
+		case MP_EXT:
+			switch (bind->ext_type) {
+			case MP_UUID:
+				mem_set_uuid(pVar, &bind->uuid);
+				break;
+			case MP_DECIMAL:
+				mem_set_dec(pVar, &bind->dec);
+				break;
+			case MP_DATETIME:
+				mem_set_datetime(pVar, &bind->dt);
+				break;
+			case MP_INTERVAL:
+				mem_set_interval(pVar, &bind->itv);
+				break;
+			default:
+				unreachable();
+				break;
+			}
+			break;
+		default:
+			unreachable();
+		}
+	} else {
+		pVar = sql_xmalloc(sizeof(Mem));
+		mem_create(pVar);
+	}
+	mem_copy_as_ephemeral(mem, pVar);
+	return 0;
 }
 
 void

--- a/src/box/sql/mem.h
+++ b/src/box/sql/mem.h
@@ -111,6 +111,12 @@ struct Mem {
 #define MEM_Static    0x1000	/* Mem.z points to a static string */
 #define MEM_Ephem     0x2000	/* Mem.z points to an ephemeral string */
 
+/**
+ * Create Mem element which correspond to bind element.
+ */
+int
+sql_mem_create_from_bind(struct Mem *mem, const struct sql_bind *bind);
+
 static inline bool
 mem_is_null(const struct Mem *mem)
 {

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -4568,3 +4568,13 @@ sql_generate_column_name(uint32_t number)
 struct Mem *
 sql_create_pVar_for_numeric_variable(const struct sql_bind *bind,
 				     uint32_t p1, uint32_t bind_count);
+
+/** Set the type of a bound variable that occurs in the result set. */
+int
+sql_bind_type(struct Vdbe *v, uint32_t position, const char *type);
+
+/**
+ * This function set types in metadata in result columns in vdbe.
+ */
+void
+sql_set_types(struct Vdbe *v, const struct sql_bind *bind, uint32_t bind_count);

--- a/src/box/sql/sqlInt.h
+++ b/src/box/sql/sqlInt.h
@@ -213,6 +213,7 @@
 #include <assert.h>
 #include <stddef.h>
 
+struct sql_bind;
 typedef long long int sql_int64;
 typedef unsigned long long int sql_uint64;
 typedef sql_int64 sql_int64;
@@ -309,7 +310,7 @@ sql_stmt_compile(const char *sql, struct Vdbe *re_prepared);
 
 /** This is the top-level implementation of sqlStep(). */
 int
-sql_step(struct Vdbe *v);
+sql_step(struct Vdbe *v, const struct sql_bind *bind, uint32_t bind_count);
 
 /** Encode the result of an SQL statement in msgpack. */
 char *
@@ -3898,6 +3899,14 @@ const char *sqlVListNumToName(VList *, int);
 int sqlVListNameToNum(VList *, const char *, int);
 
 /*
+ * Return a pointer to the name of a variable in the given VList that
+ * coincides with name.  Or return a NULL if there is no such variable in
+ * the list
+ */
+const char *
+sql_find_var_by_name(VList *pIn, const char *name);
+
+/*
  * Routines to read and write variable-length integers.  These used to
  * be defined locally, but now we use the varint routines in the util.c
  * file.
@@ -4552,3 +4561,10 @@ sql_generate_column_name(uint32_t number)
 }
 
 #endif				/* sqlINT_H */
+
+/**
+ * Create a pVar in execution for numeric bind variables.
+ */
+struct Mem *
+sql_create_pVar_for_numeric_variable(const struct sql_bind *bind,
+				     uint32_t p1, uint32_t bind_count);

--- a/src/box/sql/util.c
+++ b/src/box/sql/util.c
@@ -1123,6 +1123,22 @@ sqlVListNumToName(VList * pIn, int iVal)
 	return 0;
 }
 
+const char *
+sql_find_var_by_name(VList *pIn, const char *name)
+{
+	int i, mx;
+	if (pIn == 0)
+		return 0;
+	mx = pIn[1];
+	i = 2;
+	do {
+		if (strcmp((char *)&pIn[i + 2], name) == 0)
+			return (char *)&pIn[i + 2];
+		i += pIn[i + 1];
+	} while (i < mx);
+	return 0;
+}
+
 /*
  * Return the number of the variable named zName, if it is in VList.
  * or return 0 if there is no such variable.

--- a/src/box/sql/vdbe.c
+++ b/src/box/sql/vdbe.c
@@ -48,6 +48,7 @@
 #include "mem.h"
 #include "vdbeInt.h"
 #include "tarantoolInt.h"
+#include "box/bind.h"
 
 #include "msgpuck/msgpuck.h"
 #include "mpstream/mpstream.h"
@@ -356,7 +357,8 @@ vdbe_field_ref_fetch(struct vdbe_field_ref *field_ref, uint32_t fieldno,
  * Execute as much of a VDBE program as we can.
  * This is the core of sql_step().
  */
-int sqlVdbeExec(Vdbe *p)
+int
+sqlVdbeExec(struct Vdbe *p, const struct sql_bind *bind, uint32_t bind_count)
 {
 	Op *aOp = p->aOp;          /* Copy of p->aOp */
 	Op *pOp = aOp;             /* Current operation */
@@ -861,15 +863,21 @@ case OP_Blob: {                /* out2 */
  */
 case OP_Variable: {            /* out2 */
 	Mem *pVar;       /* Value being transferred */
-
 	assert(pOp->p1>0 && pOp->p1<=p->nVar);
-	assert(pOp->p4.z==0 || pOp->p4.z==sqlVListNumToName(p->pVList,pOp->p1));
-	pVar = &p->aVar[pOp->p1 - 1];
-	if (sqlVdbeMemTooBig(pVar)) {
-		goto too_big;
+	if (pOp->p4.z != NULL && pOp->p4.z[0] == '$') {
+		pOut = vdbe_prepare_null_out(p, pOp->p2);
+		if ((uint32_t)pOp->p1 <= bind_count)
+			sql_mem_create_from_bind(pOut, &bind[pOp->p1 - 1]);
+		else
+			sql_mem_create_from_bind(pOut, NULL);
+	} else {
+		pVar = &p->aVar[pOp->p1 - 1];
+		if (sqlVdbeMemTooBig(pVar)) {
+			goto too_big;
+		}
+		pOut = vdbe_prepare_null_out(p, pOp->p2);
+		mem_copy_as_ephemeral(pOut, pVar);
 	}
-	pOut = vdbe_prepare_null_out(p, pOp->p2);
-	mem_copy_as_ephemeral(pOut, pVar);
 	UPDATE_MAX_BLOBSIZE(pOut);
 	break;
 }

--- a/src/box/sql/vdbeInt.h
+++ b/src/box/sql/vdbeInt.h
@@ -328,7 +328,12 @@ int sqlVdbeCursorRestore(VdbeCursor *);
 void sqlVdbePrintOp(FILE *, int, Op *);
 #endif
 
-int sqlVdbeExec(Vdbe *);
+/**
+ * Execute as much of a VDBE program as we can.
+ * This is the core of sql_step().
+ */
+int
+sqlVdbeExec(struct Vdbe *, const struct sql_bind *, uint32_t bind_count);
 int sqlVdbeList(Vdbe *);
 
 int sqlVdbeHalt(Vdbe *);

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -311,7 +311,7 @@ vdbeUnbind(struct Vdbe *p, int i)
  * @param type String literal representing type of binding param.
  * @retval 0 on success.
  */
-static int
+int
 sql_bind_type(struct Vdbe *v, uint32_t position, const char *type)
 {
 	if (v->res_var_count < position)
@@ -359,9 +359,8 @@ sql_bind_double(struct Vdbe *p, int i, double rValue)
 {
 	if (vdbeUnbind(p, i) != 0)
 		return -1;
-	int rc = sql_bind_type(p, i, "numeric");
 	mem_set_double(&p->aVar[i - 1], rValue);
-	return rc;
+	return 0;
 }
 
 int
@@ -369,9 +368,8 @@ sql_bind_boolean(struct Vdbe *p, int i, bool value)
 {
 	if (vdbeUnbind(p, i) != 0)
 		return -1;
-	int rc = sql_bind_type(p, i, "boolean");
 	mem_set_bool(&p->aVar[i - 1], value);
-	return rc;
+	return 0;
 }
 
 int
@@ -385,9 +383,8 @@ sql_bind_int64(struct Vdbe *p, int i, int64_t iValue)
 {
 	if (vdbeUnbind(p, i) != 0)
 		return -1;
-	int rc = sql_bind_type(p, i, "integer");
 	mem_set_int(&p->aVar[i - 1], iValue);
-	return rc;
+	return 0;
 }
 
 int
@@ -395,9 +392,8 @@ sql_bind_uint64(struct Vdbe *p, int i, uint64_t value)
 {
 	if (vdbeUnbind(p, i) != 0)
 		return -1;
-	int rc = sql_bind_type(p, i, "integer");
 	mem_set_uint(&p->aVar[i - 1], value);
-	return rc;
+	return 0;
 }
 
 int
@@ -405,7 +401,7 @@ sql_bind_null(struct Vdbe *p, int i)
 {
 	if (vdbeUnbind(p, i) != 0)
 		return -1;
-	return sql_bind_type(p, i, "boolean");
+	return 0;
 }
 
 int
@@ -413,7 +409,6 @@ sql_bind_ptr(struct Vdbe *p, int i, void *ptr)
 {
 	int rc = vdbeUnbind(p, i);
 	if (rc == 0) {
-		rc = sql_bind_type(p, i, "varbinary");
 		mem_set_ptr(&p->aVar[i - 1], ptr);
 	}
 	return rc;
@@ -423,34 +418,34 @@ int
 sql_bind_str_static(struct Vdbe *vdbe, int i, const char *str, uint32_t len)
 {
 	mem_set_str_static(&vdbe->aVar[i - 1], (char *)str, len);
-	return sql_bind_type(vdbe, i, "text");
+	return 0;
 }
 
 int
 sql_bind_bin_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
 {
 	mem_set_bin_static(&vdbe->aVar[i - 1], (char *)str, size);
-	return sql_bind_type(vdbe, i, "text");
+	return 0;
 }
 
 int
 sql_bind_array_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
 {
 	mem_set_array_static(&vdbe->aVar[i - 1], (char *)str, size);
-	return sql_bind_type(vdbe, i, "array");
+	return 0;
 }
 
 int
 sql_bind_map_static(struct Vdbe *vdbe, int i, const char *str, uint32_t size)
 {
 	mem_set_map_static(&vdbe->aVar[i - 1], (char *)str, size);
-	return sql_bind_type(vdbe, i, "map");
+	return 0;
 }
 
 int
 sql_bind_uuid(struct Vdbe *p, int i, const struct tt_uuid *uuid)
 {
-	if (vdbeUnbind(p, i) != 0 || sql_bind_type(p, i, "uuid") != 0)
+	if (vdbeUnbind(p, i) != 0)
 		return -1;
 	mem_set_uuid(&p->aVar[i - 1], uuid);
 	return 0;
@@ -459,7 +454,7 @@ sql_bind_uuid(struct Vdbe *p, int i, const struct tt_uuid *uuid)
 int
 sql_bind_dec(struct Vdbe *p, int i, const decimal_t *dec)
 {
-	if (vdbeUnbind(p, i) != 0 || sql_bind_type(p, i, "decimal") != 0)
+	if (vdbeUnbind(p, i) != 0)
 		return -1;
 	mem_set_dec(&p->aVar[i - 1], dec);
 	return 0;
@@ -468,7 +463,7 @@ sql_bind_dec(struct Vdbe *p, int i, const decimal_t *dec)
 int
 sql_bind_datetime(struct Vdbe *p, int i, const struct datetime *dt)
 {
-	if (vdbeUnbind(p, i) != 0 || sql_bind_type(p, i, "datetime") != 0)
+	if (vdbeUnbind(p, i) != 0)
 		return -1;
 	mem_set_datetime(&p->aVar[i - 1], dt);
 	return 0;
@@ -477,7 +472,7 @@ sql_bind_datetime(struct Vdbe *p, int i, const struct datetime *dt)
 int
 sql_bind_interval(struct Vdbe *p, int i, const struct interval *itv)
 {
-	if (vdbeUnbind(p, i) != 0 || sql_bind_type(p, i, "interval") != 0)
+	if (vdbeUnbind(p, i) != 0)
 		return -1;
 	mem_set_interval(&p->aVar[i - 1], itv);
 	return 0;
@@ -538,4 +533,132 @@ const char *
 sql_sql(struct Vdbe *p)
 {
 	return p ? p->zSql : 0;
+}
+
+/**
+ * This function find number of bind variable whose name matches
+ * the result column name in vdbe.
+ */
+static uint32_t
+sql_find_name_in_bind(const struct sql_bind *bind, uint32_t bind_count,
+		      const char *name)
+{
+	uint32_t pos = 0;
+	for (uint32_t i = 0; i < bind_count; i++) {
+		pos = i + 1;
+		if (strncmp(bind[i].name, name, bind[i].name_len) == 0) {
+			return pos;
+		}
+	}
+	return 0;
+}
+
+/**
+ * This function is auxiliary. It set type in one result column in vdbe.
+ */
+static void
+sql_set_type(struct Vdbe *stmt, const struct sql_bind *bind, uint32_t i, uint32_t pos)
+{
+	const struct sql_bind *p = &bind[pos - 1];
+	switch (p->type) {
+	case MP_INT:
+		sql_bind_type(stmt, i, "integer");
+		break;
+	case MP_UINT:
+		sql_bind_type(stmt, i, "integer");
+		break;
+	case MP_BOOL:
+		sql_bind_type(stmt, i, "boolean");
+		break;
+	case MP_DOUBLE:
+	case MP_FLOAT:
+		sql_bind_type(stmt, i, "numeric");
+		break;
+	case MP_STR:
+		/*
+		 * Parameters are allocated within message pack,
+		 * received from the iproto thread. IProto thread
+		 * now is waiting for the response and it will not
+		 * free the packet until sql_stmt_finalize. So
+		 * there is no need to copy the packet and we can
+		 * use SQL_STATIC.
+		 */
+		sql_bind_type(stmt, i, "text");
+		break;
+	case MP_NIL:
+		sql_bind_type(stmt, i, "boolean");
+		break;
+	case MP_BIN:
+		sql_bind_type(stmt, i, "text");
+		break;
+	case MP_ARRAY:
+		sql_bind_type(stmt, i, "array");
+		break;
+	case MP_MAP:
+		sql_bind_type(stmt, i, "map");
+		break;
+	case MP_EXT:
+		switch (p->ext_type) {
+		case MP_UUID:
+			sql_bind_type(stmt, i, "uuid");
+			break;
+		case MP_DECIMAL:
+			sql_bind_type(stmt, i, "decimal");
+			break;
+		case MP_DATETIME:
+			sql_bind_type(stmt, i, "datetime");
+			break;
+		case MP_INTERVAL:
+			sql_bind_type(stmt, i, "interval");
+			break;
+		default:
+			unreachable();
+		}
+		break;
+	default:
+		unreachable();
+	}
+}
+
+void
+sql_set_types(struct Vdbe *p, const struct sql_bind *bind, uint32_t bind_count)
+{
+	Op *aOp = p->aOp;
+	Op *pOp;
+	uint32_t i = 0;
+	uint32_t last = 0;
+	for (pOp = p->aOp; pOp < &aOp[p->nOp]; pOp++) {
+		if (pOp->opcode == OP_Variable) {
+			if (pOp->p4.z != NULL) {
+				if (pOp->p4.z[0] != '$') {
+					uint32_t pos =
+					sql_find_name_in_bind(bind, bind_count,
+							      pOp->p4.z);
+					if (pos == 0)
+						sql_bind_type(p, i + 1,
+							      "boolean");
+					else
+						sql_set_type(p, bind, i + 1,
+							     pos);
+					last = pos;
+
+				} else {
+					if ((uint32_t)pOp->p1 <= bind_count)
+						sql_set_type(p, bind, i + 1,
+							     pOp->p1);
+					else
+						sql_bind_type(p, i + 1,
+							      "boolean");
+					last = pOp->p1;
+				}
+			} else {
+				last += 1;
+				if (last <= bind_count)
+					sql_set_type(p, bind, i + 1, last);
+				else
+					sql_bind_type(p, i + 1, "boolean");
+			}
+		i++;
+		}
+	}
 }

--- a/src/box/sql/vdbeapi.c
+++ b/src/box/sql/vdbeapi.c
@@ -38,6 +38,7 @@
 #include "mem.h"
 #include "vdbeInt.h"
 #include "box/session.h"
+#include "box/bind.h"
 
 int
 sql_stmt_finalize(struct Vdbe *v)
@@ -72,7 +73,7 @@ sql_metadata_is_full()
  * outer sql_step() wrapper procedure.
  */
 static int
-sqlStep(Vdbe * p)
+sqlStep(struct Vdbe *p, const struct sql_bind *bind, uint32_t bind_count)
 {
 	struct sql *db = sql_get();
 	int rc;
@@ -93,7 +94,7 @@ sqlStep(Vdbe * p)
 		rc = sqlVdbeList(p);
 	} else {
 		db->nVdbeExec++;
-		rc = sqlVdbeExec(p);
+		rc = sqlVdbeExec(p, bind, bind_count);
 		db->nVdbeExec--;
 	}
 
@@ -108,10 +109,10 @@ sqlStep(Vdbe * p)
 }
 
 int
-sql_step(struct Vdbe *v)
+sql_step(struct Vdbe *v, const struct sql_bind *bind, uint32_t bind_count)
 {
 	assert(v != NULL);
-	return sqlStep(v);
+	return sqlStep(v, bind, bind_count);
 }
 
 int

--- a/test/sql-luatest/bind_test.lua
+++ b/test/sql-luatest/bind_test.lua
@@ -145,6 +145,29 @@ g.test_12733_numeric_bind_variables = function()
     end)
 end
 
+-- Check types of bind variables
+g.test_6551_metadata_types_for_bind_variable = function()
+    g.server:exec(function()
+        local sql = [[SELECT :a, :a, :b;]]
+        local res = box.execute(sql, {{[':a'] = 1}, {[':b'] = "aSd"}})
+        local exp = {
+            {
+                type = "integer",
+                name =  "COLUMN_1",
+            },
+            {
+                type = "integer",
+                name = "COLUMN_2",
+            },
+            {
+                type = "text",
+                name = "COLUMN_3",
+            },
+        }
+        t.assert_equals(res.metadata, exp)
+    end)
+end
+
 g = t.group("bind2", {{remote = true}, {remote = false}})
 
 g.before_all(function(cg)

--- a/test/sql-luatest/bind_test.lua
+++ b/test/sql-luatest/bind_test.lua
@@ -124,6 +124,27 @@ g.test_bind_3 = function()
     end)
 end
 
+-- Check work of numeric bind variables
+g.test_12733_numeric_bind_variables = function()
+    g.server:exec(function()
+        local sql = [[SELECT $3, $1, $2, $10;]]
+        local res = box.execute(sql, {'a', 'b', 'c'})
+        t.assert_equals(res.rows, {{'c', 'a', 'b', nil}})
+
+        res = box.execute([[select :a, $1;]], {{[':a'] = 123}})
+        t.assert_equals(res.rows, {{123, 123}})
+
+        res = box.execute([[select $1, :a;]], {{[':a'] = 123}})
+        t.assert_equals(res.rows, {{123, 123}})
+
+        res = box.execute([[select :a, $1;]], {321, {[':a'] = 123}})
+        t.assert_equals(res.rows, {{123, 321}})
+
+        res = box.execute([[select $1, :a;]], {321, {[':a'] = 123}})
+        t.assert_equals(res.rows, {{321, 123}})
+    end)
+end
+
 g = t.group("bind2", {{remote = true}, {remote = false}})
 
 g.before_all(function(cg)


### PR DESCRIPTION
After this patch commands with bind variable
have right metadata.

Prior to this patch:
```
tarantool> box.execute([[SELECT :a, :a, :a;]], {{[':a'] = 1}}).metadata
---
---
- - name: COLUMN_1
    type: integer
  - name: COLUMN_2
    type: integer
  - name: COLUMN_3
    type: integer
...
```
After this patch:
```
tarantool> box.execute([[SELECT :a, :a, :a;]], {{[':a'] = 1}}).metadata
---
- - name: COLUMN_1
    type: integer
  - name: COLUMN_2
    type: boolean
  - name: COLUMN_3
    type: boolean
...
```
Closes #6551

NO_DOC=bugfix
