### PR TITLE
build: fix CMP0175 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,10 +290,10 @@ file_is_in_directory(BINARY_DIR_INSIDE_SOURCE_DIR "${BINARY_REALPATH}"
 if (BINARY_DIR_INSIDE_SOURCE_DIR)
     set(EXCLUDE_FILES --exclude-files "${BINARY_REALPATH}/**/*.lua")
 endif()
-add_custom_target(luacheck DEPENDS LuaJIT-luacheck)
-add_custom_command(TARGET luacheck
+add_custom_target(luacheck
     COMMAND ${LUACHECK} --codes --config .luacheckrc . ${EXCLUDE_FILES}
     WORKING_DIRECTORY ${SOURCE_REALPATH}
+    DEPENDS LuaJIT-luacheck
     COMMENT "Perform static analysis of Lua code"
 )
 unset(BINARY_REALPATH)
@@ -315,11 +315,11 @@ if (WITH_JEPSEN)
     # Enable 'make run-jepsen' target.
     #
 
-    add_custom_target(run-jepsen DEPENDS jepsen-tests)
-    add_custom_command(TARGET run-jepsen
+    add_custom_target(run-jepsen
         COMMAND ${BASH} ${PROJECT_SOURCE_DIR}/tools/run-jepsen-tests.sh
 				${PROJECT_SOURCE_DIR}
                                 ${PROJECT_BINARY_DIR}
+        DEPENDS jepsen-tests
         COMMENT "Running Jepsen tests"
     )
 endif()
@@ -882,14 +882,12 @@ if (WITH_NOTIFY_SOCKET)
 endif()
 
 if(NOT "${PROJECT_BINARY_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
-    add_custom_target(distclean)
-    add_custom_command(TARGET distclean
+    add_custom_target(distclean
         COMMAND ${CMAKE_COMMAND} -E remove_directory "${PROJECT_BINARY_DIR}"
         COMMENT "Removing the build directory and its content"
     )
 elseif(IS_DIRECTORY .git AND GIT)
-    add_custom_target(distclean)
-    add_custom_command(TARGET distclean
+    add_custom_target(distclean
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMAND ${GIT} submodule foreach --recursive git clean -f -X -d
         COMMAND ${GIT} clean -f -X -d

--- a/cmake/CheckPatch.cmake
+++ b/cmake/CheckPatch.cmake
@@ -2,8 +2,6 @@ find_program(CHECKPATCH checkpatch.pl
              HINTS ${PROJECT_SOURCE_DIR}/checkpatch)
 find_program(CODESPELL codespell)
 
-add_custom_target(checkpatch)
-
 set(BASE_GIT_REF "origin/master")
 if(DEFINED ENV{CHECKPATCH_GITREF})
     set(BASE_GIT_REF "$ENV{CHECKPATCH_GITREF}")
@@ -17,14 +15,14 @@ if(CODESPELL)
 endif(CODESPELL)
 
 if(CHECKPATCH)
-    add_custom_command(TARGET checkpatch
+    add_custom_target(checkpatch
         COMMENT "Running checkpatch on a current branch against ${BASE_GIT_REF}"
         COMMAND ${CHECKPATCH} ${CHECKPATCH_OPTIONS}
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     )
 else()
     set(WARN_MSG "`checkpatch.pl' is not found, so checkpatch target is dummy.")
-    add_custom_command(TARGET checkpatch
+    add_custom_target(checkpatch
         COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --red ${WARN_MSG}
         COMMENT ${WARN_MSG}
     )

--- a/src/lib/tzcode/CMakeLists.txt
+++ b/src/lib/tzcode/CMakeLists.txt
@@ -40,12 +40,12 @@ ExternalProject_Add(${TZCODE_PROJECT}
 
 find_program(PERL perl)
 
-add_custom_target(gen-timezones DEPENDS ${TZCODE_PROJECT})
-add_custom_command(TARGET gen-timezones
+add_custom_target(gen-timezones
     COMMAND
     ${PERL} ${TZCODE_SRC}/gen-zone-abbrevs.pl
         ${TZCODE_SRC}/zone-abbrevs.txt ${TZDATA_FULL_TARGET}
         ${TZCODE_SRC}/timezones.h ${TZLUA_SRC}/timezones.lua
+    DEPENDS ${TZCODE_PROJECT}
     COMMENT "Generating timezones.h and timezones.lua"
 )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -123,7 +123,7 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/small
     COMMAND ${CMAKE_COMMAND} -E create_symlink
         ${CMAKE_CURRENT_BINARY_DIR}/../src/lib/small/test/
         ${CMAKE_CURRENT_BINARY_DIR}/small
-        COMMENT Create the symlink for libsmall test binaries)
+    COMMENT "Create the symlink for libsmall test binaries")
 
 add_custom_target(symlink_libsmall_test_binaries ALL
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/small)


### PR DESCRIPTION
The following pattern was used to add custom `make foo` commands:

```cmake
add_custom_target(foo DEPENDS <...>)
add_custom_command(TARGET foo
    COMMAND <...>
)
```

However, recent cmake versions (verified on 4.3.4) warns about the `add_custom_command` syntax (quoted [1]):

> `add_custom_command()` rejects invalid arguments.
>
> <...>
>
> The `TARGET` form requires exactly one of `PRE_BUILD`, `PRE_LINK`, or
> `POST_BUILD` to be given. Previously, if none were given, `POST_BUILD`
> was assumed, or if multiple keywords were given, the last one was
> used.

The fix could be add the `POST_BUILD` keyword. However, it is more natural to just use `add_custom_target` with `COMMAND` instead:

```cmake
add_custom_target(foo
    COMMAND <...>
    DEPENDS <...>
)
```

Also, fixed one place with an unquoted `COMMENT` argument of a `add_custom_command` call (quoted [1]):

> The `COMMENT` keyword expects exactly one value after it. If multiple
> values are given, or if the `COMMENT` keyword is given more than once,
> this is an error.

[1]: https://cmake.org/cmake/help/latest/policy/CMP0175.html